### PR TITLE
Fix KubernetesClientTest

### DIFF
--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -3,7 +3,7 @@ package io.quarkus.it.kubernetes.client;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -26,7 +26,7 @@ public class KubernetesClientTest {
     @MockServer
     private KubernetesMockServer mockServer;
 
-    @Test
+    @BeforeEach
     public void before() {
         Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
         Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
@@ -56,7 +56,6 @@ public class KubernetesClientTest {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/11783")
     public void testInteractionWithAPIServer() {
         RestAssured.when().get("/pod/test").then()
                 .body("size()", is(2)).body(containsString("pod1"), containsString("pod2"));

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -53,6 +53,9 @@ public class KubernetesClientTest {
         // same here, the content itself doesn't really matter
         mockServer.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, new PodBuilder()
                 .withNewMetadata().withResourceVersion("54321").and().build()).once();
+
+        System.out.println(mockServer.getHostName() + ":" + mockServer.getPort()
+                + " Mock server has been setup with necessary expected endpoints");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/11783

CI logs from one of the failures had:

```
2020-09-01T14:06:41.6074869Z [INFO] Running io.quarkus.it.kubernetes.client.KubernetesClientTest
2020-09-01T14:06:42.3576627Z 2020-09-01 14:06:41,644 INFO  [okh.moc.MockWebServer] (MockWebServer /127.0.0.1:33094) MockWebServer[53913] received request: GET /api/v1/namespaces/test/pods HTTP/1.1 and responded: HTTP/1.1 404 Client Error
2020-09-01T14:06:42.3577684Z 2020-09-01 14:06:41,651 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-1) HTTP Request to /pod/test failed, error id: 9684b956-6122-4e9e-8375-1c3309d562e7-1: org.jboss.resteasy.spi.UnhandledException: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: http://localhost:53913/api/v1/namespaces/test/pods.
```
Notice the "received GET ... returned 404" from mock server. That and the method name `before` provided a hint of what was going wrong :)