### PR TITLE
ArC - distinguish "bean archive" and "additional" index

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -127,6 +127,7 @@ public class ArcProcessor {
     public ContextRegistrationPhaseBuildItem initialize(
             ArcConfig arcConfig,
             BeanArchiveIndexBuildItem beanArchiveIndex,
+            CombinedIndexBuildItem combinedIndex,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             List<AnnotationsTransformerBuildItem> annotationTransformers,
             List<InjectionPointTransformerBuildItem> injectionPointTransformers,
@@ -193,7 +194,8 @@ public class ArcProcessor {
                 }
             }
         });
-        builder.setIndex(index);
+        builder.setBeanArchiveIndex(index);
+        builder.setApplicationIndex(combinedIndex.getIndex());
         List<BeanDefiningAnnotation> beanDefiningAnnotations = additionalBeanDefiningAnnotations.stream()
                 .map((s) -> new BeanDefiningAnnotation(s.getName(), s.getDefaultScope())).collect(Collectors.toList());
         beanDefiningAnnotations.add(new BeanDefiningAnnotation(ADDITIONAL_BEAN, null));

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoAddScopeBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoAddScopeBuildItem.java
@@ -169,7 +169,6 @@ public final class AutoAddScopeBuildItem extends MultiBuildItem {
          * The final predicate is a short-circuiting logical AND of the previous predicate (if any) and this condition.
          * 
          * @param interfaceName
-         * @param index
          * @return self
          */
         public Builder implementsInterface(DotName interfaceName) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -44,7 +44,7 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
      */
     public void done() {
         if (consumed.compareAndSet(false, true)) {
-            ClassInfo implClass = getClassByName(beanDeployment.getIndex(), Objects.requireNonNull(implClazz));
+            ClassInfo implClass = getClassByName(beanDeployment.getBeanArchiveIndex(), Objects.requireNonNull(implClazz));
             if (implClass == null) {
                 throw new IllegalStateException("Unable to find the bean class in the index: " + implClazz);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -742,7 +742,7 @@ public class BeanGenerator extends AbstractGenerator {
                 // PreDestroy callbacks
                 List<MethodInfo> preDestroyCallbacks = Beans.getCallbacks(bean.getTarget().get().asClass(),
                         DotNames.PRE_DESTROY,
-                        bean.getDeployment().getIndex());
+                        bean.getDeployment().getBeanArchiveIndex());
                 for (MethodInfo callback : preDestroyCallbacks) {
                     if (Modifier.isPrivate(callback.flags())) {
                         privateMembers.add(isApplicationClass, String.format("@PreDestroy callback %s#%s()",
@@ -1483,7 +1483,7 @@ public class BeanGenerator extends AbstractGenerator {
         if (!bean.isInterceptor()) {
             List<MethodInfo> postConstructCallbacks = Beans.getCallbacks(bean.getTarget().get().asClass(),
                     DotNames.POST_CONSTRUCT,
-                    bean.getDeployment().getIndex());
+                    bean.getDeployment().getBeanArchiveIndex());
             for (MethodInfo callback : postConstructCallbacks) {
                 if (isReflectionFallbackNeeded(callback, targetPackage)) {
                     if (Modifier.isPrivate(callback.flags())) {
@@ -1531,7 +1531,7 @@ public class BeanGenerator extends AbstractGenerator {
                 canBeOptimized = bean.getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()
                         && Beans.getCallbacks(bean.getTarget().get().asClass(),
                                 DotNames.PRE_DESTROY,
-                                bean.getDeployment().getIndex()).isEmpty();
+                                bean.getDeployment().getBeanArchiveIndex()).isEmpty();
             } else if (bean.isProducerMethod() || bean.isProducerField()) {
                 canBeOptimized = bean.getDisposer() == null;
             }
@@ -1817,7 +1817,7 @@ public class BeanGenerator extends AbstractGenerator {
                         .readStaticField(FieldDescriptor.of(InjectLiteral.class, "INSTANCE", InjectLiteral.class));
             } else {
                 // Create annotation literal if needed
-                ClassInfo literalClass = getClassByName(beanDeployment.getIndex(), annotation.name());
+                ClassInfo literalClass = getClassByName(beanDeployment.getBeanArchiveIndex(), annotation.name());
                 annotationHandle = annotationLiterals.process(constructor,
                         classOutput, literalClass, annotation,
                         Types.getPackageName(beanCreator.getClassName()));

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -281,7 +281,8 @@ public class BeanInfo implements InjectionTargetInfo {
         }
         if (isClassBean()) {
             return getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()
-                    && Beans.getCallbacks(target.get().asClass(), DotNames.PRE_DESTROY, beanDeployment.getIndex()).isEmpty();
+                    && Beans.getCallbacks(target.get().asClass(), DotNames.PRE_DESTROY, beanDeployment.getBeanArchiveIndex())
+                            .isEmpty();
         } else {
             return disposer == null && destroyerConsumer == null;
         }
@@ -452,7 +453,7 @@ public class BeanInfo implements InjectionTargetInfo {
                         && bindings.stream().noneMatch(e -> e.name().equals(a.name())))
                 .forEach(a -> bindings.add(a));
         if (classInfo.superClassType() != null && !classInfo.superClassType().name().equals(DotNames.OBJECT)) {
-            ClassInfo superClass = getClassByName(beanDeployment.getIndex(), classInfo.superName());
+            ClassInfo superClass = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (superClass != null) {
                 addClassLevelBindings(superClass, bindings);
             }
@@ -536,9 +537,9 @@ public class BeanInfo implements InjectionTargetInfo {
             case CLASS:
                 return target.asClass();
             case FIELD:
-                return getClassByName(beanDeployment.getIndex(), target.asField().type());
+                return getClassByName(beanDeployment.getBeanArchiveIndex(), target.asField().type());
             case METHOD:
-                return getClassByName(beanDeployment.getIndex(), target.asMethod().returnType());
+                return getClassByName(beanDeployment.getBeanArchiveIndex(), target.asMethod().returnType());
             default:
                 break;
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -84,13 +84,13 @@ public class BeanProcessor {
 
         // Initialize all build processors
         buildContext = new BuildContextImpl();
-        buildContext.putInternal(Key.INDEX.asString(), builder.index);
+        buildContext.putInternal(Key.INDEX.asString(), builder.beanArchiveIndex);
 
         this.beanRegistrars = initAndSort(builder.beanRegistrars, buildContext);
         this.observerRegistrars = initAndSort(builder.observerRegistrars, buildContext);
         this.contextRegistrars = initAndSort(builder.contextRegistrars, buildContext);
         this.beanDeploymentValidators = initAndSort(builder.beanDeploymentValidators, buildContext);
-        this.beanDeployment = new BeanDeployment(builder.index, buildContext, builder);
+        this.beanDeployment = new BeanDeployment(buildContext, builder);
 
         // Make it configurable if we find that the set of annotations needs to grow
         this.injectionPointAnnotationsPredicate = annotationName -> !annotationName.equals(DotNames.DEPRECATED);
@@ -247,7 +247,8 @@ public class BeanProcessor {
 
         String name = DEFAULT_NAME;
 
-        IndexView index;
+        IndexView beanArchiveIndex;
+        IndexView applicationIndex;
 
         Collection<BeanDefiningAnnotation> additionalBeanDefiningAnnotations = Collections.emptySet();
         Map<DotName, Collection<AnnotationInstance>> additionalStereotypes = Collections.emptyMap();
@@ -290,8 +291,28 @@ public class BeanProcessor {
             return this;
         }
 
-        public Builder setIndex(IndexView index) {
-            this.index = index;
+        /**
+         * Set the bean archive index. This index is mandatory and is used to discover components (beans, interceptors,
+         * qualifiers, etc.) and during type-safe resolution.
+         * 
+         * @param beanArchiveIndex
+         * @return self
+         */
+        public Builder setBeanArchiveIndex(IndexView beanArchiveIndex) {
+            this.beanArchiveIndex = beanArchiveIndex;
+            return this;
+        }
+
+        /**
+         * Set the application index. This index is optional and is also used to discover types during type-safe resolution.
+         * <p>
+         * Some types may not be part of the bean archive index but are still needed during type-safe resolution.
+         * 
+         * @param applicationIndex
+         * @return self
+         */
+        public Builder setApplicationIndex(IndexView applicationIndex) {
+            this.applicationIndex = applicationIndex;
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
@@ -9,7 +9,6 @@ import static org.jboss.jandex.Type.Kind.WILDCARD_TYPE;
 
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -27,8 +26,7 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.jandex.WildcardType;
 
 /**
- *
- * @author Martin Kouba
+ * Implements type-safe resolution rules.
  */
 class BeanResolver {
 
@@ -45,13 +43,19 @@ class BeanResolver {
         this.assignableFromMap = new ConcurrentHashMap<>();
         this.assignableFromMapFunction = name -> {
             Set<DotName> assignables = new HashSet<>();
-            Collection<ClassInfo> subclasses = beanDeployment.getIndex().getAllKnownSubclasses(name);
-            for (ClassInfo subclass : subclasses) {
+            for (ClassInfo subclass : beanDeployment.getBeanArchiveIndex().getAllKnownSubclasses(name)) {
                 assignables.add(subclass.name());
             }
-            Collection<ClassInfo> implementors = beanDeployment.getIndex().getAllKnownImplementors(name);
-            for (ClassInfo implementor : implementors) {
+            for (ClassInfo implementor : beanDeployment.getBeanArchiveIndex().getAllKnownImplementors(name)) {
                 assignables.add(implementor.name());
+            }
+            if (beanDeployment.hasApplicationIndex()) {
+                for (ClassInfo subclass : beanDeployment.getApplicationIndex().getAllKnownSubclasses(name)) {
+                    assignables.add(subclass.name());
+                }
+                for (ClassInfo implementor : beanDeployment.getApplicationIndex().getAllKnownImplementors(name)) {
+                    assignables.add(implementor.name());
+                }
             }
             return assignables;
         };

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -151,7 +151,7 @@ final class Beans {
     private static ScopeInfo inheritScope(ClassInfo beanClass, BeanDeployment beanDeployment) {
         DotName superClassName = beanClass.superName();
         while (!superClassName.equals(DotNames.OBJECT)) {
-            ClassInfo classFromIndex = getClassByName(beanDeployment.getIndex(), superClassName);
+            ClassInfo classFromIndex = getClassByName(beanDeployment.getBeanArchiveIndex(), superClassName);
             if (classFromIndex == null) {
                 // class not in index
                 LOGGER.warnf("Unable to determine scope for bean %s using inheritance because its super class " +
@@ -680,7 +680,7 @@ final class Beans {
                 if (bean.getDeployment().transformUnproxyableClasses) {
                     DotName superName = beanClass.superName();
                     if (!DotNames.OBJECT.equals(superName)) {
-                        ClassInfo superClass = bean.getDeployment().getIndex().getClassByName(beanClass.superName());
+                        ClassInfo superClass = bean.getDeployment().getBeanArchiveIndex().getClassByName(beanClass.superName());
                         if (superClass == null || !superClass.hasNoArgsConstructor()) {
                             // Bean class extends a class without no-args constructor
                             // It is not possible to generate a no-args constructor reliably
@@ -720,7 +720,7 @@ final class Beans {
             }
 
         } else if (bean.isProducerField() || bean.isProducerMethod()) {
-            ClassInfo returnTypeClass = getClassByName(bean.getDeployment().getIndex(),
+            ClassInfo returnTypeClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(),
                     bean.isProducerMethod() ? bean.getTarget().get().asMethod().returnType()
                             : bean.getTarget().get().asField().type());
             // can be null for primitive types
@@ -743,7 +743,8 @@ final class Beans {
                     if (bean.getDeployment().transformUnproxyableClasses) {
                         DotName superName = returnTypeClass.superName();
                         if (!DotNames.OBJECT.equals(superName)) {
-                            ClassInfo superClass = bean.getDeployment().getIndex().getClassByName(returnTypeClass.superName());
+                            ClassInfo superClass = bean.getDeployment().getBeanArchiveIndex()
+                                    .getClassByName(returnTypeClass.superName());
                             if (superClass == null || !superClass.hasNoArgsConstructor()) {
                                 // Bean class extends a class without no-args constructor
                                 // It is not possible to generate a no-args constructor reliably
@@ -787,7 +788,7 @@ final class Beans {
         }
         if (type.kind() == Type.Kind.CLASS) {
             // Index the class additionally if needed
-            getClassByName(beanDeployment.getIndex(), type.name());
+            getClassByName(beanDeployment.getBeanArchiveIndex(), type.name());
         } else {
             analyzeType(type, beanDeployment);
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -168,7 +168,7 @@ enum BuiltinBean {
         if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
             for (AnnotationInstance annotation : ctx.injectionPoint.getRequiredQualifiers()) {
                 // Create annotation literal first
-                ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getIndex(), annotation.name());
+                ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getBeanArchiveIndex(), annotation.name());
                 ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotations,
                         ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
                                 annotationClass, annotation,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -85,7 +85,7 @@ public class ClientProxyGenerator extends AbstractGenerator {
                 generateSources);
 
         Type providerType = bean.getProviderType();
-        ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());
+        ClassInfo providerClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String baseName = getBaseName(bean, beanClassName);
         String targetPackage = getPackageName(bean);
@@ -316,7 +316,7 @@ public class ClientProxyGenerator extends AbstractGenerator {
         if (bean.isClassBean()) {
             Set<Methods.NameAndDescriptor> methodsFromWhichToRemoveFinal = new HashSet<>();
             ClassInfo classInfo = bean.getTarget().get().asClass();
-            Methods.addDelegatingMethods(bean.getDeployment().getIndex(), classInfo,
+            Methods.addDelegatingMethods(bean.getDeployment().getBeanArchiveIndex(), classInfo,
                     methods, methodsFromWhichToRemoveFinal, transformUnproxyableClasses);
             if (!methodsFromWhichToRemoveFinal.isEmpty()) {
                 String className = classInfo.name().toString();
@@ -325,16 +325,16 @@ public class ClientProxyGenerator extends AbstractGenerator {
             }
         } else if (bean.isProducerMethod()) {
             MethodInfo producerMethod = bean.getTarget().get().asMethod();
-            ClassInfo returnTypeClass = getClassByName(bean.getDeployment().getIndex(), producerMethod.returnType());
-            Methods.addDelegatingMethods(bean.getDeployment().getIndex(), returnTypeClass, methods, null,
+            ClassInfo returnTypeClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), producerMethod.returnType());
+            Methods.addDelegatingMethods(bean.getDeployment().getBeanArchiveIndex(), returnTypeClass, methods, null,
                     transformUnproxyableClasses);
         } else if (bean.isProducerField()) {
             FieldInfo producerField = bean.getTarget().get().asField();
-            ClassInfo fieldClass = getClassByName(bean.getDeployment().getIndex(), producerField.type());
-            Methods.addDelegatingMethods(bean.getDeployment().getIndex(), fieldClass, methods, null,
+            ClassInfo fieldClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), producerField.type());
+            Methods.addDelegatingMethods(bean.getDeployment().getBeanArchiveIndex(), fieldClass, methods, null,
                     transformUnproxyableClasses);
         } else if (bean.isSynthetic()) {
-            Methods.addDelegatingMethods(bean.getDeployment().getIndex(), bean.getImplClazz(), methods, null,
+            Methods.addDelegatingMethods(bean.getDeployment().getBeanArchiveIndex(), bean.getImplClazz(), methods, null,
                     transformUnproxyableClasses);
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -130,7 +130,7 @@ public class Injection {
         }
 
         if (!classInfo.superName().equals(DotNames.OBJECT)) {
-            ClassInfo info = getClassByName(beanDeployment.getIndex(), classInfo.superName());
+            ClassInfo info = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (info != null) {
                 forClassBean(beanClass, info, beanDeployment, injections, transformer, true);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -66,7 +66,7 @@ public class InterceptorGenerator extends BeanGenerator {
         } else {
             baseName = DotNames.simpleName(interceptorClass);
         }
-        ClassInfo providerClass = getClassByName(interceptor.getDeployment().getIndex(), providerType.name());
+        ClassInfo providerClass = getClassByName(interceptor.getDeployment().getBeanArchiveIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String targetPackage = DotNames.packageName(providerType.name());
         String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
@@ -58,11 +58,7 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
         List<MethodInfo> preDestroys = new ArrayList<>();
 
         ClassInfo aClass = target.asClass();
-        Set<DotName> scanned = new HashSet<>();
         while (aClass != null) {
-            if (!scanned.add(aClass.name())) {
-                continue;
-            }
             for (MethodInfo method : aClass.methods()) {
                 if (Modifier.isStatic(method.flags())) {
                     continue;
@@ -95,7 +91,7 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
 
             DotName superTypeName = aClass.superName();
             aClass = superTypeName == null || DotNames.OBJECT.equals(superTypeName) ? null
-                    : getClassByName(beanDeployment.getIndex(), superTypeName);
+                    : getClassByName(beanDeployment.getBeanArchiveIndex(), superTypeName);
         }
 
         this.aroundInvoke = aroundInvokes.isEmpty() ? null : aroundInvokes.get(0);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
@@ -83,11 +83,12 @@ public class InterceptorResolver {
             // Must have the same annotation member value for each member which is not annotated @Nonbinding
             boolean matches = true;
             Set<String> nonBindingFields = beanDeployment.getNonBindingFields(interceptorBinding.name());
-            for (AnnotationValue value : candidate.valuesWithDefaults(beanDeployment.getIndex())) {
+            for (AnnotationValue value : candidate.valuesWithDefaults(beanDeployment.getBeanArchiveIndex())) {
                 String annotationField = value.name();
                 if (!interceptorBindingClass.method(annotationField).hasAnnotation(DotNames.NONBINDING)
                         && !nonBindingFields.contains(annotationField)
-                        && !value.equals(interceptorBinding.valueWithDefault(beanDeployment.getIndex(), annotationField))) {
+                        && !value.equals(
+                                interceptorBinding.valueWithDefault(beanDeployment.getBeanArchiveIndex(), annotationField))) {
                     matches = false;
                     break;
                 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -188,7 +188,7 @@ final class Methods {
         }
 
         if (classInfo.superClassType() != null) {
-            ClassInfo superClassInfo = getClassByName(beanDeployment.getIndex(), classInfo.superName());
+            ClassInfo superClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (superClassInfo != null) {
                 finalMethodsFoundAndNotChanged.addAll(addInterceptedMethodCandidates(beanDeployment, superClassInfo, candidates,
                         classLevelBindings, bytecodeTransformerConsumer, transformUnproxyableClasses));
@@ -197,7 +197,7 @@ final class Methods {
 
         // Interface default methods can be intercepted too
         for (DotName i : classInfo.interfaceNames()) {
-            ClassInfo interfaceInfo = getClassByName(beanDeployment.getIndex(), i);
+            ClassInfo interfaceInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), i);
             if (interfaceInfo != null) {
                 //interfaces can't have final methods
                 addInterceptedMethodCandidates(beanDeployment, interfaceInfo, candidates,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -108,7 +108,7 @@ public class SubclassGenerator extends AbstractGenerator {
                 generateSources);
 
         Type providerType = bean.getProviderType();
-        ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());
+        ClassInfo providerClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String baseName = getBaseName(bean, beanClassName);
         String generatedName = generatedName(providerType.name(), baseName);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import javax.enterprise.inject.spi.DefinitionException;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
@@ -164,13 +165,16 @@ final class Types {
     static Set<Type> getProducerMethodTypeClosure(MethodInfo producerMethod, BeanDeployment beanDeployment) {
         Set<Type> types;
         Type returnType = producerMethod.returnType();
+        if (returnType.kind() == Kind.TYPE_VARIABLE) {
+            throw new DefinitionException("A type variable is not a legal bean type: " + producerMethod);
+        }
         if (returnType.kind() == Kind.PRIMITIVE || returnType.kind() == Kind.ARRAY) {
             types = new HashSet<>();
             types.add(returnType);
             types.add(OBJECT_TYPE);
             return types;
         } else {
-            ClassInfo returnTypeClassInfo = getClassByName(beanDeployment.getIndex(), returnType);
+            ClassInfo returnTypeClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), returnType);
             if (returnTypeClassInfo == null) {
                 throw new IllegalArgumentException(
                         "Producer method return type not found in index: " + producerMethod.returnType().name());
@@ -180,7 +184,7 @@ final class Types {
             } else if (Kind.PARAMETERIZED_TYPE.equals(returnType.kind())) {
                 types = getTypeClosure(returnTypeClassInfo, producerMethod,
                         buildResolvedMap(returnType.asParameterizedType().arguments(), returnTypeClassInfo.typeParameters(),
-                                Collections.emptyMap(), beanDeployment.getIndex()),
+                                Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()),
                         beanDeployment, null);
             } else {
                 throw new IllegalArgumentException("Unsupported return type");
@@ -192,12 +196,15 @@ final class Types {
     static Set<Type> getProducerFieldTypeClosure(FieldInfo producerField, BeanDeployment beanDeployment) {
         Set<Type> types;
         Type fieldType = producerField.type();
+        if (fieldType.kind() == Kind.TYPE_VARIABLE) {
+            throw new DefinitionException("A type variable is not a legal bean type: " + producerField);
+        }
         if (fieldType.kind() == Kind.PRIMITIVE || fieldType.kind() == Kind.ARRAY) {
             types = new HashSet<>();
             types.add(fieldType);
             types.add(OBJECT_TYPE);
         } else {
-            ClassInfo fieldClassInfo = getClassByName(beanDeployment.getIndex(), producerField.type());
+            ClassInfo fieldClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), producerField.type());
             if (fieldClassInfo == null) {
                 throw new IllegalArgumentException("Producer field type not found in index: " + producerField.type().name());
             }
@@ -206,7 +213,7 @@ final class Types {
             } else if (Kind.PARAMETERIZED_TYPE.equals(fieldType.kind())) {
                 types = getTypeClosure(fieldClassInfo, producerField,
                         buildResolvedMap(fieldType.asParameterizedType().arguments(), fieldClassInfo.typeParameters(),
-                                Collections.emptyMap(), beanDeployment.getIndex()),
+                                Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()),
                         beanDeployment, null);
             } else {
                 throw new IllegalArgumentException("Unsupported return type");
@@ -222,7 +229,7 @@ final class Types {
             types = getTypeClosure(classInfo, null, Collections.emptyMap(), beanDeployment, null);
         } else {
             types = getTypeClosure(classInfo, null, buildResolvedMap(typeParameters, typeParameters,
-                    Collections.emptyMap(), beanDeployment.getIndex()), beanDeployment, null);
+                    Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()), beanDeployment, null);
         }
         return restrictBeanTypes(types, beanDeployment.getAnnotations(classInfo));
     }
@@ -269,12 +276,12 @@ final class Types {
             if (BANNED_INTERFACE_TYPES.contains(interfaceType.name())) {
                 continue;
             }
-            ClassInfo interfaceClassInfo = getClassByName(beanDeployment.getIndex(), interfaceType.name());
+            ClassInfo interfaceClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), interfaceType.name());
             if (interfaceClassInfo != null) {
                 Map<TypeVariable, Type> resolved = Collections.emptyMap();
                 if (Kind.PARAMETERIZED_TYPE.equals(interfaceType.kind())) {
                     resolved = buildResolvedMap(interfaceType.asParameterizedType().arguments(),
-                            interfaceClassInfo.typeParameters(), resolvedTypeParameters, beanDeployment.getIndex());
+                            interfaceClassInfo.typeParameters(), resolvedTypeParameters, beanDeployment.getBeanArchiveIndex());
                 }
                 types.addAll(getTypeClosure(interfaceClassInfo, producerFieldOrMethod, resolved, beanDeployment,
                         resolvedTypeVariablesConsumer));
@@ -282,13 +289,13 @@ final class Types {
         }
         // Superclass
         if (classInfo.superClassType() != null) {
-            ClassInfo superClassInfo = getClassByName(beanDeployment.getIndex(), classInfo.superName());
+            ClassInfo superClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (superClassInfo != null) {
                 Map<TypeVariable, Type> resolved = Collections.emptyMap();
                 if (Kind.PARAMETERIZED_TYPE.equals(classInfo.superClassType().kind())) {
                     resolved = buildResolvedMap(classInfo.superClassType().asParameterizedType().arguments(),
                             superClassInfo.typeParameters(),
-                            resolvedTypeParameters, beanDeployment.getIndex());
+                            resolvedTypeParameters, beanDeployment.getBeanArchiveIndex());
                 }
                 types.addAll(getTypeClosure(superClassInfo, producerFieldOrMethod, resolved, beanDeployment,
                         resolvedTypeVariablesConsumer));

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
@@ -40,7 +40,7 @@ public class BeanInfoInjectionsTest {
         Type listStringType = ParameterizedType.create(name(List.class),
                 new Type[] { Type.create(name(String.class), Kind.CLASS) }, null);
 
-        BeanDeployment deployment = BeanProcessor.builder().setIndex(index).build().getBeanDeployment();
+        BeanDeployment deployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
         deployment.registerCustomContexts(Collections.emptyList());
         deployment.registerBeans(Collections.emptyList());
         BeanInfo barBean = deployment.getBeans().stream().filter(b -> b.getTarget().get().equals(barClass)).findFirst().get();

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
@@ -34,7 +34,8 @@ public class BeanInfoQualifiersTest {
         DotName fooQualifierName = name(FooQualifier.class);
         ClassInfo fooClass = index.getClassByName(fooName);
 
-        BeanInfo bean = Beans.createClassBean(fooClass, BeanProcessor.builder().setIndex(index).build().getBeanDeployment(),
+        BeanInfo bean = Beans.createClassBean(fooClass,
+                BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment(),
                 null);
 
         AnnotationInstance requiredFooQualifier = index.getAnnotations(fooQualifierName).stream()

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
@@ -35,7 +35,7 @@ public class BeanInfoTypesTest {
                 Collection.class, List.class,
                 Iterable.class, Object.class, String.class);
 
-        BeanDeployment deployment = BeanProcessor.builder().setIndex(index).build().getBeanDeployment();
+        BeanDeployment deployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
         DotName fooName = name(Foo.class);
 
         ClassInfo fooClass = index.getClassByName(fooName);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -32,7 +32,7 @@ public class TypesTest {
         DotName producerName = DotName.createSimple(Producer.class.getName());
         ClassInfo fooClass = index.getClassByName(fooName);
         Map<ClassInfo, Map<TypeVariable, Type>> resolvedTypeVariables = new HashMap<>();
-        BeanDeployment dummyDeployment = BeanProcessor.builder().setIndex(index).build().getBeanDeployment();
+        BeanDeployment dummyDeployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
 
         // Baz, Foo<String>, Object
         Set<Type> bazTypes = Types.getTypeClosure(index.getClassByName(bazName), null,

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/index/AdditionalIndexTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/index/AdditionalIndexTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.index;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.ArrayList;
+import java.util.List;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AdditionalIndexTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Client.class, SuperProducer.class, SuperClazz.class)
+            // SubClazz is not part of the bean archive index
+            .additionalClasses(SubClazz.class).build();
+
+    @Test
+    public void testTypesafeResolution() {
+        Client client = Arc.container().instance(Client.class).get();
+        // Test that the build does not fail and we're able to inject the producer
+        assertTrue(client.list.isEmpty());
+    }
+
+    @Dependent
+    static class Client {
+
+        // This injection point should be satisfied by SuperProducer#produce()
+        // because SubClazz extends SuperClazz
+        @Inject
+        List<SubClazz> list;
+    }
+
+    public static class SuperProducer {
+
+        @Produces
+        <T extends SuperClazz> List<T> produce() {
+            return new ArrayList<>();
+        }
+
+    }
+
+    public static class SuperClazz {
+
+        public void ping() {
+        }
+    }
+
+    public static class SubClazz extends SuperClazz {
+
+    }
+
+}


### PR DESCRIPTION
- the first one is used to discover beans, etc.
- the latter one is also used to discover types during type-safe
discovery
- fixes #11863