### PR TITLE
Fix disabled k8s client test

### DIFF
--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -91,6 +91,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <!--
+                    The prod mode tests need to be part of a different execution to ensure that they don't mess with the standard tests.
+                    By adding this configuration we ensure that the maven surefire plugin will execute twice, one for the regular **/*Test.java
+                    tests (using the 'default-test' execution), and one for the prod mode tests (this 'prod-mode' execution)
+                    -->
+                    <execution>
+                        <id>prod-mode</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>**/*PMT.java</includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
@@ -1,7 +1,5 @@
 package io.quarkus.it.kubernetes.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
@@ -14,7 +12,7 @@ import io.quarkus.test.QuarkusProdModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
 @QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
-public class AbsentConfigMapPropertiesTest {
+public class AbsentConfigMapPropertiesPMT {
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -3,7 +3,6 @@ package io.quarkus.it.kubernetes.client;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -56,7 +55,6 @@ public class KubernetesClientTest {
     }
 
     @Test
-    @Disabled("https://github.com/quarkusio/quarkus/issues/11783")
     public void testInteractionWithAPIServer() {
         RestAssured.when().get("/pod/test").then()
                 .body("size()", is(2)).body(containsString("pod1"), containsString("pod2"));


### PR DESCRIPTION
This is done because as @jaikiran figured out, the test resource
of the prod mode test can leak into the regular @QuarkusTest.

Follow up of: #11799