### PR TITLE
Upgrade SmallRye GraphQL to 1.0.9

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -37,7 +37,7 @@
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
         <smallrye-open-api.version>2.0.7</smallrye-open-api.version>
-        <smallrye-graphql.version>1.0.7</smallrye-graphql.version>
+        <smallrye-graphql.version>1.0.9</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.2.0</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -71,8 +71,8 @@ import io.smallrye.graphql.schema.model.InterfaceType;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.spi.EventingService;
 import io.smallrye.graphql.spi.LookupService;
-import io.smallrye.graphql.spi.SchemaBuildingExtensionService;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -130,14 +130,15 @@ public class SmallRyeGraphQLProcessor {
         serviceProvider.produce(
                 new ServiceProviderBuildItem(LookupService.class.getName(), lookupImplementations.toArray(new String[0])));
 
-        // Schema Extension Service (We use the one from the CDI Module)
-        String schemaExtensionService = SPI_PATH + SchemaBuildingExtensionService.class.getName();
-        Set<String> schemaExtensionImplementations = ServiceUtil.classNamesNamedIn(
+        // Eventing Service (We use the one from the CDI Module)
+        String eventingService = SPI_PATH + EventingService.class.getName();
+        Set<String> eventingServiceImplementations = ServiceUtil.classNamesNamedIn(
                 Thread.currentThread().getContextClassLoader(),
-                schemaExtensionService);
-        serviceProvider.produce(
-                new ServiceProviderBuildItem(SchemaBuildingExtensionService.class.getName(),
-                        schemaExtensionImplementations.toArray(new String[0])));
+                eventingService);
+        for (String eventingServiceImplementation : eventingServiceImplementations) {
+            serviceProvider.produce(
+                    new ServiceProviderBuildItem(EventingService.class.getName(), eventingServiceImplementation));
+        }
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
@@ -79,6 +79,6 @@ public abstract class AbstractGraphQLTest {
     static {
         PROPERTIES.put("smallrye.graphql.allowGet", "true");
         PROPERTIES.put("smallrye.graphql.printDataFetcherException", "true");
-        //        PROPERTIES.put("quarkus.log.category.\"io.quarkus.arc.processor\".level", "DEBUG");
+        PROPERTIES.put("smallrye.graphql.events.enabled", "true");
     }
 }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/MetricsTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/MetricsTest.java
@@ -10,6 +10,7 @@ import javax.json.JsonObject;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.hamcrest.CoreMatchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -38,7 +39,8 @@ public class MetricsTest {
     // Run a Query and check that its corresponding metric is updated
     @Test
     public void testQuery() {
-        SimpleTimer metric = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_Query_ping"));
+        SimpleTimer metric = metricRegistry.getSimpleTimers()
+                .get(new MetricID("mp_graphql", new Tag("type", "Query"), new Tag("name", "ping")));
         assertNotNull(metric, "Metrics should be registered eagerly");
 
         String pingRequest = getPayload("{\n" +

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -21,8 +21,7 @@ public class SmallRyeGraphQLRecorder {
 
     public void createExecutionService(BeanContainer beanContainer, Schema schema) {
         GraphQLProducer graphQLProducer = beanContainer.instance(GraphQLProducer.class);
-        graphQLProducer.setSchema(schema);
-        graphQLProducer.initialize();
+        graphQLProducer.initialize(schema);
     }
 
     public Handler<RoutingContext> executionHandler(boolean allowGet) {


### PR DESCRIPTION
This PR Upgrades SmallRye GraphQL to version 1.0.9.

It contains small bug and performance fixes and some new features, including:
- Support for Generics (thanks to @velias) 
- Convert metrics to dimensional (thanks to @jmartisk)
- Batch support for `@Source` methods (experimental)

(see https://github.com/smallrye/smallrye-graphql/compare/1.0.7...1.0.9 for full list of changes)

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>