### PR TITLE
Support Hibernate option "max_fetch_depth"

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -81,6 +81,14 @@ public class HibernateOrmConfigPersistenceUnit {
     public int batchFetchSize;
 
     /**
+     * The maximum depth of outer join fetch tree for single-ended associations (one-to-one, many-to-one).
+     *
+     * A `0` disables default outer join fetching.
+     */
+    @ConfigItem
+    public OptionalInt maxFetchDepth;
+
+    /**
      * Pluggable strategy contract for applying physical naming rules for database object names.
      *
      * Class name of the Hibernate PhysicalNamingStrategy implementation
@@ -145,6 +153,7 @@ public class HibernateOrmConfigPersistenceUnit {
         return dialect.isAnyPropertySet() ||
                 sqlLoadScript.isPresent() ||
                 batchFetchSize > 0 ||
+                maxFetchDepth.isPresent() ||
                 query.isAnyPropertySet() ||
                 database.isAnyPropertySet() ||
                 jdbc.isAnyPropertySet() ||

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -688,6 +688,9 @@ public final class HibernateOrmProcessor {
             descriptor.getProperties().setProperty(AvailableSettings.BATCH_FETCH_STYLE, BatchFetchStyle.PADDED.toString());
         }
 
+        persistenceUnitConfig.maxFetchDepth.ifPresent(
+                depth -> descriptor.getProperties().setProperty(AvailableSettings.MAX_FETCH_DEPTH, String.valueOf(depth)));
+
         persistenceUnitConfig.query.queryPlanCacheMaxSize.ifPresent(
                 maxSize -> descriptor.getProperties().setProperty(AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, maxSize));
 

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -219,6 +219,9 @@ public final class HibernateReactiveProcessor {
             desc.getProperties().setProperty(AvailableSettings.BATCH_FETCH_STYLE, BatchFetchStyle.PADDED.toString());
         }
 
+        persistenceUnitConfig.maxFetchDepth.ifPresent(
+                depth -> desc.getProperties().setProperty(AvailableSettings.MAX_FETCH_DEPTH, String.valueOf(depth)));
+
         persistenceUnitConfig.query.queryPlanCacheMaxSize.ifPresent(
                 maxSize -> desc.getProperties().setProperty(AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, maxSize));
 


### PR DESCRIPTION
There is a new corresponding Quarkus config property `quarkus.hibernate-orm.query.max-fetch-depth`.

Fixes #11526.