### PR TITLE
Handle gradle included-builds in quarkusDev task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -35,6 +36,7 @@ import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.plugins.Convention;
@@ -45,6 +47,7 @@ import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.bootstrap.resolver.QuarkusGradleModelFactory;
 import io.quarkus.bootstrap.resolver.model.ArtifactCoords;
 import io.quarkus.bootstrap.resolver.model.Dependency;
 import io.quarkus.bootstrap.resolver.model.ModelParameter;
@@ -103,9 +106,9 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         final Map<ArtifactCoords, Dependency> appDependencies = new LinkedHashMap<>();
         final Set<ArtifactCoords> visitedDeps = new HashSet<>();
 
-        final ResolvedConfiguration configuration = classpathConfig(project, mode).getResolvedConfiguration();
-        collectDependencies(configuration, mode, project, appDependencies);
-        collectFirstMetDeploymentDeps(configuration.getFirstLevelModuleDependencies(), appDependencies,
+        final ResolvedConfiguration resolvedConfiguration = classpathConfig(project, mode).getResolvedConfiguration();
+        collectDependencies(resolvedConfiguration, mode, project, appDependencies);
+        collectFirstMetDeploymentDeps(resolvedConfiguration.getFirstLevelModuleDependencies(), appDependencies,
                 deploymentDeps, visitedDeps);
 
         final List<Dependency> extensionDependencies = collectExtensionDependencies(project, deploymentDeps);
@@ -113,7 +116,8 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         ArtifactCoords appArtifactCoords = new ArtifactCoordsImpl(project.getGroup().toString(), project.getName(),
                 project.getVersion().toString());
 
-        return new QuarkusModelImpl(new WorkspaceImpl(appArtifactCoords, getWorkspace(project.getRootProject(), mode)),
+        return new QuarkusModelImpl(
+                new WorkspaceImpl(appArtifactCoords, getWorkspace(project.getRootProject(), mode)),
                 new LinkedList<>(appDependencies.values()),
                 extensionDependencies,
                 deploymentDeps.stream().map(QuarkusModelBuilder::toEnforcedPlatformDependency)
@@ -317,8 +321,10 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
 
     private void collectDependencies(ResolvedConfiguration configuration,
             LaunchMode mode, Project project, Map<ArtifactCoords, Dependency> appDependencies) {
+
         final Set<ResolvedArtifact> artifacts = configuration.getResolvedArtifacts();
         Set<File> artifactFiles = null;
+
         // if the number of artifacts is less than the number of files then probably
         // the project includes direct file dependencies
         if (artifacts.size() < configuration.getFiles().size()) {
@@ -331,9 +337,14 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             final DependencyImpl dep = initDependency(a);
             if (LaunchMode.DEVELOPMENT.equals(mode) &&
                     a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
-                Project projectDep = project.getRootProject()
-                        .findProject(((ProjectComponentIdentifier) a.getId().getComponentIdentifier()).getProjectPath());
-                addDevModePaths(dep, a, projectDep);
+                IncludedBuild includedBuild = includedBuild(project, a.getName());
+                if (includedBuild != null) {
+                    addSubstitutedProject(dep, includedBuild.getProjectDir(), mode);
+                } else {
+                    Project projectDep = project.getRootProject()
+                            .findProject(((ProjectComponentIdentifier) a.getId().getComponentIdentifier()).getProjectPath());
+                    addDevModePaths(dep, a, projectDep);
+                }
             } else {
                 dep.addPath(a.getFile());
             }
@@ -399,6 +410,24 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             if (outputDir.exists()) {
                 dep.addPath(outputDir);
             }
+        }
+    }
+
+    private void addSubstitutedProject(final DependencyImpl dep, File projectFile, LaunchMode mode) {
+        final QuarkusModel quarkusModel = QuarkusGradleModelFactory.create(projectFile, mode.name());
+        final io.quarkus.bootstrap.resolver.model.SourceSet moduleOutput = quarkusModel.getWorkspace().getMainModule()
+                .getSourceSet();
+        dep.addPath(moduleOutput.getResourceDirectory());
+        for (File sourceDirectory : moduleOutput.getSourceDirectories()) {
+            dep.addPath(sourceDirectory);
+        }
+    }
+
+    private IncludedBuild includedBuild(final Project project, final String projectName) {
+        try {
+            return project.getGradle().includedBuild(projectName);
+        } catch (UnknownDomainObjectException ignore) {
+            return null;
         }
     }
 

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -19,6 +19,7 @@ public class QuarkusGradleModelFactory {
                 .forProjectDirectory(projectDir)
                 .connect()) {
             connection.newBuild().forTasks(tasks).addJvmArguments(jvmArgs).run();
+
             return connection.action(new QuarkusModelBuildAction(mode)).run();
         }
     }
@@ -28,7 +29,9 @@ public class QuarkusGradleModelFactory {
                 .forProjectDirectory(projectDir)
                 .connect()) {
             final ModelBuilder<QuarkusModel> modelBuilder = connection.model(QuarkusModel.class);
-            modelBuilder.forTasks(tasks);
+            if (tasks.length != 0) {
+                modelBuilder.forTasks(tasks);
+            }
             return modelBuilder.get();
         }
     }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/WorkspaceImpl.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/WorkspaceImpl.java
@@ -35,4 +35,5 @@ public class WorkspaceImpl implements Workspace, Serializable {
     public WorkspaceModule getModule(ArtifactCoords key) {
         return modules.get(key);
     }
+
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -33,6 +33,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
                 .directory(projectDir)
                 .command(command)
                 .redirectInput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(logOutput)
                 .redirectOutput(logOutput)
                 .redirectError(logOutput)
                 .start();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleIncludedBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleIncludedBuildTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MultiModuleIncludedBuildTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "multi-module-included-build";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "--include-build", "../external-library", "quarkusDev" };
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("foo bar");
+    }
+
+    @Override
+    protected File getProjectDir() {
+        File projectDir = super.getProjectDir();
+        final File appProjectProperties = new File(projectDir, "app/gradle.properties");
+        final File libProjectProperties = new File(projectDir, "external-library/gradle.properties");
+        final Path projectProperties = projectDir.toPath().resolve("gradle.properties");
+
+        try {
+            Files.copy(projectProperties, appProjectProperties.toPath());
+            Files.copy(projectProperties, libProjectProperties.toPath());
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to copy gradle.properties file", e);
+        }
+        this.projectDir = appProjectProperties.getParentFile();
+        return this.projectDir;
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -28,7 +28,7 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
     private static final String PLUGIN_UNDER_TEST_METADATA_PROPERTIES = "plugin-under-test-metadata.properties";
 
     private Future<?> quarkusDev;
-    private File projectDir;
+    protected File projectDir;
 
     @Test
     public void main() throws Exception {

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/app/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'org.acme:external-library:1.0.0-SNAPSHOT'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/app/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/app/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name='app'

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/app/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/app/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,22 @@
+package org.acme;
+
+import org.acme.lib.LibService;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @Inject
+    LibService libService;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "foo " + libService.bar();
+    }
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/app/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/app/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id "org.kordamp.gradle.jandex" version '0.6.0'
+}
+
+repositories {
+    mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-core'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name='external-library'

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/src/main/java/org/acme/lib/LibService.java
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/src/main/java/org/acme/lib/LibService.java
@@ -1,0 +1,10 @@
+package org.acme.lib;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class LibService {
+    public String bar() {
+        return "bar";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/gradle.properties
@@ -1,0 +1,4 @@
+#Gradle properties
+#Tue Aug 25 06:41:36 GMT 2020
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus


### PR DESCRIPTION
Right now, included build were ignored while creating the quarkus model. 

This branch add support for included build by: 

- Looking for included build
- Building the quarkus model of those projects
- Adding the model and its dependencies to the current model. 

When looking for included builds, the gradle API only gives us the project name and the project directory. That's why I use the Quarkus model to collect included build infos. 

close #11902 