### PR TITLE
Use smallrye-common-bom 1.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,8 +62,7 @@ updates:
       - dependency-name: io.smallrye:smallrye-opentracing
       - dependency-name: io.smallrye:smallrye-fault-tolerance
       - dependency-name: io.smallrye:smallrye-context-propagation
-      - dependency-name: io.smallrye.common:smallrye-common-annotation
-      - dependency-name: io.smallrye.common:smallrye-common-io
+      - dependency-name: io.smallrye.common:smallrye-common-bom
       - dependency-name: io.smallrye.config:smallrye-config
       - dependency-name: io.smallrye.reactive:mutiny
       - dependency-name: io.smallrye.reactive:smallrye-reactive-messaging

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -33,7 +33,7 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
-        <smallrye-common.version>1.3.0</smallrye-common.version>
+        <smallrye-common.version>1.4.0</smallrye-common.version>
         <smallrye-config.version>1.8.6</smallrye-config.version>
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.3</smallrye-metrics.version>
@@ -283,6 +283,15 @@
                 <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Smallrye Common dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${smallrye-common.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!-- Quarkus core -->
@@ -2455,11 +2464,6 @@
                 <artifactId>smallrye-config-common</artifactId>
                 <!-- This is intentionally hard-coded -->
                 <version>1.5.0</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-annotation</artifactId>
-                <version>${smallrye-common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -360,10 +360,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Smallrye Common dependencies, imported as a BOM -->
             <dependency>
                 <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-io</artifactId>
+                <artifactId>smallrye-common-bom</artifactId>
                 <version>${smallrye-common.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This ensures that all smallrye-common subprojects used in Quarkus are in the same version