### PR TITLE
Use neutral container image over docker image

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.fast-jar
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.fast-jar
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package
 #

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package
 #

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package -Pnative -Dquarkus.native.container-build=true
 #

--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package
 #

--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package
 #

--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
@@ -1,7 +1,7 @@
 ####
 # This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
 #
-# Before building the docker image run:
+# Before building the container image run:
 #
 # mvn package -Pnative -Dquarkus.native.container-build=true
 #


### PR DESCRIPTION
as raised on quarkus-dev its better to refer to container images 
rather than docker image as it is not limited to docker container runtime.