### PR TITLE
Bean Validation support in reactive routes

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -475,6 +475,40 @@ id: 3
 
 ----
 
+=== Using Bean Validation
+
+You can combine reactive routes and Bean Validation.
+First, don't forget to add the `quarkus-hibernate-validator` extension to your project.
+Then, you can add constraints to your route parameter (annotated with `@Param` or `@Body`):
+
+[source,java]
+----
+@Route(produces = "application/json")
+Person createPerson(@Body @Valid Person person, @NonNull @Param("id") String primaryKey) {
+  // ...
+}
+----
+
+If the parameters do not pass the tests, it returns an HTTP 400 response.
+If the request accepts JSON payload, the response follows the https://opensource.zalando.com/problem/constraint-violation/[Problem] format.
+
+When returning an object or a `Uni`, you can also use the `@Valid` annotation:
+
+[source,java]
+----
+@Route(...)
+@Valid Uni<Person> createPerson(@Body @Valid Person person, @NonNull @Param("id") String primaryKey) {
+  // ...
+}
+----
+
+If the item produced by the route does not pass the validation, it returns a HTTP 500 response.
+If the request accepts JSON payload, the response follows the https://opensource.zalando.com/problem/constraint-violation/[Problem] format.
+
+Note that only `@Valid` is supported on the return type.
+The returned class can use any constraint.
+In the case of `Uni`, it checks the item produced asynchronously.
+
 == Using the Vert.x Web Router
 
 You can also register your route directly on the _HTTP routing layer_ by registering routes directly on the `Router` object.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -73,7 +73,7 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         if (event.failure() instanceof AuthenticationFailedException) {
             return; //handled elsewhere
         }
-        event.response().setStatusCode(500);
+        event.response().setStatusCode(event.statusCode() > 0 ? event.statusCode() : 500);
         String uuid = BASE_ID + ERROR_COUNT.incrementAndGet();
         String details = "";
         String stack = "";

--- a/extensions/vertx-web/deployment/pom.xml
+++ b/extensions/vertx-web/deployment/pom.xml
@@ -26,6 +26,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-spi</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -35,6 +39,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
@@ -1,8 +1,11 @@
 package io.quarkus.vertx.web.deployment;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+
+import io.quarkus.hibernate.validator.spi.BeanValidationAnnotationsBuildItem;
 
 /**
  * Describe a request handler.
@@ -10,9 +13,11 @@ import org.jboss.jandex.Type;
 class HandlerDescriptor {
 
     private final MethodInfo method;
+    private final BeanValidationAnnotationsBuildItem validationAnnotations;
 
-    HandlerDescriptor(MethodInfo method) {
+    HandlerDescriptor(MethodInfo method, BeanValidationAnnotationsBuildItem bvAnnotations) {
         this.method = method;
+        this.validationAnnotations = bvAnnotations;
     }
 
     Type getReturnType() {
@@ -29,6 +34,39 @@ class HandlerDescriptor {
 
     boolean isReturningMulti() {
         return method.returnType().name().equals(DotNames.MULTI);
+    }
+
+    /**
+     * @return {@code true} if the method is annotated with a constraint or {@code @Valid} or any parameter has such kind of
+     *         annotation.
+     */
+    boolean requireValidation() {
+        if (validationAnnotations == null) {
+            return false;
+        }
+        for (AnnotationInstance annotation : method.annotations()) {
+            String name = annotation.name().toString();
+            if (validationAnnotations.getAllAnnotations().contains(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return {@code true} if the method is annotated with {@code @Valid}.
+     */
+    boolean isProducedResponseValidated() {
+        if (validationAnnotations == null) {
+            return false;
+        }
+        for (AnnotationInstance annotation : method.annotations()) {
+            String name = annotation.name().toString();
+            if (validationAnnotations.getValidAnnotation().equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     Type getContentType() {

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -4,8 +4,8 @@ import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.vertx.web.deployment.DotNames.PARAM;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -70,6 +71,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldCreator;
@@ -77,6 +79,8 @@ import io.quarkus.gizmo.FunctionCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.hibernate.validator.spi.BeanValidationAnnotationsBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
@@ -96,6 +100,8 @@ import io.quarkus.vertx.web.runtime.RoutingExchangeImpl;
 import io.quarkus.vertx.web.runtime.UniFailureCallback;
 import io.quarkus.vertx.web.runtime.VertxWebRecorder;
 import io.quarkus.vertx.web.runtime.devmode.ResourceNotFoundRecorder;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -125,10 +131,13 @@ class VertxWebProcessor {
 
     @BuildStep
     void unremovableBeans(BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
-        unremovableBeans.produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE));
-        unremovableBeans.produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTES));
         unremovableBeans
-                .produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE_FILTER));
+                .produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE));
+        unremovableBeans
+                .produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTES));
+        unremovableBeans
+                .produce(UnremovableBeanBuildItem
+                        .beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE_FILTER));
     }
 
     @BuildStep
