### PR TITLE
Add OIDC session-age-extension property

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -674,6 +674,17 @@ public class OidcTenantConfig {
         public boolean userInfoRequired;
 
         /**
+         * Session age extension in minutes.
+         * The user session age property is set to the value of the ID token life-span by default and
+         * the user will be redirected to the OIDC provider to re-authenticate once the session has expired.
+         * If this property is set to a non-zero value then the expired ID token can be refreshed before
+         * the session has expired.
+         * This property will be ignored if the `token.refresh-expired` property has not been enabled.
+         */
+        @ConfigItem(defaultValue = "5M")
+        public Duration sessionAgeExtension = Duration.ofMinutes(5);
+
+        /**
          * If this property is set to 'true' then a normal 302 redirect response will be returned
          * if the request was initiated via XMLHttpRequest and the current user needs to be
          * (re)authenticated which may not be desirable for Single Page Applications since
@@ -764,6 +775,15 @@ public class OidcTenantConfig {
         public void setVerifyAccessToken(boolean verifyAccessToken) {
             this.verifyAccessToken = verifyAccessToken;
         }
+
+        public Duration getSessionAgeExtension() {
+            return sessionAgeExtension;
+        }
+
+        public void setSessionAgeExtension(Duration sessionAgeExtension) {
+            this.sessionAgeExtension = sessionAgeExtension;
+        }
+
     }
 
     @ConfigGroup
@@ -820,11 +840,15 @@ public class OidcTenantConfig {
 
         /**
          * Refresh expired ID tokens.
-         * If this property is enabled then a refresh token request is performed and, if successful, the local session is
-         * updated with the new set of tokens.
-         * Otherwise, the local session is invalidated as an indication that the session at the OpenID Provider no longer
-         * exists.
-         * This option is only valid when the application is of type {@link ApplicationType#WEB_APP}}.
+         * If this property is enabled then a refresh token request will be performed if the ID token has expired
+         * and, if successful, the local session will be updated with the new set of tokens.
+         * Otherwise, the local session will be invalidated and the user redirected to the OpenID Provider to re-authenticate.
+         * In this case the user may not be challenged again if the OIDC provider session is still active.
+         *
+         * For this option be effective the `authentication.session-age-extension` property should also be set to a non-zero
+         * value since the refresh token is currently kept in the user session.
+         *
+         * This option is valid only when the application is of type {@link ApplicationType#WEB_APP}}.
          */
         @ConfigItem
         public boolean refreshExpired;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -360,6 +360,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (configContext.oidcConfig.token.lifespanGrace.isPresent()) {
             maxAge += configContext.oidcConfig.token.lifespanGrace.getAsInt();
         }
+        if (configContext.oidcConfig.token.refreshExpired) {
+            maxAge += configContext.oidcConfig.authentication.sessionAgeExtension.getSeconds();
+        }
         createCookie(context, configContext, getSessionCookieName(configContext), cookieValue, maxAge);
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -65,10 +65,10 @@ quarkus.oidc.tenant-logout.client-id=quarkus-app
 quarkus.oidc.tenant-logout.credentials.secret=secret
 quarkus.oidc.tenant-logout.application-type=web-app
 quarkus.oidc.tenant-logout.authentication.cookie-path=/tenant-logout
+quarkus.oidc.tenant-logout.authentication.session-age-extension=2M
 quarkus.oidc.tenant-logout.logout.path=/tenant-logout/logout
 quarkus.oidc.tenant-logout.logout.post-logout-path=/tenant-logout/post-logout
 quarkus.oidc.tenant-logout.token.refresh-expired=true
-quarkus.oidc.tenant-logout.token.lifespan-grace=120
 
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
 quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus


### PR DESCRIPTION
Fixes #11715.

As reported in #11715, RT is lost after the ID token expiry given that RT is kept in the session.
As it happens `token.lifespan-grace` does allow to extend the session but using `token.lifespan-grace` specifically to extend the session is risky if it goes beyond a few secs since `token.lifespan-grace` is really about avoiding the token issued-at or expiry errors which can be caused by the clock skew.
This PR introduces a dedicated `authentication.session-age-extension` property. This property is ignored unless `token.refresh-expired` is set, because there is no reason right now to let the users extend the session in other cases because the session validity is tied in to the ID token validity and if no `token.refresh-expired` is set then ID token verification failure will cause the redirect.

If `token.refresh-expired` is set then the session will be auto-extended by 5 mins - again - there is no security risk at all since the session validity is about the ID token validity. But what it gives is for the option to refresh the tokens assuming the OP session is still active.

In practice the users may want to set to 30 mins or so, hence the Duration format is in minutes.

I've updated the test to use the new property instead of relying on the `lifespan-grace`