### PR TITLE
Don't use JSON formatted logs for main integration tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -547,13 +547,14 @@ jobs:
             test-modules: >
               kubernetes-client
           - category: Misc4
-            timeout: 45
+            timeout: 50
             test-modules: >
               smallrye-graphql
               picocli-native
               gradle
               micrometer-mp-metrics
               micrometer-prometheus
+              logging-json
           - category: Spring
             timeout: 50
             test-modules: >

--- a/integration-tests/logging-json/pom.xml
+++ b/integration-tests/logging-json/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-integration-test-logging-json</artifactId>
-    <name>Quarkus - Integration Tests - Logging (JSON)</name>
+    <name>Quarkus - Integration Tests - Logging - JSON</name>
     <description>
         Tests the JSON logging extension
     </description>

--- a/integration-tests/logging-json/pom.xml
+++ b/integration-tests/logging-json/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-logging-json</artifactId>
+    <name>Quarkus - Integration Tests - Logging (JSON)</name>
+    <description>
+        Tests the JSON logging extension
+    </description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/logging-json/src/main/java/io/quarkus/it/logging/json/GreetingResource.java
+++ b/integration-tests/logging-json/src/main/java/io/quarkus/it/logging/json/GreetingResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.logging.json;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    private static final Logger logger = Logger.getLogger(GreetingResource.class.getName());
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        logger.info("Hello to \"Quarkus\"");
+        return "hello";
+    }
+}

--- a/integration-tests/logging-json/src/test/java/io/quarkus/it/logging/json/GreetingResourceTest.java
+++ b/integration-tests/logging-json/src/test/java/io/quarkus/it/logging/json/GreetingResourceTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.logging.json;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class GreetingResourceTest {
+
+    @Test
+    public void testHelloEndpoint() throws Exception {
+        given()
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
+    }
+
+}

--- a/integration-tests/logging-json/src/test/java/io/quarkus/it/logging/json/NativeGreetingResourceIT.java
+++ b/integration-tests/logging-json/src/test/java/io/quarkus/it/logging/json/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.json;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -131,12 +131,6 @@
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
         </dependency>
 
-        <!-- JSON Logging -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-logging-json</artifactId>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -135,6 +135,7 @@
         <module>micrometer-jmx</module>
         <module>micrometer-mp-metrics</module>
         <module>micrometer-prometheus</module>
+        <module>logging-json</module>
 
         <!-- gRPC tests -->
         <module>grpc-plain-text</module>


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/8857 we introduced the `quarkus-logging-json` dependency in the `integration-tests/main` to help us catch issues with JSON formatted logging in native mode. However, recent CI issue investigations and this issue https://github.com/quarkusio/quarkus/issues/11774 have shown that it makes it difficult to debug/read the logs when something goes wrong.

@gsmet, I remember you had mentioned in some old PR that we should perhaps remove this from this `main` integration-tests. So here's the PR. 
I think additionally, we need a new module perhaps to test the JSON formatted logging in integration tests? I know that's a bit of a pain to create and maintain, but I don't see any other way.

Fixes https://github.com/quarkusio/quarkus/issues/11774