### PR TITLE
Narayana - make LifecycleManager from SM CP unremovable

### DIFF
--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -17,6 +17,7 @@ import com.arjuna.common.util.propertyservice.PropertiesFactory;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.ContextRegistrarBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.ContextRegistrar;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -39,6 +40,7 @@ import io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorNotSu
 import io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired;
 import io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequiresNew;
 import io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorSupports;
+import io.smallrye.context.jta.context.propagation.JtaContextProvider;
 
 class NarayanaJtaProcessor {
 
@@ -106,6 +108,12 @@ class NarayanaJtaProcessor {
                 registrationContext.configure(TransactionScoped.class).normal().contextClass(TransactionContext.class).done();
             }
         }, TransactionScoped.class));
+    }
+
+    @BuildStep
+    UnremovableBeanBuildItem unremovableBean() {
+        // LifecycleManager comes from smallrye-context-propagation-jta and is only used via programmatic lookup in JtaContextProvider
+        return UnremovableBeanBuildItem.beanClassNames(JtaContextProvider.LifecycleManager.class.getName());
     }
 
 }


### PR DESCRIPTION
- it is only used via programmatic lookup in JtaContextProvider and
was removed during build
- we need to ensure a proper cleanup of JtaContextProvider