### PR TITLE
chore: bump dekorate to 0.12.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -148,7 +148,7 @@
         <aws-alexa-sdk.version>2.32.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.72</kotlin.version>
-        <dekorate.version>0.12.7</dekorate.version>
+        <dekorate.version>0.12.8</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>


### PR DESCRIPTION
This is meant to address: https://github.com/quarkus-qe/quarkus-openshift-test-suite/issues/82
and also some ohter bugs related to dekorate.