### PR TITLE
Fix incorrect ImagePullPolicy forced setting

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
@@ -30,7 +30,7 @@ public final class ContainerImageCapabilitiesUtil {
         if (activeContainerImageCapabilities.size() > 1) {
             throw new IllegalStateException(String.join(" and ", activeContainerImageCapabilities)
                     + " were detected, at most one container-image extension can be present.\n"
-                    + "Either remove the uneeded ones, or select one using the property 'quarkus.container-image-builder=<extension name (without the `container-image-` prefix)>'.");
+                    + "Either remove the unneeded ones, or select one using the property 'quarkus.container-image-builder=<extension name (without the `container-image-` prefix)>'.");
         }
         return activeContainerImageCapabilities.isEmpty() ? Optional.empty()
                 : Optional.of(activeContainerImageCapabilities.iterator().next());

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
@@ -35,33 +35,6 @@ public final class ImageUtil {
         return sb.toString();
     }
 
-    /*
-     * Checks if the specified image has a registry part.
-     * 
-     * @param image the image
-     * 
-     * @return true if registry is part of the image, false otherwise
-     */
-    public static boolean hasRegistry(String image) {
-        String r = getRegistry(image);
-        return r != null && !r.isEmpty();
-    }
-
-    /**
-     * Return the registry part of the docker image.
-     * 
-     * @param image The actual docker image.
-     * @return The registry or null, if not registry was found.
-     */
-    public static String getRegistry(String image) {
-        String[] parts = image.split(SLASH);
-        if (parts.length <= 2) {
-            return null;
-        } else {
-            return parts[0];
-        }
-    }
-
     /**
      * Return the docker image repository.
      * 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerImageUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerImageUtil.java
@@ -1,7 +1,5 @@
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.container.image.deployment.util.ImageUtil.hasRegistry;
-
 import java.util.Optional;
 
 import io.quarkus.container.image.deployment.ContainerImageCapabilitiesUtil;
@@ -21,7 +19,7 @@ final class ContainerImageUtil {
             return false;
         }
 
-        return !hasRegistry(containerImageInfo.getImage())
-                && !Capability.CONTAINER_IMAGE_S2I.equals(activeContainerImageCapability.get());
+        return !containerImageInfo.getRegistry().isPresent()
+                && !Capability.CONTAINER_IMAGE_S2I.getName().equals(activeContainerImageCapability.get());
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -1,7 +1,6 @@
 
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.container.image.deployment.util.ImageUtil.hasRegistry;
 import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
 import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
 import static io.quarkus.kubernetes.deployment.Constants.MINIKUBE;
@@ -150,7 +149,7 @@ public class KubernetesDeployer {
             checkForMissingRegistry = false;
         }
 
-        if (checkForMissingRegistry && !hasRegistry(containerImageInfo.getImage())) {
+        if (checkForMissingRegistry && !containerImageInfo.getRegistry().isPresent()) {
             log.warn(
                     "A Kubernetes deployment was requested, but the container image to be built will not be pushed to any registry"
                             + " because \"quarkus.container-image.registry\" has not been set. The Kubernetes deployment will only work properly"


### PR DESCRIPTION
When the container image group was being set to empty
(which is allowed as a result of https://github.com/quarkusio/quarkus/pull/8139), then the
registry was incorrectly being determined as not being set

Fixes: #11917