### PR TITLE
Manage org.apache.httpcomponents:httpmime

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2764,6 +2764,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpasyncclient</artifactId>
                 <version>${httpasync.version}</version>
             </dependency>


### PR DESCRIPTION
We import Quarkus BOM into our BOM in Camel Quarkus. Managing `httpmime` in addition to other `org.apache.httpcomponents` artifacts would simplify our maintenance.