### PR TITLE
Make sure test classes are compiled before running test

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
@@ -59,13 +59,13 @@ public class BuildToolHelper {
         return null;
     }
 
-    public static QuarkusModel enableGradleAppModel(Path projectRoot, String mode)
+    public static QuarkusModel enableGradleAppModel(Path projectRoot, String mode, String... tasks)
             throws IOException, AppModelResolverException {
         if (isMavenProject(projectRoot)) {
             return null;
         }
         final QuarkusModel model = QuarkusGradleModelFactory.create(getBuildFile(projectRoot, BuildTool.GRADLE).toFile(),
-                mode);
+                mode, tasks);
         QuarkusModelHelper.exportModel(model);
         return model;
     }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -8,10 +8,11 @@ import org.gradle.tooling.ProjectConnection;
 
 public class QuarkusGradleModelFactory {
 
-    public static QuarkusModel create(File projectDir, String mode) {
+    public static QuarkusModel create(File projectDir, String mode, String... tasks) {
         try (ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(projectDir)
                 .connect()) {
+            connection.newBuild().forTasks(tasks).run();
             return connection.action(new QuarkusModelBuildAction(mode)).run();
         }
     }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
@@ -36,6 +36,7 @@ public class QuarkusModelHelper {
     }
 
     public final static String[] DEVMODE_REQUIRED_TASKS = new String[] { "classes" };
+    public final static String[] TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses" };
 
     public static void exportModel(QuarkusModel model) throws AppModelResolverException, IOException {
         Path serializedModel = QuarkusModelHelper

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -57,6 +57,7 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.runner.Timing;
+import io.quarkus.bootstrap.util.QuarkusModelHelper;
 import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
@@ -181,7 +182,7 @@ public class QuarkusTestExtension
             Path root = Paths.get("").normalize().toAbsolutePath();
             // If gradle project running directly with IDE
             if (System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL) == null) {
-                BuildToolHelper.enableGradleAppModel(root, "TEST");
+                BuildToolHelper.enableGradleAppModel(root, "TEST", QuarkusModelHelper.TEST_REQUIRED_TASKS);
             }
 
             runnerBuilder.setApplicationRoot(rootBuilder.build());


### PR DESCRIPTION
This branch make sure `classes` and `testClasses` tasks are ran before running tests. This will compile other dependent module if needed.

close #11472 