### PR TITLE
Provides a @Blocking annotation for gRPC

### DIFF
--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMutinyHelloService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMutinyHelloService.java
@@ -1,0 +1,21 @@
+package io.quarkus.grpc.server.blocking;
+
+import javax.inject.Singleton;
+
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
+import io.quarkus.grpc.runtime.annotations.Blocking;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+@Blocking
+public class BlockingMutinyHelloService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        return Uni.createFrom().item(request.getName())
+                .map(s -> Thread.currentThread().getName() + " " + s)
+                .map(s -> HelloReply.newBuilder().setMessage(s).build());
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloReplyOrBuilder;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.HelloRequestOrBuilder;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BlockingServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BlockingMutinyHelloService.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
+                            HelloRequestOrBuilder.class, HelloReplyOrBuilder.class));
+
+    protected ManagedChannel channel;
+
+    @BeforeEach
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void test() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
+import io.quarkus.grpc.runtime.annotations.Blocking;
 import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
 
 @ApplicationScoped
@@ -19,6 +20,11 @@ public class GrpcContainer {
 
     @Inject
     Instance<BindableService> services;
+
+    @Inject
+    @Blocking
+    Instance<BindableService> blockingServices;
+
     @Inject
     Instance<ServerInterceptor> interceptors;
     @Inject
@@ -52,7 +58,11 @@ public class GrpcContainer {
         return healthStorage;
     }
 
-    public Instance<BindableService> getServices() {
+    public Instance<BindableService> getNonBlockingServices() {
         return services;
+    }
+
+    public Instance<BindableService> getBlockingServices() {
+        return blockingServices;
     }
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/annotations/Blocking.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/annotations/Blocking.java
@@ -1,0 +1,26 @@
+package io.quarkus.grpc.runtime.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import io.grpc.BindableService;
+
+/**
+ * Qualifier used to indicate that the annotated {@link BindableService} should not be executed on the IO thread but on
+ * a worker thread.
+ *
+ * Use this annotation if your service implementation need to use blocking APIs such as <em>traditional</em> database
+ * access.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ TYPE, FIELD, METHOD })
+public @interface Blocking {
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
@@ -1,0 +1,99 @@
+package io.quarkus.grpc.runtime.supports;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.grpc.*;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class BlockingServerInterceptor implements ServerInterceptor {
+
+    private final Vertx vertx;
+
+    public BlockingServerInterceptor(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        ReplayListener<ReqT> replay = new ReplayListener<>();
+
+        vertx.executeBlocking(f -> {
+            ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
+            replay.setDelegate(listener);
+            f.complete(null);
+        }, null);
+
+        return replay;
+    }
+
+    /**
+     * Stores the incoming events until the listener is injected.
+     * When injected, replay the events.
+     *
+     * Note that event must be executed in order, explaining the `ordered:true`.
+     */
+    private class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
+        private ServerCall.Listener<ReqT> delegate;
+        private final List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
+
+        synchronized void setDelegate(ServerCall.Listener<ReqT> delegate) {
+            this.delegate = delegate;
+            for (Consumer<ServerCall.Listener<ReqT>> event : incomingEvents) {
+                event.accept(delegate);
+            }
+            incomingEvents.clear();
+        }
+
+        private synchronized void executeOnContextOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
+            if (this.delegate != null) {
+                vertx.executeBlocking(new Handler<Promise<Object>>() {
+                    @Override
+                    public void handle(Promise<Object> f) {
+                        consumer.accept(delegate);
+                        f.complete();
+                    }
+                }, true, null);
+            } else {
+                incomingEvents.add(consumer);
+            }
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            executeOnContextOrEnqueue(new Consumer<ServerCall.Listener<ReqT>>() {
+                @Override
+                public void accept(ServerCall.Listener<ReqT> t) {
+                    t.onMessage(message);
+                }
+            });
+        }
+
+        @Override
+        public void onHalfClose() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onHalfClose);
+        }
+
+        @Override
+        public void onCancel() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onCancel);
+        }
+
+        @Override
+        public void onComplete() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onComplete);
+        }
+
+        @Override
+        public void onReady() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onReady);
+        }
+    }
+
+}


### PR DESCRIPTION
This is a follow up of #11535.
With @Blocking the service implementation is called on a worker thread instead of an IO thread.
This support is experimental.
