### PR TITLE
Assorted Quartz cleanup

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
@@ -217,7 +217,8 @@ class ConfigDoItemFinder {
                     DeclaredType declaredType = (DeclaredType) typeMirror;
                     TypeElement typeElement = (TypeElement) declaredType.asElement();
                     Name qualifiedName = typeElement.getQualifiedName();
-                    optional = qualifiedName.toString().startsWith(Optional.class.getName());
+                    optional = qualifiedName.toString().startsWith(Optional.class.getName())
+                            || qualifiedName.contentEquals(Map.class.getName());
                     list = qualifiedName.contentEquals(List.class.getName())
                             || qualifiedName.contentEquals(Set.class.getName());
 

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -411,17 +411,17 @@ You can also generate the native executable with `./mvnw clean package -Pnative`
 [[quartz-register-plugin-listeners]]
 == Registering Plugin and Listeners
 
-You can register a plugin, jobListener or triggerListener through Quarkus configuration.
+You can register `plugins`, `job-listeners` and `trigger-listeners` through Quarkus configuration.
 
-The example bellow registers the plugin `org.quartz.plugins.history.LoggingJobHistoryPlugin` named as `jobHistory` with the property `jobSuccessMessage` defined as `Job [{1}.{0}] execution complete and reports: {8}`
+The example below registers the plugin `org.quartz.plugins.history.LoggingJobHistoryPlugin` named as `jobHistory` with the property `jobSuccessMessage` defined as `Job [{1}.{0}] execution complete and reports: {8}`
 
 [source,conf]
 ----
-quarkus.quartz.plugin.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
-quarkus.quartz.plugin.jobHistory.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}
+quarkus.quartz.plugins.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
+quarkus.quartz.plugins.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}
 ----
 
-You can also register a listener programmatically with an injected `org.quartz.Scheduler`
+You can also register a listener programmatically with an injected `org.quartz.Scheduler`:
 
 [source,java]
 ----

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -18,6 +18,7 @@ import org.quartz.core.QuartzSchedulerThread;
 import org.quartz.core.SchedulerSignalerImpl;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.jdbcjobstore.AttributeRestoringConnectionInvocationHandler;
+import org.quartz.impl.jdbcjobstore.DB2v8Delegate;
 import org.quartz.impl.jdbcjobstore.HSQLDBDelegate;
 import org.quartz.impl.jdbcjobstore.JobStoreSupport;
 import org.quartz.impl.jdbcjobstore.MSSQLDelegate;
