### PR TITLE
Avoid NPE at boot if a MetricsFactoryConsumerBuildItem contains null

### DIFF
--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
@@ -61,9 +61,10 @@ class Neo4jDriverProcessor {
             Neo4jDriverRecorder recorder,
             BuildProducer<MetricsFactoryConsumerBuildItem> metrics) {
         Consumer<MetricsFactory> metricsFactoryConsumer = recorder.registerMetrics(configuration);
-        if (metricsFactoryConsumer != null) {
-            metrics.produce(new MetricsFactoryConsumerBuildItem(metricsFactoryConsumer));
-        }
+        // If metrics for neo4j are disabled, the returned consumer will be null,
+        // but in a processor we can't know that (it's controlled by a runtime config property)
+        // so the BuildItem might contain null and in that case will be ignored by the metrics recorder
+        metrics.produce(new MetricsFactoryConsumerBuildItem(metricsFactoryConsumer));
     }
 
 }

--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
@@ -214,7 +214,9 @@ public class SmallRyeMetricsRecorder {
     }
 
     public void registerMetrics(Consumer<MetricsFactory> consumer) {
-        consumer.accept(factory);
+        if (consumer != null) {
+            consumer.accept(factory);
+        }
     }
 
     public void createRegistries(BeanContainer container) {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/11736