### PR TITLE
AdditionalBeanBuildItem - clarify javadoc and improve the transformer

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalBeanBuildItem.java
@@ -12,10 +12,15 @@ import org.jboss.jandex.DotName;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * This build item is used to specify one or more additional bean classes to be analyzed.
+ * This build item is used to specify one or more additional bean classes to be analyzed during bean discovery.
  * <p>
  * By default, the resulting beans may be removed if they are considered unused and {@link ArcConfig#removeUnusedBeans} is
- * enabled.
+ * enabled. You can change the default behavior by setting the {@link #removable} to {@code false} and via
+ * {@link Builder#setUnremovable()}.
+ * <p>
+ * An additional bean may have the scope defaulted via {@link #defaultScope} and {@link Builder#setDefaultScope(DotName)}. The
+ * default scope is only used if there is no scope declared on the bean class. The default scope should be used in cases where a
+ * bean class source is not controlled by the extension and the scope annotation cannot be declared directly on the class.
  */
 public final class AdditionalBeanBuildItem extends MultiBuildItem {
 
@@ -122,6 +127,15 @@ public final class AdditionalBeanBuildItem extends MultiBuildItem {
             return this;
         }
 
+        /**
+         * The default scope is only used if there is no scope declared on the bean class.
+         * <p>
+         * The default scope should be used in cases where a bean class source is not controlled by the extension and the
+         * scope annotation cannot be declared directly on the class.
+         * 
+         * @param defaultScope
+         * @return self
+         */
         public Builder setDefaultScope(DotName defaultScope) {
             this.defaultScope = defaultScope;
             return this;

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveIndexBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveIndexBuildItem.java
@@ -42,6 +42,13 @@ public final class BeanArchiveIndexBuildItem extends SimpleBuildItem {
         return generatedClassNames;
     }
 
+    /**
+     * This method will be removed at some point post Quarkus 1.9.
+     * 
+     * @return the list of additional beans
+     * @deprecated Use {@link AdditionalBeanBuildItem} instead
+     */
+    @Deprecated
     public List<String> getAdditionalBeans() {
         return additionalBeans;
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -64,7 +64,10 @@ public class BeanArchiveProcessor {
         for (AdditionalBeanBuildItem i : this.additionalBeans) {
             additionalBeans.addAll(i.getBeanClasses());
         }
+        // NOTE: the types added directly must always declare a scope annotation otherwise they will be ignored during bean discovery
         additionalBeans.add(LifecycleEventRunner.class.getName());
+
+        // Build the index for additional beans and generated bean classes
         Set<DotName> additionalIndex = new HashSet<>();
         for (String beanClass : additionalBeans) {
             IndexingUtil.indexClass(beanClass, additionalBeanIndexer, applicationIndex, additionalIndex,

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/AdditionalBean.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/AdditionalBean.java
@@ -6,10 +6,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Stereotype;
 
 /**
- * This built-in stereotype is automatically added to all additional beans.
+ * This built-in stereotype is automatically added to all additional beans that do not have a scope annotation declared.
+ * <p>
+ * Note that stereotypes are bean defining annotations and so bean classes annotated with this stereotype but no scope have
+ * their scope defaulted to {@link Dependent}.
  */
 @Stereotype
 @Target({ TYPE })


### PR DESCRIPTION
- clarify javadoc in the AdditionalBean annotation
- also deprecate BeanArchiveIndexBuildItem#getAdditionalBeans()

Follows up on https://github.com/quarkusio/quarkus/pull/12051