### PR TITLE
Update grpc-getting-started.adoc

### DIFF
--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -93,22 +93,21 @@ In a terminal, run:
 $ mvn compile
 ----
 
-Once generated, you can look at the `target/generated-sources/protobuf` directory:
+Once generated, you can look at the `target/generated-sources/grpc` directory:
 
 [source, txt]
 ----
-target/generated-sources/protobuf
-└── java
-    └── io
-        └── quarkus
-            └── example
-                ├── GreeterGrpc.java
-                ├── HelloReply.java
-                ├── HelloReplyOrBuilder.java
-                ├── HelloRequest.java
-                ├── HelloRequestOrBuilder.java
-                ├── HelloWorldProto.java
-                └── MutinyGreeterGrpc.java
+target/generated-sources/grpc
+└── io
+    └── quarkus
+        └── example
+            ├── GreeterGrpc.java
+            ├── HelloReply.java
+            ├── HelloReplyOrBuilder.java
+            ├── HelloRequest.java
+            ├── HelloRequestOrBuilder.java
+            ├── HelloWorldProto.java
+            └── MutinyGreeterGrpc.java
 ----
 
 These are the classes we are going to use.

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -98,15 +98,11 @@ Once generated, you can look at the `target/generated-sources/protobuf` director
 [source, txt]
 ----
 target/generated-sources/protobuf
-├── grpc-java
-│   └── io
-│       └── quarkus
-│           └── example
-│               └── GreeterGrpc.java
 └── java
     └── io
         └── quarkus
             └── example
+                ├── GreeterGrpc.java
                 ├── HelloReply.java
                 ├── HelloReplyOrBuilder.java
                 ├── HelloRequest.java


### PR DESCRIPTION
I was following the tutorial, and realized there is a problem with generated sources' tree.

This is in documentation:
```
target/generated-sources/protobuf
├── grpc-java
│   └── io
│       └── quarkus
│           └── example
│               └── GreeterGrpc.java
└── java
    └── io
        └── quarkus
            └── example
                ├── HelloReply.java
                ├── HelloReplyOrBuilder.java
                ├── HelloRequest.java
                ├── HelloRequestOrBuilder.java
                ├── HelloWorldProto.java
                └── MutinyGreeterGrpc.java
```

This is actual result:
```
rpc-test/target/generated-sources % tree                              
.
├── annotations
└── grpc
    └── io
        └── quarkus
            └── example
                ├── GreeterGrpc.java
                ├── HelloReply.java
                ├── HelloReplyOrBuilder.java
                ├── HelloRequest.java
                ├── HelloRequestOrBuilder.java
                ├── HelloWorldProto.java
                └── MutinyGreeterGrpc.java

5 directories, 7 files
```