### PR TITLE
Allow to ignore explicit JAX-RS application-classes

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -552,9 +552,16 @@ to solve this problem.
 
 Configuration via an application-supplied subclass of `Application` is supported, but not required.
 
+=== Only a single JAX-RS application
+
+In contrast to JAX-RS (and RESTeasy) running in a standard servlet-container, Quarkus only supports the deployment of a single JAX-RS application.
+If multiple JAX-RS `Application` classes are defined, the build will fail with the message `Multiple classes have been annotated with @ApplicationPath which is currently not supported`.
+
+If multiple JAX-RS applications are defined, the property `quarkus.resteasy.ignoreApplicationClasses=true` can be used to ignore all explicit `Application` classes. This makes all resource-classes available via the application-path as defined by `quarkus.resteasy.path` (default: `/`).
+
 === Lifecycle of Resources
 
-In Quarkus all JAX-RS resources are treated as CDI beans. 
+In Quarkus all JAX-RS resources are treated as CDI beans.
 It's possible to inject other beans via `@Inject`, bind interceptors using bindings such as `@Transactional`, define `@PostConstruct` callbacks, etc.
 
 If there is no scope annotation declared on the resource class then the scope is defaulted.

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -15,6 +16,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Application;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -148,6 +151,13 @@ public class ResteasyServerCommonProcessor {
          */
         @ConfigItem(name = "metrics.enabled", defaultValue = "false")
         public boolean metricsEnabled;
+
+        /**
+         * Ignore all explict JAX-RS {@link Application} classes.
+         * As multiple JAX-RS applications are not supported, this can be used to effectively merge all JAX-RS applications.
+         */
+        @ConfigItem(defaultValue = "false")
+        boolean ignoreApplicationClasses;
     }
 
     @BuildStep
@@ -180,7 +190,11 @@ public class ResteasyServerCommonProcessor {
             CustomScopeAnnotationsBuildItem scopes) throws Exception {
         IndexView index = combinedIndexBuildItem.getIndex();
 
-        Collection<AnnotationInstance> applicationPaths = index.getAnnotations(ResteasyDotNames.APPLICATION_PATH);
+        Collection<AnnotationInstance> applicationPaths = Collections.emptySet();
+
+        if (!resteasyConfig.ignoreApplicationClasses) {
+            applicationPaths = index.getAnnotations(ResteasyDotNames.APPLICATION_PATH);
+        }
 
         // currently we only examine the first class that is annotated with @ApplicationPath so best
         // fail if the user code has multiple such annotations instead of surprising the user


### PR DESCRIPTION
quarkus.resteasy.ignoreApplicationClasses=true

This allows multiple JAX-RS application-classes to be present and not fail the build because of it. Effectively, this makes all rest resources available via a single JAX-RS application.

Fixes #11966