### PR TITLE
Change RedisClientProcessor to singleton

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
@@ -25,7 +25,7 @@ public class RedisClientProcessor {
     @BuildStep
     AdditionalBeanBuildItem registerAPIsProducer() {
         return new AdditionalBeanBuildItem.Builder().addBeanClass("io.quarkus.redis.client.runtime.RedisAPIProducer")
-                .setDefaultScope(BuiltinScope.APPLICATION.getName())
+                .setDefaultScope(BuiltinScope.SINGLETON.getName())
                 .setUnremovable()
                 .build();
     }


### PR DESCRIPTION
ApplicationScoped requires a proxy, and as the class does
not have a no-arg constructor we end up transforming the class
for no real reason.