### PR TITLE
Upgrade to Hibernate ORM 5.4.21.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -84,7 +84,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.19.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.21.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha8</hibernate-reactive.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta9</hibernate-search.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -85,7 +85,7 @@
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.21.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.Alpha8</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.Alpha9</hibernate-reactive.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta9</hibernate-search.version>
         <narayana.version>5.10.5.Final</narayana.version>

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionProducer.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionProducer.java
@@ -1,7 +1,5 @@
 package io.quarkus.hibernate.reactive.runtime;
 
-import java.util.concurrent.CompletionStage;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Disposes;
@@ -12,7 +10,6 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
 import io.quarkus.arc.DefaultBean;
-import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class ReactiveSessionProducer {
@@ -26,40 +23,15 @@ public class ReactiveSessionProducer {
     @Produces
     @RequestScoped
     @DefaultBean
-    public CompletionStage<Stage.Session> stageSession() {
+    public Stage.Session createStageSession() {
         return reactiveSessionFactory.openSession();
     }
 
     @Produces
     @RequestScoped
     @DefaultBean
-    public Uni<Mutiny.Session> mutinySession() {
-        return mutinySessionFactory.openSession().cache();
-    }
-
-    public void disposeStageSession(@Disposes CompletionStage<Stage.Session> reactiveSession) {
-        reactiveSession.whenComplete((s, t) -> {
-            if (s != null)
-                s.close();
-        });
-    }
-
-    public void disposeMutinySession(@Disposes Uni<Mutiny.Session> reactiveSession) {
-        reactiveSession.subscribe().with(Mutiny.Session::close);
-    }
-
-    @Produces
-    @RequestScoped
-    @DefaultBean
-    public Stage.Session createStageSession() {
-        return reactiveSessionFactory.createSession();
-    }
-
-    @Produces
-    @RequestScoped
-    @DefaultBean
     public Mutiny.Session createMutinySession() {
-        return mutinySessionFactory.createSession();
+        return mutinySessionFactory.openSession();
     }
 
     public void disposeStageSession(@Disposes Stage.Session reactiveSession) {

--- a/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
@@ -21,10 +21,10 @@ import io.vertx.mutiny.sqlclient.Tuple;
 public class HibernateReactiveDB2TestEndpoint {
 
     @Inject
-    CompletionStage<Stage.Session> stageSession;
+    Stage.Session stageSession;
 
     @Inject
-    Uni<Mutiny.Session> mutinySession;
+    Mutiny.Session mutinySession;
 
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
@@ -36,11 +36,8 @@ public class HibernateReactiveDB2TestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return stageSession
-                .thenCompose(session -> {
-                    return populateDB().convert().toCompletionStage()
-                            .thenCompose(junk -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB().convert().toCompletionStage()
+                .thenCompose(junk -> stageSession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
@@ -48,20 +45,16 @@ public class HibernateReactiveDB2TestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return mutinySession
-                .flatMap(session -> {
-                    return populateDB()
-                            .then(() -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
     @Path("/reactivePersist")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
-        return mutinySession
-                .flatMap(s -> s.persist(new GuineaPig(10, "Tulip")))
-                .flatMap(s -> s.flush())
+        return mutinySession.persist(new GuineaPig(10, "Tulip"))
+                .chain(s -> s.flush())
                 .then(() -> selectNameFromId(10));
     }
 
@@ -69,46 +62,33 @@ public class HibernateReactiveDB2TestEndpoint {
     @Path("/reactiveRemoveTransientEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(name -> {
-                                if (name == null)
-                                    throw new AssertionError("Database was not populated properly");
-                                return name;
-                            })
-                            .flatMap(junk -> mutinySession.merge(new GuineaPig(5, "Aloi")))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
-                });
+        return populateDB()
+                .then(() -> selectNameFromId(5))
+                .map(name -> {
+                    if (name == null) {
+                        throw new AssertionError("Database was not populated properly");
+                    }
+                    return name;
+                })
+                .then(() -> mutinySession.merge(new GuineaPig(5, "Aloi")))
+                .chain(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
     }
 
     @GET
     @Path("/reactiveRemoveManagedEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .chain(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
     }
 
     @GET
@@ -116,24 +96,22 @@ public class HibernateReactiveDB2TestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .map(pig -> {
-                                if (NEW_NAME.equals(pig.getName()))
-                                    throw new AssertionError("Pig already had name " + NEW_NAME);
-                                pig.setName(NEW_NAME);
-                                return pig;
-                            })
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5));
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .map(pig -> {
+                    if (NEW_NAME.equals(pig.getName())) {
+                        throw new AssertionError("Pig already had name " + NEW_NAME);
+                    }
+                    pig.setName(NEW_NAME);
+                    return pig;
+                })
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5));
     }
 
     private Uni<RowSet<Row>> populateDB() {
         return db2Pool.query("DELETE FROM Pig").execute()
-                .flatMap(junk -> db2Pool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
+                .then(() -> db2Pool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
     }
 
     private Uni<String> selectNameFromId(Integer id) {

--- a/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
@@ -21,10 +21,10 @@ import io.vertx.mutiny.sqlclient.Tuple;
 public class HibernateReactiveMySQLTestEndpoint {
 
     @Inject
-    CompletionStage<Stage.Session> stageSession;
+    Stage.Session stageSession;
 
     @Inject
-    Uni<Mutiny.Session> mutinySession;
+    Mutiny.Session mutinySession;
 
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
@@ -36,11 +36,8 @@ public class HibernateReactiveMySQLTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return stageSession
-                .thenCompose(session -> {
-                    return populateDB().convert().toCompletionStage()
-                            .thenCompose(junk -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB().convert().toCompletionStage()
+                .thenCompose(junk -> stageSession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
@@ -48,67 +45,50 @@ public class HibernateReactiveMySQLTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return mutinySession
-                .flatMap(session -> {
-                    return populateDB()
-                            .then(() -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
     @Path("/reactivePersist")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
-        return mutinySession
-                .flatMap(s -> s.persist(new GuineaPig(10, "Tulip")))
-                .flatMap(s -> s.flush())
-                .flatMap(junk -> selectNameFromId(10));
+        return mutinySession.persist(new GuineaPig(10, "Tulip"))
+                .chain(s -> s.flush())
+                .then(() -> selectNameFromId(10));
     }
 
     @GET
     @Path("/reactiveRemoveTransientEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(name -> {
-                                if (name == null)
-                                    throw new AssertionError("Database was not populated properly");
-                                return name;
-                            })
-                            .flatMap(junk -> mutinySession.merge(new GuineaPig(5, "Aloi")))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
-                });
+        return populateDB()
+                .then(() -> selectNameFromId(5))
+                .map(name -> {
+                    if (name == null) {
+                        throw new AssertionError("Database was not populated properly");
+                    }
+                    return name;
+                })
+                .then(() -> mutinySession.merge(new GuineaPig(5, "Aloi")))
+                .chain(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
     }
 
     @GET
     @Path("/reactiveRemoveManagedEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .chain(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
     }
 
     @GET
@@ -116,19 +96,17 @@ public class HibernateReactiveMySQLTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .map(pig -> {
-                                if (NEW_NAME.equals(pig.getName()))
-                                    throw new AssertionError("Pig already had name " + NEW_NAME);
-                                pig.setName(NEW_NAME);
-                                return pig;
-                            })
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5));
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .map(pig -> {
+                    if (NEW_NAME.equals(pig.getName())) {
+                        throw new AssertionError("Pig already had name " + NEW_NAME);
+                    }
+                    pig.setName(NEW_NAME);
+                    return pig;
+                })
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5));
     }
 
     private Uni<RowSet<Row>> populateDB() {

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
@@ -21,10 +21,10 @@ import io.vertx.mutiny.sqlclient.Tuple;
 public class HibernateReactiveTestEndpoint {
 
     @Inject
-    CompletionStage<Stage.Session> stageSession;
+    Stage.Session stageSession;
 
     @Inject
-    Uni<Mutiny.Session> mutinySession;
+    Mutiny.Session mutinySession;
 
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
@@ -36,11 +36,8 @@ public class HibernateReactiveTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return stageSession
-                .thenCompose(session -> {
-                    return populateDB().convert().toCompletionStage()
-                            .thenCompose(junk -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB().convert().toCompletionStage()
+                .thenCompose(junk -> stageSession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
@@ -48,21 +45,18 @@ public class HibernateReactiveTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
-        return mutinySession
-                .flatMap(session -> {
-                    return populateDB()
-                            .then(() -> session.find(GuineaPig.class, expectedPig.getId()));
-                });
+        return populateDB().then(() -> mutinySession.find(GuineaPig.class, expectedPig.getId()));
     }
 
     @GET
     @Path("/reactivePersist")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
+        final GuineaPig pig = new GuineaPig(10, "Tulip");
         return mutinySession
-                .flatMap(s -> s.persist(new GuineaPig(10, "Tulip")))
-                .flatMap(s -> s.flush())
-                .flatMap(junk -> selectNameFromId(10));
+                .persist(pig)
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(10));
     }
 
     @GET
@@ -72,8 +66,8 @@ public class HibernateReactiveTestEndpoint {
         final FriesianCow cow = new FriesianCow();
         cow.name = "Carolina";
         return mutinySession
-                .flatMap(s -> s.persist(cow))
-                .flatMap(s -> s.flush())
+                .persist(cow)
+                .then(() -> mutinySession.flush())
                 .flatMap(s -> s.createQuery("from FriesianCow f where f.name = :name", FriesianCow.class)
                         .setParameter("name", cow.name).getSingleResult());
     }
@@ -82,25 +76,21 @@ public class HibernateReactiveTestEndpoint {
     @Path("/reactiveRemoveTransientEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(name -> {
-                                if (name == null)
-                                    throw new AssertionError("Database was not populated properly");
-                                return name;
-                            })
-                            .flatMap(junk -> mutinySession.merge(new GuineaPig(5, "Aloi")))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
+        return populateDB()
+                .then(() -> selectNameFromId(5))
+                .invoke(name -> {
+                    if (name == null)
+                        throw new AssertionError("Database was not populated properly");
+                })
+                .then(() -> mutinySession.merge(new GuineaPig(5, "Aloi")))
+                .invoke(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .map(result -> {
+                    if (result == null)
+                        return "OK";
+                    else
+                        return result;
                 });
     }
 
@@ -108,19 +98,16 @@ public class HibernateReactiveTestEndpoint {
     @Path("/reactiveRemoveManagedEntity")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .flatMap(aloi -> mutinySession.remove(aloi))
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5))
-                            .map(result -> {
-                                if (result == null)
-                                    return "OK";
-                                else
-                                    return result;
-                            });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .chain(aloi -> mutinySession.remove(aloi))
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5))
+                .map(result -> {
+                    if (result == null)
+                        return "OK";
+                    else
+                        return result;
                 });
     }
 
@@ -129,25 +116,23 @@ public class HibernateReactiveTestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
-        return mutinySession
-                .flatMap(mutinySession -> {
-                    return populateDB()
-                            .flatMap(junk -> mutinySession.find(GuineaPig.class, 5))
-                            .map(pig -> {
-                                if (NEW_NAME.equals(pig.getName()))
-                                    throw new AssertionError("Pig already had name " + NEW_NAME);
-                                pig.setName(NEW_NAME);
-                                return pig;
-                            })
-                            .flatMap(junk -> mutinySession.flush())
-                            .flatMap(junk -> selectNameFromId(5));
-                });
+        return populateDB()
+                .then(() -> mutinySession.find(GuineaPig.class, 5))
+                .invoke(pig -> {
+                    if (NEW_NAME.equals(pig.getName()))
+                        throw new AssertionError("Pig already had name " + NEW_NAME);
+                    pig.setName(NEW_NAME);
+                })
+                .then(() -> mutinySession.flush())
+                .then(() -> selectNameFromId(5));
     }
 
     private Uni<RowSet<Row>> populateDB() {
-        return pgPool.query("DELETE FROM Pig").execute()
-                .and(pgPool.query("DELETE FROM Cow").execute())
-                .flatMap(junk -> pgPool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
+        return Uni.combine().all().unis(
+                pgPool.query("DELETE FROM Pig").execute(),
+                pgPool.query("DELETE FROM Cow").execute())
+                .asTuple()
+                .then(() -> pgPool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
     }
 
     private Uni<String> selectNameFromId(Integer id) {


### PR DESCRIPTION
Fixes #11231 - Upgrade to Hibernate ORM 5.4.21
Fixes #11325 - Hibernate no active session in hashcode() of lazy loaded collections
Fixes #11589 - Lazy loading fails if an entity appears twice in the object graph
Fixes #7591   - SQL import - commented out lines not ignored

I couldn't test all databases locally, as I have some issues with docker. Not expecting any problem, so let's have CI run those.