@@ -209,11 +218,14 @@ class VertxWebProcessor {
             TransformedAnnotationsBuildItem transformedAnnotations,
             ShutdownContextBuildItem shutdown,
             LaunchModeBuildItem launchMode,
-            BuildProducer<RouteDescriptionBuildItem> descriptions) throws IOException {
+            BuildProducer<RouteDescriptionBuildItem> descriptions,
+            Capabilities capabilities,
+            Optional<BeanValidationAnnotationsBuildItem> beanValidationAnnotations) {
 
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
         IndexView index = beanArchive.getIndex();
         Map<RouteMatcher, MethodInfo> matchers = new HashMap<>();
+        boolean validatorAvailable = capabilities.isPresent(Capability.HIBERNATE_VALIDATOR);
 
         for (AnnotatedRouteHandlerBuildItem businessMethod : routeHandlerBusinessMethods) {
             AnnotationInstance routeBaseAnnotation = businessMethod.getRouteBase();
@@ -292,9 +304,11 @@ class VertxWebProcessor {
                 }
 
                 if (routeHandler == null) {
-                    String handlerClass = generateHandler(new HandlerDescriptor(businessMethod.getMethod()),
+                    String handlerClass = generateHandler(
+                            new HandlerDescriptor(businessMethod.getMethod(), beanValidationAnnotations.orElse(null)),
                             businessMethod.getBean(), businessMethod.getMethod(), classOutput, transformedAnnotations,
-                            routeString, reflectiveHierarchy, produces.length > 0 ? produces[0] : null);
+                            routeString, reflectiveHierarchy, produces.length > 0 ? produces[0] : null,
+                            validatorAvailable);
                     reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, handlerClass));
                     routeHandler = recorder.createHandler(handlerClass);
                     routeHandlers.put(routeString, routeHandler);
@@ -319,7 +333,7 @@ class VertxWebProcessor {
                             handlerType = HandlerType.FAILURE;
                             break;
                         default:
-                            throw new IllegalStateException("Unkown type " + typeString);
+                            throw new IllegalStateException("Unknown type " + typeString);
                     }
                 }
                 routeProducer.produce(new RouteBuildItem(routeFunction, routeHandler, handlerType));
@@ -340,9 +354,10 @@ class VertxWebProcessor {
         }
 
         for (AnnotatedRouteFilterBuildItem filterMethod : routeFilterBusinessMethods) {
-            String handlerClass = generateHandler(new HandlerDescriptor(filterMethod.getMethod()),
+            String handlerClass = generateHandler(
+                    new HandlerDescriptor(filterMethod.getMethod(), beanValidationAnnotations.orElse(null)),
                     filterMethod.getBean(), filterMethod.getMethod(), classOutput, transformedAnnotations,
-                    filterMethod.getRouteFilter().toString(true), reflectiveHierarchy, null);
+                    filterMethod.getRouteFilter().toString(true), reflectiveHierarchy, null, validatorAvailable);
             reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, handlerClass));
             Handler<RoutingContext> routingHandler = recorder.createHandler(handlerClass);
             AnnotationValue priorityValue = filterMethod.getRouteFilter().value();
@@ -386,14 +401,16 @@ class VertxWebProcessor {
                     String.format("Route filter method must return void [method: %s, bean: %s]", method, bean));
         }
         List<Type> params = method.parameters();
-        if (params.size() != 1 || !params.get(0).name().equals(io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT)) {
+        if (params.size() != 1 || !params.get(0).name()
+                .equals(io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT)) {
             throw new IllegalStateException(String.format(
                     "Route filter method must accept exactly one parameter of type %s: %s [method: %s, bean: %s]",
                     io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT, params, method, bean));
         }
     }
 
