### PR TITLE
Add area/codestarts to boring-cyborg

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -83,6 +83,11 @@ labelPRBasedOnFilePath:
         - core/runtime/src/main/java/io/quarkus/runtime/configuration/**/*
     area/core:
         - core/**/*
+    area/codestarts:
+        - independent-projects/tools/codestarts/**/*
+        - devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/**/*
+        - devtools/platform-descriptor-json/src/main/resources/codestarts/**/*
+        - devtools/platform-descriptor-json/src/main/resources/templates/**/*
     area/dependencies:
         - .github/dependabot.yml
         - bom/**/*


### PR DESCRIPTION


@gsmet @quarkusio/devtools Also from now on when we modify the `devtools/platform-descriptor-json/src/main/resources/templates/` we need to have the same patch in the codestarts.