### PR TITLE
ArC - normalize @Named qualifier when the name is defaulted

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -149,6 +149,17 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         return self();
     }
 
+    /**
+     * Unlike for the {@link #name(String)} method a new {@link javax.inject.Named} qualifier with the specified value is added
+     * to the configured bean.
+     * 
+     * @param name
+     * @return self
+     */
+    public B named(String name) {
+        return name(name).addQualifier().annotation(DotNames.NAMED).addValue("value", name).done();
+    }
+
     public B defaultBean() {
         this.defaultBean = true;
         return self();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -65,6 +65,7 @@ final class Beans {
                     name = nameValue.asString();
                 } else {
                     name = getDefaultName(beanClass);
+                    annotation = normalizedNamedQualifier(name, annotation);
                 }
             }
             Collection<AnnotationInstance> qualifierCollection = beanDeployment.extractQualifiers(annotation);
@@ -202,6 +203,7 @@ final class Beans {
                     name = nameValue.asString();
                 } else {
                     name = getDefaultName(producerMethod);
+                    annotation = normalizedNamedQualifier(name, annotation);
                 }
             }
             Collection<AnnotationInstance> qualifierCollection = beanDeployment.extractQualifiers(annotation);
@@ -301,6 +303,7 @@ final class Beans {
                     name = nameValue.asString();
                 } else {
                     name = producerField.name();
+                    annotation = normalizedNamedQualifier(name, annotation);
                 }
             }
             Collection<AnnotationInstance> qualifierCollection = beanDeployment.extractQualifiers(annotation);
@@ -371,6 +374,13 @@ final class Beans {
         BeanInfo bean = new BeanInfo(producerField, beanDeployment, scope, types, qualifiers, Collections.emptyList(),
                 declaringBean, disposer, alternativePriority, stereotypes, name, isDefaultBean);
         return bean;
+    }
+
+    private static AnnotationInstance normalizedNamedQualifier(String defaultedName, AnnotationInstance originalAnnotation) {
+        // Replace @Named("") with @Named("foo")
+        // This is not explicitly defined by the spec but better align with the RI behavior
+        return AnnotationInstance.create(DotNames.NAMED, originalAnnotation.target(),
+                Collections.singletonList(AnnotationValue.createStringValue("value", defaultedName)));
     }
 
     private static DefinitionException multipleScopesFound(String baseMessage, List<ScopeInfo> scopes) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NameResolutionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NameResolutionTest.java
@@ -7,6 +7,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,8 @@ public class NameResolutionTest {
         assertEquals(12345, Arc.container().instance("bongo").get());
         assertEquals("bing", Arc.container().instance("producedBing").get());
         assertEquals(1, Arc.container().beanManager().getBeans("bongo").size());
+        // Test that for defaulted name the @Named qualifier is replaced the defaulted value
+        assertEquals("bing", Arc.container().instance(String.class, NamedLiteral.of("producedBing")).get());
     }
 
     @Named("A")


### PR DESCRIPTION
- this is not explicitly required by the spec but better align with the
RI behavior