### PR TITLE
Ensure that the Spring Web extension doesn't result in RESTEASY002155

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/JaxrsProvidersToRegisterBuildItem.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/JaxrsProvidersToRegisterBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.common.deployment;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import io.quarkus.builder.item.SimpleBuildItem;
@@ -8,11 +9,20 @@ public final class JaxrsProvidersToRegisterBuildItem extends SimpleBuildItem {
 
     private final Set<String> providers;
     private final Set<String> contributedProviders;
+    private final Set<String> contributedProvidersWithoutResteasy;
     private final boolean useBuiltIn;
 
     public JaxrsProvidersToRegisterBuildItem(Set<String> providers, Set<String> contributedProviders, boolean useBuiltIn) {
         this.providers = providers;
         this.contributedProviders = contributedProviders;
+        // extensions can end up contributing RESTEasy providers, so we like to filter them out when necessary
+        // in order to avoid 'RESTEASY002155: Provider class ... '
+        this.contributedProvidersWithoutResteasy = new HashSet<>();
+        for (String contributedProvider : contributedProviders) {
+            if (!contributedProvider.startsWith(ResteasyCommonProcessor.RESTEASY_PROVIDERS_BASE_PACKAGE)) {
+                contributedProvidersWithoutResteasy.add(contributedProvider);
+            }
+        }
         this.useBuiltIn = useBuiltIn;
     }
 
@@ -22,6 +32,10 @@ public final class JaxrsProvidersToRegisterBuildItem extends SimpleBuildItem {
 
     public Set<String> getContributedProviders() {
         return this.contributedProviders;
+    }
+
+    public Set<String> getContributedProvidersWithoutResteasy() {
+        return this.contributedProvidersWithoutResteasy;
     }
 
     public boolean useBuiltIn() {

--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -77,6 +77,8 @@ public class ResteasyCommonProcessor {
             new ProviderDiscoverer(ResteasyDotNames.PUT, true, false)
     };
 
+    static final String RESTEASY_PROVIDERS_BASE_PACKAGE = "org.jboss.resteasy.plugins.providers";
+
     private static final DotName QUARKUS_OBJECT_MAPPER_CONTEXT_RESOLVER = DotName
             .createSimple("io.quarkus.resteasy.common.runtime.jackson.QuarkusObjectMapperContextResolver");
     private static final DotName OBJECT_MAPPER = DotName.createSimple("com.fasterxml.jackson.databind.ObjectMapper");

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -564,9 +564,10 @@ public class ResteasyServerCommonProcessor {
             deployment.setRegisterBuiltin(true);
 
             if (!jaxrsProvidersToRegisterBuildItem.getContributedProviders().isEmpty()) {
-                deployment.getProviderClasses().addAll(jaxrsProvidersToRegisterBuildItem.getContributedProviders());
+                deployment.getProviderClasses()
+                        .addAll(jaxrsProvidersToRegisterBuildItem.getContributedProvidersWithoutResteasy());
                 resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_PROVIDERS,
-                        String.join(",", jaxrsProvidersToRegisterBuildItem.getContributedProviders()));
+                        String.join(",", jaxrsProvidersToRegisterBuildItem.getContributedProvidersWithoutResteasy()));
             }
         } else {
             deployment.setRegisterBuiltin(false);


### PR DESCRIPTION
Since the Spring Web extension does it's own discovery of providers,
it can happen that when using the built in providers,
the ones that where discovered by Spring Web and assigned to
contributed status, get registered twice

Fixes: #11810