### PR TITLE
Fix wrong extension name in kafka example

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -48,7 +48,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-quickstart \
-    -Dextensions="kafka"
+    -Dextensions="smallrye-reactive-messaging-kafka"
 cd kafka-quickstart
 ----
 
@@ -59,7 +59,7 @@ to your project by running the following command in your project base directory:
 
 [source,bash]
 ----
-./mvnw quarkus:add-extension -Dextensions="kafka"
+./mvnw quarkus:add-extension -Dextensions="smallrye-reactive-messaging-kafka"
 ----
 
 This will add the following to your `pom.xml`:


### PR DESCRIPTION
The extension "kafka" does not exist, should be "smallrye-reactive-messaging-kafka"