### PR TITLE
Cleanup the log records held in-memory, in Quarkus test extensions

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
@@ -17,7 +17,7 @@ public class InMemoryLogHandler extends Handler {
         this.predicate = Assert.checkNotNullParam("predicate", predicate);
     }
 
-    public final List<LogRecord> records = new ArrayList<>();
+    final List<LogRecord> records = new ArrayList<>();
 
     @Override
     public void publish(LogRecord record) {
@@ -37,6 +37,10 @@ public class InMemoryLogHandler extends Handler {
 
     @Override
     public void close() throws SecurityException {
+        this.records.clear();
+    }
 
+    void clearRecords() {
+        this.records.clear();
     }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -209,6 +209,7 @@ public class QuarkusDevModeTest
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
         rootLogger.setHandlers(originalRootLoggerHandlers);
+        inMemoryLogHandler.clearRecords();
     }
 
     @Override

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -558,6 +558,7 @@ public class QuarkusProdModeTest
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
         rootLogger.setHandlers(originalHandlers);
+        inMemoryLogHandler.clearRecords();
 
         if (run) {
             RestAssuredURLManager.clearURL();


### PR DESCRIPTION
I don't think these end up accumulating a lot, but I think it's worth to have this cleanup in place.