### PR TITLE
Use an instance of the proper service initiator for SQL import

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusImportSqlCommandExtractorInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusImportSqlCommandExtractorInitiator.java
@@ -5,11 +5,12 @@ import java.util.Map;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractor;
-import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
 import org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor;
 
 public final class QuarkusImportSqlCommandExtractorInitiator implements StandardServiceInitiator<ImportSqlCommandExtractor> {
-    public static final ImportSqlCommandExtractorInitiator INSTANCE = new ImportSqlCommandExtractorInitiator();
+
+    public static final QuarkusImportSqlCommandExtractorInitiator INSTANCE = new QuarkusImportSqlCommandExtractorInitiator();
+
     private static final MultipleLinesSqlCommandExtractor SERVICE_INSTANCE = new MultipleLinesSqlCommandExtractor();
 
     @Override

--- a/integration-tests/jpa/src/main/resources/application.properties
+++ b/integration-tests/jpa/src/main/resources/application.properties
@@ -2,5 +2,4 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
-quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/jpa/src/main/resources/import.sql
+++ b/integration-tests/jpa/src/main/resources/import.sql
@@ -1,2 +1,4 @@
 DELETE FROM Gift WHERE id=100000;
-INSERT INTO Gift (id,name) VALUES (100000,'Teddy bear');
+-- on multiple lines to properly test the multi-line SQL extractor
+INSERT INTO Gift (id, name)
+        VALUES (100000,'Teddy bear');


### PR DESCRIPTION
Tentative fix for #11566 but doesn't work :/

@Sanne I fixed the most obvious issue but it still doesn't work AFAICS. The jpa tests are failing even with my fix. Looks like the service initiator is not called.

Do you have an idea?