### PR TITLE
Register a global exception handler on the Vert.x instance so uncaught exceptions are logged properly.

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -195,6 +195,12 @@ public class VertxCoreRecorder {
         } else {
             vertx = Vertx.vertx(options);
         }
+        vertx.exceptionHandler(new Handler<Throwable>() {
+            @Override
+            public void handle(Throwable error) {
+                LOGGER.error("Uncaught exception received by Vert.x", error);
+            }
+        });
         return logVertxInitialization(vertx);
     }
 


### PR DESCRIPTION
If the code throws an unhandled exception in a Vert.x thread (event loop or worker), this handler is invoked and log the error.
Before, it delegated to the Vert.x internal exception handler.
