### PR TITLE
Using Modifier.isFinal instead of org.objectweb.asm.Opcodes.ACC_FINAL - 1.7

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
@@ -1,8 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.proxies;
 
-import static org.objectweb.asm.Opcodes.ACC_FINAL;
-
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,7 +101,7 @@ public final class ProxyDefinitions {
             PreGeneratedProxies preGeneratedProxies) {
         final String entityName = persistentClass.getEntityName();
         final Class mappedClass = persistentClass.getMappedClass();
-        if ((mappedClass.getModifiers() & ACC_FINAL) == ACC_FINAL) {
+        if (Modifier.isFinal(mappedClass.getModifiers())) {
             LOGGER.warn("Could not generate an enhanced proxy for entity '" + entityName + "' (class='"
                     + mappedClass.getCanonicalName()
                     + "') as it's final. Your application might perform better if we're allowed to extend it.");


### PR DESCRIPTION
Just backporting a GraalVM 20.2 fix made by @gastaldi to 1.7 as it's a problem with Mandrel.