### PR TITLE
Normalize duration default values rendered in documentation

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
@@ -20,6 +20,7 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.stri
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -286,6 +287,8 @@ class ConfigDoItemFinder {
                                 defaultValue = hyphenateEnumValue(defaultValue);
                             }
                             acceptedValues = extractEnumValues(declaredType, useHyphenateEnumValue);
+                        } else if (isDurationType(declaredType) && !defaultValue.isEmpty()) {
+                            defaultValue = DocGeneratorUtil.normalizeDurationValue(defaultValue);
                         }
                     }
                 }
@@ -358,6 +361,10 @@ class ConfigDoItemFinder {
     private boolean isEnumType(TypeMirror realTypeMirror) {
         return realTypeMirror instanceof DeclaredType
                 && ((DeclaredType) realTypeMirror).asElement().getKind() == ElementKind.ENUM;
+    }
+
+    private boolean isDurationType(TypeMirror realTypeMirror) {
+        return realTypeMirror.toString().equals(Duration.class.getName());
     }
 
     /**

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
@@ -257,6 +257,17 @@ public class DocGeneratorUtil {
         return target.toString();
     }
 
+    static String normalizeDurationValue(String value) {
+        if (!value.isEmpty() && Character.isDigit(value.charAt(value.length() - 1))) {
+            try {
+                value = Integer.parseInt(value) + "S";
+            } catch (NumberFormatException ignore) {
+            }
+        }
+        value = value.toUpperCase(Locale.ROOT);
+        return value;
+    }
+
     static String joinAcceptedValues(List<String> acceptedValues) {
         if (acceptedValues == null || acceptedValues.isEmpty()) {
             return "";

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
@@ -9,6 +9,7 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.comp
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.computeExtensionDocFileName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.deriveConfigRootName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJavaDocSiteLink;
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.normalizeDurationValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
@@ -353,5 +354,17 @@ public class DocGeneratorUtilTest {
         simpleClassName = "RootNameBuildTimeConfiguration";
         actual = deriveConfigRootName(simpleClassName, ConfigPhase.BUILD_TIME);
         assertEquals("quarkus.root-name", actual);
+    }
+
+    @Test
+    public void normalizeDurationValueTest() {
+        assertEquals("", normalizeDurationValue(""));
+        assertEquals("1S", normalizeDurationValue("1"));
+        assertEquals("1S", normalizeDurationValue("1S"));
+        assertEquals("1S", normalizeDurationValue("1s"));
+
+        // values are not validated here
+        assertEquals("1_000", normalizeDurationValue("1_000"));
+        assertEquals("FOO", normalizeDurationValue("foo"));
     }
 }


### PR DESCRIPTION
The duration default values rendered in the documentation are now normalized by appending an `S` to any default value which is a number only. Additionally the duration values are all converted to upper-case.

Fixes #10022