### PR TITLE
Add system property as gradle quarkusBuild task input

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle.tasks;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -76,6 +77,29 @@ public class QuarkusBuild extends QuarkusTask {
         return mainSourceSet.getCompileClasspath().plus(mainSourceSet.getRuntimeClasspath())
                 .plus(mainSourceSet.getAnnotationProcessorPath())
                 .plus(mainSourceSet.getResources());
+    }
+
+    @Input
+    public Map<Object, Object> getQuarkusBuildSystemProperties() {
+        Map<Object, Object> quarkusSystemProperties = new HashMap<>();
+        for (Map.Entry<Object, Object> systemProperty : System.getProperties().entrySet()) {
+            if (systemProperty.getKey().toString().startsWith("quarkus.") &&
+                    systemProperty.getValue() instanceof Serializable) {
+                quarkusSystemProperties.put(systemProperty.getKey(), systemProperty.getValue());
+            }
+        }
+        return quarkusSystemProperties;
+    }
+
+    @Input
+    public Map<String, String> getQuarkusBuildEnvProperties() {
+        Map<String, String> quarkusEnvProperties = new HashMap<>();
+        for (Map.Entry<String, String> systemProperty : System.getenv().entrySet()) {
+            if (systemProperty.getKey() != null && systemProperty.getKey().startsWith("QUARKUS_")) {
+                quarkusEnvProperties.put(systemProperty.getKey(), systemProperty.getValue());
+            }
+        }
+        return quarkusEnvProperties;
     }
 
     @OutputFile

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -134,6 +134,21 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleWrapperTestBase {
     }
 
     @Test
+    public void canDetectSystemPropertyChangeWhenBuilding() throws Exception {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
+
+        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(projectRoot.toPath().resolve("build").resolve("foo-1.0.0-SNAPSHOT-runner.jar")).exists();
+
+        BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "-Dquarkus.package.type=fast-jar");
+
+        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(projectRoot.toPath().resolve("build").resolve("quarkus-app")).exists();
+    }
+
+    @Test
     public void canRunTest() throws Exception {
         createProject(SourceType.JAVA);
 


### PR DESCRIPTION
This adds `quarkus.*` system property as `quarkusBuild` task input.
This avoid getting `UP-TO-DATE` result when running a command with different arguments.

close #11944 
 