### PR TITLE
Declare native output to in gradle quarkusBuild task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -83,6 +83,11 @@ public class QuarkusBuild extends QuarkusTask {
         return new File(getProject().getBuildDir(), extension().finalName() + "-runner.jar");
     }
 
+    @OutputFile
+    public File getNativeRunner() {
+        return new File(getProject().getBuildDir(), extension().finalName() + "-runner");
+    }
+
     @OutputDirectory
     public File getFastJar() {
         return new File(getProject().getBuildDir(), "quarkus-app");


### PR DESCRIPTION
As mentioned few weeks ago, the native executable result was not declared as `quarkusBuild` task output.  
When building a native executable using `quarkusBuild` in gradle, the task was never marked as `UP-TO-DATE`. 

This branch as the native executable as output of the task