### PR TITLE
Make vault work against recent releases of Java 8

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -110,13 +110,7 @@ jobs:
         java :
           - { name: Java8,
               java-version: 8,
-              maven_args: "-pl !integration-tests/vault-app,!integration-tests/vault-agroal,!integration-tests/vault,!integration-tests/google-cloud-functions-http,!integration-tests/gradle,!integration-tests/google-cloud-functions,!integration-tests/funqy-google-cloud-functions"
-          }
-          - {
-            name: "Java 8 - 242",
-            java-version: 8,
-            release: "jdk8u242-b08",
-            maven_args: "-pl !integration-tests/google-cloud-functions-http,!integration-tests/gradle,!integration-tests/google-cloud-functions,!integration-tests/funqy-google-cloud-functions"
+              maven_args: "-pl !integration-tests/google-cloud-functions-http,!integration-tests/gradle,!integration-tests/google-cloud-functions,!integration-tests/funqy-google-cloud-functions"
           }
           - {
             name: Java 11,

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -164,7 +164,7 @@
         <mongo-crypt.version>1.0.1</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
         <proton-j.version>0.33.6</proton-j.version>
-        <okhttp.version>3.14.6</okhttp.version>
+        <okhttp.version>3.14.9</okhttp.version>
         <sentry.version>1.7.30</sentry.version>
         <!-- Used for integration tests, to make sure webjars work-->
         <bootstrap.version>3.1.0</bootstrap.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -35,8 +35,8 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.DeploymentResultBuildItem;
-import io.quarkus.deployment.util.JavaVersionUtil;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.util.JavaVersionUtil;
 
 public class QuarkusAugmentor {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -24,8 +24,8 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.steps.MainClassBuildStep;
-import io.quarkus.deployment.util.JavaVersionUtil;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.util.JavaVersionUtil;
 import io.quarkus.utilities.JavaBinFinder;
 
 public class AppCDSBuildStep {

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -1,4 +1,4 @@
-package io.quarkus.deployment.util;
+package io.quarkus.runtime.util;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.deployment.util;
+package io.quarkus.runtime.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -80,9 +80,9 @@ import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.DevModeMain;
-import io.quarkus.deployment.util.JavaVersionUtil;
 import io.quarkus.maven.components.MavenVersionEnforcer;
 import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.runtime.util.JavaVersionUtil;
 import io.quarkus.utilities.JavaBinFinder;
 
 /**


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/8880 we introduced a workaround to get past issues with Vault when Java 8 releases higher than 242 (jdk8u242) were used. 

I took a look at the failures, which vault runs into, when using recent Java 8 releases. The root cause is that Java 8 recent releases brought in changes related to TLS1.3 which cause HTTP libraries (like OKHttp in this specific case) to run into issue during protocol negotiations over HTTPS. Some of these issues have been fixed upstream in OkHttp library itself.

The commits here do the following:

1. Upgrade to OkHttp 3.14.9 which is the latest in the 3.14.x series. This has some fixes related to the protocol negotiation issues. Those fixes though don't solve the problems Vault runs into. I will separately spend some time to narrow it down much more to try and report it back to OkHttp, if time permits.

2. Given that the whole issue stems from protocol negotiation through ALPN, when HTTP/2 protocol is enabled, I've now disabled HTTP/2 in OkHttpClient whenever a Java version lesser than 11 is involved.

3. I've removed the `jdk8u242` JDK matrix from the CI job since it is no longer needed after the fix done in `#2`.
I've run these changes against my personal repo's github actions and these previously failing tests in vault, all pass now in JDK8.

Although I started these changes in an effort to try and get rid of the `jdk8u242` JDK matrix from the CI jobs and reduce its complexity and the resources used, I think this fix is much more than that since this now allows users to actually use the vault extension in Quarkus in any recent Java 8 releases.

I kept these as 3 separate commits, but if prefered, I can squash them into one.

@gsmet, I moved the `io.quarkus.deployment.util.JavaVersionUtil` from `core/deployment` to `io.quarkus.runtime.util.JavaVersionUtil` in `core/runtime` so that I can reuse that class in a runtime part of the vault extension. I didn't want to introduce yet another Java version parsing util in this extension or some place else. In theory, this is a backward incompatible change (given that I moved that public class to a new package and artifact), but given that this was an internal util class, I don't think it should matter. However, if it does, then let me know and I'll undo that part of the change and come up with something else for that part.