### PR TITLE
MySQL upgrade for integration tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           netstat -ln
           sudo service mysql stop || true
-          docker run --rm --publish 127.0.0.1:3306:3306 --name build-mysql -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_RANDOM_ROOT_PASSWORD=true -e MYSQL_DATABASE=hibernate_orm_test -d mysql:5 --skip-ssl
+          docker run --rm --publish 127.0.0.1:3306:3306 --name build-mysql -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_RANDOM_ROOT_PASSWORD=true -e MYSQL_DATABASE=hibernate_orm_test -d mysql:8.0.21 --skip-ssl
       - name: Start DB2
         # Cannot run as a service becuase the service schema does not support --privileged mode
         shell: bash

--- a/integration-tests/jpa-mysql/README.md
+++ b/integration-tests/jpa-mysql/README.md
@@ -32,7 +32,19 @@ If you have specific requirements, you can define a specific connection URL with
 To run the MySQL server "manually" via command line for testing, the following command line could be useful:
 
 ```
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mysql:8.0.17
+docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mysql:8.0.21
+```
+
+Alternatively to docker, with podman:
+
+```
+podman run -it --rm=true --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mysql:8.0.21
+```
+
+To connect with a CLI client and inspect the database content:
+
+```
+mysql -h localhost -u hibernate_orm_test -phibernate_orm_test hibernate_orm_test --protocol tcp
 ```
 
 N.B. it takes a while for MySQL to be actually booted and accepting connections.

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -15,8 +15,8 @@
     <description>Module that contains JPA related tests running with the MySQL database</description>
 
     <properties>
-        <mysql.url>jdbc:mysql://localhost:3306/hibernate_orm_test</mysql.url>
-        <mysql.image>mysql:8.0.17</mysql.image>
+        <mysql.url>jdbc:mysql://localhost:3306/hibernate_orm_test?allowPublicKeyRetrieval=true</mysql.url>
+        <mysql.image>mysql:8.0.21</mysql.image>
     </properties>
 
     <dependencies>
@@ -172,7 +172,7 @@
                 </property>
             </activation>
             <properties>
-                <mysql.url>jdbc:mysql://localhost:3306/hibernate_orm_test</mysql.url>
+                <mysql.url>jdbc:mysql://localhost:3306/hibernate_orm_test?allowPublicKeyRetrieval=true</mysql.url>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Since we support MySQL v.8, we should use that version to run integration tests.