### PR TITLE
Allow Vert.x compressed responses

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.http;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+public class CompressionTest {
+    private static final String APP_PROPS = "" +
+            "quarkus.http.enable-compression=true\n";
+
+    static String longString;
+    static {
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1000; ++i) {
+            sb.append("Hello World;");
+        }
+        longString = sb.toString();
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties")
+                    .addClasses(BeanRegisteringRouteUsingObserves.class));
+
+    @Test
+    public void test() throws Exception {
+        // RestAssured is aware of quarkus.http.root-path
+        // If this changes then please modify quarkus-azure-functions-http maven archetype to reflect this
+        // in its test classes
+        RestAssured.given().get("/compress").then().statusCode(200)
+                .header("content-encoding", "gzip")
+                .header("content-length", Matchers.not(Matchers.equalTo(Integer.toString(longString.length()))))
+                .body(Matchers.equalTo(longString));
+
+        RestAssured.given().get("/nocompress").then().statusCode(200)
+                .header("content-encoding", "identity")
+                .header("content-length", Matchers.equalTo(Integer.toString(longString.length())))
+                .body(Matchers.equalTo(longString));
+    }
+
+    @ApplicationScoped
+    static class BeanRegisteringRouteUsingObserves {
+
+        public void register(@Observes Router router) {
+
+            router.route("/compress").handler(rc -> {
+                rc.response().end(longString);
+            });
+            router.route("/nocompress").handler(rc -> {
+                rc.response().headers().set("content-encoding", "identity");
+                rc.response().end(longString);
+            });
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -203,6 +203,19 @@ public class HttpConfiguration {
     @ConfigItem
     public Map<String, SameSiteCookieConfig> sameSiteCookie;
 
+    /**
+     * If responses should be compressed.
+     *
+     * Note that this will attempt to compress all responses, to avoid compressing
+     * already compressed content (such as images) you need to set the following header:
+     * 
+     * Content-Encoding: identity
+     * 
+     * Which will tell vert.x not to compress the response.
+     */
+    @ConfigItem
+    public boolean enableCompression;
+
     public ProxyConfig proxy;
 
     public int determinePort(LaunchMode launchMode) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -721,6 +721,7 @@ public class VertxHttpRecorder {
         options.setTcpQuickAck(httpConfiguration.tcpQuickAck);
         options.setTcpCork(httpConfiguration.tcpCork);
         options.setTcpFastOpen(httpConfiguration.tcpFastOpen);
+        options.setCompressionSupported(httpConfiguration.enableCompression);
         options.setMaxInitialLineLength(httpConfiguration.limits.maxInitialLineLength);
         return options;
     }


### PR DESCRIPTION
The allows Vert.x to serve gzip or
deflate encoded responses.