### PR TITLE
Mention cassandra-quarkus-client in the section about extensions that support SSL

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -82,6 +82,7 @@ As SSL is de facto the standard nowadays, we decided to enable its support autom
  * the Reactive client for PostgreSQL extension (`quarkus-reactive-pg-client`),
  * the Reactive client for MySQL extension (`quarkus-reactive-mysql-client`),
  * the Reactive client for DB2 extension (`quarkus-reactive-db2-client`).
+ * the Cassandra client extensions (`cassandra-quarkus-client`)
 
 As long as you have one of those extensions in your project, the SSL support will be enabled by default.
 


### PR DESCRIPTION
As part of https://github.com/datastax/cassandra-quarkus/issues/111, we did add support for
`extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(CASSANDRA_CLIENT))`
we would like to mention the fact that our extension supports SSL out of the box in the quarkus docs.