### PR TITLE
Don't launch an additional daemon process for Gradle build

### DIFF
--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -82,6 +82,7 @@
                                 <argument>-Pdescription=${project.description}</argument>
                                 <argument>-S</argument>
                                 <argument>--stacktrace</argument>
+                                <argument>--no-daemon</argument>
                             </arguments>
                             <environmentVariables>
                                 <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>


### PR DESCRIPTION
Right now the `devtools/gradle` build launches an additional Gradle daemon process. This isn't really needed and should be avoided especially on CI. The commit here adds the `--no-daemon` to prevent this additional daemon process.