### PR TITLE
Remove jdk8u242-b08 CI job for Gradle tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -253,11 +253,6 @@ jobs:
               java-version: 8
           }
           - {
-            name: "Java 8 - 242",
-            java-version: 8,
-            release: "jdk8u242-b08"
-          }
-          - {
             name: Java 11,
             java-version: 11
           }


### PR DESCRIPTION
Unlike its Maven tests counterpart, I don't see any specific reason to (additionally) run Gradle tests against this specific `jdk8u242-b08` Java version. The commit in this PR removes this from the CI job matrix and should help reduce the time/resources spent on PR testing.