### PR TITLE
Increase timeout in ReactiveMongodbPanacheResourceTest

### DIFF
--- a/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.kt
@@ -200,7 +200,7 @@ internal open class ReactiveMongodbPanacheResourceTest {
                 nbEvent.increment()
             }
             source.open()
-            await().atMost(Duration.ofSeconds(1)).until({ nbEvent.count() == 3 })
+            await().atMost(Duration.ofSeconds(10)).until({ nbEvent.count() == 3 })
         }
 
         //delete all

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
@@ -205,7 +205,7 @@ class ReactiveMongodbPanacheResourceTest {
                 nbEvent.increment();
             });
             source.open();
-            await().atMost(Duration.ofSeconds(1)).until(() -> nbEvent.count() == 3);
+            await().atMost(Duration.ofSeconds(10)).until(() -> nbEvent.count() == 3);
         }
 
         //delete all


### PR DESCRIPTION
Increases an await timeout in the `ReactiveMongodbPanacheResourceTest` to get past failures seen in some recent CI runs:

```
2020-08-27T23:52:42.0190799Z [ERROR] Tests run: 6, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.648 s <<< FAILURE! - in io.quarkus.it.mongodb.panache.reactive.ReactiveMongodbPanacheResourceTest
2020-08-27T23:52:42.0398831Z [ERROR] io.quarkus.it.mongodb.panache.reactive.ReactiveMongodbPanacheResourceTest.testReactiveBookEntity  Time elapsed: 1.779 s  <<< ERROR!
2020-08-27T23:52:42.0405225Z org.awaitility.core.ConditionTimeoutException: Condition returned by method "callReactiveBookEndpoint" in class io.quarkus.it.mongodb.panache.reactive.ReactiveMongodbPanacheResourceTest was not fulfilled within 1 seconds.
2020-08-27T23:52:42.0413114Z 	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:165)
2020-08-27T23:52:42.0413280Z 	at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
2020-08-27T23:52:42.0413444Z 	at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
2020-08-27T23:52:42.0413576Z 	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:895)
2020-08-27T23:52:42.0413730Z 	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:864)
2020-08-27T23:52:42.0413919Z 	at io.quarkus.it.mongodb.panache.reactive.ReactiveMongodbPanacheResourceTest.callReactiveBookEndpoint(ReactiveMongodbPanacheResourceTest.kt:203)
2020-08-27T23:52:42.0414175Z 	at io.quarkus.it.mongodb.panache.reactive.ReactiveMongodbPanacheResourceTest.testReactiveBookEntity(ReactiveMongodbPanacheResourceTest.kt:46)
2020-08-27T23:52:42.0414370Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2020-08-27T23:52:42.0414554Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2020-08-27T23:52:42.0415017Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-08-27T23:52:42.0415302Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2020-08-27T23:52:42.0415468Z 	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:753)
2020-08-27T23:52:42.0415638Z 	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestMethod(QuarkusTestExtension.java:660)
2020-08-27T23:52:42.0415816Z 	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
2020-08-27T23:52:42.0415990Z 	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
2020-08-27T23:52:42.0416185Z 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
2020-08-27T23:52:42.0416338Z 	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
2020-08-27T23:52:42.0416510Z 	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
```