### PR TITLE
Disable DefaultPackageMetricsTest

### DIFF
--- a/extensions/smallrye-metrics/deployment/src/test/java/DefaultPackageMetricsTest.java
+++ b/extensions/smallrye-metrics/deployment/src/test/java/DefaultPackageMetricsTest.java
@@ -7,11 +7,13 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
+@Disabled("See https://github.com/quarkusio/quarkus/pull/11656")
 public class DefaultPackageMetricsTest {
 
     @RegisterExtension


### PR DESCRIPTION
Disables the newly introduced `DefaultPackageMetricsTest` since it's failing with a NPE on Java 8.
See https://github.com/quarkusio/quarkus/pull/11656