### PR TITLE
Attempt to get around AccessDeniedException in Windows

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
@@ -129,8 +129,7 @@ public class DevModeTask {
                 //not all local projects are dependencies
                 continue;
             }
-            IoUtils.recursiveDelete(moduleClasses);
-            Files.createDirectories(moduleClasses);
+            IoUtils.recursiveDeleteAndThenCreate(moduleClasses);
             for (Path p : dep.getPaths()) {
                 if (Files.isDirectory(p)) {
                     Path moduleTarget = moduleClasses;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -38,8 +38,7 @@ public class AppCDSBuildStep {
     public void requested(OutputTargetBuildItem outputTarget, BuildProducer<AppCDSRequestedBuildItem> producer)
             throws IOException {
         Path appCDSDir = outputTarget.getOutputDirectory().resolve("appcds");
-        IoUtils.recursiveDelete(appCDSDir);
-        Files.createDirectories(appCDSDir);
+        IoUtils.recursiveDeleteAndThenCreate(appCDSDir);
 
         producer.produce(new AppCDSRequestedBuildItem(outputTarget.getOutputDirectory().resolve("appcds")));
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -414,8 +414,7 @@ public class JarResultBuildStep {
                 .resolve(outputTargetBuildItem.getBaseName() + packageConfig.runnerSuffix + ".jar");
         Path libDir = outputTargetBuildItem.getOutputDirectory().resolve("lib");
         Files.deleteIfExists(runnerJar);
-        IoUtils.recursiveDelete(libDir);
-        Files.createDirectories(libDir);
+        IoUtils.recursiveDeleteAndThenCreate(libDir);
 
         try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
 
@@ -464,8 +463,7 @@ public class JarResultBuildStep {
             userProviders = buildDir.resolve(packageConfig.userProvidersDirectory.get());
         }
         if (!rebuild) {
-            IoUtils.recursiveDelete(buildDir);
-            Files.createDirectories(buildDir);
+            IoUtils.recursiveDeleteAndThenCreate(buildDir);
             Files.createDirectories(mainLib);
             Files.createDirectories(baseLib);
             Files.createDirectories(appDir);
@@ -477,8 +475,7 @@ public class JarResultBuildStep {
                 Files.createFile(userProviders.resolve(".keep"));
             }
         } else {
-            IoUtils.recursiveDelete(quarkus);
-            Files.createDirectories(quarkus);
+            IoUtils.recursiveDeleteAndThenCreate(quarkus);
         }
         Map<AppArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
 
@@ -712,8 +709,7 @@ public class JarResultBuildStep {
             List<UberJarRequiredBuildItem> uberJarRequired) throws Exception {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
-        IoUtils.recursiveDelete(targetDirectory);
-        Files.createDirectories(targetDirectory);
+        IoUtils.recursiveDeleteAndThenCreate(targetDirectory);
 
         List<GeneratedClassBuildItem> allClasses = new ArrayList<>(generatedClasses);
         allClasses.addAll(nativeImageResources.stream()

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/PropertyUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/PropertyUtils.java
@@ -21,7 +21,7 @@ public class PropertyUtils {
     }
 
     public static boolean isWindows() {
-        return getProperty(OS_NAME).toLowerCase(Locale.ENGLISH).indexOf(WINDOWS) >= 0;
+        return getProperty(OS_NAME).toLowerCase(Locale.ENGLISH).contains(WINDOWS);
     }
 
     public static String getUserHome() {


### PR DESCRIPTION
In Windows it seems like `AccessDeniedException` can be thrown
when a directory is deleted and then immediately recreated.
The problem can be mitigated by retrying the operation as
is mentioned in https://bugs.openjdk.java.net/browse/JDK-8029608

Fixes: #11900