### PR TITLE
Gradle IT: if set, pass maven.repo.local to the run task

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
@@ -43,7 +43,6 @@ public class MultiModuleUberJarTest extends QuarkusGradleWrapperTestBase {
             }, output, ConditionTimeoutException.class);
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
-
             assertThatOutputWorksCorrectly(logs);
 
             // test that the http response is correct

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -49,7 +49,7 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
                 }
             });
             testDevMode();
-        } catch (Exception e) {
+        } catch (Exception | AssertionError e) {
             if (buildResult[0] != null) {
                 System.err.println("BELOW IS THE CAPTURED LOGGING OF THE FAILED GRADLE TEST PROJECT BUILD");
                 System.err.println(buildResult[0].getOutput());

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
@@ -24,3 +24,10 @@ compileJava {
 application {
     mainClass = 'org.acme.EntryPoint'
 }
+
+run {
+    // propagate the custom local maven repo, in case it's configured
+    if (System.properties.containsKey('maven.repo.local')) {
+        systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
+    }
+}


### PR DESCRIPTION
In case the local maven repo specified with maven.repo.local system property, it should be propagated to the run task explicitly in the config.