### PR TITLE
Use Mandrel floating tag and warn about its use

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -34,7 +34,7 @@
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
         <graal-sdk.version-for-documentation>20.1.0</graal-sdk.version-for-documentation>
-        <mandrel.version-for-documentation>20.1.0.1.Final</mandrel.version-for-documentation>
+        <mandrel.version-for-documentation>20.1</mandrel.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>1.1.0</axle-client.version>
         <mutiny-client.version>1.1.0</mutiny-client.version>

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -395,6 +395,9 @@ Building with Mandrel requires a custom builder image parameter to be passed add
 ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor}
 ----
 
+Please note that the above command points to a floating tag for ease of use,
+and to make sure you get the newest Mandrel version supported by Quarkus.
+Consider using specific tags when going into production.
 Check https://quay.io/repository/quarkus/ubi-quarkus-mandrel?tab=tags[here] to find out about available tags.
 
 ====


### PR DESCRIPTION
A 20.1 floating tag is now available (see [here](https://github.com/graalvm/mandrel/issues/95)). This PR switches documentation to use floating tag and warns about its use.