### PR TITLE
Fix typo in the OpenAPI Guide

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -416,7 +416,7 @@ will be used. You can also define the version in SmallRye using the following co
 mp.openapi.extensions.smallrye.openapi=3.0.2
 ----
 
-This might be useful if your API go through a Gateway that needs a certain version.
+This might be useful if your API goes through a Gateway that needs a certain version.
 
 == Auto-generation of Operation Id
 


### PR DESCRIPTION
This fixes a small typo I stumbled upon while reading the [Using OpenAPI and Swagger UI Guide](https://quarkus.io/guides/openapi-swaggerui).
I'm not a native English speaker, so please feel free to close this PR if you think it doesn't make sense ;)