### PR TITLE
Support for custom token headers for OIDC service applications

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -28,6 +28,7 @@ import io.quarkus.oidc.runtime.OidcRecorder;
 import io.quarkus.oidc.runtime.OidcTokenCredentialProducer;
 import io.quarkus.oidc.runtime.TenantConfigBean;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
 import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
@@ -49,6 +50,7 @@ public class OidcBuildStep {
             removable.addBeanClass(CommonJwtProducer.class);
             removable.addBeanClass(RawClaimTypeProducer.class);
             removable.addBeanClass(JsonValueProducer.class);
+            removable.addBeanClass(ClaimValueProducer.class);
             removable.addBeanClass(Claim.class);
             return removable.build();
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -869,12 +869,27 @@ public class OidcTenantConfig {
         @ConfigItem(defaultValue = "10M")
         public Duration forcedJwkRefreshInterval = Duration.ofMinutes(10);
 
+        /**
+         * Custom HTTP header that contains a bearer token.
+         * This option is valid only when the application is of type {@link ApplicationType#SERVICE}}.
+         */
+        @ConfigItem
+        public Optional<String> header = Optional.empty();
+
         public Optional<String> getIssuer() {
             return issuer;
         }
 
         public void setIssuer(String issuer) {
             this.issuer = Optional.of(issuer);
+        }
+
+        public Optional<String> getHeader() {
+            return header;
+        }
+
+        public void setHeader(String header) {
+            this.header = Optional.of(header);
         }
 
         public Optional<List<String>> getAudience() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.runtime;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -19,7 +20,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager,
             DefaultTenantConfigResolver resolver) {
-        String token = extractBearerToken(context);
+        String token = extractBearerToken(context, resolver.resolve(context, false).oidcConfig);
 
         // if a bearer token is provided try to authenticate
         if (token != null) {
@@ -32,20 +33,27 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         return Uni.createFrom().item(UNAUTHORIZED_CHALLENGE);
     }
 
-    private String extractBearerToken(RoutingContext context) {
+    private String extractBearerToken(RoutingContext context, OidcTenantConfig oidcConfig) {
         final HttpServerRequest request = context.request();
-        final String authorization = request.headers().get(HttpHeaders.AUTHORIZATION);
+        String header = oidcConfig.token.header.isPresent() ? oidcConfig.token.header.get()
+                : HttpHeaders.AUTHORIZATION.toString();
+        final String headerValue = request.headers().get(header);
 
-        if (authorization == null) {
+        if (headerValue == null) {
             return null;
         }
 
-        int idx = authorization.indexOf(' ');
+        int idx = headerValue.indexOf(' ');
+        final String scheme = idx > 0 ? headerValue.substring(0, idx) : null;
 
-        if (idx <= 0 || !BEARER.equalsIgnoreCase(authorization.substring(0, idx))) {
+        if (scheme == null && !header.equalsIgnoreCase(HttpHeaders.AUTHORIZATION.toString())) {
+            return headerValue;
+        }
+
+        if (!BEARER.equalsIgnoreCase(scheme)) {
             return null;
         }
 
-        return authorization.substring(idx + 1);
+        return headerValue.substring(idx + 1);
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -4,21 +4,21 @@ quarkus.http.cors=true
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus-a
 quarkus.oidc.client-id=quarkus-app-a
 quarkus.oidc.credentials.secret=secret
-quarkus.oidc.tenant-web-app.application-type=service
+quarkus.oidc.application-type=service
 
 # Tenant B
 quarkus.oidc.tenant-b.auth-server-url=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-b.client-id=quarkus-app-b
 quarkus.oidc.tenant-b.credentials.secret=secret
 quarkus.oidc.tenant-b.token.issuer=${keycloak.url}/realms/quarkus-b
-quarkus.oidc.tenant-web-app.application-type=service
+quarkus.oidc.tenant-b.application-type=service
 
 # Tenant C
 quarkus.oidc.tenant-c.auth-server-url=${keycloak.url}/realms/quarkus-c
 quarkus.oidc.tenant-c.client-id=quarkus-app-c
 quarkus.oidc.tenant-c.credentials.secret=secret
 quarkus.oidc.tenant-c.token.audience=${keycloak.url}/realms/quarkus-c
-quarkus.oidc.tenant-web-app.application-type=service
+quarkus.oidc.tenant-c.application-type=service
 
 # Tenant Web App
 quarkus.oidc.tenant-web-app.auth-server-url=${keycloak.url}/realms/quarkus-webapp
@@ -34,6 +34,14 @@ quarkus.oidc.tenant-web-app2.client-id=quarkus-app-webapp2
 quarkus.oidc.tenant-web-app2.credentials.secret=secret
 quarkus.oidc.tenant-web-app2.application-type=web-app
 quarkus.oidc.tenant-web-app2.roles.source=accesstoken
+
+# Custom header
+quarkus.oidc.tenant-customheader.auth-server-url=${keycloak.url}/realms/quarkus-b
+quarkus.oidc.tenant-customheader.client-id=quarkus-app-b
+quarkus.oidc.tenant-customheader.credentials.secret=secret
+quarkus.oidc.tenant-customheader.token.header=X-Forwarded-Authorization
+quarkus.oidc.tenant-customheader.application-type=service
+
 
 quarkus.oidc.tenant-public-key.client-id=test
 quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -111,6 +111,40 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testCustomHeader() {
+        RestAssured.given().header("X-Forwarded-Authorization", getAccessToken("alice", "b"))
+                .when().get("/tenant/tenant-customheader/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-customheader:alice"));
+    }
+
+    @Test
+    public void testCustomHeaderBearerScheme() {
+        RestAssured.given().header("X-Forwarded-Authorization", "Bearer " + getAccessToken("alice", "b"))
+                .when().get("/tenant/tenant-customheader/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-customheader:alice"));
+    }
+
+    @Test
+    public void testWrongCustomHeader() {
+        RestAssured.given().header("X-Authorization", getAccessToken("alice", "b"))
+                .when().get("/tenant/tenant-customheader/api/user")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testCustomHeaderCustomScheme() {
+        RestAssured.given().header("X-Forwarded-Authorization", "DPoP " + getAccessToken("alice", "b"))
+                .when().get("/tenant/tenant-customheader/api/user")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testResolveTenantConfig() {
         RestAssured.given().auth().oauth2(getAccessToken("alice", "d"))
                 .when().get("/tenant/tenant-d/api/user")

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.Claim;
+import org.eclipse.microprofile.jwt.ClaimValue;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -15,12 +16,12 @@ import org.eclipse.microprofile.jwt.Claim;
 public class AdminResource {
 
     @Claim("preferred_username")
-    String claim;
+    ClaimValue<String> claim;
 
     @GET
     @RolesAllowed("admin")
     @Produces(MediaType.APPLICATION_JSON)
     public String admin() {
-        return "granted:" + claim;
+        return "granted:" + claim.getValue();
     }
 }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -79,6 +79,22 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testAccessAdminResourceCustomHeaderNoBearerScheme() {
+        RestAssured.given().header("X-Forwarded-Authorization", getAccessToken("admin"))
+                .when().get("/api/admin")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testAccessAdminResourceCustomHeaderBearerScheme() {
+        RestAssured.given().header("X-Forwarded-Authorization", getAccessToken("admin"))
+                .when().get("/api/admin")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testAccessAdminResourceWithRefreshToken() {
         RestAssured.given().auth().oauth2(getRefreshToken("admin"))
                 .when().get("/api/admin")


### PR DESCRIPTION
Fixes #11790.

This PR:
- introduces `quarkus.oidc.token.header` similar to `smallrye.jwt.token.header` to support the cases where `Authorization: Bearer <jwt>` was replaced at the gateway level by a custom header (custom gateways, or even Istio).
- if the custom header is used then it can be used without a scheme, example, `MyAuthorization: <jwt>` or with a scheme, for example: `X-Forwarded-Authorization: Bearer <jwt>` - there was a `smallrye-jwt` issue opened by a user to support `X-Forwarded-Authorization: Bearer <jwt>` with some Google Identity deployments.
- if the custom headers are used with the scheme then only `Bearer` is supported. It will be relaxed once we start supporting `DPoP`.
- added a missing `ClaimValueProducer` to support MP-JWT `ClaimValue` injection
- and fixed a few `application.properties` typos in `integration-tests/oidc-tenancy` (they were harmless since for a given tenant `service` is a default value)