### PR TITLE
security jpa documentation update

### DIFF
--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -262,6 +262,11 @@ As a result, the `security-jpa` defaults to using bcrypt-hashed passwords.
 
 == Testing the Application
 
+[NOTE]
+====
+In the following tests we use the basic authentication mechanism, you can enable it by setting `quarkus.http.auth.basic=true` in the `application.properties` file.
+====
+
 The application is now protected and the identities are provided by our database.
 The very first thing to check is to ensure the anonymous access works.
 


### PR DESCRIPTION
Adds a reminder for enable `quarkus.http.auth.basic=true` before running the tests, if is not enable all tests results in `401`. 

**Note** follow up of https://github.com/quarkusio/quarkus/pull/11995, my apologies, this is my second time collaborating and things got a little messy. Now I know that adding the `upstream` is the way to go.

cc: @sberyozkin