@@ -57,7 +58,7 @@ import io.quarkus.quartz.runtime.QuartzScheduler;
 import io.quarkus.quartz.runtime.QuartzSupport;
 
 /**
- * 
+ *
  */
 public class QuartzProcessor {
 
@@ -134,6 +135,9 @@ public class QuartzProcessor {
         }
         if (DatabaseKind.isMsSQL(dataSourceKind)) {
             return MSSQLDelegate.class.getName();
+        }
+        if (DatabaseKind.isDB2(dataSourceKind)) {
+            return DB2v8Delegate.class.getName();
         }
 
         return StdJDBCDelegate.class.getName();

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -50,8 +50,8 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.quartz.runtime.QuarkusQuartzConnectionPoolProvider;
-import io.quarkus.quartz.runtime.QuartzAdditionalPropsConfig;
 import io.quarkus.quartz.runtime.QuartzBuildTimeConfig;
+import io.quarkus.quartz.runtime.QuartzExtensionPointConfig;
 import io.quarkus.quartz.runtime.QuartzRecorder;
 import io.quarkus.quartz.runtime.QuartzRuntimeConfig;
 import io.quarkus.quartz.runtime.QuartzScheduler;
@@ -176,9 +176,9 @@ public class QuartzProcessor {
     }
 
     private List<ReflectiveClassBuildItem> getAdditionalConfigurationReflectiveClasses(
-            Map<String, QuartzAdditionalPropsConfig> config, Class<?> clazz) {
+            Map<String, QuartzExtensionPointConfig> config, Class<?> clazz) {
         List<ReflectiveClassBuildItem> reflectiveClasses = new ArrayList<>();
-        for (QuartzAdditionalPropsConfig props : config.values()) {
+        for (QuartzExtensionPointConfig props : config.values()) {
             try {
                 if (!clazz
                         .isAssignableFrom(Class.forName(props.clazz, false, Thread.currentThread().getContextClassLoader()))) {

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
 
 import javax.inject.Singleton;
 
@@ -196,15 +197,17 @@ public class QuartzProcessor {
     public List<LogCleanupFilterBuildItem> logCleanup(QuartzBuildTimeConfig config) {
         List<LogCleanupFilterBuildItem> logCleanUps = new ArrayList<>();
         logCleanUps.add(new LogCleanupFilterBuildItem(StdSchedulerFactory.class.getName(),
+                Level.INFO,
                 "Quartz scheduler version:",
                 "Using default implementation for",
-                "Quartz scheduler 'QuarkusQuartzScheduler'"));
+                "Quartz scheduler '"));
 
         logCleanUps.add(new LogCleanupFilterBuildItem(org.quartz.core.QuartzScheduler.class.getName(),
+                Level.INFO,
                 "Quartz Scheduler v",
                 "JobFactory set to:",
                 "Scheduler meta-data:",
-                "Scheduler QuarkusQuartzScheduler"));
+                "Scheduler "));
 
         logCleanUps.add(new LogCleanupFilterBuildItem(config.storeType.clazz, config.storeType.simpleName
                 + " initialized.", "Handling", "Using db table-based data access locking",

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InvalidTriggerListenerConfigurationTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InvalidTriggerListenerConfigurationTest.java
@@ -17,8 +17,8 @@ public class InvalidTriggerListenerConfigurationTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(SimpleJobs.class)
                     .addAsResource(new StringAsset(
-                            "quarkus.quartz.triggerListener.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin\n"
-                                    + "quarkus.quartz.triggerListener.jobHistory.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}"),
+                            "quarkus.quartz.trigger-listeners.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin\n"
+                                    + "quarkus.quartz.trigger-listeners.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}"),
                             "application.properties"));
 
     @Test

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/RegisterJobListenerTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/RegisterJobListenerTest.java
@@ -26,7 +26,7 @@ public class RegisterJobListenerTest {
                     .addClasses(Jobs.class)
                     .addClass(HelloJobListener.class)
                     .addAsResource(new StringAsset(
-                            "quarkus.quartz.jobListener.testJobListener.class=io.quarkus.quartz.test.listeners.HelloJobListener"),
+                            "quarkus.quartz.job-listeners.testJobListener.class=io.quarkus.quartz.test.listeners.HelloJobListener"),
                             "application.properties"));
 
     @Test

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -50,21 +51,24 @@ public class QuartzBuildTimeConfig {
     public String tablePrefix;
 
     /**
-     * The named trigged listeners list
+     * Trigger listeners.
      */
-    @ConfigItem(name = "triggerListener")
-    @ConfigDocMapKey("namedTriggerListener")
-    public Map<String, QuartzAdditionalPropsConfig> triggerListeners;
+    @ConfigItem
+    @ConfigDocMapKey("listener-name")
+    @ConfigDocSection
+    public Map<String, QuartzExtensionPointConfig> triggerListeners;
     /**
-     * The named job listeners list
+     * Job listeners.
      */
-    @ConfigItem(name = "jobListener")
-    @ConfigDocMapKey("namedJobListener")
-    public Map<String, QuartzAdditionalPropsConfig> jobListeners;
+    @ConfigItem
+    @ConfigDocMapKey("listener-name")
+    @ConfigDocSection
+    public Map<String, QuartzExtensionPointConfig> jobListeners;
     /**
-     * The named plugins list
+     * Plugins.
      */
-    @ConfigItem(name = "plugin")
-    @ConfigDocMapKey("namedPlugin")
-    public Map<String, QuartzAdditionalPropsConfig> plugins;
+    @ConfigItem
+    @ConfigDocMapKey("plugin-name")
+    @ConfigDocSection
+    public Map<String, QuartzExtensionPointConfig> plugins;
 }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
@@ -3,12 +3,11 @@ package io.quarkus.quartz.runtime;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class QuartzAdditionalPropsConfig {
+public class QuartzExtensionPointConfig {
     /**
      * Class name for the configuration.
      */
@@ -16,10 +15,8 @@ public class QuartzAdditionalPropsConfig {
     public String clazz;
 
     /**
-     * The props name and the values for the props.
+     * The properties passed to the class.
      */
-    @ConfigDocSection
-    @ConfigDocMapKey("propsAndValue")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, String> propsValue;
+    @ConfigDocMapKey("property-name")
+    public Map<String, String> properties;
 }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -8,6 +8,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class QuartzRuntimeConfig {
 
     /**
+     * The name of the Quartz instance.
+     */
+    @ConfigItem(defaultValue = "QuarkusQuartzScheduler")
+    public String instanceName;
+
+    /**
      * The size of scheduler thread pool. This will initialize the number of worker threads in the pool.
      */
     @ConfigItem(defaultValue = "25")

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -334,11 +334,11 @@ public class QuartzScheduler implements Scheduler {
         return props;
     }
 
-    private Properties getAdditionalConfigurationProperties(String prefix, Map<String, QuartzAdditionalPropsConfig> config) {
+    private Properties getAdditionalConfigurationProperties(String prefix, Map<String, QuartzExtensionPointConfig> config) {
         Properties props = new Properties();
-        for (Map.Entry<String, QuartzAdditionalPropsConfig> configEntry : config.entrySet()) {
+        for (Map.Entry<String, QuartzExtensionPointConfig> configEntry : config.entrySet()) {
             props.put(String.format("%s.%s.class", prefix, configEntry.getKey()), configEntry.getValue().clazz);
-            for (Map.Entry<String, String> propsEntry : configEntry.getValue().propsValue.entrySet()) {
+            for (Map.Entry<String, String> propsEntry : configEntry.getValue().properties.entrySet()) {
                 props.put(String.format("%s.%s.%s", prefix, configEntry.getKey(), propsEntry.getKey()), propsEntry.getValue());
             }
         }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -292,7 +292,7 @@ public class QuartzScheduler implements Scheduler {
         QuartzBuildTimeConfig buildTimeConfig = quartzSupport.getBuildTimeConfig();
         props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_ID, "AUTO");
         props.put("org.quartz.scheduler.skipUpdateCheck", "true");
-        props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, "QuarkusQuartzScheduler");
+        props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, quartzSupport.getRuntimeConfig().instanceName);
         props.put(StdSchedulerFactory.PROP_SCHED_WRAP_JOB_IN_USER_TX, "false");
         props.put(StdSchedulerFactory.PROP_SCHED_SCHEDULER_THREADS_INHERIT_CONTEXT_CLASS_LOADER_OF_INITIALIZING_THREAD, "true");
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_CLASS, "org.quartz.simpl.SimpleThreadPool");


### PR DESCRIPTION
Fix #11945 

@machi1990 any chance you could have a look at it today? I'm leaning towards including this in 1.8, at least 3 of the commits (still pondering if it's a good idea to break the config now or wait for 1.9).

This is how the config for the extension points now looks:

![Screenshot_2020-09-08 Quarkus - Scheduling Periodic Tasks with Quartz](https://user-images.githubusercontent.com/1279749/92451720-655e1900-f1bd-11ea-997f-0303a9ae7867.png)

Compared to:
https://quarkus.io/guides/quartz#quartz-configuration-reference

I think maintaining the old behavior will be buggy at best so I decided to break the compatibility. Given it's extension points, I think that's OK.

I also added a commit to make Maps optional in the doc, they were marked as mandatory which makes no sense.