### PR TITLE
Only run Gradle tests for Java 11

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -242,18 +242,10 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - { name: Java8,
-              java-version: 8
-          }
           - {
             name: Java 11,
             java-version: 11
           }
-          - {
-            name: Java 14,
-            java-version: 14
-          }
-    steps:
       - uses: actions/checkout@v2
       - name: Download Maven Repo
         uses: actions/download-artifact@v1


### PR DESCRIPTION
This is done in order to free up runners as the Gradle tests
take a long time