### PR TITLE
Reorder gradle code generation task

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleKotlinProjectBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleKotlinProjectBuildTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.gradle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 
 import org.junit.jupiter.api.Test;
@@ -8,9 +10,9 @@ public class MultiModuleKotlinProjectBuildTest extends QuarkusGradleWrapperTestB
 
     @Test
     public void testBasicMultiModuleBuild() throws Exception {
-
         final File projectDir = getProjectDir("multi-module-kotlin-project");
-
-        runGradleWrapper(projectDir, "clean", "build");
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(build.getTasks().get(":quarkusGenerateCode")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(build.getTasks().get(":compileKotlin")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
     }
 }


### PR DESCRIPTION
This branch makes sure `quarkusGenerateCode` and `quarkusGenerateCodeTests` are ran before `compileJava` and `compileKotlin` tasks. 

Close #11641 #11670 