### PR TITLE
More security documentation updates

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -67,6 +67,7 @@ will be served relative to `{quarkus.http.root-path}/{quarkus.servlet.context-pa
 If REST Assured is used for testing and `quarkus.http.root-path` is set then Quarkus will automatically configure the
 base URL for use in Quarkus tests, so test URL's should not include the root path.
 
+[[ssl]]
 == Supporting secure connections with SSL
 
 In order to have Quarkus support secure connections, you must either provide a certificate and associated key file, or supply a keystore.

--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -40,7 +40,7 @@ include::{generated-dir}/config/quarkus-vertx-http-config-group-form-auth-config
 
 Quarkus provides mTLS authentication so that you can authenticate users based on their X.509 certificates.
 
-To use this authentication method, you should first enable SSL for your application. For more details, check the link:http-reference[Supporting secure connections with SSL] guide.
+To use this authentication method, you should first enable SSL for your application. For more details, check the link:http-reference#ssl[Supporting secure connections with SSL] guide.
 
 Once your application is accepting secure connections, the next step is to configure a `quarkus.http.ssl.certificate.trust-store-file`
 holding all the certificates that your application should trust as well as how your application should ask for certificates when

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -99,6 +99,10 @@ The `quarkus.oidc.application-type` property is set to `web-app` in order to tel
 For last, the `quarkus.http.auth.permission.authenticated` permission is set to tell Quarkus about the paths you want to protect. In this case,
 all paths are being protected by a policy that ensures that only `authenticated` users are allowed to access. For more details check link:security[Security Guide].
 
+=== Configuring CORS
+
+If you plan to consume this application from another application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). Please read the link:http-reference#cors-filter[HTTP CORS documentation] for more details.
+
 == Starting and Configuring the Keycloak Server
 
 To start a Keycloak Server you can use Docker and just run the following command:
@@ -287,7 +291,7 @@ If UserInfo is the source of the roles then set `quarkus.oidc.user-info-required
 
 Please check if implementing SPAs the way it is suggested in the link:security-openid-connect#single-page-applications[Single Page Applications for Service Applications] section can meet your requirements.
 
-If you prefer to use SPA and `XMLHttpRequest`(XHR) with Quarkus applications, please be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
+If you prefer to use SPA and `XMLHttpRequest`(XHR) with Quarkus web applications, please be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
 
 In such cases, set the `quarkus.oidc.authentication.xhr-auto-redirect` property to `false` which will instruct Quarkus to return a `499` status code and `WWW-Authenticate` header with the `OIDC` value. The browser script also needs to be updated to set `X-Requested-With` header with the `XMLHttpRequest` value and reload the last requested page in case of `499`, for example:
 
@@ -306,6 +310,13 @@ Future<void> callQuarkusService() async {
   }
 ----
 
+== Running behind a reverse proxy
+
+OIDC authentication mechanism can be affected if your Quarkus application is running behind a reverse proxy/gateway/firewall when HTTP `Host` header may be reset to the internal IP address, HTTPS connection may be terminated, etc. For example, an authorization code flow `redirect_uri` parameter may be set to the internal host instead of the expected external one.
+
+In such cases configuring Quarkus to recognize the original headers forwarded by the proxy will be required, see link:vertx#reverse-proxy[Running behind a reverse proxy] Vert.x documentation section for more information.
+
+`quarkus.oidc.authentication.force-redirect-https-scheme` property may also be used when the Quarkus application is running behind a SSL terminating reverse proxy.
 
 == Configuration Reference
 

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -120,6 +120,14 @@ Quarkus Security is highly customizable. One can register custom ``HttpAuthentic
 
 See link:security-customization[Security Customization] for more information about customizing Quarkus Security and other useful tips about the reactive security, registering the security providers, etc.
 
+== Secure connections with SSL
+
+See the link:http-reference#ssl[Supporting secure connections with SSL] guide for more information.
+
+== Cross-Origin Resource Sharing
+
+If you plan to make your Quarkus application accessible to another application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). Please read the link:http-reference#cors-filter[HTTP CORS documentation] for more information.
+
 == Testing
 
 See link:security-testing[Security Testing] for more information about testing Quarkus Security.
@@ -127,4 +135,3 @@ See link:security-testing[Security Testing] for more information about testing Q
 == Secret Engines
 
 Quarkus provides a very comprehensive HashiCorp Vault support, please see the link:vault[Quarkus and HashiCorp Vault] documentation for more information.
-

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -703,6 +703,7 @@ java.lang.IllegalStateException: Failed to create cache dir
 
 Assuming `/tmp/` is writeable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
 
+[[reverse-proxy]]
 == Running behind a reverse proxy
 
 Quarkus could be accessed through proxies that additionally generate headers (e.g. `X-Forwarded-Host`) to keep
@@ -722,14 +723,14 @@ quarkus.http.proxy-address-forwarding=true
 To consider only de-facto standard header (`Forwarded` header), please include the following lines in `src/main/resources/application.properties`:
 [source]
 ----
-quarkus.http.allow-forwarded=true
+quarkus.http.proxy.allow-forwarded=true
 ----
 
 To consider only non-standard headers, please include the following lines instead in `src/main/resources/application.properties`:
 
 [source]
 ----
-quarkus.http.proxy-address-forwarding=true
+quarkus.http.proxy.proxy-address-forwarding=true
 quarkus.http.proxy.enable-forwarded-host=true
 quarkus.http.proxy.enable-forwarded-prefix=true
 ----


### PR DESCRIPTION
This PR:
- updates the main `security.adoc` page with references to HTTP `SSL`, `CORS` guides
- updates the OIDC web app page with references to `CORS` and `Running behind a reverse proxy` guides
- updates `Running behind a reverse proxy` section to use the new property names.