### PR TITLE
By default use lower heap settings while launching Quarkus application from QuarkusProdModeTest

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -97,6 +97,8 @@ public class QuarkusProdModeTest
 
     private String logFileName;
     private Map<String, String> runtimeProperties;
+    // by default, we use these lower heap settings
+    private List<String> jvmArgs = Collections.singletonList("-Xmx128m");
     private Map<String, String> testResourceProperties = new HashMap<>();
 
     private Process process;
@@ -178,6 +180,14 @@ public class QuarkusProdModeTest
      */
     public QuarkusProdModeTest setLogFileName(String logFileName) {
         this.logFileName = logFileName;
+        return this;
+    }
+
+    /**
+     * The complete set of JVM args to be used if the built artifact is configured to be run
+     */
+    public QuarkusProdModeTest setJVMArgs(final List<String> jvmArgs) {
+        this.jvmArgs = jvmArgs;
         return this;
     }
 
@@ -458,16 +468,21 @@ public class QuarkusProdModeTest
         List<String> command = new ArrayList<>(systemProperties.size() + 3);
         if (builtResultArtifact.getFileName().toString().endsWith(".jar")) {
             command.add(JavaBinFinder.findBin());
+            if (this.jvmArgs != null) {
+                command.addAll(this.jvmArgs);
+            }
             command.addAll(systemProperties);
             command.add("-jar");
             command.add(builtResultArtifact.toAbsolutePath().toString());
         } else {
             command.add(builtResultArtifact.toAbsolutePath().toString());
+            if (this.jvmArgs != null) {
+                command.addAll(this.jvmArgs);
+            }
             command.addAll(systemProperties);
         }
 
         command.addAll(Arrays.asList(commandLineParameters));
-
         process = new ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .directory(builtResultArtifactParentDir.toFile())


### PR DESCRIPTION
`ProcessBuilder` documentation states that it inherits the `environment` of the parent process. The commit here explicitly sets the `-Xmx` to a lower value for some of these processes that get launched during tests to avoid inheriting Maven's heap settings (which appears to be `2048m` in CI jobs).

Please do not merge this. This is an experiment to see if this helps get us past some of the CI issues we are currently seeing. If this does work, then this change needs to be done in a better and more configurable/controlled manner.