### PR TITLE
Ignore javax.persistence interfaces when registering entities for reflection

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -271,7 +271,8 @@ final class JpaJandexScavenger {
     private static boolean isIgnored(DotName classDotName) {
         String className = classDotName.toString();
         if (className.startsWith("java.util.") || className.startsWith("java.lang.")
-                || className.startsWith("org.hibernate.engine.spi.")) {
+                || className.startsWith("org.hibernate.engine.spi.")
+                || className.startsWith("javax.persistence.")) {
             return true;
         }
         return false;


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/63535552/quarkus-javax-persistence-attributeconverter-not-in-jandex-index

We already ignored the Hibernate ORM SPI classes, I think it makes
perfect sense to also ignore the javax.persistence interfaces.