### PR TITLE
No server shutdown required with Mandrel

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -204,7 +204,7 @@ public class NativeImageBuildStep {
 
         try {
             List<String> command = new ArrayList<>(nativeImage);
-            if (nativeConfig.cleanupServer) {
+            if (nativeConfig.cleanupServer && !graalVMVersion.isMandrel()) {
                 List<String> cleanup = new ArrayList<>(nativeImage);
                 cleanup.add("--server-shutdown");
                 final ProcessBuilder pb = new ProcessBuilder(cleanup.toArray(new String[0]));


### PR DESCRIPTION
* Because no native image compilation server is ever started with Mandrel.

Fixes #11600