### PR TITLE
enable uber-jar for cli to make it directly runnable

### DIFF
--- a/devtools/cli/src/main/resources/application.properties
+++ b/devtools/cli/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.log.level=WARN
 quarkus.banner.enabled=false
-#quarkus.package.type=fast-jar
+quarkus.package.type=uber-jar
 quarkus.native.additional-build-args=--allow-incomplete-classpath
 #quarkus.native.auto-service-loader-registration=true
 #quarkus.native.resources.includes=quarkus.properties,bundled-codestarts/**,codestarts/**


### PR DESCRIPTION
as long as we can't run cli as native i suggest we use uber-jar
to at least make `jbang io.quarkus:quarkus-cli:999-SNAPSHOT:runner` work
as well as a `java -jar quarkus-cli-999-SNAPSHOT-runner.jar` after downloading it.

This also makes it easier to download/distribute the cli using other package managers.

It does create a big "binary" (~21mb) but not sure there is a better alternative.