### PR TITLE
Fix Quarkus ClassLoader's jar ProtectionDomain handling

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.deployment;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -217,7 +218,8 @@ class VertxHttpProcessor {
             logger.debug("Skipping registration of service providers for " + ExchangeAttributeBuilder.class);
             return;
         }
-        try (final FileSystem jarFileSystem = ZipUtils.newFileSystem(codeSource.getLocation().toURI(),
+        try (final FileSystem jarFileSystem = ZipUtils.newFileSystem(
+                new URI("jar", codeSource.getLocation().toURI().toString(), null),
                 Collections.emptyMap())) {
             final Path serviceDescriptorFilePath = jarFileSystem.getPath("META-INF", "services",
                     "io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder");

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -156,14 +156,13 @@ public class JarClassPathElement implements ClassPathElement {
     public ProtectionDomain getProtectionDomain(ClassLoader classLoader) {
         URL url = null;
         try {
-            URI uri = new URI("jar:file", null, jarPath.getPath() + "!/", null);
+            URI uri = new URI("file", null, jarPath.getPath(), null);
             url = uri.toURL();
         } catch (URISyntaxException | MalformedURLException e) {
             throw new RuntimeException("Unable to create protection domain for " + jarPath, e);
         }
         CodeSource codesource = new CodeSource(url, (Certificate[]) null);
-        ProtectionDomain protectionDomain = new ProtectionDomain(codesource, null, classLoader, null);
-        return protectionDomain;
+        return new ProtectionDomain(codesource, null, classLoader, null);
     }
 
     @Override

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -80,14 +80,13 @@ public class JarResource implements ClassLoadingResource {
             if (!path.startsWith("/")) {
                 path = "/" + path;
             }
-            URI uri = new URI("jar:file", null, path + "!/", null);
+            URI uri = new URI("file", null, path, null);
             url = uri.toURL();
         } catch (URISyntaxException | MalformedURLException e) {
             throw new RuntimeException("Unable to create protection domain for " + jarPath, e);
         }
         CodeSource codesource = new CodeSource(url, (Certificate[]) null);
-        ProtectionDomain protectionDomain = new ProtectionDomain(codesource, null, classLoader, null);
-        return protectionDomain;
+        return new ProtectionDomain(codesource, null, classLoader, null);
     }
 
     private ZipFile file() {

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusClassloaderProtectionDomainTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusClassloaderProtectionDomainTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * The purpose of this test is to ensure that using the projection domain of a class loaded
+ * from the QuarkusClassLoader yields the appropriate result
+ */
+@QuarkusTest
+public class QuarkusClassloaderProtectionDomainTest {
+
+    @Test
+    public void testClassFromJar() throws IOException {
+        Class<?> testClass = org.h2.tools.Server.class;
+        ClassLoader classLoader = testClass.getClassLoader();
+        assertTrue(classLoader instanceof QuarkusClassLoader);
+
+        URL location = testClass.getProtectionDomain().getCodeSource().getLocation();
+        assertNotNull(location);
+
+        try (InputStream inputStream = location.openStream()) {
+            try (JarInputStream jarInputStream = new JarInputStream(inputStream)) {
+                Manifest manifest = jarInputStream.getManifest();
+                assertNotNull(manifest);
+                assertNotNull(manifest.getMainAttributes().getValue("Implementation-Version"));
+            }
+        }
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/projects/classic/src/main/java/org/acme/ProtectionDomain.java
+++ b/integration-tests/maven/src/test/resources/projects/classic/src/main/java/org/acme/ProtectionDomain.java
@@ -1,0 +1,77 @@
+package org.acme;
+
+import org.apache.commons.io.IOUtils;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+
+@Path("/protectionDomain")
+public class ProtectionDomain {
+
+    private static final String SUCCESS = "success";
+
+    @GET
+    public String useProtectionDomain() {
+        return runAssertions(
+                () -> assertReadManifestFromJar()
+        );
+    }
+
+    private String runAssertions(Supplier<String>... assertions) {
+        String result;
+        for (Supplier<String> assertion : assertions) {
+            result = assertion.get();
+            if (!SUCCESS.equals(result)) {
+                return result;
+            }
+        }
+        return SUCCESS;
+    }
+
+    private String assertReadManifestFromJar() {
+        final String testType = "manifest-from-jar";
+        try {
+            URL location = org.apache.commons.io.Charsets.class.getProtectionDomain().getCodeSource().getLocation();
+            if (location == null) {
+                return errorResult(testType, "location should not be null");
+            }
+
+            try (InputStream inputStream = location.openStream()) {
+                try (JarInputStream jarInputStream = new JarInputStream(inputStream)) {
+                    Manifest manifest = jarInputStream.getManifest();
+                    if (manifest == null) {
+                        return errorResult(testType, "manifest should not be null");
+                    }
+                    String implementationVersion = manifest.getMainAttributes().getValue("Implementation-Version");
+                    if (implementationVersion == null) {
+                        return errorResult(testType, "implementation-version should not be null");
+                    }
+                }
+            }
+            return SUCCESS;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return errorResult(testType, "exception during resolution of resource");
+        }
+    }
+
+    private String errorResult(String testType, String message) {
+        return testType + " / " + message;
+    }
+}


### PR DESCRIPTION
Bring it inline with what `URLClassLoader` does

Fixes: #11549