### PR TITLE
Fix NPE when combining security-jpa with form auth

### DIFF
--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/FormAuthJpaTestCase.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/FormAuthJpaTestCase.java
@@ -66,6 +66,19 @@ public class FormAuthJpaTestCase {
                 .header("location", containsString("/login"))
                 .cookie("quarkus-redirect-location", containsString("/servlet-secured"));
 
+        // test with a non existent user
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "dummy")
+                .formParam("j_password", "dummy")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302);
+
         RestAssured
                 .given()
                 .filter(cookies)


### PR DESCRIPTION
Fixes: #11868

Although `null`should probably be handled more smoothly by `PersistentLoginManager`,
in this case however having the generated `JpaIdentityProvider` is incorrect according to the Javadoc of  `io.quarkus.security.identity.IdentityProvider` which states:

```
If this is unsuccessful because the provided credentials are invalid then this should fail with an 
{@link AuthenticationFailedException}, otherwise it should complete with a null value.
```
