### PR TITLE
Handle empty non existing resource directory in gradle plugin

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IDEDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IDEDevModeMain.java
@@ -73,14 +73,17 @@ public class IDEDevModeMain implements BiConsumer<CuratedApplication, Map<String
             sourceDirectories.add(srcDir.getPath());
             sourceParents.add(srcDir.getParent());
         }
-
+        String resourceDirectory = null;
+        if (module.getSourceSet().getResourceDirectory() != null) {
+            resourceDirectory = module.getSourceSet().getResourceDirectory().getPath();
+        }
         return new DevModeContext.ModuleInfo(key,
                 module.getArtifactCoords().getArtifactId(),
                 module.getProjectRoot().getPath(),
                 sourceDirectories,
                 QuarkusModelHelper.getClassPath(module).toAbsolutePath().toString(),
                 module.getSourceSourceSet().getResourceDirectory().toString(),
-                module.getSourceSet().getResourceDirectory().getPath(),
+                resourceDirectory,
                 sourceParents,
                 module.getBuildDir().toPath().resolve("generated-sources").toAbsolutePath().toString(),
                 module.getBuildDir().toString());

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -316,9 +316,13 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
     }
 
     private SourceSetImpl convert(SourceSet sourceSet) {
+        if (sourceSet.getOutput().getResourcesDir().exists()) {
+            return new SourceSetImpl(
+                    sourceSet.getOutput().getClassesDirs().getFiles(),
+                    sourceSet.getOutput().getResourcesDir());
+        }
         return new SourceSetImpl(
-                sourceSet.getOutput().getClassesDirs().getFiles(),
-                sourceSet.getOutput().getResourcesDir());
+                sourceSet.getOutput().getClassesDirs().getFiles());
     }
 
     private io.quarkus.bootstrap.resolver.model.SourceSet getSourceSourceSet(SourceSet sourceSet) {

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
@@ -69,7 +69,7 @@ class QuarkusModelBuilderTest {
         assertEquals(new File(projectDir, "build"), workspaceModule.getBuildDir());
         final SourceSet sourceSet = workspaceModule.getSourceSet();
         assertNotNull(sourceSet);
-        assertEquals(new File(projectDir, "build/resources/main"), sourceSet.getResourceDirectory());
+        assertNull(sourceSet.getResourceDirectory());
         assertEquals(1, sourceSet.getSourceDirectories().size());
         assertEquals(new File(projectDir, "build/classes/java/main"), sourceSet.getSourceDirectories().iterator().next());
         final SourceSet sourceSourceSet = workspaceModule.getSourceSourceSet();

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/SourceSetImpl.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/SourceSetImpl.java
@@ -10,11 +10,15 @@ import java.util.stream.Collectors;
 public class SourceSetImpl implements SourceSet, Serializable {
 
     private Set<File> sourceDirectories = new HashSet<>();
-    private final File resourceDirectory;
+    private File resourceDirectory;
 
     public SourceSetImpl(Set<File> sourceDirectories, File resourceDirectory) {
         this.sourceDirectories.addAll(sourceDirectories);
         this.resourceDirectory = resourceDirectory;
+    }
+
+    public SourceSetImpl(Set<File> sourceDirectories) {
+        this.sourceDirectories.addAll(sourceDirectories);
     }
 
     public void addSourceDirectories(Set<File> files) {

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
@@ -135,8 +135,9 @@ public class QuarkusModelHelper {
             WorkspaceModule module = model.getWorkspace().getMainModule();
             module.getSourceSet().getSourceDirectories().stream().filter(File::exists).map(File::toPath)
                     .forEach(paths::add);
-            if (module.getSourceSet().getResourceDirectory().exists()) {
-                paths.add(module.getSourceSet().getResourceDirectory().toPath());
+            File resourceDirectory = module.getSourceSet().getResourceDirectory();
+            if (resourceDirectory != null && resourceDirectory.exists()) {
+                paths.add(resourceDirectory.toPath());
             }
             appArtifact.setPaths(paths.build());
         }

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
@@ -9,6 +9,3 @@ pluginManagement {
     }
 }
 rootProject.name='code-with-quarkus'
-include 'library'
-include 'application'
-


### PR DESCRIPTION
This branch remove the `resources` directory from the module model.
A non-existing resources folder causes quarkus to throw an error at startup. 

close #11725 