### PR TITLE
Remove DEBUG logging for Micrometer tests

### DIFF
--- a/extensions/micrometer/deployment/src/test/resources/test-logging.properties
+++ b/extensions/micrometer/deployment/src/test/resources/test-logging.properties
@@ -1,4 +1,4 @@
-quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.bootstrap".level=INFO
-quarkus.log.category."io.quarkus.arc".level=DEBUG
+#quarkus.log.category."io.quarkus.arc".level=DEBUG
 quarkus.log.category."io.netty".level=INFO

--- a/integration-tests/micrometer-jmx/pom.xml
+++ b/integration-tests/micrometer-jmx/pom.xml
@@ -113,7 +113,6 @@
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <quarkus.log.level>DEBUG</quarkus.log.level>
                     </systemProperties>
                 </configuration>
             </plugin>

--- a/integration-tests/micrometer-jmx/src/main/resources/application.properties
+++ b/integration-tests/micrometer-jmx/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 
-quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.bootstrap".level=INFO
 quarkus.log.category."io.quarkus.netty".level=INFO
 quarkus.log.category."io.quarkus.resteasy.runtime".level=INFO

--- a/integration-tests/micrometer-mp-metrics/pom.xml
+++ b/integration-tests/micrometer-mp-metrics/pom.xml
@@ -119,7 +119,6 @@
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <quarkus.log.level>DEBUG</quarkus.log.level>
                     </systemProperties>
                 </configuration>
             </plugin>

--- a/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
+++ b/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.micrometer.runtime.binder.vertx".level=INFO
 
 quarkus.log.category."io.quarkus.bootstrap".level=INFO

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -151,7 +151,6 @@
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <quarkus.log.level>DEBUG</quarkus.log.level>
                     </systemProperties>
                 </configuration>
             </plugin>

--- a/integration-tests/micrometer-prometheus/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.bootstrap".level=INFO
 quarkus.log.category."io.quarkus.netty".level=INFO
 quarkus.log.category."io.quarkus.resteasy.runtime".level=INFO


### PR DESCRIPTION
DEBUG logging creates too many log lines for the CI.

I commented the configuration options so they can easily be re-enabled for debugging purpose.