### PR TITLE
Disable random port usage in tests

### DIFF
--- a/integration-tests/spring-web/src/main/resources/application.properties
+++ b/integration-tests/spring-web/src/main/resources/application.properties
@@ -2,8 +2,10 @@ quarkus.security.users.file.enabled=true
 quarkus.security.users.file.users=test-users.properties
 quarkus.security.users.file.roles=test-roles.properties
 quarkus.security.users.file.plain-text=true
-quarkus.http.test-port=0
-quarkus.http.port=0
+# The following random port settings are disabled because they can cause a failure on CI that is entirely unrelated to the PR
+# if the chosen port happens to not be available
+# quarkus.http.test-port=0
+# quarkus.http.port=0
 
 # we add this because we also use @TestSecurity which means that basic auth is disabled by default because @TestSecurity
 # contributes TestHttpAuthenticationMechanism


### PR DESCRIPTION
Done because of the failure we saw in https://github.com/quarkusio/quarkus/pull/11935