### PR TITLE
Hibernate Validator: status 400 instead of 500 if JAX-RS method is defined in interface

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -117,12 +117,11 @@ jobs:
             java-version: 11,
             maven_args: "-pl !integration-tests/gradle"
           }
-          # Disabled for now as totally unstable
-          #- {
-          #  name: Java 14,
-          #  java-version: 14,
-          #  maven_args: "-pl !integration-tests/gradle"
-          #}
+          - {
+            name: Java 14,
+            java-version: 14,
+            maven_args: "-pl !integration-tests/gradle"
+          }
 
     services:
       keycloak:

--- a/extensions/hibernate-validator/deployment/pom.xml
+++ b/extensions/hibernate-validator/deployment/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-server-common-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -5,7 +5,6 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,6 +65,7 @@ import io.quarkus.hibernate.validator.runtime.HibernateValidatorBuildTimeConfig;
 import io.quarkus.hibernate.validator.runtime.HibernateValidatorRecorder;
 import io.quarkus.hibernate.validator.runtime.ValidatorProvider;
 import io.quarkus.hibernate.validator.runtime.interceptor.MethodValidationInterceptor;
+import io.quarkus.resteasy.common.spi.ResteasyDotNames;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodAnnotationsBuildItem;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 
@@ -93,16 +93,6 @@ class HibernateValidatorProcessor {
     private static final DotName VALID = DotName.createSimple(Valid.class.getName());
 
     private static final DotName REPEATABLE = DotName.createSimple(Repeatable.class.getName());
-
-    private static final DotName[] JAXRS_METHOD_ANNOTATIONS = {
-            DotName.createSimple("javax.ws.rs.GET"),
-            DotName.createSimple("javax.ws.rs.HEAD"),
-            DotName.createSimple("javax.ws.rs.DELETE"),
-            DotName.createSimple("javax.ws.rs.OPTIONS"),
-            DotName.createSimple("javax.ws.rs.PATCH"),
-            DotName.createSimple("javax.ws.rs.POST"),
-            DotName.createSimple("javax.ws.rs.PUT"),
-    };
 
     private static final Pattern BUILT_IN_CONSTRAINT_REPEATABLE_CONTAINER_PATTERN = Pattern.compile("\\$List$");
 
@@ -349,8 +339,8 @@ class HibernateValidatorProcessor {
         Map<DotName, Set<SimpleMethodSignatureKey>> jaxRsMethods = new HashMap<>();
 
         Collection<DotName> jaxRsMethodDefiningAnnotations = new ArrayList<>(
-                JAXRS_METHOD_ANNOTATIONS.length + additionalJaxRsResourceMethodAnnotations.size());
-        jaxRsMethodDefiningAnnotations.addAll(Arrays.asList(JAXRS_METHOD_ANNOTATIONS));
+                ResteasyDotNames.JAXRS_METHOD_ANNOTATIONS.size() + additionalJaxRsResourceMethodAnnotations.size());
+        jaxRsMethodDefiningAnnotations.addAll(ResteasyDotNames.JAXRS_METHOD_ANNOTATIONS);
         for (AdditionalJaxRsResourceMethodAnnotationsBuildItem additionalJaxRsResourceMethodAnnotation : additionalJaxRsResourceMethodAnnotations) {
             jaxRsMethodDefiningAnnotations.addAll(additionalJaxRsResourceMethodAnnotation.getAnnotationClasses());
         }

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
@@ -1,9 +1,6 @@
 package io.quarkus.hibernate.validator.deployment;
 
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -14,6 +11,7 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.hibernate.validator.runtime.interceptor.MethodValidated;
 import io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidated;
 
@@ -24,30 +22,16 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
 
     private static final Logger LOGGER = Logger.getLogger(MethodValidatedAnnotationsTransformer.class.getPackage().getName());
 
-    private static final DotName[] JAXRS_METHOD_ANNOTATIONS = {
-            DotName.createSimple("javax.ws.rs.GET"),
-            DotName.createSimple("javax.ws.rs.HEAD"),
-            DotName.createSimple("javax.ws.rs.DELETE"),
-            DotName.createSimple("javax.ws.rs.OPTIONS"),
-            DotName.createSimple("javax.ws.rs.PATCH"),
-            DotName.createSimple("javax.ws.rs.POST"),
-            DotName.createSimple("javax.ws.rs.PUT"),
-    };
-
     private final Set<DotName> consideredAnnotations;
-    private final Collection<DotName> effectiveJaxRsMethodDefiningAnnotations;
-    private final Map<DotName, Set<String>> inheritedAnnotationsToBeValidated;
+    private final Map<DotName, Set<SimpleMethodSignatureKey>> inheritedAnnotationsToBeValidated;
+    private final Map<DotName, Set<SimpleMethodSignatureKey>> jaxRsMethods;
 
     MethodValidatedAnnotationsTransformer(Set<DotName> consideredAnnotations,
-            Collection<DotName> additionalJaxRsMethodAnnotationsDotNames,
-            Map<DotName, Set<String>> inheritedAnnotationsToBeValidated) {
+            Map<DotName, Set<SimpleMethodSignatureKey>> jaxRsMethods,
+            Map<DotName, Set<SimpleMethodSignatureKey>> inheritedAnnotationsToBeValidated) {
         this.consideredAnnotations = consideredAnnotations;
+        this.jaxRsMethods = jaxRsMethods;
         this.inheritedAnnotationsToBeValidated = inheritedAnnotationsToBeValidated;
-
-        this.effectiveJaxRsMethodDefiningAnnotations = new ArrayList<>(
-                JAXRS_METHOD_ANNOTATIONS.length + additionalJaxRsMethodAnnotationsDotNames.size());
-        effectiveJaxRsMethodDefiningAnnotations.addAll(Arrays.asList(JAXRS_METHOD_ANNOTATIONS));
-        effectiveJaxRsMethodDefiningAnnotations.addAll(additionalJaxRsMethodAnnotationsDotNames);
     }
 
     @Override
@@ -85,10 +69,12 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
         }
         // This method has no annotations of its own: look for inherited annotations
         ClassInfo clazz = method.declaringClass();
