### PR TITLE
Update to xstream 1.4.13 to reduce illegal reflective access warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,6 +117,7 @@ updates:
       - dependency-name: com.amazonaws:aws-lambda-java-events
       # Apache Commons
       - dependency-name: commons-io:commons-io
+      - dependency-name: com.thoughtworks.xstream:xstream
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/integration-tests/gradle"

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -48,8 +48,8 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <!-- Avoid adding this to the BOM / Version has to be kept in sync with what optaplanner uses otherwise the enforcer complains -->
-            <version>1.4.11.1</version>
+            <!-- Avoid adding this to the BOM -->
+            <version>1.4.13</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes #10303 for some cases when using JUnit5 ParameterResolver.

Includes https://github.com/x-stream/xstream/pull/218 that tries to avoid such warnings at XStream creation time.

 Also adds xstream to dependabot. Comment regardings optaplanner was outdated.

It does remove the warnings in my current project but it really depends how on your parameter looks like internally (which results in different xstream converters being actually used).

A good example is `ParameterResolverTest`, before:
```
[ERROR] WARNING: An illegal reflective access operation has occurred
[ERROR] WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/C:/Users/Falko/.m2/repository/com/thoughtworks/xstream/xstream/1.4.11.1/xstream-1.4.11.1.jar) to field java.util.TreeMap.comparator
[ERROR] WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.core.util.Fields
[ERROR] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[ERROR] WARNING: All illegal access operations will be denied in a future release
```
after:
```
[ERROR] WARNING: An illegal reflective access operation has occurred
[ERROR] WARNING: Illegal reflective access by com.thoughtworks.xstream.converters.reflection.FieldDictionary (file:/C:/Users/Falko/.m2/repository/com/thoughtworks/xstream/xstream/1.4.13/xstream-1.4.13.jar) to field java.util.AbstractCollection.MAX_ARRAY_SIZE
[ERROR] WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.converters.reflection.FieldDictionary
[ERROR] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[ERROR] WARNING: All illegal access operations will be denied in a future release
```
Trace (after):
```
[ERROR]         at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildDictionaryEntryForClass(FieldDictionary.java:176)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildMap(FieldDictionary.java:142)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.FieldDictionary.fieldOrNull(FieldDictionary.java:115)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.getFieldOrNull(PureJavaReflectionProvider.java:197)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.canAccess(AbstractReflectionConverter.java:68)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.ReflectionConverter.canConvert(ReflectionConverter.java:38)
[ERROR]         at com.thoughtworks.xstream.core.DefaultConverterLookup.lookupConverterForType(DefaultConverterLookup.java:75)
[ERROR]         at com.thoughtworks.xstream.XStream$1.lookupConverterForType(XStream.java:478)
[ERROR]         at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:48)
[ERROR]         at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshallField(AbstractReflectionConverter.java:270)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter$2.writeField(AbstractReflectionConverter.java:174)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doMarshal(AbstractReflectionConverter.java:262)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshal(AbstractReflectionConverter.java:90)
[ERROR]         at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
[ERROR]         at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
[ERROR]         at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshallField(AbstractReflectionConverter.java:270)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter$2.writeField(AbstractReflectionConverter.java:174)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doMarshal(AbstractReflectionConverter.java:262)
[ERROR]         at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshal(AbstractReflectionConverter.java:90)
[ERROR]         at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
[ERROR]         at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
[ERROR]         at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
[ERROR]         at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
[ERROR]         at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
[ERROR]         at com.thoughtworks.xstream.XStream.marshal(XStream.java:1250)
[ERROR]         at com.thoughtworks.xstream.XStream.marshal(XStream.java:1239)
[ERROR]         at com.thoughtworks.xstream.XStream.toXML(XStream.java:1212)
[ERROR]         at com.thoughtworks.xstream.XStream.toXML(XStream.java:1199)
[ERROR]         at io.quarkus.test.junit.internal.XStreamDeepClone.doClone(XStreamDeepClone.java:48)
```

This issue won't be solved entirely until xstream 1.5 (ETA is unknown).