### PR TITLE
OIDC ID token auto-refresh support

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -854,6 +854,16 @@ public class OidcTenantConfig {
         public boolean refreshExpired;
 
         /**
+         * Token auto-refresh interval in seconds during the user re-authentication.
+         * If this option is set then the valid ID token will be refreshed if it will expire in less than a number of minutes
+         * set by this option. The user will still be authenticated if the ID token can no longer be refreshed but is still
+         * valid.
+         * This option will be ignored if the 'refresh-expired' property is not enabled.
+         */
+        @ConfigItem
+        public Optional<Duration> autoRefreshInterval = Optional.empty();
+
+        /**
          * Forced JWK set refresh interval in minutes.
          */
         @ConfigItem(defaultValue = "10M")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenAutoRefreshException.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenAutoRefreshException.java
@@ -1,0 +1,16 @@
+package io.quarkus.oidc.runtime;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+@SuppressWarnings("serial")
+public class TokenAutoRefreshException extends RuntimeException {
+    private SecurityIdentity securityIdentity;
+
+    public TokenAutoRefreshException(SecurityIdentity securityIdentity) {
+        this.securityIdentity = securityIdentity;
+    }
+
+    public SecurityIdentity getSecurityIdentity() {
+        return securityIdentity;
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -23,6 +23,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-logout";
         }
 
+        if (path.contains("tenant-autorefresh")) {
+            return "tenant-autorefresh";
+        }
+
         if (path.contains("tenant-https")) {
             return "tenant-https";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAutoRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAutoRefresh.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/tenant-autorefresh")
+public class TenantAutoRefresh {
+    @Authenticated
+    @GET
+    public String getTenantLogout() {
+        return "Tenant AutoRefresh";
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -70,6 +70,14 @@ quarkus.oidc.tenant-logout.logout.path=/tenant-logout/logout
 quarkus.oidc.tenant-logout.logout.post-logout-path=/tenant-logout/post-logout
 quarkus.oidc.tenant-logout.token.refresh-expired=true
 
+quarkus.oidc.tenant-autorefresh.auth-server-url=${keycloak.url}/realms/logout-realm
+quarkus.oidc.tenant-autorefresh.client-id=quarkus-app
+quarkus.oidc.tenant-autorefresh.credentials.secret=secret
+quarkus.oidc.tenant-autorefresh.application-type=web-app
+quarkus.oidc.tenant-autorefresh.authentication.cookie-path=/tenant-autorefresh
+quarkus.oidc.tenant-autorefresh.token.refresh-expired=true
+quarkus.oidc.tenant-autorefresh.token.auto-refresh-interval=4S
+
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
 quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-https.client-id=quarkus-app
@@ -91,6 +99,9 @@ quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
 
 quarkus.http.auth.permission.logout.paths=/tenant-logout
+quarkus.http.auth.permission.logout.policy=authenticated
+
+quarkus.http.auth.permission.logout.paths=/tenant-autorefresh
 quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.http.auth.permission.https.paths=/tenant-https

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -213,6 +213,44 @@ public class CodeFlowTest {
             page = webClient.getPage("http://localhost:8081/tenant-logout");
             assertNull(getSessionCookie(webClient, "tenant-logout"));
             assertEquals("Log in to logout-realm", page.getTitleText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testTokenAutoRefresh() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant-autorefresh");
+            assertEquals("Log in to logout-realm", page.getTitleText());
+            HtmlForm loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getInputByName("login").click();
+            assertTrue(page.asText().contains("Tenant AutoRefresh"));
+
+            Cookie sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
+            assertNotNull(sessionCookie);
+            String idToken = getIdToken(sessionCookie);
+
+            //wait now so that we reach the refresh timeout
+            await().atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(new Callable<Boolean>() {
+                        @Override
+                        public Boolean call() throws Exception {
+                            webClient.getOptions().setRedirectEnabled(false);
+                            WebResponse webResponse = webClient
+                                    .loadWebResponse(
+                                            new WebRequest(URI.create("http://localhost:8081/tenant-autorefresh").toURL()));
+                            assertEquals(200, webResponse.getStatusCode());
+                            assertTrue(webResponse.getContentAsString().contains("Tenant AutoRefresh"));
+                            // Should not redirect to OP but silently refresh token
+                            Cookie newSessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
+                            assertNotNull(newSessionCookie);
+                            return !idToken.equals(getIdToken(newSessionCookie));
+                        }
+                    });
+            webClient.getCookieManager().clearCookies();
         }
     }
 


### PR DESCRIPTION
This PR follows up #11718 (which adds an option to extend the session in order to keep RT around for longer) and adds another option to auto-refresh ID tokens if the validated ID token will expire within the configured `token.auto-refresh-interval`. 
This should offer a more robust solution, as extending the session on its own only relies on the possibility of the OP session still being active for the RT grant to work.
I've added a test and also verified that without adding a new property in the new `tenant-autorefresh` configuration the test fails.

In this PR an exception is thrown for the recovery code in `CodeAuthenticationMechanism` which does refresh the tokens and updates the session to take control. The exception is thrown only after the ID token has been verified and the SecurityIdentity calculated - the difference in this case is that if the RT grant fails we still continue because the current ID token is still valid (not expired).
Also some precautions are taken to 1) avoid auto-refreshing on the initial authentication request and 2) avoid looping as the refreshed tokens also get verified.