### PR TITLE
Define the version of the main wildfly-elytron artifact

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3306,6 +3306,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron</artifactId>
+                <version>${wildfly-elytron.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-auth-server</artifactId>
                 <version>${wildfly-elytron.version}</version>
             </dependency>


### PR DESCRIPTION
Related to the failure in: https://github.com/quarkusio/quarkus/pull/12053/checks?check_run_id=1103875599

Not sure we want the upgrade but I think we want this anyway.