### PR TITLE
Maven bootstrap: resolve workspace for layouts with directory breaks

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -114,6 +114,7 @@ public class BootstrapMavenContext {
     private Boolean currentProjectExists;
     private DefaultServiceLocator serviceLocator;
     private String alternatePomName;
+    private Path rootProjectDir;
 
     public static BootstrapMavenContextConfig<?> config() {
         return new BootstrapMavenContextConfig<>();
@@ -139,6 +140,7 @@ public class BootstrapMavenContext {
         this.remoteRepos = config.remoteRepos;
         this.remoteRepoManager = config.remoteRepoManager;
         this.cliOptions = config.cliOptions;
+        this.rootProjectDir = config.rootProjectDir;
         if (config.currentProject != null) {
             this.currentProject = config.currentProject;
             this.currentPom = currentProject.getRawModel().getPomFile().toPath();
@@ -771,6 +773,10 @@ public class BootstrapMavenContext {
     }
 
     public Path getRootProjectBaseDir() {
+        return rootProjectDir == null ? rootProjectDir = resolveRootProjectDir() : rootProjectDir;
+    }
+
+    private Path resolveRootProjectDir() {
         final String rootBaseDir = System.getenv(MAVEN_PROJECTBASEDIR);
         if (rootBaseDir == null) {
             return null;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
@@ -26,6 +26,7 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     protected File userSettings;
     protected boolean artifactTransferLogging = true;
     protected BootstrapMavenOptions cliOptions;
+    protected Path rootProjectDir;
 
     /**
      * Local repository location
@@ -181,6 +182,18 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
                 ? getInitializedCliOptions().getOptionValue(BootstrapMavenOptions.ALTERNATE_POM_FILE)
                 : alternatePomName;
         return BootstrapMavenContext.getPomForDirOrNull(basedir, altPom == null ? null : Paths.get(altPom));
+    }
+
+    /**
+     * Root project directory.
+     *
+     * @param rootProjectDir root project directory
+     * @return this instance
+     */
+    @SuppressWarnings("unchecked")
+    public T setRootProjectDir(Path rootProjectDir) {
+        this.rootProjectDir = rootProjectDir;
+        return (T) this;
     }
 
     private BootstrapMavenOptions getInitializedCliOptions() {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -36,6 +36,8 @@ public class LocalProject {
         private final Map<Path, Model> cachedModels = new HashMap<>();
         private final Path currentProjectPom;
         private Path workspaceRootPom;
+        // indicates whetehr the workspace root pom has been resolved or provided by the caller
+        private boolean workspaceRootResolved;
 
         private WorkspaceLoader(Path currentProjectPom) throws BootstrapMavenException {
             this.currentProjectPom = isPom(currentProjectPom) ? currentProjectPom
@@ -73,10 +75,10 @@ public class LocalProject {
         }
 
         private Path getWorkspaceRootPom() throws BootstrapMavenException {
-            return workspaceRootPom == null ? workspaceRootPom = resolveWorkspaceRootPom() : workspaceRootPom;
+            return workspaceRootPom == null ? workspaceRootPom = resolveWorkspaceRootPom(false) : workspaceRootPom;
         }
 
-        private Path resolveWorkspaceRootPom() throws BootstrapMavenException {
+        private Path resolveWorkspaceRootPom(boolean stopAtCached) throws BootstrapMavenException {
             Path rootPom = null;
             Path projectPom = currentProjectPom;
             Model model = model(projectPom);
@@ -105,11 +107,15 @@ public class LocalProject {
                     } else {
                         // if the parent is not at the top of the FS tree, it might have already been parsed
                         model = null;
-                        for (Map.Entry<Path, Model> entry : cachedModels.entrySet()) {
-                            // we are looking for the root dir of the workspace
-                            if (rootPom.getNameCount() > entry.getKey().getNameCount()) {
-                                rootPom = entry.getValue().getPomFile().toPath();
+                        if (!stopAtCached) {
+                            for (Map.Entry<Path, Model> entry : cachedModels.entrySet()) {
+                                // we are looking for the root dir of the workspace
+                                if (rootPom.getNameCount() > entry.getKey().getNameCount()) {
+                                    rootPom = entry.getValue().getPomFile().toPath();
+                                }
                             }
+                            // it is supposed to be the root pom
+                            workspaceRootResolved = true;
                         }
                     }
                 }
@@ -118,10 +124,22 @@ public class LocalProject {
         }
 
         LocalProject load() throws BootstrapMavenException {
-            load(null, getWorkspaceRootPom());
+            final Path rootPom = getWorkspaceRootPom();
+            load(null, rootPom);
             if (workspace.getCurrentProject() == null) {
-                if (!currentProjectPom.equals(getWorkspaceRootPom())) {
-                    load(null, currentProjectPom);
+                if (!currentProjectPom.equals(rootPom)) {
+                    // if the root pom wasn't resolved but provided we are going to try to navigate
+                    // to the very top pom that hasn't already been loaded
+                    if (!workspaceRootResolved) {
+                        final Path resolvedRootPom = resolveWorkspaceRootPom(true);
+                        if (!rootPom.equals(resolvedRootPom)) {
+                            load(null, resolvedRootPom);
+                        }
+                    }
+                    // if the project still wasn't found, we load it directly
+                    if (workspace.getCurrentProject() == null) {
+                        load(null, currentProjectPom);
+                    }
                 }
                 if (workspace.getCurrentProject() == null) {
                     throw new BootstrapMavenException(

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/module1/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>nested-project-parent</artifactId>
+        <version>1.0</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>nested-project-module1</artifactId>
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>root-module1</artifactId>
+        <version>1.0</version>
+        <relativePath/>
+    </parent>
+
+    <artifactId>nested-project-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module1</module>
+    </modules>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>root</artifactId>
+        <version>1.0</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>root-module1</artifactId>
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module1</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
This is the kind of project layout we may end up being using for the platform repo and its integration tests.