-    private void validateRouteMethod(BeanInfo bean, MethodInfo method, TransformedAnnotationsBuildItem transformedAnnotations) {
+    private void validateRouteMethod(BeanInfo bean, MethodInfo method,
+            TransformedAnnotationsBuildItem transformedAnnotations) {
         List<Type> params = method.parameters();
         if (params.isEmpty()) {
             if (method.returnType().kind() == Kind.VOID && params.isEmpty()) {
@@ -412,17 +429,20 @@ class VertxWebProcessor {
             }
             int idx = 0;
             for (Type paramType : params) {
-                Set<AnnotationInstance> paramAnnotations = Annotations.getParameterAnnotations(transformedAnnotations, method,
-                        idx);
+                Set<AnnotationInstance> paramAnnotations = Annotations
+                        .getParameterAnnotations(transformedAnnotations, method,
+                                idx);
                 List<ParameterInjector> injectors = getMatchingInjectors(paramType, paramAnnotations);
                 if (injectors.isEmpty()) {
                     throw new IllegalStateException(String.format(
-                            "No parameter injector found for parameter %s of route method %s declared on %s", idx, method,
+                            "No parameter injector found for parameter %s of route method %s declared on %s", idx,
+                            method,
                             bean));
                 }
                 if (injectors.size() > 1) {
                     throw new IllegalStateException(String.format(
-                            "Multiple parameter injectors found for parameter %s of route method %s declared on %s", idx,
+                            "Multiple parameter injectors found for parameter %s of route method %s declared on %s",
+                            idx,
                             method, bean));
                 }
                 idx++;
@@ -432,7 +452,13 @@ class VertxWebProcessor {
 
     private String generateHandler(HandlerDescriptor desc, BeanInfo bean, MethodInfo method, ClassOutput classOutput,
             TransformedAnnotationsBuildItem transformedAnnotations, String hashSuffix,
-            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy, String defaultProduces) {
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy, String defaultProduces,
+            boolean validatorAvailable) {
+
+        if (desc.requireValidation() && !validatorAvailable) {
+            throw new IllegalStateException(
+                    "A route requires validation, but the Hibernate Validator extension is not present");
+        }
 
         String baseName;
         if (bean.getImplClazz().enclosingClass() != null) {
@@ -468,8 +494,16 @@ class VertxWebProcessor {
                     .setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
 
-        implementConstructor(bean, invokerCreator, beanField, contextField, containerField);
-        implementInvoke(desc, bean, method, invokerCreator, beanField, contextField, containerField, transformedAnnotations,
+        FieldCreator validatorField = null;
+        if (desc.isProducedResponseValidated()) {
+            // If the produced item needs to be validated, we inject the Validator
+            validatorField = invokerCreator.getFieldCreator("validator", Methods.VALIDATION_VALIDATOR)
+                    .setModifiers(ACC_PUBLIC | ACC_FINAL);
+        }
+
+        implementConstructor(bean, invokerCreator, beanField, contextField, containerField, validatorField);
+        implementInvoke(desc, bean, method, invokerCreator, beanField, contextField, containerField, validatorField,
+                transformedAnnotations,
                 reflectiveHierarchy, defaultProduces);
 
         invokerCreator.close();
@@ -478,7 +512,7 @@ class VertxWebProcessor {
 
     void implementConstructor(BeanInfo bean, ClassCreator invokerCreator, FieldCreator beanField,
             FieldCreator contextField,
-            FieldCreator containerField) {
+            FieldCreator containerField, FieldCreator validatorField) {
         MethodCreator constructor = invokerCreator.getMethodCreator("<init>", void.class);
         // Invoke super()
         constructor.invokeSpecialMethod(Methods.OBJECT_CONSTRUCTOR, constructor.getThis());
@@ -500,11 +534,17 @@ class VertxWebProcessor {
         } else {
             constructor.writeInstanceField(containerField.getFieldDescriptor(), constructor.getThis(), containerHandle);
         }
+
+        if (validatorField != null) {
+            constructor.writeInstanceField(validatorField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.invokeStaticMethod(Methods.VALIDATION_GET_VALIDATOR, containerHandle));
+        }
+
         constructor.returnValue(null);
     }
 
     void implementInvoke(HandlerDescriptor descriptor, BeanInfo bean, MethodInfo method, ClassCreator invokerCreator,
-            FieldCreator beanField, FieldCreator contextField, FieldCreator containerField,
+            FieldCreator beanField, FieldCreator contextField, FieldCreator containerField, FieldCreator validatorField,
             TransformedAnnotationsBuildItem transformedAnnotations,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy, String defaultProduces) {
         // The descriptor is: void invoke(RoutingContext rc)
@@ -538,8 +578,9 @@ class VertxWebProcessor {
                         "Context not active: " + bean.getScope().getDotName());
             }
             // First try to obtain the bean via Context.get(bean)
-            invoke.assign(beanInstanceHandle, invoke.invokeInterfaceMethod(Methods.CONTEXT_GET_IF_PRESENT, contextInvokeHandle,
-                    beanHandle));
+            invoke.assign(beanInstanceHandle,
+                    invoke.invokeInterfaceMethod(Methods.CONTEXT_GET_IF_PRESENT, contextInvokeHandle,
+                            beanHandle));
             // If not present, try Context.get(bean,creationalContext)
             BytecodeCreator doesNotExist = invoke.ifNull(beanInstanceHandle).trueBranch();
             doesNotExist.assign(beanInstanceHandle,
@@ -557,10 +598,12 @@ class VertxWebProcessor {
 
         int idx = 0;
         for (Type paramType : parameters) {
-            Set<AnnotationInstance> paramAnnotations = Annotations.getParameterAnnotations(transformedAnnotations, method, idx);
+            Set<AnnotationInstance> paramAnnotations = Annotations
+                    .getParameterAnnotations(transformedAnnotations, method, idx);
             // At this point we can be sure that a matching injector is available
-            paramHandles[idx] = getMatchingInjectors(paramType, paramAnnotations).get(0).getResultHandle(method, paramType,
-                    paramAnnotations, routingContext, invoke, idx, reflectiveHierarchy);
+            paramHandles[idx] = getMatchingInjectors(paramType, paramAnnotations).get(0)
+                    .getResultHandle(method, paramType,
+                            paramAnnotations, routingContext, invoke, idx, reflectiveHierarchy);
             parameterTypes[idx] = paramType.name().toString();
             idx++;
         }
@@ -574,7 +617,32 @@ class VertxWebProcessor {
                 defaultProduces == null ? invoke.loadNull() : invoke.load(defaultProduces));
 
         // Invoke the business method handler
-        ResultHandle res = invoke.invokeVirtualMethod(methodDescriptor, beanInstanceHandle, paramHandles);
+        AssignableResultHandle res;
+        if (descriptor.isReturningUni()) {
+            res = invoke.createVariable(Uni.class);
+        } else if (descriptor.isReturningMulti()) {
+            res = invoke.createVariable(Multi.class);
+        } else {
+            res = invoke.createVariable(Object.class);
+        }
+        invoke.assign(res, invoke.loadNull());
+        if (!descriptor.requireValidation()) {
+            ResultHandle value = invoke.invokeVirtualMethod(methodDescriptor, beanInstanceHandle, paramHandles);
+            if (value != null) {
+                invoke.assign(res, value);
+            }
+        } else {
+            TryBlock block = invoke.tryBlock();
+            ResultHandle value = block.invokeVirtualMethod(methodDescriptor, beanInstanceHandle, paramHandles);
+            if (value != null) {
+                block.assign(res, value);
+            }
+            CatchBlockCreator caught = block.addCatch(Methods.VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION);
+            caught.invokeStaticMethod(
+                    Methods.VALIDATION_HANDLE_VIOLATION_EXCEPTION,
+                    caught.getCaughtException(), invoke.getMethodParam(0));
+            caught.returnValue(caught.loadNull());
+        }
 
         // Get the response: HttpServerResponse response = rc.response()
         MethodDescriptor end = Methods.getEndMethodForContentType(descriptor);
@@ -588,7 +656,9 @@ class VertxWebProcessor {
             // If the provided item is not null, if it's a string or buffer, the response.end method is used to write the response
             // If the provided item is not null, and it's an object, the item is mapped to JSON and written into the response
 
-            FunctionCreator successCallback = getUniOnItemCallback(descriptor, invoke, routingContext, end, response);
+            FunctionCreator successCallback = getUniOnItemCallback(descriptor, invoke, routingContext, end, response,
+                    validatorField);
+
             ResultHandle failureCallback = getUniOnFailureCallback(invoke, routingContext);
 
             ResultHandle sub = invoke.invokeInterfaceMethod(Methods.UNI_SUBSCRIBE, res);
@@ -598,7 +668,6 @@ class VertxWebProcessor {
             registerForReflection(descriptor.getContentType(), reflectiveHierarchy);
 
         } else if (descriptor.isReturningMulti()) {
-
             // 3 cases - regular multi vs. sse multi vs. json array multi, we need to check the type.
             BranchResult isItSSE = invoke.ifTrue(invoke.invokeStaticMethod(Methods.IS_SSE, res));
             BytecodeCreator isSSE = isItSSE.trueBranch();
@@ -610,6 +679,7 @@ class VertxWebProcessor {
             BytecodeCreator isJson = isItJson.trueBranch();
             handleJsonArrayMulti(descriptor, isJson, routingContext, res);
             isJson.close();
+
             BytecodeCreator isRegular = isItJson.falseBranch();
             handleRegularMulti(descriptor, isRegular, routingContext, res);
             isRegular.close();
@@ -623,7 +693,9 @@ class VertxWebProcessor {
             // If the method returned null, we fail
             // If the method returns string or buffer, the response.end method is used to write the response
             // If the method returns an object, the result is mapped to JSON and written into the response
-            ResultHandle content = getContentToWrite(descriptor, response, res, invoke);
+
+            ResultHandle content = getContentToWrite(descriptor, response, res, invoke, validatorField,
+                    invoke.getThis());
             invoke.invokeInterfaceMethod(end, response, content);
 
             registerForReflection(descriptor.getContentType(), reflectiveHierarchy);
@@ -637,8 +709,9 @@ class VertxWebProcessor {
         invoke.returnValue(null);
     }
 
-    private static final List<DotName> TYPES_IGNORED_FOR_REFLECTION = Arrays.asList(io.quarkus.arc.processor.DotNames.STRING,
-            DotNames.BUFFER, DotNames.JSON_ARRAY, DotNames.JSON_OBJECT);
+    private static final List<DotName> TYPES_IGNORED_FOR_REFLECTION = Arrays
+            .asList(io.quarkus.arc.processor.DotNames.STRING,
+                    DotNames.BUFFER, DotNames.JSON_ARRAY, DotNames.JSON_OBJECT);
 
     private static void registerForReflection(Type contentType,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
@@ -731,13 +804,13 @@ class VertxWebProcessor {
 
     /**
      * Generates the following function depending on the payload type
-     *
+     * <p>
      * If the method returns a {@code Uni<Void>}
      *
      * <pre>
      *     item -> rc.response().setStatusCode(204).end();
      * </pre>
-     *
+     * <p>
      * If the method returns a {@code Uni<Buffer>}:
      *
      * <pre>
@@ -750,7 +823,7 @@ class VertxWebProcessor {
      *       }
      *     }
      * </pre>
-     *
+     * <p>
      * If the method returns a {@code Uni<String>} :
      *
      * <pre>
@@ -762,7 +835,7 @@ class VertxWebProcessor {
      *       }
      *     }
      * </pre>
-     *
+     * <p>
      * If the method returns a {@code Uni<T>} :
      *
      * <pre>
@@ -775,7 +848,7 @@ class VertxWebProcessor {
      *       }
      *     }
      * </pre>
-     *
+     * <p>
      * This last version also set the {@code content-type} header to {@code application/json }if not set.
      *
      * @param descriptor the method descriptor
@@ -783,10 +856,11 @@ class VertxWebProcessor {
      * @param rc the reference to the routing context variable
      * @param end the end method to use
      * @param response the reference to the response variable
+     * @param validatorField the validator field if validation is enabled
      * @return the function creator
      */
     private FunctionCreator getUniOnItemCallback(HandlerDescriptor descriptor, MethodCreator invoke, ResultHandle rc,
-            MethodDescriptor end, ResultHandle response) {
+            MethodDescriptor end, ResultHandle response, FieldCreator validatorField) {
         FunctionCreator callback = invoke.createFunction(Consumer.class);
         BytecodeCreator creator = callback.getBytecode();
         if (Methods.isNoContent(descriptor)) { // Uni<Void> - so return a 204.
@@ -798,7 +872,8 @@ class VertxWebProcessor {
             BranchResult isItemNull = creator.ifNull(item);
 
             BytecodeCreator itemIfNotNull = isItemNull.falseBranch();
-            ResultHandle content = getContentToWrite(descriptor, response, item, itemIfNotNull);
+            ResultHandle content = getContentToWrite(descriptor, response, item, itemIfNotNull, validatorField,
+                    invoke.getThis());
             itemIfNotNull.invokeInterfaceMethod(end, response, content);
             itemIfNotNull.close();
 
@@ -812,13 +887,12 @@ class VertxWebProcessor {
     }
 
     private ResultHandle getUniOnFailureCallback(MethodCreator writer, ResultHandle routingContext) {
-        // new UniFailureCallback(ctx)
         return writer.newInstance(MethodDescriptor.ofConstructor(UniFailureCallback.class, RoutingContext.class),
                 routingContext);
     }
 
     private ResultHandle getContentToWrite(HandlerDescriptor descriptor, ResultHandle response, ResultHandle res,
-            BytecodeCreator writer) {
+            BytecodeCreator writer, FieldCreator validatorField, ResultHandle owner) {
         if (descriptor.isContentTypeString() || descriptor.isContentTypeBuffer()) {
             return res;
         }
@@ -833,7 +907,13 @@ class VertxWebProcessor {
 
         // Encode to Json
         Methods.setContentTypeToJson(response, writer);
-        return writer.invokeStaticMethod(Methods.JSON_ENCODE, res);
+        // Validate res if needed
+        if (descriptor.isProducedResponseValidated()) {
+            return Methods.validateProducedItem(response, writer, res, validatorField, owner);
+        } else {
+            return writer.invokeStaticMethod(Methods.JSON_ENCODE, res);
+        }
+
     }
 
     private static String dashify(String value) {
@@ -964,7 +1044,8 @@ class VertxWebProcessor {
                             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                         return invoke.newInstance(
                                 MethodDescriptor
-                                        .ofConstructor(io.vertx.reactivex.ext.web.RoutingContext.class, RoutingContext.class),
+                                        .ofConstructor(io.vertx.reactivex.ext.web.RoutingContext.class,
+                                                RoutingContext.class),
                                 routingContext);
                     }
                 }).build());
@@ -976,7 +1057,8 @@ class VertxWebProcessor {
                             ResultHandle routingContext, MethodCreator invoke, int position,
                             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                         return invoke
-                                .newInstance(MethodDescriptor.ofConstructor(RoutingExchangeImpl.class, RoutingContext.class),
+                                .newInstance(
+                                        MethodDescriptor.ofConstructor(RoutingExchangeImpl.class, RoutingContext.class),
                                         routingContext);
                     }
                 }).build());
@@ -1025,7 +1107,8 @@ class VertxWebProcessor {
                 .add(ParameterInjector.builder().matchType(DotNames.RX_HTTP_SERVER_RESPONSE)
                         .resultHandleProvider(new ResultHandleProvider() {
                             @Override
-                            public ResultHandle get(MethodInfo method, Type paramType, Set<AnnotationInstance> annotations,
+                            public ResultHandle get(MethodInfo method, Type paramType,
+                                    Set<AnnotationInstance> annotations,
                                     ResultHandle routingContext, MethodCreator invoke, int position,
                                     BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                                 return invoke.newInstance(
@@ -1132,7 +1215,8 @@ class VertxWebProcessor {
                         .requireAnnotations(DotNames.BODY)
                         .resultHandleProvider(new ResultHandleProvider() {
                             @Override
-                            public ResultHandle get(MethodInfo method, Type paramType, Set<AnnotationInstance> annotations,
+                            public ResultHandle get(MethodInfo method, Type paramType,
+                                    Set<AnnotationInstance> annotations,
                                     ResultHandle routingContext, MethodCreator invoke, int position,
                                     BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                                 if (paramType.name().equals(io.quarkus.arc.processor.DotNames.STRING)) {
@@ -1158,7 +1242,8 @@ class VertxWebProcessor {
                         .requireAnnotations(DotNames.BODY)
                         .resultHandleProvider(new ResultHandleProvider() {
                             @Override
-                            public ResultHandle get(MethodInfo method, Type paramType, Set<AnnotationInstance> annotations,
+                            public ResultHandle get(MethodInfo method, Type paramType,
+                                    Set<AnnotationInstance> annotations,
                                     ResultHandle routingContext, MethodCreator invoke, int position,
                                     BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                                 registerForReflection(paramType, reflectiveHierarchy);
@@ -1180,9 +1265,10 @@ class VertxWebProcessor {
     }
 
     private static IllegalStateException parameterNameNotAvailable(int position, MethodInfo method) {
-        return new IllegalStateException("Unable to determine the name of the parameter at position " + position + " in method "
-                + method.declaringClass().name() + "#" + method.name()
-                + "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or specify the appropriate annotation value");
+        return new IllegalStateException(
+                "Unable to determine the name of the parameter at position " + position + " in method "
+                        + method.declaringClass().name() + "#" + method.name()
+                        + "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or specify the appropriate annotation value");
 
     }
 
@@ -1215,7 +1301,8 @@ class VertxWebProcessor {
                         return false;
                     }
                     if (skipType.kind() == Kind.PARAMETERIZED_TYPE && skipType.name().equals(paramType.name())
-                            && skipType.asParameterizedType().arguments().equals(paramType.asParameterizedType().arguments())) {
+                            && skipType.asParameterizedType().arguments()
+                                    .equals(paramType.asParameterizedType().arguments())) {
                         return false;
                     }
                 }
@@ -1261,11 +1348,10 @@ class VertxWebProcessor {
 
         @Override
         public String toString() {
-            StringBuilder builder = new StringBuilder();
-            builder.append("ParameterInjector [matchTypes=").append(matchTypes).append(", skipTypes=").append(skipTypes)
-                    .append(", requiredAnnotationNames=")
-                    .append(requiredAnnotationNames).append("]");
-            return builder.toString();
+            String builder = "ParameterInjector [matchTypes=" + matchTypes + ", skipTypes=" + skipTypes
+                    + ", requiredAnnotationNames="
+                    + requiredAnnotationNames + "]";
+            return builder;
         }
 
         static class Builder {

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
@@ -1,0 +1,94 @@
+package io.quarkus.vertx.web.validation;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.emptyString;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.http.HttpMethod;
+
+public class MultiValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyRoutes.class));
+
+    @Test
+    public void test() {
+
+        // Valid parameter
+        given()
+                .queryParam("name", "neo")
+                .when()
+                .get("/query")
+                .then().statusCode(200);
+
+        // Input parameter violation - JSON
+        given()
+                .header("Accept", "application/json")
+                .queryParam("name", "doesNotMatch")
+                .when()
+                .get("/query")
+                .then().statusCode(400)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(400))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        // Input parameter violation - HTML
+        given()
+                .queryParam("name", "doesNotMatch")
+                .when()
+                .get("/query")
+                .then().statusCode(400)
+                .body(containsString("ConstraintViolation"))
+                .body(is(not(emptyString())));
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        @Route(methods = HttpMethod.GET, path = "/query")
+        public Multi<Greeting> getGreetingWithName(@Pattern(regexp = "ne.*") @NotNull @Param("name") String name) {
+            return Multi.createFrom().item(new Greeting(name, "hi"));
+        }
+
+    }
+
+    public static class Greeting {
+
+        private String name;
+        private String welcome;
+
+        public Greeting(String name, String welcome) {
+            this.name = name;
+            this.welcome = welcome;
+        }
+
+        @Length(min = 4)
+        public String getName() {
+            return name;
+        }
+
+        @Length(min = 4)
+        public String getWelcome() {
+            return welcome;
+        }
+    }
+
+}

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
@@ -1,0 +1,149 @@
+package io.quarkus.vertx.web.validation;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.emptyString;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.vertx.core.http.HttpMethod;
+
+public class SyncValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyRoutes.class));
+
+    @Test
+    public void test() {
+        // Valid result
+        get("/valid").then().statusCode(200)
+                .body("name", is("luke"))
+                .body("welcome", is("hello"));
+
+        // Valid parameter
+        given()
+                .queryParam("name", "neo")
+                .when()
+                .get("/query")
+                .then().statusCode(200);
+
+        // JSON output
+        given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/invalid")
+                .then()
+                .statusCode(500)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(500))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        // HTML output
+        get("/invalid")
+                .then()
+                .statusCode(500)
+                .body(containsString("ConstraintViolation"), is(not(emptyString())));
+
+        given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/invalid2").then().statusCode(500)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(500))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", anyOf(containsString("name"), containsString("welcome")))
+                .body("violations[0].message", is(not(emptyString())))
+                .body("violations[1].field", anyOf(containsString("name"), containsString("welcome")))
+                .body("violations[1].message", is(not(emptyString())));
+
+        // Input parameter violation - JSON
+        given()
+                .header("Accept", "application/json")
+                .queryParam("name", "doesNotMatch")
+                .when()
+                .get("/query")
+                .then().statusCode(400)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(400))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        // Input parameter violation - HTML
+        given()
+                .queryParam("name", "doesNotMatch")
+                .when()
+                .get("/query")
+                .then().statusCode(400)
+                .body(containsString("ConstraintViolation"))
+                .body(is(not(emptyString())));
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        @Route(methods = HttpMethod.GET, path = "/valid")
+        public Greeting getValidGreeting() {
+            return new Greeting("luke", "hello");
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/invalid")
+        @Valid
+        public Greeting getInvalidValidGreeting() {
+            return new Greeting("neo", "hello");
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/invalid2")
+        public @Valid Greeting getDoubleInValidGreeting() {
+            return new Greeting("neo", "hi");
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/query")
+        public Greeting getGreetingWithName(@Pattern(regexp = "ne.*") @NotNull @Param("name") String name) {
+            return new Greeting(name, "hi");
+        }
+
+    }
+
+    public static class Greeting {
+
+        private String name;
+        private String welcome;
+
+        public Greeting(String name, String welcome) {
+            this.name = name;
+            this.welcome = welcome;
+        }
+
+        @Length(min = 4)
+        public String getName() {
+            return name;
+        }
+
+        @Length(min = 4)
+        public String getWelcome() {
+            return welcome;
+        }
+    }
+
+}

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/UniValidationTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/UniValidationTest.java
@@ -1,0 +1,147 @@
+package io.quarkus.vertx.web.validation;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.emptyString;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpMethod;
+
+public class UniValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyRoutes.class));
+
+    @Test
+    public void test() {
+        // Valid result
+        get("/valid").then().statusCode(200)
+                .body("name", is("luke"))
+                .body("welcome", is("hello"));
+
+        // Valid parameter
+        given()
+                .queryParam("name", "neo")
+                .when()
+                .get("/query")
+                .then().statusCode(200);
+
+        // JSON output
+        given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/invalid")
+                .then()
+                .statusCode(500)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(500))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        // JSON output as it\s a Uni of object
+        given()
+                .when()
+                .get("/invalid")
+                .then()
+                .statusCode(500)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(500))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/invalid2").then().statusCode(500)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(500))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", anyOf(containsString("name"), containsString("welcome")))
+                .body("violations[0].message", is(not(emptyString())))
+                .body("violations[1].field", anyOf(containsString("name"), containsString("welcome")))
+                .body("violations[1].message", is(not(emptyString())));
+
+        // Input parameter violation - JSON
+        given()
+                .header("Accept", "application/json")
+                .queryParam("name", "doesNotMatch")
+                .when()
+                .get("/query")
+                .then().statusCode(400)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(400))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        @Route(methods = HttpMethod.GET, path = "/valid")
+        public Uni<Greeting> getValidGreeting() {
+            return Uni.createFrom().item(new Greeting("luke", "hello"));
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/invalid")
+        @Valid
+        public Uni<Greeting> getInvalidValidGreeting() {
+            return Uni.createFrom().item(new Greeting("neo", "hello"));
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/invalid2")
+        public @Valid Uni<Greeting> getDoubleInValidGreeting() {
+            return Uni.createFrom().item(new Greeting("neo", "hi"));
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/query")
+        public Uni<Greeting> getGreetingWithName(@Pattern(regexp = "ne.*") @NotNull @Param("name") String name) {
+            return Uni.createFrom().item(new Greeting(name, "hi"));
+        }
+
+    }
+
+    public static class Greeting {
+
+        private String name;
+        private String welcome;
+
+        public Greeting(String name, String welcome) {
+            this.name = name;
+            this.welcome = welcome;
+        }
+
+        @Length(min = 4)
+        public String getName() {
+            return name;
+        }
+
+        @Length(min = 4)
+        public String getWelcome() {
+            return welcome;
+        }
+    }
+
+}

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -40,6 +40,11 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
@@ -1,0 +1,87 @@
+package io.quarkus.vertx.web.runtime;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+
+import io.quarkus.arc.ArcContainer;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+public class ValidationSupport {
+
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String ACCEPT_HEADER = "Accept";
+    public static final String PROBLEM_TITLE = "title";
+    public static final String PROBLEM_DETAIL = "details";
+    public static final String PROBLEM_FIELD = "field";
+    public static final String PROBLEM_MESSAGE = "message";
+    public static final String PROBLEM_STATUS = "status";
+    public static final String PROBLEM_VIOLATIONS = "violations";
+
+    private ValidationSupport() {
+        // Avoid direct instantiation
+    }
+
+    public static Validator getValidator(ArcContainer container) {
+        return container.instance(Validator.class).get();
+    }
+
+    public static String mapViolationsToJson(Set<ConstraintViolation<?>> violations, HttpServerResponse response) {
+        response.setStatusCode(500);
+        JsonObject json = generateJsonResponse(violations, true);
+        return json.encode();
+    }
+
+    /**
+     * Generates a JSON response following https://opensource.zalando.com/problem/constraint-violation/
+     * 
+     * @param violations the violations
+     * @return the json object
+     */
+    private static JsonObject generateJsonResponse(Set<ConstraintViolation<?>> violations, boolean violationInProducedItem) {
+        JsonObject json = new JsonObject()
+                .put(PROBLEM_TITLE, "Constraint Violation")
+                .put(PROBLEM_DETAIL, "validation constraint violations");
+
+        JsonArray array = new JsonArray();
+        boolean isProduced = false;
+        for (ConstraintViolation<?> cv : violations) {
+            if (cv.getExecutableReturnValue() != null) {
+                isProduced = true;
+            }
+            JsonObject violation = new JsonObject();
+            violation.put(PROBLEM_FIELD, cv.getPropertyPath().toString());
+            violation.put(PROBLEM_MESSAGE, cv.getMessage());
+            array.add(violation);
+        }
+        json.put(PROBLEM_STATUS, isProduced || violationInProducedItem ? 500 : 400);
+        json.put(PROBLEM_VIOLATIONS, array);
+        return json;
+    }
+
+    public static void handleViolationException(ConstraintViolationException ex, RoutingContext rc) {
+        String accept = rc.request().getHeader(ACCEPT_HEADER);
+        if (accept != null && accept.contains(APPLICATION_JSON)) {
+            rc.response().putHeader(RouteHandlers.CONTENT_TYPE, APPLICATION_JSON);
+            JsonObject json = generateJsonResponse(ex.getConstraintViolations(), false);
+            rc.response().setStatusCode(json.getInteger(PROBLEM_STATUS));
+            rc.response().end(json.encode());
+        } else {
+            // Check status
+            int status = 400;
+            for (ConstraintViolation<?> constraintViolation : ex.getConstraintViolations()) {
+                if (constraintViolation.getExecutableReturnValue() != null) {
+                    status = 500;
+                    break;
+                }
+            }
+            // If not JSON just fails.
+            rc.fail(status, ex);
+        }
+    }
+}


### PR DESCRIPTION
Implement the support of bean validation with reactive routes:

* parameters are checked
* synchronous returns objects, and `Uni<X>` are validated - only `@Valid` is supported in this case

Multis are not supported, as the use case is not clear. 

﻿Ths PR also fixes the Quarkus Error Handler. It  was not enforcing the status code that could have been configured in the context.

