### PR TITLE
Only run Kubernetes tests for Java 11

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -110,7 +110,7 @@ jobs:
         java :
           - { name: Java8,
               java-version: 8,
-              maven_args: "-pl !integration-tests/gradle"
+              maven_args: "-pl !integration-tests/gradle -pl !integration-tests/kubernetes/quarkus-standard-way"
           }
           - {
             name: Java 11,
@@ -120,7 +120,7 @@ jobs:
           - {
             name: Java 14,
             java-version: 14,
-            maven_args: "-pl !integration-tests/gradle"
+            maven_args: "-pl !integration-tests/gradle -pl !integration-tests/kubernetes/quarkus-standard-way"
           }
 
     services:


### PR DESCRIPTION
This is done in order to reduce the time and memory used
to run JVM tests