### PR TITLE
fixed property names in docs where grpc-server was used instead of grpc.server

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -177,7 +177,7 @@ Quarkus gRPC Server implements the https://github.com/grpc/grpc/blob/master/doc/
 This service allows tools like https://github.com/fullstorydev/grpcurl[grpcurl] or https://github.com/gusaul/grpcox[grpcox] to interact with your services.
 
 The reflection service is enabled by default in _dev_ mode.
-In test or production mode, you need to enable it explicitly by setting `quarkus.grpc-server.enable-reflection-service` to `true`.
+In test or production mode, you need to enable it explicitly by setting `quarkus.grpc.server.enable-reflection-service` to `true`.
 
 == Scaling
 By default, quarkus-grpc starts a single gRPC server running on a single event loop.
@@ -196,8 +196,8 @@ To enable TLS, use the following configuration:
 
 [source]
 ----
-quarkus.grpc-server.ssl.certificate=src/main/resources/tls/server.pem
-quarkus.grpc-server.ssl.key=src/main/resources/tls/server.key
+quarkus.grpc.server.ssl.certificate=src/main/resources/tls/server.pem
+quarkus.grpc.server.ssl.key=src/main/resources/tls/server.key
 ----
 
 NOTE: When SSL/TLS is configured, `plain-text` is automatically disabled.
@@ -208,9 +208,9 @@ To use TLS with mutual authentication, use the following configuration:
 
 [source]
 ----
-quarkus.grpc-server.ssl.certificate=src/main/resources/tls/server.pem
-quarkus.grpc-server.ssl.key=src/main/resources/tls/server.key
-quarkus.grpc-server.ssl.trust-store=src/main/resources/tls/ca.jks
-quarkus.grpc-server.ssl.trust-store-password=*****
-quarkus.grpc-server.ssl.client-auth=REQUIRED
+quarkus.grpc.server.ssl.certificate=src/main/resources/tls/server.pem
+quarkus.grpc.server.ssl.key=src/main/resources/tls/server.key
+quarkus.grpc.server.ssl.trust-store=src/main/resources/tls/ca.jks
+quarkus.grpc.server.ssl.trust-store-password=*****
+quarkus.grpc.server.ssl.client-auth=REQUIRED
 ----


### PR DESCRIPTION
Property names in generated "Server configuration" block have dot, while some property mentions have dash. This pull request fixes this