### PR TITLE
Fix for Constructor injection when using OpenApi annotations in JAX-Rs resource

### DIFF
--- a/extensions/resteasy-server-common/spi/src/main/java/io/quarkus/resteasy/server/common/spi/AllowedJaxRsAnnotationPrefixBuildItem.java
+++ b/extensions/resteasy-server-common/spi/src/main/java/io/quarkus/resteasy/server/common/spi/AllowedJaxRsAnnotationPrefixBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.server.common.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * The package prefix of any annotations that have to be compatible with JaxRs resource class
+ * to allow constructor injection.
+ */
+public final class AllowedJaxRsAnnotationPrefixBuildItem extends MultiBuildItem {
+
+    private final String prefix;
+
+    public AllowedJaxRsAnnotationPrefixBuildItem(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getAnnotationPrefix() {
+        return prefix;
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.resteasy.server.common.spi.AllowedJaxRsAnnotationPrefixBuildItem;
 import io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
@@ -157,6 +158,13 @@ public class SmallRyeOpenApiProcessor {
                 new FilteredIndexView(
                         compositeIndex,
                         new OpenApiConfigImpl(ConfigProvider.getConfig())));
+    }
+
+    @BuildStep
+    public List<AllowedJaxRsAnnotationPrefixBuildItem> registerJaxRsSupportedAnnotation() {
+        List<AllowedJaxRsAnnotationPrefixBuildItem> prefixes = new ArrayList<>();
+        prefixes.add(new AllowedJaxRsAnnotationPrefixBuildItem("org.eclipse.microprofile.openapi.annotations"));
+        return prefixes;
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
@@ -15,7 +15,7 @@ public class OpenApiDefaultPathTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class));
+                    .addClasses(OpenApiResource.class, ResourceBean.class));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -34,7 +34,11 @@ public class OpenApiDefaultPathTestCase {
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
                 .body("info.title", Matchers.equalTo("Generated API"))
-                .body("paths", Matchers.hasKey("/resource"));
+                .body("tags.name[0]", Matchers.equalTo("test"))
+                .body("paths.'/resource'.get.servers[0]", Matchers.hasKey("url"))
+                .body("paths.'/resource'.get.security[0]", Matchers.hasKey("securityRequirement"))
+                .body("paths.'/resource'.get", Matchers.hasKey("openApiExtension"));
+
         RestAssured.given()
                 .when().options(OPEN_API_PATH)
                 .then().header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
@@ -16,7 +16,7 @@ public class OpenApiHttpRootDefaultPathTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
 
     @Test

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
@@ -15,7 +15,7 @@ public class OpenApiPathWithSegmentsTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
                             "application.properties"));
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
@@ -15,7 +15,7 @@ public class OpenApiPathWithoutSegmentsTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
                             "application.properties"));
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResource.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResource.java
@@ -1,15 +1,32 @@
 package io.quarkus.smallrye.openapi.test.jaxrs;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
 @Path("/resource")
+@Tag(name = "test")
+@Extension(name = "openApiExtension", value = "openApiExtensionValue")
+@SecurityRequirement(name = "securityRequirement", scopes = "securityRequirementScope")
+@Server(url = "serverUrl")
 public class OpenApiResource {
+
+    private ResourceBean resourceBean;
+
+    @Inject
+    public OpenApiResource(ResourceBean resourceBean) {
+        this.resourceBean = resourceBean;
+    }
 
     @GET
     public String root() {
-        return "resource";
+        return resourceBean.toString();
     }
 
     @GET

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
@@ -16,7 +16,7 @@ public class OpenApiWithConfigTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
                     .addAsResource(new StringAsset("mp.openapi.scan.disable=true\nmp.openapi.servers=https://api.acme.org/"),
                             "application.properties"));

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
@@ -16,7 +16,7 @@ public class OpenApiWithResteasyPathHttpRootDefaultPathTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.http.root-path=/http-root-path\n" +
                             "quarkus.resteasy.path=/resteasy-path"),
                             "application.properties"));

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
@@ -16,7 +16,7 @@ public class OpenApiWithResteasyPathTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.resteasy.path=/foo/bar"),
                             "application.properties"));
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ResourceBean {
+    @Override
+    public String toString() {
+        return "resource";
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -19,7 +19,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(OpenApiResource.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=/swagger"), "application.properties"));
 
     @Test


### PR DESCRIPTION
Fix #11313 