-        String methodName = method.name().toString();
-        for (Map.Entry<DotName, Set<String>> validatedMethod : inheritedAnnotationsToBeValidated.entrySet()) {
-            if (clazz.interfaceNames().contains(validatedMethod.getKey())
-                    && validatedMethod.getValue().contains(methodName)) {
+        SimpleMethodSignatureKey signatureKey = new SimpleMethodSignatureKey(method);
+        for (Map.Entry<DotName, Set<SimpleMethodSignatureKey>> validatedMethod : inheritedAnnotationsToBeValidated.entrySet()) {
+            DotName ifaceOrSuperClass = validatedMethod.getKey();
+            // note: only check the direct superclass since we do not (yet) have the entire ClassInfo hierarchy here
+            if ((clazz.interfaceNames().contains(ifaceOrSuperClass) || ifaceOrSuperClass.equals(clazz.superName()))
+                    && validatedMethod.getValue().contains(signatureKey)) {
                 return true;
             }
         }
@@ -96,11 +82,32 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
     }
 
     private boolean isJaxrsMethod(MethodInfo method) {
-        for (DotName jaxrsMethodAnnotation : effectiveJaxRsMethodDefiningAnnotations) {
-            if (method.hasAnnotation(jaxrsMethodAnnotation)) {
+        ClassInfo clazz = method.declaringClass();
+        SimpleMethodSignatureKey signatureKey = new SimpleMethodSignatureKey(method);
+
+        if (isJaxrsMethod(signatureKey, clazz.name())) {
+            return true;
+        }
+
+        // check interfaces
+        for (DotName iface : clazz.interfaceNames()) {
+            if (isJaxrsMethod(signatureKey, iface)) {
+                return true;
+            }
+        }
+
+        // check superclass, but only the direct one since we do not (yet) have the entire ClassInfo hierarchy here
+        DotName superClass = clazz.superName();
+        if (!superClass.equals(IndexingUtil.OBJECT)) {
+            if (isJaxrsMethod(signatureKey, superClass)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean isJaxrsMethod(SimpleMethodSignatureKey signatureKey, DotName dotName) {
+        Set<SimpleMethodSignatureKey> signatureKeys = jaxRsMethods.get(dotName);
+        return signatureKeys != null && signatureKeys.contains(signatureKey);
     }
 }

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/SimpleMethodSignatureKey.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/SimpleMethodSignatureKey.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.validator.deployment;
+
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+class SimpleMethodSignatureKey {
+
+    private final String key;
+
+    SimpleMethodSignatureKey(MethodInfo method) {
+        // Notes:
+        // - MethodInfo.toString() is not usable here because it includes the declaring class
+        // - just parameters() for the second part would include annotations (see Type.toString())
+        key = method.name() + method.parameters().stream()
+                .map(Type::name)
+                .map(DotName::toString)
+                .collect(Collectors.joining(", ", "(", ")"));
+    }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SimpleMethodSignatureKey other = (SimpleMethodSignatureKey) obj;
+        return key.equals(other.key);
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+}

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -76,8 +76,7 @@ public class HibernateValidatorFunctionalityTest {
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-interface-validation/plop/")
                 .then()
-                // 500 until this is fixed: https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350
-                .statusCode(500)
+                .statusCode(400)
                 .body(containsString("numeric value out of bounds"));
 
         RestAssured.when()
@@ -91,8 +90,7 @@ public class HibernateValidatorFunctionalityTest {
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-impl-method/plop/")
                 .then()
-                // 500 until this is fixed: https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350
-                .statusCode(500)
+                .statusCode(400)
                 .body(containsString("numeric value out of bounds"));
 
         RestAssured.when()


### PR DESCRIPTION
Follow up to #11429, fixes https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350.
See also: https://github.com/quarkusio/quarkus/pull/11429#discussion_r471786768

I basically just gather all JAX-RS methods (whether or not defined in interfaces).

This is my first time working with the Quarkus deployment framework so please bear with me in case I did something stupid or inefficient. 😉 