### PR TITLE
Revert "Only integrate with Bean Validation if the HV extension is present" - 1.7

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -47,6 +47,7 @@ import org.hibernate.boot.spi.MetadataBuilderContributor;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;
 import org.hibernate.cache.internal.CollectionCacheInvalidator;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.beanvalidation.BeanValidationIntegrator;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
@@ -355,6 +356,7 @@ public class FastBootMetadataBuilder {
 
     private Collection<Integrator> getIntegrators() {
         LinkedHashSet<Integrator> integrators = new LinkedHashSet<>();
+        integrators.add(new BeanValidationIntegrator());
         integrators.add(new CollectionCacheInvalidator());
 
         for (Class<? extends Integrator> integratorClass : additionalIntegrators) {

--- a/extensions/hibernate-validator/runtime/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/extensions/hibernate-validator/runtime/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,1 +1,0 @@
-org.hibernate.cfg.beanvalidation.BeanValidationIntegrator


### PR DESCRIPTION
This reverts commit 386c20e3968a02cc06ce7c36bdd1f479d5c5aae8.

I will write another fix for master.