### PR TITLE
Add an SPI BuildItem to publish detected Bean Validation annotations

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -747,6 +747,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-validator-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-infinispan-client</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/hibernate-validator/deployment/pom.xml
+++ b/extensions/hibernate-validator/deployment/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
 

--- a/extensions/hibernate-validator/pom.xml
+++ b/extensions/hibernate-validator/pom.xml
@@ -14,6 +14,7 @@
     <name>Quarkus - Hibernate Validator</name>
     <packaging>pom</packaging>
     <modules>
+        <module>spi</module>
         <module>deployment</module>
         <module>runtime</module>
     </modules>

--- a/extensions/hibernate-validator/spi/pom.xml
+++ b/extensions/hibernate-validator/spi/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-hibernate-validator-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-validator-spi</artifactId>
+    <name>Quarkus - Hibernate Validator - SPI</name>
+    <description>Artifact that provides BuildItems specific to Hibernate Validator</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/BeanValidationAnnotationsBuildItem.java
+++ b/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/BeanValidationAnnotationsBuildItem.java
@@ -1,0 +1,35 @@
+package io.quarkus.hibernate.validator.spi;
+
+import java.util.Collections;
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * BuildItem used to publish the list of detected Bean Validation annotations
+ * for consumption by other extensions.
+ */
+public final class BeanValidationAnnotationsBuildItem extends SimpleBuildItem {
+
+    private final String valid;
+    private final Set<String> constraints;
+    private final Set<String> all;
+
+    public BeanValidationAnnotationsBuildItem(String valid, Set<String> constraints, Set<String> all) {
+        this.valid = valid;
+        this.constraints = Collections.unmodifiableSet(constraints);
+        this.all = Collections.unmodifiableSet(all);
+    }
+
+    public String getValidAnnotation() {
+        return valid;
+    }
+
+    public Set<String> getConstraintAnnotations() {
+        return constraints;
+    }
+
+    public Set<String> getAllAnnotations() {
+        return all;
+    }
+}


### PR DESCRIPTION
/cc @cescoffier 

Obviously, it has to be consumed as `Optional`.

I also published the `@Valid` annotation so that we won't have to update things everywhere when/if moving to Jakarta EE 9.