### PR TITLE
Rename ContextAwareTokenCredential to OidcTokenCredential and move it out of the runtime package

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AccessTokenCredential.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AccessTokenCredential.java
@@ -1,10 +1,9 @@
 package io.quarkus.oidc;
 
-import io.quarkus.oidc.runtime.ContextAwareTokenCredential;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.vertx.ext.web.RoutingContext;
 
-public class AccessTokenCredential extends ContextAwareTokenCredential {
+public class AccessTokenCredential extends OidcTokenCredential {
 
     private RefreshToken refreshToken;
     private boolean opaque;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/IdTokenCredential.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/IdTokenCredential.java
@@ -1,9 +1,8 @@
 package io.quarkus.oidc;
 
-import io.quarkus.oidc.runtime.ContextAwareTokenCredential;
 import io.vertx.ext.web.RoutingContext;
 
-public class IdTokenCredential extends ContextAwareTokenCredential {
+public class IdTokenCredential extends OidcTokenCredential {
 
     public IdTokenCredential() {
         this(null, null);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTokenCredential.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTokenCredential.java
@@ -1,18 +1,18 @@
-package io.quarkus.oidc.runtime;
+package io.quarkus.oidc;
 
 import io.quarkus.security.credential.TokenCredential;
 import io.vertx.ext.web.RoutingContext;
 
-public class ContextAwareTokenCredential extends TokenCredential {
+public class OidcTokenCredential extends TokenCredential {
 
     private RoutingContext context;
 
-    protected ContextAwareTokenCredential(String token, String type, RoutingContext context) {
+    protected OidcTokenCredential(String token, String type, RoutingContext context) {
         super(token, type);
         this.context = context;
     }
 
-    RoutingContext getContext() {
+    public RoutingContext getRoutingContext() {
         return context;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -13,6 +13,7 @@ import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
+import io.quarkus.oidc.OidcTokenCredential;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.identity.AuthenticationRequestContext;
@@ -43,8 +44,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     @Override
     public Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request,
             AuthenticationRequestContext context) {
-        ContextAwareTokenCredential credential = (ContextAwareTokenCredential) request.getToken();
-        RoutingContext vertxContext = credential.getContext();
+        OidcTokenCredential credential = (OidcTokenCredential) request.getToken();
+        RoutingContext vertxContext = credential.getRoutingContext();
         return Uni.createFrom().deferred(new Supplier<Uni<SecurityIdentity>>() {
             @Override
             public Uni<SecurityIdentity> get() {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.keycloak;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        IdTokenCredential cred = identity.getCredential(IdTokenCredential.class);
+        if (cred != null) {
+            QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+            builder.addAttribute(RoutingContext.class.getName(), cred.getRoutingContext());
+            identity = builder.build();
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -14,10 +14,15 @@ import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.RefreshToken;
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.ext.web.RoutingContext;
 
 @Path("/web-app")
 @Authenticated
 public class ProtectedResource {
+
+    @Inject
+    SecurityIdentity identity;
 
     @Inject
     @IdToken
@@ -39,6 +44,9 @@ public class ProtectedResource {
     public String getName() {
         if (!idTokenCredential.getToken().equals(idToken.getRawToken())) {
             throw new OIDCException("ID token values are not equal");
+        }
+        if (idTokenCredential.getRoutingContext() != identity.getAttribute(RoutingContext.class.getName())) {
+            throw new OIDCException("SecurityIdentity must have a RoutingContext attribute");
         }
         return idToken.getName();
     }


### PR DESCRIPTION
Fixes #10907.

There have been a few queries to do with accessing `RoutingContext` in the custom `SecurityIdentityAugmentor`.

Pedro @pedroigor has already provided a useful `ContextAwareTokenCredential` for the internal (runtime) OIDC purposes.
So I've only moved this class to out of the runtime package to make it part of the API, and also renamed it to `OidcTokenCredential` (we may add more properties into it which will be common to both OIDC ID and AccessToken credentials) and renamed `getContext`to `getRoutIngContext` and made it public.

Stuart, Pedro's original solution looks simple enough for me at the moment and should work, but you may have a better idea how to pass the routing context around, have a look please :-)