### PR TITLE
Add CDI name to named Mongo client connections

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -276,7 +276,8 @@ public class MongoClientProcessor {
             configurator.addQualifier(Default.class);
         } else {
             String namedQualifier = MongoClientBeanUtil.namedQualifier(clientName, isReactive);
-            configurator.addQualifier().annotation(DotNames.NAMED).addValue("value", namedQualifier).done();
+            configurator.name(namedQualifier).addQualifier().annotation(DotNames.NAMED).addValue("value", namedQualifier)
+                    .done();
             if (addMongoClientQualifier) {
                 configurator.addQualifier().annotation(MONGO_CLIENT_ANNOTATION).addValue("value", clientName).done();
                 configurator.addQualifier().annotation(LEGACY_MONGO_CLIENT_ANNOTATION).addValue("value", clientName).done();

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
@@ -55,6 +55,10 @@ public class DefaultAndNamedMongoClientConfigTest extends MongoWithReplicasTestB
         assertThat(Arc.container().instance(MongoClient.class, Default.Literal.INSTANCE).get()).isNotNull();
         assertThat(Arc.container().instance(MongoClient.class, NamedLiteral.of("cluster2")).get()).isNotNull();
         assertThat(Arc.container().instance(MongoClient.class, NamedLiteral.of("cluster3")).get()).isNull();
+
+        // assert using a CDI name results in the retrieving the client
+        assertThat(Arc.container().instance("cluster2").get()).isNotNull();
+        assertThat(Arc.container().instance("cluster3").get()).isNull();
     }
 
     private void assertProperConnection(MongoClient client, int expectedPort) {

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedReactiveMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedReactiveMongoClientConfigTest.java
@@ -59,6 +59,10 @@ public class NamedReactiveMongoClientConfigTest extends MongoWithReplicasTestBas
         assertThat(client2.listDatabases().collectItems().first().await().indefinitely()).isNotEmpty();
 
         assertNoDefaultClient();
+
+        assertThat(Arc.container().instance("cluster1reactive").get()).isNotNull();
+        assertThat(Arc.container().instance("cluster2reactive").get()).isNotNull();
+        assertThat(Arc.container().instance("cluster3reactive").get()).isNull();
     }
 
     private void assertProperConnection(ReactiveMongoClient client, int expectedPort) {


### PR DESCRIPTION
Based on the discussion at: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/MongoDB.20clients.20CDI

This does **not** add a name for the default connection.

cc @lburgazzoli @squakez  