### PR TITLE
Disable MutinyTest#testSSE for now as it's unstable on CI

### DIFF
--- a/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
+++ b/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -79,6 +80,7 @@ public class MutinyTest {
     }
 
     @Test
+    @Disabled("https://github.com/quarkusio/quarkus/issues/11687")
     public void testSSE() {
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target("http://localhost:" + RestAssured.port + "/mutiny/pets");


### PR DESCRIPTION
Requesting approval to merge this one. Our other CI experiment PRs keep running into this one and we haven't been able to run those jobs to completion. This commit has been tested in @gsmet's https://github.com/quarkusio/quarkus/pull/11679 PR (which is currently open), so I don't think we have to wait for the whole 2-3 hours to merge this PR.

/cc @stuartwdouglas @geoand 