### PR TITLE
Default platform version range should be [major.minor-alpha,major.minor+1]

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -85,9 +85,8 @@ public final class CreateUtils {
                 DefaultArtifactVersion pluginVersion = new DefaultArtifactVersion(baseVersion);
                 int majorVer = pluginVersion.getMajorVersion();
                 int minorVer = pluginVersion.getMinorVersion();
-                version = "[" + majorVer + "." + minorVer + "-snapshot, " + majorVer + "." + (minorVer + 1) + ")";
+                version = "[" + majorVer + "." + minorVer + "-alpha, " + majorVer + "." + (minorVer + 1) + ")";
             }
-
         }
 
         final QuarkusPlatformDescriptor platform;


### PR DESCRIPTION
Fixes #11815 
Following https://maven.apache.org/pom.html
```
Non-numeric ("qualifiers") tokens have the alphabetical order, except for the following tokens which come first in this order:
"alpha" < "beta" < "milestone" < "rc" = "cr" < "snapshot" < "" = "final" = "ga" < "sp"
```