### PR TITLE
Add a hint to OIDC and Hibernate Multitenancy docs about passing a tenant id

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -745,6 +745,7 @@ it's implemented by the Agroal connection pool extension for Quarkus.
 
 Jump over to link:datasource[Quarkus - Datasources] for all details.
 
+[[multitenancy]]
 == Multitenancy
 
 "The term multitenancy, in general, is applied to software development to indicate an architecture in which a single running instance of an application simultaneously serves multiple clients (tenants). This is highly common in SaaS solutions. Isolating information (data, customizations, etc.) pertaining to the various tenants is a particular challenge in these systems. This includes the data owned by each tenant stored in the database" (link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy[Hibernate User Guide]).
@@ -844,6 +845,30 @@ public class CustomTenantResolver implements TenantResolver {
 }
 ----
 <1> Make sure to use the `@io.quarkus.hibernate.orm.PersistenceUnit` annotation, not the JPA one.
+====
+
+[NOTE]
+====
+If you also use link:security-openid-connect-multitenancy[OIDC multitenancy] and both OIDC and Hibernate ORM tenant IDs are the same and must be extracted from the Vert.x `RoutingContext` then you can pass the tenant id from the OIDC Tenant Resolver to the Hibernate ORM Tenant Resolver as a `RoutingContext` attribute, for example:
+
+[source,java]
+----
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+import io.vertx.ext.web.RoutingContext;
+
+@RequestScoped
+public class CustomTenantResolver implements TenantResolver {
+
+    @Inject
+    RoutingContext context;
+    ...
+    @Override
+    public String resolveTenantId() {
+        // OIDC TenantResolver has already calculated the tenant id and saved it as a RoutingContext `tenantId` attribute:
+        return context.get("tenantId");
+    }
+}
+----
 ====
 
 === Configuring the application

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -151,6 +151,24 @@ public class CustomTenantResolver implements TenantResolver {
 
 From the implementation above, tenants are resolved from the request path so that in case no tenant could be inferred, `null` is returned to indicate that the default tenant configuration should be used.
 
+[NOTE]
+===
+If you also use link:hibernate-orm#multitenancy[Hibernate ORM multitenancy] and both OIDC and Hibernate ORM tenant IDs are the same and must be extracted from the Vert.x `RoutingContext` then you can pass the tenant id from the OIDC Tenant Resolver to the Hibernate ORM Tenant Resolver as a `RoutingContext` attribute, for example:
+
+[source,java]
+----
+public class CustomTenantResolver implements TenantResolver {
+
+    @Override
+    public String resolve(RoutingContext context) {
+        String tenantId = extractTenantId(context);
+        context.put("tenantId", tenantId);
+        return tenantId;
+    }
+}
+----
+===
+
 == Configuring the application
 
 [source,properties]


### PR DESCRIPTION
Fixes #11949. 

This PR updates OIDC and Hibernate Multitenancy docs to suggest a simple way of passing a tenant id across 2 resolvers. This can be very obvious anyway, but adding this hint won't harm as 1) some users may be copy-pasting from the docs and may not realize `RoutingContext` can be used as a medium to pass this id around to save on duplicating the parsing code in the Hibernate resolver 2) Highlights that both OIDC and Hibernate multitenancy can work in tandem