### PR TITLE
Revert "Disable MutinyTest#testSSE for now as it's unstable on CI"

### DIFF
--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
@@ -56,7 +56,6 @@ public class SomeService {
                 new Pet().setName("indy").setKind("dog"),
                 new Pet().setName("plume").setKind("dog"),
                 new Pet().setName("titi").setKind("bird"),
-                new Pet().setName("rex").setKind("mouse"))
-                .emitOn(executor);
+                new Pet().setName("rex").setKind("mouse"));
     }
 }

--- a/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
+++ b/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.SseEventSource;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -83,7 +82,6 @@ public class MutinyTest {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/11687")
     public void testSSE() {
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target("http://localhost:" + RestAssured.port + "/mutiny/pets");


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/11693 we disabled the `MutinyTest#testSSE` due to CI issues. Now that CI has stabilized, re-enabling this to see if there are any genuine issues.

Fixes #11687