### PR TITLE
Added option to save the generated OpenAPI schema document on build.

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.openapi.common.deployment;
 
+import java.nio.file.Path;
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -10,4 +13,11 @@ public final class SmallRyeOpenApiConfig {
      */
     @ConfigItem(defaultValue = "/openapi")
     public String path;
+
+    /**
+     * If set, the generated OpenAPI schema documents will be stored here on build.
+     * Both openapi.json and openapi.yaml will be stored here if this is set.
+     */
+    @ConfigItem
+    public Optional<Path> storeSchemaDirectory;
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStoreSchemaTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStoreSchemaTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.openapi.runtime.io.Format;
+
+public class OpenApiStoreSchemaTestCase {
+
+    private static String directory = "target/generated/jax-rs/";
+    private static final String OPEN_API_DOT = "openapi.";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.store-schema-directory=" + directory),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        Path json = Paths.get(directory, OPEN_API_DOT + Format.JSON.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(json));
+        Path yaml = Paths.get(directory, OPEN_API_DOT + Format.YAML.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(yaml));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiStoreSchemaTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiStoreSchemaTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.openapi.runtime.io.Format;
+
+public class OpenApiStoreSchemaTestCase {
+
+    private static String directory = "target/generated/spring/";
+    private static final String OPEN_API_DOT = "openapi.";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiController.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.store-schema-directory=" + directory),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        Path json = Paths.get(directory, OPEN_API_DOT + Format.JSON.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(json));
+        Path yaml = Paths.get(directory, OPEN_API_DOT + Format.YAML.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(yaml));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiStoreSchemaTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiStoreSchemaTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.openapi.runtime.io.Format;
+
+public class OpenApiStoreSchemaTestCase {
+
+    private static String directory = "target/generated/vertx/";
+    private static final String OPEN_API_DOT = "openapi.";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.store-schema-directory=" + directory),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        Path json = Paths.get(directory, OPEN_API_DOT + Format.JSON.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(json));
+        Path yaml = Paths.get(directory, OPEN_API_DOT + Format.YAML.toString().toLowerCase());
+        Assertions.assertTrue(Files.exists(yaml));
+    }
+}


### PR DESCRIPTION
As discussed in Zulip a few times, this will add a new config option, `quarkus.smallrye-openapi.store-schema-directory`, that if
set, allow users to store the generated `openapi.json` and `openapi.yaml` to the configured directory


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>