### PR TITLE
Make LocaleConverter more lenient

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/LocaleConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/LocaleConverter.java
@@ -30,7 +30,7 @@ public class LocaleConverter implements Converter<Locale>, Serializable {
         }
 
         Locale locale = Locale.forLanguageTag(NORMALIZE_LOCALE_PATTERN.matcher(localeValue).replaceAll("-"));
-        if (locale.getLanguage() == null || locale.getLanguage().isEmpty()) {
+        if (locale != Locale.ROOT && (locale.getLanguage() == null || locale.getLanguage().isEmpty())) {
             throw new IllegalArgumentException("Unable to resolve locale: " + value);
         }
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/LocaleConverterTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/LocaleConverterTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.runtime.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Locale;
 
@@ -19,8 +21,23 @@ public class LocaleConverterTest {
     @Test
     public void testUnderscoreLocale() {
         LocaleConverter localeConverter = new LocaleConverter();
-        Locale locale = localeConverter.convert("fr-FR");
+        Locale locale = localeConverter.convert("fr_FR");
         assertEquals("fr", locale.getLanguage());
         assertEquals("FR", locale.getCountry());
     }
+
+    @Test
+    public void testCLocale() {
+        LocaleConverter localeConverter = new LocaleConverter();
+        Locale locale = localeConverter.convert("c.u-US");
+        assertSame(Locale.ROOT, locale);
+    }
+
+    @Test
+    public void testEmptyLocale() {
+        LocaleConverter localeConverter = new LocaleConverter();
+        Locale locale = localeConverter.convert("");
+        assertNull(locale);
+    }
+
 }


### PR DESCRIPTION
This is necessary in environments where the C.UTF-8 locale is used (like in IBM Cloud toolchain environments).

Fixes #11430