### PR TITLE
Allow RestEasy JAXB collection serialization in native mode

### DIFF
--- a/extensions/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
+++ b/extensions/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
@@ -1,14 +1,52 @@
 package io.quarkus.resteasy.jaxb.deployment;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
+import org.jboss.resteasy.annotations.providers.jaxb.WrappedMap;
+
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class ResteasyJaxbProcessor {
+
+    private static final List<Class<? extends Annotation>> RESTEASY_JAXB_ANNOTATIONS = Arrays.asList(
+            Wrapped.class,
+            WrappedMap.class);
+
+    @BuildStep
+    void processAnnotations(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            CombinedIndexBuildItem combinedIndexBuildItem) {
+        IndexView index = combinedIndexBuildItem.getIndex();
+
+        // Handle RESTEasy annotations usage.
+        for (Class annotationClazz : RESTEASY_JAXB_ANNOTATIONS) {
+            DotName annotation = DotName.createSimple(annotationClazz.getName());
+
+            if (!index.getAnnotations(annotation).isEmpty()) {
+                addReflectiveClass(reflectiveClass, true, true, "org.jboss.resteasy.plugins.providers.jaxb.JaxbCollection");
+                addReflectiveClass(reflectiveClass, true, true, "org.jboss.resteasy.plugins.providers.jaxb.JaxbMap");
+                addReflectiveClass(reflectiveClass, true, true, "javax.xml.bind.annotation.W3CDomHandler");
+                break;
+            }
+        }
+    }
 
     @BuildStep
     void build(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(Feature.RESTEASY_JAXB));
+    }
+
+    private void addReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, boolean methods, boolean fields,
+            String... className) {
+        reflectiveClass.produce(new ReflectiveClassBuildItem(methods, fields, className));
     }
 }

--- a/extensions/resteasy-jaxb/deployment/src/test/java/io/quarkus/resteasy/jaxb/deployment/ProducesXMLTestCase.java
+++ b/extensions/resteasy-jaxb/deployment/src/test/java/io/quarkus/resteasy/jaxb/deployment/ProducesXMLTestCase.java
@@ -1,11 +1,18 @@
 package io.quarkus.resteasy.jaxb.deployment;
 
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
@@ -34,6 +41,15 @@ public class ProducesXMLTestCase {
                 .contentType(MediaType.APPLICATION_XML)
                 .extract().as(Bar.class);
         Assertions.assertEquals(new Bar("open", "bar"), res);
+
+        RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .when().get("/foo")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(MediaType.APPLICATION_XML)
+                .body("bars.bar.size()", is(2));
     }
 
     @Path("/foo")
@@ -46,6 +62,14 @@ public class ProducesXMLTestCase {
             final String[] s = bar.split(" ");
             return new Bar(s[0], s[1]);
         }
-    }
 
+        @GET
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.APPLICATION_XML)
+        @Wrapped(element = "bars")
+        public List<Bar> list() {
+            return Arrays.asList(new Bar("name_1", "description_1"),
+                    new Bar("name_2", "description_2"));
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes #11806

It adds a `BuildStep` for checking if specific RestEasy JAXB annotations are used for enforcing the Xml of the collection wrapping element (see https://docs.jboss.org/resteasy/docs/3.6.1.Final/userguide/html_single/#JAXB_Collections). If found, it is adding the wrapping RestEasy implementations as well as `W3CDomHandler` to the reflective classes.