### PR TITLE
Prevent potential NPE during shutdown in GrpcServerReloader

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devmode/GrpcServerReloader.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devmode/GrpcServerReloader.java
@@ -87,7 +87,9 @@ public class GrpcServerReloader {
     }
 
     public static void shutdown() {
-        server.shutdown();
-        server = null;
+        if (server != null) {
+            server.shutdown();
+            server = null;
+        }
     }
 }


### PR DESCRIPTION
Prevents a potential NPE, that's been reported in Quarkus dev mailing list, during shutdown of the GrpcServerReloader.