### PR TITLE
Don't skip the doc in the initial JDK 11 build

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -84,7 +84,7 @@ jobs:
           restore-only: ${{ github.event_name == 'pull_request' }}
       - name: Build
         run: |
-          mvn -e -B -DskipTests -DskipITs -Dno-format -DskipDocs clean install
+          mvn -e -B -DskipTests -DskipITs -Dno-format clean install
       - name: Tar Maven Repo
         shell: bash
         run: tar -czf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
While we have a specific doc build now, we still need to build the doc
when the config classes have changed and having a pattern catching all
of them is relatively brittle.

Better build the doc anyway in the Initial JDK 11 build.

I thought about it because of the latest Hibernate Search upgrade that
touches the config classes but not the guide.