### PR TITLE
Add missing @ApplicationScoped in Panache-Kotlin docs

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -89,6 +89,7 @@ by making them implement `PanacheRepository`:
 
 [source,kotlin]
 ----
+@ApplicationScoped
 class PersonRepository: PanacheRepository<Person> {
      fun findByName(name: String) = find("name", name).firstResult()
      fun findAlive() = list("status", Status.Alive)


### PR DESCRIPTION
The annotation is present in the hibernate-orm-panache docs, but not in the hibernate-orm-panache-kotlin docs.