### PR TITLE
Work around Caffeine warnings during cache computations - 1.7

### DIFF
--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineComputationThrowable.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineComputationThrowable.java
@@ -1,0 +1,17 @@
+package io.quarkus.cache.runtime.caffeine;
+
+/**
+ * This class is used to prevent Caffeine from logging unwanted warnings.
+ */
+public class CaffeineComputationThrowable {
+
+    private Throwable cause;
+
+    public CaffeineComputationThrowable(Throwable cause) {
+        this.cause = cause;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}


### PR DESCRIPTION
Backport of #11546 for 1.7.

I couldn't take care of it yesterday, I'm not sure if this is still needed now but here's the backport anyway.