### PR TITLE
Add double quotes around java executable

### DIFF
--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
@@ -204,7 +204,7 @@ public class GrpcCodeGen implements CodeGenProvider {
     }
 
     private static void writePluginExeCmd(Path pluginPath, BufferedWriter writer) throws IOException {
-        writer.write(JavaBinFinder.findBin() + " -cp \"" +
+        writer.write("\"" + JavaBinFinder.findBin() + "\" -cp \"" +
                 pluginPath.toAbsolutePath().toString() + "\" " + quarkusProtocPluginMain);
         writer.newLine();
     }


### PR DESCRIPTION
Fix #11550 adding double quotes