### PR TITLE
Update to smallrye-jwt 2.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -40,7 +40,7 @@
         <smallrye-graphql.version>1.0.7</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>2.2.0</smallrye-jwt.version>
+        <smallrye-jwt.version>2.3.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.1.0</smallrye-converter-api.version>

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -641,6 +641,7 @@ SmallRye JWT provides more properties which can be used to customize the token p
 |smallrye.jwt.verify.algorithm|`RS256`|Signature algorithm. Set it to `ES256` to support the Elliptic Curve signature algorithm.
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.
 |smallrye.jwt.verify.relax-key-validation|false|Relax the validation of the verification keys, setting this property to `true` will allow public RSA keys with the length less than 2048 bit.
+|smallrye.jwt.verify.certificate-thumbprint|false|If this property is enabled then a signed token must contain either 'x5t' or 'x5t#S256' X509Certificate thumbprint headers. Verification keys can only be in JWK or PEM Certificate key formats in this case. JWK keys must have a 'x5c' (Base64-encoded X509Certificate) property set.
 |smallrye.jwt.token.header|`Authorization`|Set this property if another header such as `Cookie` is used to pass the token.
 |smallrye.jwt.token.cookie|none|Name of the cookie containing a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
 |smallrye.jwt.always-check-authorization|false|Set this property to true for Authorization header be checked even if the smallrye.jwt.token.header is set to Cookie but no cookie with a smallrye.jwt.token.cookie name exists.
@@ -692,20 +693,22 @@ import io.smallrye.jwt.build.Jwt;
 @Path("/secured")
 public class SecuredResource {
  @Inject JWTParser parser;
- private SecretKey key = createSecretKey();
+ private String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMko";
 
  @GET
  @Produces("text/plain")
  public Response getUserName(@CookieParam("jwt") String jwtCookie) {
     Response response = null;
     if (jwtCookie == null) {
-        String newJwtCookie = Jwt.upn("Alice").sign(key);
-        // or newJwtCookie = Jwt.upn("alice").encrypt(key);
+        // Create a JWT token signed using the 'HS256' algorithm
+        String newJwtCookie = Jwt.upn("Alice").signWithSecret(secret);
+        // or create a JWT token encrypted using the 'A256KW' algorithm
+        // Jwt.upn("alice").encryptWithSecret(secret);
         return Response.ok("Alice").cookie(new NewCookie("jwt", newJwtCookie)).build();
     else {
         // All mp.jwt and smallrye.jwt properties are still effective, only the verification key is customized.
-        JsonWebToken jwt = parser.verify(jwtCookie, key);
-        // or jwt = parser.decrypt(jwtCookie, key);
+        JsonWebToken jwt = parser.verify(jwtCookie, secret);
+        // or jwt = parser.decrypt(jwtCookie, secret);
         return Response.ok(jwt.getName()).build();
     }
 }
@@ -725,6 +728,46 @@ See <<generate-jwt-tokens, Generate JWT tokens with SmallRye JWT>> and learn how
 == How to check the errors in the logs ==
 
 Set `quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE` to see more details about the token verification or decryption errors.
+
+== Custom Factories
+
+`io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipalFactory` is used by default to parse and verify JWT tokens and convert them to `JsonWebToken` principals.
+It uses `MP JWT` and `smallrye-jwt` properties listed in the `Configuration` section to verify and customize JWT tokens.
+
+If you need to provide your own factory, for example, to avoid verifying the tokens again which have already been verified by the firewall, then you can either use a `ServiceLoader` mechanism by providing a `META-INF/services/io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory` resource or simply have an `Alternative` CDI bean implementation like this one:
+
+[source,java]
+----
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.ParseException;
+
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class TestJWTCallerPrincipalFactory extends JWTCallerPrincipalFactory {
+
+    @Override
+    public JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException {
+        try {
+            // Token has already been verified, parse the token claims only
+            String json = new String(Base64.getUrlDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8);
+            return new DefaultJWTCallerPrincipal(JwtClaims.parse(json));
+        } catch (InvalidJwtException ex) {
+            throw new ParseException(ex.getMessage());
+        }
+    }
+}
+----
 
 [[generate-jwt-tokens]]
 == Generate JWT tokens with SmallRye JWT

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -38,6 +38,7 @@ import io.quarkus.smallrye.jwt.runtime.auth.RawOptionalClaimCreator;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
+import io.smallrye.jwt.auth.cdi.JWTCallerPrincipalFactoryProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
 import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
 import io.smallrye.jwt.auth.principal.DefaultJWTParser;
@@ -83,6 +84,7 @@ class SmallRyeJwtProcessor {
         removable.addBeanClass(RawClaimTypeProducer.class);
         removable.addBeanClass(JsonValueProducer.class);
         removable.addBeanClass(JwtPrincipalProducer.class);
+        removable.addBeanClass(JWTCallerPrincipalFactoryProducer.class);
         removable.addBeanClass(Claim.class);
         additionalBeans.produce(removable.build());
 

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsCustomFactoryUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsCustomFactoryUnitTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.jwt.test;
+
+import java.net.HttpURLConnection;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DefaultGroupsCustomFactoryUnitTest {
+    private static Class<?>[] testClasses = {
+            DefaultGroupsEndpoint.class,
+            TestJWTCallerPrincipalFactory.class,
+            TokenUtils.class
+    };
+    /**
+     * The test generated JWT token string
+     */
+    private String token;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("privateKey.pem")
+                    .addAsResource("TokenUserGroup.json"));
+
+    @BeforeEach
+    public void generateToken() throws Exception {
+        token = TokenUtils.generateTokenString("/TokenUserGroup.json");
+    }
+
+    /**
+     * Validate a request with MP-JWT without a 'groups' claim is successful
+     * due to the default value being provided in the configuration
+     *
+     */
+    @Test
+    public void echoGroups() {
+        io.restassured.response.Response response = RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/echo").andReturn();
+
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
+        Assertions.assertEquals("User", response.body().asString());
+    }
+
+    @Test
+    public void echoGroupsWithParser() {
+        io.restassured.response.Response response = RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/echo-parser").andReturn();
+
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
+        Assertions.assertEquals("parser:User", response.body().asString());
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestJWTCallerPrincipalFactory.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestJWTCallerPrincipalFactory.java
@@ -1,0 +1,31 @@
+package io.quarkus.jwt.test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+
+import io.quarkus.arc.AlternativePriority;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.ParseException;
+
+@ApplicationScoped
+@AlternativePriority(1)
+public class TestJWTCallerPrincipalFactory extends JWTCallerPrincipalFactory {
+
+    @Override
+    public JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException {
+        try {
+            String json = new String(Base64.getUrlDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8);
+            return new DefaultJWTCallerPrincipal(JwtClaims.parse(json));
+        } catch (InvalidJwtException ex) {
+            throw new ParseException(ex.getMessage());
+        }
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/TokenUserGroup.json
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/TokenUserGroup.json
@@ -1,0 +1,12 @@
+{
+  "iss": "https://server.example.com",
+  "jti": "a-123.2",
+  "sub": "24400320#2",
+  "upn": "jdoe2@example.com",
+  "preferred_username": "jdoe2",
+  "aud": "s6BhdRkqt3.2",
+  "exp": 1311281970,
+  "iat": 1311280970,
+  "auth_time": 1311280969,
+  "groups": ["User"]
+}


### PR DESCRIPTION
This PR updates to `smallrye-jwt 2.3.0` and:
- Fixes #9965.
- Adds a few build methods to simplify securing the tokens with the secrets
- Supports the injection of the custom JWT verification factories

