### PR TITLE
Improve CI consistency

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build
         run: sleep 30
   build-jdk11:
-    name: "JDK 11 Build"
+    name: "Initial JDK 11 Build"
     runs-on: ubuntu-latest
     # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
     if: "github.event_name != 'pull_request' || ( \
@@ -98,7 +98,7 @@ jobs:
         run: rm -r ~/.m2/repository/io/quarkus
 
   linux-jvm-tests:
-    name: JDK ${{matrix.java.name}} JVM Tests
+    name: JVM Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
     needs: build-jdk11
     timeout-minutes: 240
@@ -108,17 +108,17 @@ jobs:
       fail-fast: false
       matrix:
         java :
-          - { name: Java8,
+          - { name: "8",
               java-version: 8,
               maven_args: "-pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/kubernetes/quarkus-standard-way"
           }
           - {
-            name: Java 11,
+            name: "11",
             java-version: 11,
             maven_args: "-pl !integration-tests/gradle -pl !integration-tests/maven"
           }
           - {
-            name: Java 14,
+            name: "14",
             java-version: 14,
             maven_args: "-pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/kubernetes/quarkus-standard-way"
           }
@@ -168,7 +168,7 @@ jobs:
           path: 'test-reports.tgz'
 
   windows-jdk11-jvm-tests:
-    name: JDK 11 Windows JVM Tests
+    name: JVM Tests - JDK 11 Windows
     needs: build-jdk11
     runs-on: windows-latest
     timeout-minutes: 180
@@ -192,7 +192,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         shell: bash
-        run: mvn -B --settings .github/mvn-settings.xml -DskipDocs -Dno-native -Dformat.skip -pl !integration-tests/gradle install
+        run: mvn -B --settings .github/mvn-settings.xml -DskipDocs -Dno-native -Dformat.skip -pl !integration-tests/gradle -pl !integration-tests/maven install
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -206,41 +206,8 @@ jobs:
           name: test-reports-windows-jdk11-jvm
           path: 'test-reports.tgz'
 
-  linux-jvm-gradle-tests:
-    name: Gradle Tests JDK ${{matrix.java.name}}
-    runs-on: ubuntu-latest
-    needs: build-jdk11
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        java:
-         - {
-            name: Java 11,
-            java-version: 11
-          }
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
-      - name: Build with Gradle
-        uses: eskatos/gradle-command-action@v1
-        env:
-          GRADLE_OPTS: -Xmx1408m
-        with:
-          gradle-version: wrapper
-          wrapper-directory: integration-tests/gradle
-          build-root-directory: integration-tests/gradle
-          arguments: clean test -i -S --stacktrace --no-daemon
-
   linux-jvm-maven-tests:
-    name: Maven Tests JDK ${{matrix.java.name}}
+    name: Maven Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
     needs: build-jdk11
     timeout-minutes: 60
@@ -249,7 +216,7 @@ jobs:
       matrix:
         java:
           - {
-            name: Java 11,
+            name: "11",
             java-version: 11
           }
     steps:
@@ -262,6 +229,11 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
+      - name: Set up JDK ${{ matrix.java.name }}
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        with:
+          java-version: ${{ matrix.java.java-version }}
       - name: Run Maven integration tests
         run: eval mvn $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
       - name: Prepare failure archive (if maven failed)
@@ -275,8 +247,82 @@ jobs:
           name: test-reports-linux-maven-java${{matrix.java.name}}
           path: 'test-reports.tgz'
 
+  windows-jdk11-jvm-maven-tests:
+    name: Maven Tests - JDK 11 Windows
+    runs-on: windows-latest
+    needs: build-jdk11
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Set up JDK 11
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        with:
+          java-version: 11
+      - name: Run Maven integration tests
+        shell: bash
+        run: mvn $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-windows-maven-java11
+          path: 'test-reports.tgz'
+
+  linux-jvm-gradle-tests:
+    name: Gradle Tests - JDK ${{matrix.java.name}}
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+         - {
+            name: "11",
+            java-version: 11
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Set up JDK ${{ matrix.java.name }}
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        with:
+          java-version: ${{ matrix.java.java-version }}
+      - name: Build with Gradle
+        uses: eskatos/gradle-command-action@v1
+        env:
+          GRADLE_OPTS: -Xmx1408m
+        with:
+          gradle-version: wrapper
+          wrapper-directory: integration-tests/gradle
+          build-root-directory: integration-tests/gradle
+          arguments: clean test -i -S --stacktrace --no-daemon
+
   windows-jdk11-jvm-gradle-tests:
-    name: Gradle Tests JDK 11 Windows
+    name: Gradle Tests - JDK 11 Windows
     needs: build-jdk11
     runs-on: windows-latest
     timeout-minutes: 80

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -198,8 +199,13 @@ public class CreateExtensionMojoTest {
             expectedFiles.add(relative);
             final Path actualPath = actual.resolve(relative);
             try {
-                assertEquals(new String(Files.readAllBytes(p), StandardCharsets.UTF_8),
-                        new String(Files.readAllBytes(actualPath), StandardCharsets.UTF_8));
+                String expectedContent = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+                String actualContent = new String(Files.readAllBytes(actualPath), StandardCharsets.UTF_8);
+                if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
+                    expectedContent = expectedContent.replace(System.lineSeparator(), "\n");
+                    actualContent = actualContent.replace(System.lineSeparator(), "\n");
+                }
+                assertEquals(expectedContent, actualContent);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This mostly brings a few minor improvements to our CI runs:
- names should be better and more consistent
- they should be properly ordered
- the Maven tests are now run in an external job also for Windows as it's already the case for Linux

Nothing revolutionary, just a nice cleanup.