### PR TITLE
Kill the docker container used by JPA DB2 integration tests, after a timeout

### DIFF
--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -249,6 +249,9 @@
                                             <log>.*Setup has completed\..*</log>
                                             <!-- Unfortunately booting DB2 is slow, needs to set a generous (10m) timeout: -->
                                             <time>600000</time>
+                                            <!-- Kill the container, if it doesn't stop before this given time
+                                             duration since a graceful stop was issued -->
+                                            <kill>300000</kill>
                                         </wait>
                                     </run>
                                 </image>


### PR DESCRIPTION
Every once in a while, the JDK 14 JVM CI job gets "cancelled". When this happens, that job usually has lasted around 4 odd hours. Each time this has happened, the logs have shown that the last thing that was going on in that job was stopping the DB2 docker container that was started for the `jpa-db2` integration tests. Here's one example[1] which looks like:
```
2020-09-05T20:27:08.7684745Z 20:27:08.767 DB2:(*) Done
2020-09-05T23:25:46.6954736Z ##[error]The operation was canceled.
2020-09-05T23:25:46.7315379Z Post job cleanup.

```
The `DB2:(*) Done` is what gets logged during the docker stop command. Notice the timestamp on it and then a almost 3 hour wait before the job gets cancelled. Compared to a normal successful run which looks like (from a different PR run):

```
2020-09-06T08:49:49.8178319Z 08:49:49.817 DB2:(*) Done
2020-09-06T08:49:50.9654775Z [INFO] DOCKER> [ibmcom/db2:11.5.0.0a] "quarkus-test-db2": Stop and removed container 1eebd6d9a7fa after 0 ms
```

The commit in this PR is an attempt to see if the `kill` attribute as documented here[2] will help us get past this. I have no experience with this docker plugin, so I'm not sure how useful this will be, but worth a try. I have set it only for this `jpa-db2` integration-test because this is the only one which has shown this issue so far.


[1] https://github.com/quarkusio/quarkus/pull/11922/checks?check_run_id=1076171668
[2] https://dmp.fabric8.io/#start-wait