### PR TITLE
Update SmallRye Reactive Messaging to version 2.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -44,7 +44,7 @@
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.1.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.2.1</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.3.0</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.32.3</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>


### PR DESCRIPTION
Update SmallRye Reactive Messaging to version 2.3.0﻿.
This update fixes #11160.
It also provides the new commit-strategy support in the Kafka connector and a few fixes improving the hot-reload reliability.
