### PR TITLE
CDI programmatic lookup - detect "unused" false positives at runtime

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1086,11 +1086,13 @@ Here is a summary of which extensions can access which metadata:
 
 In the development mode, two special endpoints are registered automatically to provide some basic debug info in the JSON format:
 
+* HTTP GET `/quarkus/arc` - returns the summary; number of beans, config properties, etc.
 * HTTP GET `/quarkus/arc/beans` - returns the list of all beans
 ** You can use query params to filter the output:
 *** `scope` - include beans with scope that ends with the given value, i.e. `http://localhost:8080/quarkus/arc/beans?scope=ApplicationScoped`
 *** `beanClass` - include beans with bean class that starts with the given value, i.e. `http://localhost:8080/quarkus/arc/beans?beanClass=org.acme.Foo`
 *** `kind` - include beans of the specified kind (`CLASS`, `PRODUCER_FIELD`, `PRODUCER_METHOD`, `INTERCEPTOR` or `SYNTHETIC`), i.e. `http://localhost:8080/quarkus/arc/beans?kind=PRODUCER_METHOD`
+* HTTP GET `/quarkus/arc/removed-beans` - returns the list of unused beans removed during build
 * HTTP GET `/quarkus/arc/observers` - returns the list of all observer methods
 
 NOTE: These endpoints are only available in the development mode, i.e. when you run your application via `mvn quarkus:dev` (or `./gradlew quarkusDev`).

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -146,6 +146,15 @@ public class ArcConfig {
     @ConfigItem
     Map<String, IndexDependencyConfig> excludeDependency;
 
+    /**
+     * If set to true then the container attempts to detect "unused removed beans" false positives during programmatic lookup at
+     * runtime. You can disable this feature to conserve some memory when running your application in production.
+     * 
+     * @see ArcConfig#removeUnusedBeans
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean detectUnusedFalsePositives;
+
     public final boolean isRemoveUnusedBeansFieldValid() {
         return ALLOWED_REMOVE_UNUSED_BEANS_VALUES.contains(removeUnusedBeans.toLowerCase());
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -396,7 +396,7 @@ public class ArcProcessor {
     // PHASE 5 - generate resources and initialize the container
     @BuildStep
     @Record(STATIC_INIT)
-    public BeanContainerBuildItem generateResources(ArcRecorder recorder, ShutdownContextBuildItem shutdown,
+    public BeanContainerBuildItem generateResources(ArcConfig config, ArcRecorder recorder, ShutdownContextBuildItem shutdown,
             ValidationPhaseBuildItem validationPhase,
             List<ValidationPhaseBuildItem.ValidationErrorBuildItem> validationErrors,
             List<BeanContainerListenerBuildItem> beanContainerListenerBuildItems,
@@ -435,7 +435,8 @@ public class ArcProcessor {
             public void registerField(FieldInfo fieldInfo) {
                 reflectiveFields.produce(new ReflectiveFieldBuildItem(fieldInfo));
             }
-        }, existingClasses.existingClasses, bytecodeTransformerConsumer);
+        }, existingClasses.existingClasses, bytecodeTransformerConsumer,
+                config.shouldEnableBeanRemoval() && config.detectUnusedFalsePositives);
         for (ResourceOutput.Resource resource : resources) {
             switch (resource.getType()) {
                 case JAVA_CLASS:
@@ -465,10 +466,7 @@ public class ArcProcessor {
         ArcContainer container = recorder.getContainer(shutdown);
         BeanContainer beanContainer = recorder.initBeanContainer(container,
                 beanContainerListenerBuildItems.stream().map(BeanContainerListenerBuildItem::getBeanContainerListener)
-                        .collect(Collectors.toList()),
-                beanProcessor.getBeanDeployment().getRemovedBeans().stream().flatMap(b -> b.getTypes().stream())
-                        .map(t -> t.name().toString())
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toList()));
 
         return new BeanContainerBuildItem(beanContainer);
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
@@ -1,6 +1,12 @@
 package io.quarkus.arc.test.unused;
 
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -12,7 +18,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.test.unused.subpackage.Beta;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.StaticBytecodeRecorderBuildItem;
+import io.quarkus.deployment.recording.BytecodeRecorderImpl;
+import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class UnusedExclusionTest {
@@ -21,13 +35,56 @@ public class UnusedExclusionTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(UnusedExclusionTest.class, Alpha.class, Beta.class, Charlie.class, Delta.class,
-                            ProducerBean.class)
+                            ProducerBean.class, TestRecorder.class, Gama.class, GamaProducer.class)
                     .addAsResource(new StringAsset(
                             "quarkus.arc.unremovable-types=io.quarkus.arc.test.unused.UnusedExclusionTest$Alpha,io.quarkus.arc.test.unused.subpackage.**,io.quarkus.arc.test.unused.Charlie,Delta"),
-                            "application.properties"));
+                            "application.properties"))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        BeanContainer beanContainer = context.consume(BeanContainerBuildItem.class).getValue();
+                        BytecodeRecorderImpl bytecodeRecorder = new BytecodeRecorderImpl(true,
+                                TestRecorder.class.getSimpleName(),
+                                "test", "" + TestRecorder.class.hashCode());
+                        // We need to use reflection due to some class loading problems
+                        Object recorderProxy = bytecodeRecorder.getRecordingProxy(TestRecorder.class);
+                        try {
+                            Method test = recorderProxy.getClass().getDeclaredMethod("test", BeanContainer.class);
+                            Object[] args = new Object[1];
+                            args[0] = beanContainer;
+                            test.invoke(recorderProxy, args);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        context.produce(new StaticBytecodeRecorderBuildItem(bytecodeRecorder));
+                    }
+                }).consumes(BeanContainerBuildItem.class).produces(StaticBytecodeRecorderBuildItem.class).build();
+            }
+        };
+    }
+
+    @Recorder
+    public static class TestRecorder {
+
+        public void test(BeanContainer beanContainer) {
+            // This should trigger the warning - Gama was removed
+            Gama gama = beanContainer.instance(Gama.class);
+            // Test that fallback was used - no injection was performed
+            Assertions.assertNull(gama.beanManager);
+        }
+
+    }
 
     @Test
-    public void testBeansWereNotRemoved() {
+    public void testBeans() {
         ArcContainer container = Arc.container();
         String expectedBeanResponse = "ok";
         InstanceHandle<Alpha> alphaInstance = container.instance(Alpha.class);
@@ -45,6 +102,8 @@ public class UnusedExclusionTest {
         InstanceHandle<Delta> deltaInstance = container.instance(Delta.class);
         Assertions.assertTrue(deltaInstance.isAvailable());
         Assertions.assertEquals(expectedBeanResponse, deltaInstance.get().ping());
+
+        Assertions.assertFalse(container.instance(Gama.class).isAvailable());
     }
 
     // unused bean, won't be removed
@@ -53,6 +112,28 @@ public class UnusedExclusionTest {
 
         public String ping() {
             return "ok";
+        }
+
+    }
+
+    // unused bean, will be removed
+    @ApplicationScoped
+    public static class Gama {
+
+        @Inject
+        BeanManager beanManager;
+
+        public String ping() {
+            return "ok";
+        }
+
+    }
+
+    public static class GamaProducer {
+
+        @Produces
+        public Gama ping() {
+            return new Gama();
         }
 
     }

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -1,26 +1,17 @@
 package io.quarkus.arc.runtime;
 
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
-import org.jboss.logging.Logger;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.InstanceHandle;
-import io.quarkus.arc.ManagedContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 
-/**
- */
 @Recorder
 public class ArcRecorder {
 
@@ -28,8 +19,6 @@ public class ArcRecorder {
      * Used to hold the Supplier instances used for synthetic bean declarations.
      */
     public static volatile Map<String, Supplier<?>> supplierMap;
-
-    private static final Logger LOGGER = Logger.getLogger(ArcRecorder.class.getName());
 
     public ArcContainer getContainer(ShutdownContext shutdown) throws Exception {
         ArcContainer container = Arc.initialize();
@@ -54,54 +43,12 @@ public class ArcRecorder {
         supplierMap.putAll(beans);
     }
 
-    public BeanContainer initBeanContainer(ArcContainer container, List<BeanContainerListener> listeners,
-            Collection<String> removedBeanTypes)
+    public BeanContainer initBeanContainer(ArcContainer container, List<BeanContainerListener> listeners)
             throws Exception {
-
         if (container == null) {
             throw new IllegalArgumentException("Arc container was null");
         }
-        BeanContainer beanContainer = new BeanContainer() {
-            @Override
-            public <T> Factory<T> instanceFactory(Class<T> type, Annotation... qualifiers) {
-                Supplier<InstanceHandle<T>> handleSupplier = container.instanceSupplier(type, qualifiers);
-                if (handleSupplier == null) {
-                    if (removedBeanTypes.contains(type.getName())) {
-                        // Note that this only catches the simplest use cases
-                        LOGGER.warnf(
-                                "Bean matching %s was marked as unused and removed during build.\nExtensions can eliminate false positives using:\n\t- a custom UnremovableBeanBuildItem\n\t- AdditionalBeanBuildItem(false, beanClazz)",
-                                type);
-                    } else {
-                        LOGGER.debugf(
-                                "No matching bean found for type %s and qualifiers %s. The bean might have been marked as unused and removed during build.",
-                                type, Arrays.toString(qualifiers));
-                    }
-                    return new DefaultInstanceFactory<>(type);
-                }
-                return new Factory<T>() {
-                    @Override
-                    public Instance<T> create() {
-                        InstanceHandle<T> handle = handleSupplier.get();
-                        return new Instance<T>() {
-                            @Override
-                            public T get() {
-                                return handle.get();
-                            }
-
-                            @Override
-                            public void close() {
-                                handle.close();
-                            }
-                        };
-                    }
-                };
-            }
-
-            @Override
-            public ManagedContext requestContext() {
-                return container.requestContext();
-            }
-        };
+        BeanContainer beanContainer = new BeanContainerImpl(container);
         for (BeanContainerListener listener : listeners) {
             listener.created(beanContainer);
         }
@@ -135,30 +82,6 @@ public class ArcRecorder {
                 container.instance(CommandLineArgumentsProducer.class).setCommandLineArgs(args);
             }
         };
-    }
-
-    private static final class DefaultInstanceFactory<T> implements BeanContainer.Factory<T> {
-
-        final Class<T> type;
-
-        private DefaultInstanceFactory(Class<T> type) {
-            this.type = type;
-        }
-
-        @Override
-        public BeanContainer.Instance<T> create() {
-            try {
-                T instance = type.newInstance();
-                return new BeanContainer.Instance<T>() {
-                    @Override
-                    public T get() {
-                        return instance;
-                    }
-                };
-            } catch (InstantiationException | IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
 }

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainerImpl.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainerImpl.java
@@ -1,0 +1,80 @@
+package io.quarkus.arc.runtime;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.ManagedContext;
+
+public class BeanContainerImpl implements BeanContainer {
+
+    private static final Logger LOGGER = Logger.getLogger(BeanContainerImpl.class.getName());
+
+    private final ArcContainer container;
+
+    public BeanContainerImpl(ArcContainer container) {
+        this.container = container;
+    }
+
+    @Override
+    public <T> Factory<T> instanceFactory(Class<T> type, Annotation... qualifiers) {
+        Supplier<InstanceHandle<T>> handleSupplier = container.instanceSupplier(type, qualifiers);
+        if (handleSupplier == null) {
+            LOGGER.debugf(
+                    "No matching bean found for type %s and qualifiers %s. The bean might have been marked as unused and removed during build.",
+                    type, Arrays.toString(qualifiers));
+            return new DefaultInstanceFactory<>(type);
+        }
+        return new Factory<T>() {
+            @Override
+            public Instance<T> create() {
+                InstanceHandle<T> handle = handleSupplier.get();
+                return new Instance<T>() {
+                    @Override
+                    public T get() {
+                        return handle.get();
+                    }
+
+                    @Override
+                    public void close() {
+                        handle.close();
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public ManagedContext requestContext() {
+        return container.requestContext();
+    }
+
+    static final class DefaultInstanceFactory<T> implements BeanContainer.Factory<T> {
+
+        final Class<T> type;
+
+        DefaultInstanceFactory(Class<T> type) {
+            this.type = type;
+        }
+
+        @Override
+        public BeanContainer.Instance<T> create() {
+            try {
+                T instance = type.newInstance();
+                return new BeanContainer.Instance<T>() {
+                    @Override
+                    public T get() {
+                        return instance;
+                    }
+                };
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcEndpointProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcEndpointProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.vertx.http.deployment.devmode;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.arc.deployment.ArcConfig;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -13,15 +17,38 @@ public class ArcEndpointProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep(onlyIf = IsDevelopment.class)
-    void registerRoutes(HttpBuildTimeConfig config, ArcEndpointRecorder recorder, BuildProducer<RouteBuildItem> routes,
+    void registerRoutes(HttpBuildTimeConfig httpConfig, ArcConfig arcConfig, ArcEndpointRecorder recorder,
+            BuildProducer<RouteBuildItem> routes,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints) {
-        String basePath = config.consolePath + "/arc";
+        String basePath = httpConfig.consolePath + "/arc";
         String beansPath = basePath + "/beans";
+        String removedBeansPath = basePath + "/removed-beans";
         String observersPath = basePath + "/observers";
+        routes.produce(new RouteBuildItem(basePath, recorder.createSummaryHandler(getConfigProperties(arcConfig))));
         routes.produce(new RouteBuildItem(beansPath, recorder.createBeansHandler()));
+        routes.produce(new RouteBuildItem(removedBeansPath, recorder.createRemovedBeansHandler()));
         routes.produce(new RouteBuildItem(observersPath, recorder.createObserversHandler()));
+        displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(basePath));
         displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(beansPath));
+        displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(removedBeansPath));
         displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(observersPath));
+    }
+
+    // Note that we can't turn ArcConfig into BUILD_AND_RUN_TIME_FIXED because it's referencing IndexDependencyConfig
+    // And we can't split the config due to compatibility reasons 
+    private Map<String, String> getConfigProperties(ArcConfig arcConfig) {
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.arc.remove-unused-beans", arcConfig.removeUnusedBeans);
+        props.put("quarkus.arc.unremovable-types", arcConfig.unremovableTypes.map(Object::toString).orElse(""));
+        props.put("quarkus.arc.detect-unused-false-positives", "" + arcConfig.detectUnusedFalsePositives);
+        props.put("quarkus.arc.transform-unproxyable-classes", "" + arcConfig.transformUnproxyableClasses);
+        props.put("quarkus.arc.auto-inject-fields", "" + arcConfig.autoInjectFields);
+        props.put("quarkus.arc.auto-producer-methods", "" + arcConfig.autoProducerMethods);
+        props.put("quarkus.arc.selected-alternatives", "" + arcConfig.selectedAlternatives.map(Object::toString).orElse(""));
+        props.put("quarkus.arc.exclude-types", "" + arcConfig.excludeTypes.map(Object::toString).orElse(""));
+        props.put("quarkus.arc.config-properties-default-naming-strategy",
+                "" + arcConfig.configPropertiesDefaultNamingStrategy.toString());
+        return props;
     }
 
 }

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -37,10 +37,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-core</artifactId>
         </dependency>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ArcEndpointRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ArcEndpointRecorder.java
@@ -4,12 +4,15 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableObserverMethod;
+import io.quarkus.arc.RemovedBean;
 import io.quarkus.arc.impl.ArcContainerImpl;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.Json.JsonArrayBuilder;
@@ -19,6 +22,40 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class ArcEndpointRecorder {
+
+    public Handler<RoutingContext> createSummaryHandler(Map<String, String> configProperties) {
+        return new Handler<RoutingContext>() {
+
+            @Override
+            public void handle(RoutingContext ctx) {
+                ctx.response().putHeader("Content-Type", "application/json");
+                ArcContainerImpl container = ArcContainerImpl.instance();
+                JsonObjectBuilder summary = Json.object();
+                summary.put("beans", container.getBeans().size());
+                summary.put("removedBeans", container.getRemovedBeans().size());
+                summary.put("observers", container.getObservers().size());
+                summary.put("interceptors", container.getInterceptors().size());
+                JsonArrayBuilder scopes = Json.array();
+                container.getScopes().stream().map(Class::getName).forEach(scopes::add);
+                summary.put("scopes", scopes);
+                JsonObjectBuilder config = Json.object();
+                for (Entry<String, String> entry : configProperties.entrySet()) {
+                    if (entry.getValue().equals("true") || entry.getValue().equals("false")) {
+                        config.put(entry.getKey(), Boolean.parseBoolean(entry.getValue()));
+                    } else {
+                        config.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                summary.put("config", config);
+                JsonObjectBuilder links = Json.object();
+                links.put("beans", "/quarkus/arc/beans");
+                links.put("observers", "/quarkus/arc/observers");
+                links.put("removed-beans", "/quarkus/arc/removed-beans");
+                summary.put("links", links);
+                ctx.response().end(summary.build());
+            }
+        };
+    }
 
     public Handler<RoutingContext> createBeansHandler() {
         return new Handler<RoutingContext>() {
@@ -32,7 +69,7 @@ public class ArcEndpointRecorder {
                 beans.addAll(container.getInterceptors());
 
                 String kindParam = ctx.request().getParam("kind");
-                InjectableBean.Kind kind = kindParam != null ? InjectableBean.Kind.valueOf(kindParam) : null;
+                InjectableBean.Kind kind = kindParam != null ? InjectableBean.Kind.from(kindParam.toUpperCase()) : null;
                 String scopeEndsWith = ctx.request().getParam("scope");
                 String beanClassStartsWith = ctx.request().getParam("beanClass");
 
@@ -124,6 +161,41 @@ public class ArcEndpointRecorder {
                     array.add(observer);
                 }
                 ctx.response().end(array.build());
+            }
+        };
+    }
+
+    public Handler<RoutingContext> createRemovedBeansHandler() {
+        return new Handler<RoutingContext>() {
+
+            @Override
+            public void handle(RoutingContext ctx) {
+                ArcContainerImpl container = ArcContainerImpl.instance();
+                ctx.response().putHeader("Content-Type", "application/json");
+                JsonArrayBuilder removed = Json.array();
+                for (RemovedBean removedBean : container.getRemovedBeans()) {
+                    JsonObjectBuilder bean = Json.object();
+                    bean.put("kind", removedBean.getKind().toString());
+                    bean.put("description", removedBean.getDescription());
+                    JsonArrayBuilder types = Json.array();
+                    for (Type beanType : removedBean.getTypes()) {
+                        types.add(beanType instanceof Class ? ((Class<?>) beanType).getName() : beanType.toString());
+                    }
+                    // java.lang.Object is always skipped
+                    types.add(Object.class.getName());
+                    bean.put("types", types);
+                    JsonArrayBuilder qualifiers = Json.array();
+                    for (Annotation qualifier : removedBean.getQualifiers()) {
+                        if (qualifier.annotationType().equals(Any.class) || qualifier.annotationType().equals(Default.class)) {
+                            qualifiers.add("@" + qualifier.annotationType().getSimpleName());
+                        } else {
+                            qualifiers.add(qualifier.toString());
+                        }
+                    }
+                    bean.put("qualifiers", qualifiers);
+                    removed.add(bean);
+                }
+                ctx.response().end(removed.build());
             }
         };
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -136,7 +136,7 @@ public class BeanProcessor {
     }
 
     public List<Resource> generateResources(ReflectionRegistration reflectionRegistration, Set<String> existingClasses,
-            Consumer<BytecodeTransformer> bytecodeTransformerConsumer)
+            Consumer<BytecodeTransformer> bytecodeTransformerConsumer, boolean detectUnusedFalsePositives)
             throws IOException {
         if (reflectionRegistration == null) {
             reflectionRegistration = this.reflectionRegistration;
@@ -199,7 +199,8 @@ public class BeanProcessor {
 
         // Generate _ComponentsProvider
         resources.addAll(
-                new ComponentsProviderGenerator(annotationLiterals, generateSources).generate(name, beanDeployment,
+                new ComponentsProviderGenerator(annotationLiterals, generateSources, detectUnusedFalsePositives).generate(name,
+                        beanDeployment,
                         beanToGeneratedName,
                         observerToGeneratedName));
 
@@ -238,7 +239,7 @@ public class BeanProcessor {
         initialize(unsupportedBytecodeTransformer);
         ValidationContext validationContext = validate(unsupportedBytecodeTransformer);
         processValidationErrors(validationContext);
-        generateResources(null, new HashSet<>(), unsupportedBytecodeTransformer);
+        generateResources(null, new HashSet<>(), unsupportedBytecodeTransformer, true);
         return beanDeployment;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -7,8 +7,11 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.Components;
 import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
@@ -40,13 +43,17 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     static final String COMPONENTS_PROVIDER_SUFFIX = "_ComponentsProvider";
     static final String SETUP_PACKAGE = Arc.class.getPackage().getName() + ".setup";
     static final String ADD_OBSERVERS = "addObservers";
+    static final String ADD_REMOVED_BEANS = "addRemovedBeans";
     static final String ADD_BEANS = "addBeans";
 
-    protected final AnnotationLiteralProcessor annotationLiterals;
+    private final AnnotationLiteralProcessor annotationLiterals;
+    private final boolean detectUnusedFalsePositives;
 
-    public ComponentsProviderGenerator(AnnotationLiteralProcessor annotationLiterals, boolean generateSources) {
+    public ComponentsProviderGenerator(AnnotationLiteralProcessor annotationLiterals, boolean generateSources,
+            boolean detectUnusedFalsePositives) {
         super(generateSources);
         this.annotationLiterals = annotationLiterals;
+        this.detectUnusedFalsePositives = detectUnusedFalsePositives;
     }
 
     /**
@@ -81,7 +88,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         processBeans(componentsProvider, getComponents, beanIdToBeanHandle, beanToInjections, beanToGeneratedName,
                 beanDeployment);
 
-        // Break observers processing into multiple ddObservers() methods
+        // Break observers processing into multiple addObservers() methods
         ResultHandle observersHandle = getComponents.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
         processObservers(componentsProvider, getComponents, beanDeployment, beanIdToBeanHandle, observersHandle,
                 observerToGeneratedName);
@@ -111,10 +118,16 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                 MethodDescriptor.ofMethod(Map.class, "values", Collection.class),
                 beanIdToBeanHandle);
 
+        // Break removed beans processing into multiple addRemovedBeans() methods
+        ResultHandle removedBeansHandle = getComponents.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
+        if (detectUnusedFalsePositives) {
+            processRemovedBeans(componentsProvider, getComponents, removedBeansHandle, beanDeployment, classOutput);
+        }
+
         ResultHandle componentsHandle = getComponents.newInstance(
                 MethodDescriptor.ofConstructor(Components.class, Collection.class, Collection.class, Collection.class,
-                        Map.class),
-                beansHandle, observersHandle, contextsHandle, transitiveBindingsHandle);
+                        Map.class, Collection.class),
+                beansHandle, observersHandle, contextsHandle, transitiveBindingsHandle, removedBeansHandle);
         getComponents.returnValue(componentsHandle);
 
         // Finally write the bytecode
@@ -134,7 +147,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             Map<BeanInfo, String> beanToGeneratedName, BeanDeployment beanDeployment) {
 
         Set<BeanInfo> processed = new HashSet<>();
-        BeanAdder beanAdder = new BeanAdder(componentsProvider, getComponents, processed);
+        BeanAdder beanAdder = new BeanAdder(componentsProvider, getComponents, processed, beanIdToBeanHandle,
+                beanToGeneratedName);
 
         // - iterate over beanToInjections entries and process beans for which all dependencies are already present in the map
         // - when a bean is processed the map entry is removed
@@ -176,12 +190,12 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         // Finally process beans and interceptors that are not dependencies
         for (BeanInfo bean : beanDeployment.getBeans()) {
             if (!processed.contains(bean)) {
-                beanAdder.addBean(bean, beanIdToBeanHandle, beanToGeneratedName);
+                beanAdder.addComponent(bean);
             }
         }
         for (BeanInfo interceptor : beanDeployment.getInterceptors()) {
             if (!processed.contains(interceptor)) {
-                beanAdder.addBean(interceptor, beanIdToBeanHandle, beanToGeneratedName);
+                beanAdder.addComponent(interceptor);
             }
         }
 
@@ -191,9 +205,20 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
     private void processObservers(ClassCreator componentsProvider, MethodCreator getComponents, BeanDeployment beanDeployment,
             ResultHandle beanIdToBeanHandle, ResultHandle observersHandle, Map<ObserverInfo, String> observerToGeneratedName) {
-        try (ObserverAdder observerAdder = new ObserverAdder(componentsProvider, getComponents)) {
+        try (ObserverAdder observerAdder = new ObserverAdder(componentsProvider, getComponents, observerToGeneratedName,
+                beanIdToBeanHandle, observersHandle)) {
             for (ObserverInfo observer : beanDeployment.getObservers()) {
-                observerAdder.addObserver(observer, beanIdToBeanHandle, observersHandle, observerToGeneratedName);
+                observerAdder.addComponent(observer);
+            }
+        }
+    }
+
+    private void processRemovedBeans(ClassCreator componentsProvider, MethodCreator getComponents,
+            ResultHandle removedBeansHandle, BeanDeployment beanDeployment, ClassOutput classOutput) {
+        try (RemovedBeanAdder removedBeanAdder = new RemovedBeanAdder(componentsProvider, getComponents, removedBeansHandle,
+                classOutput)) {
+            for (BeanInfo remnovedBean : beanDeployment.getRemovedBeans()) {
+                removedBeanAdder.addComponent(remnovedBean);
             }
         }
     }
@@ -247,7 +272,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             BeanInfo bean = entry.getKey();
             if (filter.test(bean)) {
                 iterator.remove();
-                beanAdder.addBean(bean, beanIdToBeanHandle, beanToGeneratedName);
+                beanAdder.addComponent(bean);
                 processed.add(bean);
                 stuck = false;
             }
@@ -265,50 +290,40 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         return false;
     }
 
-    static class ObserverAdder implements AutoCloseable {
+    static class ObserverAdder extends ComponentAdder<ObserverInfo> {
 
-        private static final int GROUP_LIMIT = 30;
-        private int group;
-        private int observersAdded;
-        private MethodCreator addObserversMethod;
-        private final MethodCreator getComponentsMethod;
-        private final ClassCreator componentsProvider;
+        private final Map<ObserverInfo, String> observerToGeneratedName;
+        private final ResultHandle beanIdToBeanHandle;
+        private final ResultHandle observersHandle;
 
-        public ObserverAdder(ClassCreator componentsProvider, MethodCreator getComponentsMethod) {
-            this.group = 1;
-            this.getComponentsMethod = getComponentsMethod;
-            this.componentsProvider = componentsProvider;
+        ObserverAdder(ClassCreator componentsProvider, MethodCreator getComponentsMethod,
+                Map<ObserverInfo, String> observerToGeneratedName, ResultHandle beanIdToBeanHandle,
+                ResultHandle observersHandle) {
+            super(getComponentsMethod, componentsProvider);
+            this.observerToGeneratedName = observerToGeneratedName;
+            this.beanIdToBeanHandle = beanIdToBeanHandle;
+            this.observersHandle = observersHandle;
         }
 
-        public void close() {
-            if (addObserversMethod != null) {
-                addObserversMethod.returnValue(null);
-            }
+        @Override
+        MethodCreator newAddMethod() {
+            return componentsProvider
+                    .getMethodCreator(ADD_OBSERVERS + group++, void.class, Map.class, List.class)
+                    .setModifiers(ACC_PRIVATE);
         }
 
-        void addObserver(ObserverInfo observer, ResultHandle beanIdToBeanHandle, ResultHandle observersHandle,
-                Map<ObserverInfo, String> observerToGeneratedName) {
+        @Override
+        void invokeAddMethod() {
+            getComponentsMethod.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(componentsProvider.getClassName(),
+                            addMethod.getMethodDescriptor().getName(), void.class, Map.class, List.class),
+                    getComponentsMethod.getThis(), beanIdToBeanHandle, observersHandle);
+        }
 
-            if (addObserversMethod == null || observersAdded >= GROUP_LIMIT) {
-                if (addObserversMethod != null) {
-                    addObserversMethod.returnValue(null);
-                }
-                observersAdded = 0;
-                // First add next addObservers(map) method
-                addObserversMethod = componentsProvider
-                        .getMethodCreator(ADD_OBSERVERS + group++, void.class, Map.class, List.class)
-                        .setModifiers(ACC_PRIVATE);
-                // Invoke addObservers(map) inside the getComponents() method
-                getComponentsMethod.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(componentsProvider.getClassName(),
-                                addObserversMethod.getMethodDescriptor().getName(), void.class, Map.class, List.class),
-                        getComponentsMethod.getThis(), beanIdToBeanHandle, observersHandle);
-            }
-            observersAdded++;
-
-            // Append to the addObservers() method body
-            beanIdToBeanHandle = addObserversMethod.getMethodParam(0);
-            observersHandle = addObserversMethod.getMethodParam(1);
+        @Override
+        void addComponentInternal(ObserverInfo observer) {
+            ResultHandle beanIdToBeanHandle = addMethod.getMethodParam(0);
+            ResultHandle observersHandle = addMethod.getMethodParam(1);
 
             String observerType = observerToGeneratedName.get(observer);
             List<ResultHandle> params = new ArrayList<>();
@@ -319,67 +334,168 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                         .filter(ip -> !BuiltinBean.resolvesTo(ip))
                         .collect(toList());
                 // First param - declaring bean
-                params.add(addObserversMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
-                        beanIdToBeanHandle, addObserversMethod.load(observer.getDeclaringBean().getIdentifier())));
+                params.add(addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
+                        beanIdToBeanHandle, addMethod.load(observer.getDeclaringBean().getIdentifier())));
                 paramTypes.add(Type.getDescriptor(Supplier.class));
                 for (InjectionPointInfo injectionPoint : injectionPoints) {
-                    params.add(addObserversMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
-                            beanIdToBeanHandle, addObserversMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
+                    params.add(addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
+                            beanIdToBeanHandle, addMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
                     paramTypes.add(Type.getDescriptor(Supplier.class));
                 }
             }
-            ResultHandle observerInstance = addObserversMethod.newInstance(
+            ResultHandle observerInstance = addMethod.newInstance(
                     MethodDescriptor.ofConstructor(observerType, paramTypes.toArray(new String[0])),
                     params.toArray(new ResultHandle[0]));
-            addObserversMethod.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, observersHandle, observerInstance);
+            addMethod.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, observersHandle, observerInstance);
         }
 
     }
 
-    static class BeanAdder implements AutoCloseable {
+    class RemovedBeanAdder extends ComponentAdder<BeanInfo> {
 
-        private static final int GROUP_LIMIT = 30;
-        private int group;
-        private int beansWritten;
-        private MethodCreator addBeansMethod;
-        private final MethodCreator getComponentsMethod;
-        private final ClassCreator componentsProvider;
-        private final Set<BeanInfo> processedBeans;
+        private final ResultHandle removedBeansHandle;
+        private final ClassOutput classOutput;
+        private ResultHandle tccl;
 
-        public BeanAdder(ClassCreator componentsProvider, MethodCreator getComponentsMethod, Set<BeanInfo> processed) {
-            this.group = 1;
-            this.getComponentsMethod = getComponentsMethod;
-            this.componentsProvider = componentsProvider;
-            this.processedBeans = processed;
+        public RemovedBeanAdder(ClassCreator componentsProvider, MethodCreator getComponentsMethod,
+                ResultHandle removedBeansHandle, ClassOutput classOutput) {
+            super(getComponentsMethod, componentsProvider);
+            this.removedBeansHandle = removedBeansHandle;
+            this.classOutput = classOutput;
         }
 
-        public void close() {
-            if (addBeansMethod != null) {
-                addBeansMethod.returnValue(null);
-            }
+        @Override
+        MethodCreator newAddMethod() {
+            MethodCreator addMethod = componentsProvider.getMethodCreator(ADD_REMOVED_BEANS + group++, void.class, List.class)
+                    .setModifiers(ACC_PRIVATE);
+            // Get the TCCL - we will use it later
+            ResultHandle currentThread = addMethod
+                    .invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
+            tccl = addMethod.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
+            return addMethod;
         }
 
-        void addBean(BeanInfo bean, ResultHandle beanIdToBeanHandle,
-                Map<BeanInfo, String> beanToGeneratedName) {
+        @Override
+        void invokeAddMethod() {
+            getComponentsMethod.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(componentsProvider.getClassName(),
+                            addMethod.getMethodDescriptor().getName(), void.class, List.class),
+                    getComponentsMethod.getThis(), removedBeansHandle);
+        }
 
-            if (addBeansMethod == null || beansWritten >= GROUP_LIMIT) {
-                if (addBeansMethod != null) {
-                    addBeansMethod.returnValue(null);
+        @Override
+        void addComponentInternal(BeanInfo removedBean) {
+
+            ResultHandle removedBeansHandle = addMethod.getMethodParam(0);
+
+            // Bean types
+            ResultHandle typesHandle = addMethod.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+            for (org.jboss.jandex.Type type : removedBean.getTypes()) {
+                if (DotNames.OBJECT.equals(type.name())) {
+                    // Skip java.lang.Object
+                    continue;
                 }
-                beansWritten = 0;
-                // First add next addBeans(map) method
-                addBeansMethod = componentsProvider.getMethodCreator(ADD_BEANS + group++, void.class, Map.class)
-                        .setModifiers(ACC_PRIVATE);
-                // Invoke addBeans(map) inside the getComponents() method
-                getComponentsMethod.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(componentsProvider.getClassName(),
-                                addBeansMethod.getMethodDescriptor().getName(), void.class, Map.class),
-                        getComponentsMethod.getThis(), beanIdToBeanHandle);
+                ResultHandle typeHandle;
+                try {
+                    typeHandle = Types.getTypeHandle(addMethod, type, tccl);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalStateException(
+                            "Unable to construct the type handle for " + removedBean + ": " + e.getMessage());
+                }
+                addMethod.invokeInterfaceMethod(MethodDescriptors.SET_ADD, typesHandle, typeHandle);
             }
-            beansWritten++;
 
-            // Append to the addBeans() method body
-            beanIdToBeanHandle = addBeansMethod.getMethodParam(0);
+            // Qualifiers
+            ResultHandle qualifiersHandle;
+            if (!removedBean.getQualifiers().isEmpty() && !removedBean.hasDefaultQualifiers()) {
+
+                qualifiersHandle = addMethod.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+
+                for (AnnotationInstance qualifierAnnotation : removedBean.getQualifiers()) {
+                    if (DotNames.ANY.equals(qualifierAnnotation.name())) {
+                        // Skip @Any
+                        continue;
+                    }
+                    BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
+                    if (qualifier != null) {
+                        addMethod.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiersHandle,
+                                qualifier.getLiteralInstance(addMethod));
+                    } else {
+                        // Create annotation literal first
+                        ClassInfo qualifierClass = removedBean.getDeployment().getQualifier(qualifierAnnotation.name());
+                        addMethod.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiersHandle,
+                                annotationLiterals.process(addMethod, classOutput,
+                                        qualifierClass, qualifierAnnotation,
+                                        Types.getPackageName(componentsProvider.getClassName())));
+                    }
+                }
+                qualifiersHandle = addMethod
+                        .invokeStaticMethod(MethodDescriptors.COLLECTIONS_UNMODIFIABLE_SET, qualifiersHandle);
+            } else {
+                qualifiersHandle = addMethod.loadNull();
+            }
+
+            InjectableBean.Kind kind;
+            String description = null;
+            if (removedBean.isClassBean()) {
+                kind = null;
+                description = removedBean.getTarget().get().toString();
+            } else if (removedBean.isProducerField()) {
+                kind = InjectableBean.Kind.PRODUCER_FIELD;
+                description = removedBean.getTarget().get().asField().declaringClass().name() + "#"
+                        + removedBean.getTarget().get().asField().name();
+            } else if (removedBean.isProducerMethod()) {
+                kind = InjectableBean.Kind.PRODUCER_METHOD;
+                description = removedBean.getTarget().get().asMethod().declaringClass().name() + "#"
+                        + removedBean.getTarget().get().asMethod().name() + "()";
+            } else {
+                // Interceptors are never removed
+                kind = InjectableBean.Kind.SYNTHETIC;
+            }
+
+            ResultHandle kindHandle = kind != null ? addMethod.readStaticField(
+                    FieldDescriptor.of(InjectableBean.Kind.class, kind.toString(), InjectableBean.Kind.class))
+                    : addMethod.loadNull();
+            ResultHandle removedBeanHandle = addMethod.newInstance(MethodDescriptors.REMOVED_BEAN_IMPL,
+                    kindHandle, description != null ? addMethod.load(description) : addMethod.loadNull(),
+                    typesHandle,
+                    qualifiersHandle);
+            addMethod.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, removedBeansHandle, removedBeanHandle);
+        }
+
+    }
+
+    static class BeanAdder extends ComponentAdder<BeanInfo> {
+
+        private final Set<BeanInfo> processedBeans;
+        private final ResultHandle beanIdToBeanHandle;
+        private final Map<BeanInfo, String> beanToGeneratedName;
+
+        public BeanAdder(ClassCreator componentsProvider, MethodCreator getComponentsMethod, Set<BeanInfo> processed,
+                ResultHandle beanIdToBeanHandle, Map<BeanInfo, String> beanToGeneratedName) {
+            super(getComponentsMethod, componentsProvider);
+            this.processedBeans = processed;
+            this.beanIdToBeanHandle = beanIdToBeanHandle;
+            this.beanToGeneratedName = beanToGeneratedName;
+        }
+
+        @Override
+        MethodCreator newAddMethod() {
+            return componentsProvider.getMethodCreator(ADD_BEANS + group++, void.class, Map.class)
+                    .setModifiers(ACC_PRIVATE);
+        }
+
+        @Override
+        void invokeAddMethod() {
+            getComponentsMethod.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(componentsProvider.getClassName(),
+                            addMethod.getMethodDescriptor().getName(), void.class, Map.class),
+                    getComponentsMethod.getThis(), beanIdToBeanHandle);
+        }
+
+        @Override
+        void addComponentInternal(BeanInfo bean) {
+            ResultHandle beanIdToBeanHandle = addMethod.getMethodParam(0);
             String beanType = beanToGeneratedName.get(bean);
             if (beanType == null) {
                 throw new IllegalStateException("No bean type found for: " + bean);
@@ -396,19 +512,19 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                             "Declaring bean of a producer bean is not available - most probably an unsupported circular dependency use case \n - declaring bean: "
                                     + bean.getDeclaringBean() + "\n - producer bean: " + bean);
                 }
-                params.add(addBeansMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
-                        beanIdToBeanHandle, addBeansMethod.load(bean.getDeclaringBean().getIdentifier())));
+                params.add(addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
+                        beanIdToBeanHandle, addMethod.load(bean.getDeclaringBean().getIdentifier())));
                 paramTypes.add(Type.getDescriptor(Supplier.class));
             }
             for (InjectionPointInfo injectionPoint : injectionPoints) {
                 if (processedBeans.contains(injectionPoint.getResolvedBean())) {
-                    params.add(addBeansMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
-                            beanIdToBeanHandle, addBeansMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
+                    params.add(addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
+                            beanIdToBeanHandle, addMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
                 } else {
                     // Dependency was not processed yet - use MapValueSupplier
-                    params.add(addBeansMethod.newInstance(
+                    params.add(addMethod.newInstance(
                             MethodDescriptors.MAP_VALUE_SUPPLIER_CONSTRUCTOR,
-                            beanIdToBeanHandle, addBeansMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
+                            beanIdToBeanHandle, addMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
                 }
                 paramTypes.add(Type.getDescriptor(Supplier.class));
             }
@@ -417,34 +533,81 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                     if (BuiltinBean.resolvesTo(injectionPoint)) {
                         continue;
                     }
-                    params.add(addBeansMethod.newInstance(
+                    params.add(addMethod.newInstance(
                             MethodDescriptors.MAP_VALUE_SUPPLIER_CONSTRUCTOR,
-                            beanIdToBeanHandle, addBeansMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
+                            beanIdToBeanHandle, addMethod.load(injectionPoint.getResolvedBean().getIdentifier())));
                     paramTypes.add(Type.getDescriptor(Supplier.class));
                 }
             }
             for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
                 if (processedBeans.contains(interceptor)) {
-                    params.add(addBeansMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
-                            beanIdToBeanHandle, addBeansMethod.load(interceptor.getIdentifier())));
+                    params.add(addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_GET,
+                            beanIdToBeanHandle, addMethod.load(interceptor.getIdentifier())));
                 } else {
                     // Bound interceptor was not processed yet - use MapValueSupplier
-                    params.add(addBeansMethod.newInstance(
+                    params.add(addMethod.newInstance(
                             MethodDescriptors.MAP_VALUE_SUPPLIER_CONSTRUCTOR,
-                            beanIdToBeanHandle, addBeansMethod.load(interceptor.getIdentifier())));
+                            beanIdToBeanHandle, addMethod.load(interceptor.getIdentifier())));
                 }
                 paramTypes.add(Type.getDescriptor(Supplier.class));
             }
 
             // Foo_Bean bean = new Foo_Bean(bean3)
-            ResultHandle beanInstance = addBeansMethod.newInstance(
+            ResultHandle beanInstance = addMethod.newInstance(
                     MethodDescriptor.ofConstructor(beanType, paramTypes.toArray(new String[0])),
                     params.toArray(new ResultHandle[0]));
             // beans.put(id, bean)
-            final ResultHandle beanIdHandle = addBeansMethod.load(bean.getIdentifier());
-            addBeansMethod.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, beanIdToBeanHandle, beanIdHandle,
+            final ResultHandle beanIdHandle = addMethod.load(bean.getIdentifier());
+            addMethod.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, beanIdToBeanHandle, beanIdHandle,
                     beanInstance);
         }
+
+    }
+
+    static abstract class ComponentAdder<T extends InjectionTargetInfo> implements AutoCloseable {
+
+        private static final int GROUP_LIMIT = 30;
+        protected int group;
+        private int componentsAdded;
+        protected MethodCreator addMethod;
+        protected final MethodCreator getComponentsMethod;
+        protected final ClassCreator componentsProvider;
+
+        public ComponentAdder(MethodCreator getComponentsMethod, ClassCreator componentsProvider) {
+            this.group = 1;
+            this.getComponentsMethod = getComponentsMethod;
+            this.componentsProvider = componentsProvider;
+        }
+
+        public void close() {
+            if (addMethod != null) {
+                addMethod.returnValue(null);
+            }
+        }
+
+        void addComponent(T component) {
+
+            if (addMethod == null || componentsAdded >= GROUP_LIMIT) {
+                if (addMethod != null) {
+                    addMethod.returnValue(null);
+                }
+                componentsAdded = 0;
+                // First add next addX() method
+                addMethod = newAddMethod();
+                // Invoke addX() inside the getComponents() method
+                invokeAddMethod();
+            }
+            componentsAdded++;
+
+            // Append component to the addX() method body
+            addComponentInternal(component);
+        }
+
+        abstract MethodCreator newAddMethod();
+
+        abstract void invokeAddMethod();
+
+        abstract void addComponentInternal(T component);
 
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -4,6 +4,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableBean.Kind;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
@@ -16,6 +17,7 @@ import io.quarkus.arc.impl.InvocationContexts;
 import io.quarkus.arc.impl.MapValueSupplier;
 import io.quarkus.arc.impl.Objects;
 import io.quarkus.arc.impl.Reflections;
+import io.quarkus.arc.impl.RemovedBeanImpl;
 import io.quarkus.gizmo.MethodDescriptor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -236,6 +238,9 @@ public final class MethodDescriptors {
     public static final MethodDescriptor CL_FOR_NAME = MethodDescriptor.ofMethod(Class.class, "forName", Class.class,
             String.class,
             boolean.class, ClassLoader.class);
+
+    public static final MethodDescriptor REMOVED_BEAN_IMPL = MethodDescriptor.ofConstructor(RemovedBeanImpl.class, Kind.class,
+            String.class, Set.class, Set.class);
 
     private MethodDescriptors() {
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
@@ -2,12 +2,14 @@ package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 public final class Components {
 
     private final Collection<InjectableBean<?>> beans;
+    private final Collection<RemovedBean> removedBeans;
     private final Collection<InjectableObserverMethod<?>> observers;
     private final Collection<InjectableContext> contexts;
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
@@ -15,10 +17,18 @@ public final class Components {
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings) {
+        this(beans, observers, contexts, transitiveInterceptorBindings, Collections.emptyList());
+    }
+
+    public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
+            Collection<InjectableContext> contexts,
+            Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings,
+            Collection<RemovedBean> removedBeans) {
         this.beans = beans;
         this.observers = observers;
         this.contexts = contexts;
         this.transitiveInterceptorBindings = transitiveInterceptorBindings;
+        this.removedBeans = removedBeans;
     }
 
     public Collection<InjectableBean<?>> getBeans() {
@@ -35,6 +45,10 @@ public final class Components {
 
     public Map<Class<? extends Annotation>, Set<Annotation>> getTransitiveInterceptorBindings() {
         return transitiveInterceptorBindings;
+    }
+
+    public Collection<RemovedBean> getRemovedBeans() {
+        return removedBeans;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
@@ -120,7 +120,16 @@ public interface InjectableBean<T> extends Bean<T>, InjectableReferenceProvider<
         PRODUCER_FIELD,
         PRODUCER_METHOD,
         SYNTHETIC,
-        INTERCEPTOR
+        INTERCEPTOR;
+
+        public static Kind from(String value) {
+            for (Kind kind : values()) {
+                if (kind.toString().equals(value)) {
+                    return kind;
+                }
+            }
+            return null;
+        }
 
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RemovedBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RemovedBean.java
@@ -1,0 +1,32 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/**
+ * An unused bean removed during the build process.
+ */
+public interface RemovedBean {
+
+    /**
+     * @return the kind of the bean
+     */
+    InjectableBean.Kind getKind();
+
+    /**
+     * @return the description
+     */
+    String getDescription();
+
+    /**
+     * @return the bean types
+     */
+    public Set<Type> getTypes();
+
+    /**
+     * @return the qualifiers
+     */
+    public Set<Annotation> getQualifiers();
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -11,6 +11,7 @@ import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableObserverMethod;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.arc.RemovedBean;
 import io.quarkus.arc.ResourceReferenceProvider;
 import io.quarkus.arc.impl.ArcCDIProvider.ArcCDI;
 import java.lang.annotation.Annotation;
@@ -22,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -71,6 +73,7 @@ public class ArcContainerImpl implements ArcContainer {
     private final AtomicBoolean running;
 
     private final List<InjectableBean<?>> beans;
+    private final List<RemovedBean> removedBeans;
     private final List<InjectableInterceptor<?>> interceptors;
     private final List<InjectableObserverMethod<?>> observers;
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
@@ -95,6 +98,7 @@ public class ArcContainerImpl implements ArcContainer {
         id = "" + ID_GENERATOR.incrementAndGet();
         running = new AtomicBoolean(true);
         beans = new ArrayList<>();
+        removedBeans = new ArrayList<>();
         interceptors = new ArrayList<>();
         observers = new ArrayList<>();
         transitiveInterceptorBindings = new HashMap<>();
@@ -114,6 +118,7 @@ public class ArcContainerImpl implements ArcContainer {
                     beans.add(bean);
                 }
             }
+            removedBeans.addAll(components.getRemovedBeans());
             observers.addAll(components.getObservers());
             // Add custom contexts
             for (InjectableContext context : components.getContexts()) {
@@ -356,6 +361,7 @@ public class ArcContainerImpl implements ArcContainer {
             Reflections.clearCaches();
             contexts.clear();
             beans.clear();
+            removedBeans.clear();
             resolved.clear();
             observers.clear();
             running.set(false);
@@ -367,6 +373,10 @@ public class ArcContainerImpl implements ArcContainer {
 
     public List<InjectableBean<?>> getBeans() {
         return new ArrayList<>(beans);
+    }
+
+    public List<RemovedBean> getRemovedBeans() {
+        return Collections.unmodifiableList(removedBeans);
     }
 
     public List<InjectableInterceptor<?>> getInterceptors() {
@@ -580,10 +590,37 @@ public class ArcContainerImpl implements ArcContainer {
     }
 
     List<InjectableBean<?>> getMatchingBeans(Resolvable resolvable) {
-        List<InjectableBean<?>> matching = new ArrayList<>();
+        List<InjectableBean<?>> matching = new LinkedList<>();
         for (InjectableBean<?> bean : beans) {
             if (matches(bean, resolvable.requiredType, resolvable.qualifiers)) {
                 matching.add(bean);
+            }
+        }
+        if (matching.isEmpty() && !removedBeans.isEmpty()) {
+            List<RemovedBean> removedMatching = new LinkedList<>();
+            for (RemovedBean removedBean : removedBeans) {
+                if (matches(removedBean.getTypes(), removedBean.getQualifiers(), resolvable.requiredType,
+                        resolvable.qualifiers)) {
+                    removedMatching.add(removedBean);
+                }
+            }
+            if (!removedMatching.isEmpty()) {
+                String separator = "====================";
+                String msg = "\n%1$s%1$s%1$s%1$s\n"
+                        + "CDI: programmatic lookup problem detected\n"
+                        + "-----------------------------------------\n"
+                        + "At least one bean matched the required type and qualifiers but was marked as unused and removed during build\n"
+                        + "Removed beans:\n\t- %2$s\n"
+                        + "Required type: %3$s\n"
+                        + "Required qualifiers: %4$s\n"
+                        + "Solutions:\n"
+                        + "\t- Application developers can eliminate false positives via the @Unremovable annotation\n"
+                        + "\t- Extensions can eliminate false positives via build items, e.g. using the UnremovableBeanBuildItem\n"
+                        + "\t- See also https://quarkus.io/guides/cdi-reference#remove_unused_beans\n"
+                        + "%1$s%1$s%1$s%1$s\n";
+                LOGGER.warnf(msg, separator,
+                        removedMatching.stream().map(Object::toString).collect(Collectors.joining("\n\t- ")),
+                        resolvable.requiredType, Arrays.toString(resolvable.qualifiers));
             }
         }
         return matching;
@@ -683,10 +720,14 @@ public class ArcContainerImpl implements ArcContainer {
     }
 
     private boolean matches(InjectableBean<?> bean, Type requiredType, Annotation... qualifiers) {
-        if (!BeanTypeAssignabilityRules.matches(requiredType, bean.getTypes())) {
+        return matches(bean.getTypes(), bean.getQualifiers(), requiredType, qualifiers);
+    }
+
+    private boolean matches(Set<Type> beanTypes, Set<Annotation> beanQualifiers, Type requiredType, Annotation... qualifiers) {
+        if (!BeanTypeAssignabilityRules.matches(requiredType, beanTypes)) {
             return false;
         }
-        return Qualifiers.hasQualifiers(bean, qualifiers);
+        return Qualifiers.hasQualifiers(beanQualifiers, qualifiers);
     }
 
     static ArcContainerImpl unwrap(ArcContainer container) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.impl;
 
-import io.quarkus.arc.InjectableBean;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -34,17 +33,13 @@ public final class Qualifiers {
         }
     }
 
-    static boolean hasQualifiers(InjectableBean<?> bean, Annotation... requiredQualifiers) {
+    static boolean hasQualifiers(Set<Annotation> beanQualifiers, Annotation... requiredQualifiers) {
         for (Annotation qualifier : requiredQualifiers) {
-            if (!hasQualifier(bean, qualifier)) {
+            if (!hasQualifier(beanQualifiers, qualifier)) {
                 return false;
             }
         }
         return true;
-    }
-
-    static boolean hasQualifier(InjectableBean<?> bean, Annotation requiredQualifier) {
-        return hasQualifier(bean.getQualifiers(), requiredQualifier);
     }
 
     static boolean hasQualifier(Iterable<Annotation> qualifiers, Annotation requiredQualifier) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
@@ -1,0 +1,52 @@
+package io.quarkus.arc.impl;
+
+import io.quarkus.arc.InjectableBean.Kind;
+import io.quarkus.arc.RemovedBean;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Set;
+
+public final class RemovedBeanImpl implements RemovedBean {
+
+    private final Kind kind;
+    private final String description;
+    private final Set<Type> types;
+    private final Set<Annotation> qualifiers;
+
+    public RemovedBeanImpl(Kind kind, String description, Set<Type> types, Set<Annotation> qualifiers) {
+        this.kind = kind != null ? kind : Kind.CLASS;
+        this.description = description;
+        this.types = Collections.unmodifiableSet(types);
+        this.qualifiers = qualifiers != null ? Collections.unmodifiableSet(qualifiers) : Qualifiers.DEFAULT_QUALIFIERS;
+    }
+
+    @Override
+    public Kind getKind() {
+        return kind;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return types;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(kind).append(" bean ").append(description).append(" [types=")
+                .append(types).append(", qualifiers=").append(qualifiers).append("]");
+        return builder.toString();
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.impl.ArcContainerImpl;
 import io.quarkus.arc.test.ArcTestContainer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -61,6 +62,7 @@ public class RemoveUnusedBeansTest {
         // Producer is unused, declaring bean is only used via Instance
         assertTrue(container.instance(UsedViaInstanceWithUnusedProducer.class).isAvailable());
         assertFalse(container.instance(Long.class).isAvailable());
+        assertFalse(ArcContainerImpl.instance().getRemovedBeans().isEmpty());
     }
 
     @Dependent
@@ -190,7 +192,7 @@ public class RemoveUnusedBeansTest {
     static class UsedViaInstanceWithUnusedProducer {
 
         @Produces
-        Long unusedLong = new Long(0);
+        Long unusedLong = Long.valueOf(0);
     }
 
     @Singleton

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultITCase.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class AgroalVaultITCase {

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -19,6 +20,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class AgroalVaultKv1ITCase {

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -15,6 +16,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestExtension;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultKv1ITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultAppRoleITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleWrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleWrapITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultAppRoleWrapITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -22,6 +23,7 @@ import io.quarkus.vault.auth.VaultKubernetesAuthConfig;
 import io.quarkus.vault.auth.VaultKubernetesAuthRole;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultAuthITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultClientTokenWrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultClientTokenWrapITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultClientTokenWrapITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -77,6 +78,7 @@ import io.quarkus.vault.test.client.TestVaultClient;
 import io.quarkus.vault.test.client.dto.VaultTransitHash;
 import io.quarkus.vault.test.client.dto.VaultTransitHashBody;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKubernetesITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKubernetesITCase.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -19,6 +20,7 @@ import io.quarkus.vault.runtime.config.VaultAuthenticationType;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultKubernetesITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiPathConfigITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiPathConfigITCase.java
@@ -6,6 +6,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -15,6 +16,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultMultiPathConfigITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultSysITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultSysITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -21,6 +22,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.sys.VaultSealStatus;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultSysITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTOTPITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTOTPITCase.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -21,6 +22,7 @@ import io.quarkus.vault.secrets.totp.KeyConfiguration;
 import io.quarkus.vault.secrets.totp.KeyDefinition;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultTOTPITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,6 +40,7 @@ import io.quarkus.vault.transit.TransitContext;
 import io.quarkus.vault.transit.VaultVerificationBatchException;
 import io.quarkus.vault.transit.VerificationRequest;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 public class VaultTransitITCase {
 
     private static final Logger log = Logger.getLogger(VaultTransitITCase.class);

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv1WrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv1WrapITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultUserpassKvv1WrapITCase {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv2WrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv2WrapITCase.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/11879")
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultUserpassKvv2WrapITCase {


### PR DESCRIPTION
- previously, we only detected this problem and logged a warning when
obtaining a bean instance via BeanContainer (extensions)
- now we also cover CDI.current() and injected
javax.enterprise.inject.Instance
- the warning message was improved - include much more information
- added /quarkus/arc/removed-beans debug endpoint in the development
mode