### PR TITLE
Abort Kafka Streams startup in case of shutdown

### DIFF
--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.kafka.streams;
+
+import static org.apache.kafka.streams.KafkaStreams.State;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.apache.kafka.streams.KafkaStreams;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
+import io.quarkus.runtime.Application;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTestResource(KafkaTestResource.class)
+@TestProfile(KafkaStreamsStartupFailureTest.NonExistingTopicProfile.class)
+@QuarkusTest
+public class KafkaStreamsStartupFailureTest {
+
+    @Inject
+    KafkaStreams kafkaStreams;
+
+    @Inject
+    KafkaStreamsTopologyManager kafkaStreamsTopologyManager;
+
+    @Test
+    @Timeout(5)
+    public void testShutdownBeforeKStreamsStarted() throws Exception {
+        assertEquals(State.CREATED, kafkaStreams.state());
+        RestAssured.get("/health/ready").then()
+                .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
+                .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
+                .body("checks[0].status", CoreMatchers.is("DOWN"))
+                .body("checks[0].data.missing_topics", CoreMatchers.is("nonexisting-topic"));
+        assertTrue(Application.currentApplication().isStarted());
+
+        Application.currentApplication().stop();
+
+        assertEquals(State.NOT_RUNNING, kafkaStreams.state());
+    }
+
+    public static class NonExistingTopicProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> conf = new HashMap<>();
+            conf.put("quarkus.kafka-streams.topics", "nonexisting-topic");
+            return conf;
+        }
+    }
+}


### PR DESCRIPTION
Fully fixes #11387
This is a follow-up of PR #11389 to avoid AdminClient TimeoutExceptions getting logged a few times in case the application is externally shutdown before it managed to successfully start, being in the while loop waiting for a missing input topic.

I didn't manage to actually reproduce the issue via KafkaStreamsStartupFailureTest, though I've validated the fix on my project.