### PR TITLE
If parent first fails see if the resource exists in this CL

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -53,7 +53,11 @@ public class RunnerClassLoader extends ClassLoader {
         }
         String packageName = getPackageNameFromClassName(name);
         if (parentFirstPackages.contains(packageName)) {
-            return getParent().loadClass(name);
+            try {
+                return getParent().loadClass(name);
+            } catch (ClassNotFoundException e) {
+                //fall through
+            }
         }
         synchronized (getClassLoadingLock(name)) {
             Class<?> loaded = findLoadedClass(name);


### PR DESCRIPTION
Note that in theory this could cause problems if there are beans
in the parent first loader that use package private methods,
however this should not be a problem in practice. The parent
loader should generally not contain bean classes, and the only
real exception to this is the Servlet API.

Fixes #11647