### PR TITLE
doc Mention need of resteasy-mutiny extension in Reactive SQL Clients guide

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -88,8 +88,16 @@ Otherwise, you can manually add this to the dependencies section of your `pom.xm
 </dependency>
 ----
 
+=== Mutiny
+
+Reactive REST endpoints in your application that return Uni or Multi need `Mutiny support for RESTEasy` extension (`io.quarkus:quarkus-resteasy-mutiny`) to work properly:
+
+[source,shell]
+----
+./mvnw quarkus:add-extension -Dextensions="resteasy-mutiny"
+----
+
 [TIP]
-.Mutiny
 ====
 In this guide, we will use the Mutiny API of the Reactive PostgreSQL Client.
 If you're not familiar with Mutiny reactive types, read the link:getting-started-reactive#mutiny[Getting Started with Reactive guide] first.


### PR DESCRIPTION
Hi,

I was following the guide here https://quarkus.io/guides/reactive-sql-clients
Then I got:
```log
2020-08-25 22:40:04,686 WARN  [io.qua.res.com.dep.ResteasyCommonProcessor] (build-10) Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny extension was not present. Reactive REST endpoints in your application that return Uni or Multi will not function as you expect until you add this extension. Endpoints that need Mutiny are: org.FruitResource{io.smallrye.mutiny.Multi<org.Fruit> get()}
```

Then when I accessed http://localhost:8080/fruits it returned an empty json.

The problem was solved when I added the `resteasy-mutiny` extension:
./mvnw quarkus:add-extension -Dextensions="resteasy-mutiny"

So I think it's important to mention that in the guide, and that's what this PR does.

What do you think @cescoffier  s'il vous plaît?