### PR TITLE
Small enhancements to the code - Map.entrySet usage, static inner classes, unused local code removal

### DIFF
--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
@@ -440,7 +440,7 @@ public class GenerateExtensionsJsonMojo extends AbstractMojo {
         }
     }
 
-    private class OverrideInfo {
+    private static class OverrideInfo {
         private Map<String, JsonObject> extOverrides;
         private JsonObject theRest;
 

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/visitors/PanacheMongoRepositoryClassVisitor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/visitors/PanacheMongoRepositoryClassVisitor.java
@@ -40,9 +40,6 @@ public class PanacheMongoRepositoryClassVisitor extends PanacheRepositoryClassVi
     @Override
     protected void generateModelBridge(MethodInfo method, AnnotationValue targetReturnTypeErased) {
         String descriptor = AsmUtil.getDescriptor(method, name -> typeArguments.get(name));
-        // JpaOperations erases the Id type to Object
-        String descriptorForJpaOperations = AsmUtil.getDescriptor(method,
-                name -> name.equals("Entity") ? entitySignature : null);
         String signature = AsmUtil.getSignature(method, name -> typeArguments.get(name));
         List<Type> parameters = method.parameters();
 

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
@@ -40,7 +40,7 @@ public class Sort {
         Descending;
     }
 
-    public class Column {
+    public static class Column {
         private String name;
         private Direction direction;
 

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -335,11 +335,10 @@ public class QuartzScheduler implements Scheduler {
 
     private Properties getAdditionalConfigurationProperties(String prefix, Map<String, QuartzAdditionalPropsConfig> config) {
         Properties props = new Properties();
-        for (String key : config.keySet()) {
-            props.put(String.format("%s.%s.class", prefix, key), config.get(key).clazz);
-            for (String propsName : config.get(key).propsValue.keySet()) {
-                props.put(String.format("%s.%s.%s", prefix, key, propsName),
-                        config.get(key).propsValue.get(propsName));
+        for (Map.Entry<String, QuartzAdditionalPropsConfig> configEntry : config.entrySet()) {
+            props.put(String.format("%s.%s.class", prefix, configEntry.getKey()), configEntry.getValue().clazz);
+            for (Map.Entry<String, String> propsEntry : configEntry.getValue().propsValue.entrySet()) {
+                props.put(String.format("%s.%s.%s", prefix, configEntry.getKey(), propsEntry.getKey()), propsEntry.getValue());
             }
         }
         return props;

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/NestedMaps.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/NestedMaps.java
@@ -36,26 +36,27 @@ public final class NestedMaps {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static void deepMerge(Map left, Map right) {
         for (Object key : right.keySet()) {
-            if (right.get(key) instanceof Map && left.get(key) instanceof Map) {
-                Map leftChild = (Map) left.get(key);
-                Map rightChild = (Map) right.get(key);
-                deepMerge(leftChild, rightChild);
-            } else if (right.get(key) instanceof Collection && left.get(key) instanceof Collection) {
+            Object rightValue = right.get(key);
+            Object leftValue = left.get(key);
+
+            if (rightValue instanceof Map && leftValue instanceof Map) {
+                deepMerge((Map) leftValue, (Map) rightValue);
+            } else if (rightValue instanceof Collection && leftValue instanceof Collection) {
                 Collection c = new LinkedHashSet();
-                c.addAll((Collection) left.get(key));
-                c.addAll((Collection) right.get(key));
+                c.addAll((Collection) leftValue);
+                c.addAll((Collection) rightValue);
                 left.put(key, c);
             } else {
                 // Override
-                left.put(key, right.get(key));
+                left.put(key, rightValue);
             }
         }
     }
 
     public static Map<String, Object> unflatten(Map<String, Object> flattened) {
         Map<String, Object> unflattened = new HashMap<>();
-        for (String key : flattened.keySet()) {
-            doUnflatten(unflattened, key, flattened.get(key));
+        for (Map.Entry<String, Object> entry : flattened.entrySet()) {
+            doUnflatten(unflattened, entry.getKey(), entry.getValue());
         }
         return unflattened;
     }


### PR DESCRIPTION
Small enhancements to the code to improve efficiency a bit

- Make inner classes static
- PanacheMongoRepositoryClassVisitor - remove unused code, probably copied from PanacheRepositoryClassVisitor
- QuartzScheduler - use entrySet in getAdditionalConfigurationProperties method
- Codestarts - NestedMaps - use entrySet and avoid multiple .get(key) calls