### PR TITLE
Limit the amount of memory surefire can use

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -287,7 +287,7 @@
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>${maven.home}</maven.home>
                         </systemPropertyVariables>
-                        <argLine>${jacoco.agent.argLine}</argLine>
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m</argLine> <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
By default surefile will take up to 1/4 of system
memory, however in memory constrained environments
this can be too much. 1024m should be plenty to run
the tests, and prevents surefire from allocating more
than it needs.