### PR TITLE
Set a injected CDI CommandListener to the mongodb configuration.

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/BsonDiscriminatorBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/BsonDiscriminatorBuildItem.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Register additional BsonDiscriminator's for the MongoDB clients.
+ */
 public final class BsonDiscriminatorBuildItem extends SimpleBuildItem {
 
     private List<String> bsonDiscriminatorClassNames;

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CodecProviderBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CodecProviderBuildItem.java
@@ -2,8 +2,13 @@ package io.quarkus.mongodb.deployment;
 
 import java.util.List;
 
+import org.bson.codecs.configuration.CodecProvider;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Register additional {@link CodecProvider}s for the MongoDB clients.
+ */
 public final class CodecProviderBuildItem extends SimpleBuildItem {
 
     private List<String> codecProviderClassNames;

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CommandListenerBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CommandListenerBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.mongodb.deployment;
+
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class CommandListenerBuildItem extends SimpleBuildItem {
+
+    private List<String> commandListenerClassNames;
+
+    public CommandListenerBuildItem(List<String> commandListenerClassNames) {
+        this.commandListenerClassNames = commandListenerClassNames;
+    }
+
+    public List<String> getCommandListenerClassNames() {
+        return commandListenerClassNames;
+    }
+}

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CommandListenerBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/CommandListenerBuildItem.java
@@ -2,8 +2,13 @@ package io.quarkus.mongodb.deployment;
 
 import java.util.List;
 
+import com.mongodb.event.CommandListener;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Register additional {@link CommandListener}s for the MongoDB clients.
+ */
 public final class CommandListenerBuildItem extends SimpleBuildItem {
 
     private List<String> commandListenerClassNames;

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildItem.java
@@ -6,6 +6,9 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.runtime.RuntimeValue;
 
+/**
+ * Provide the MongoDB clients as RuntimeValue's.
+ */
 public final class MongoClientBuildItem extends MultiBuildItem {
     private final RuntimeValue<MongoClient> client;
     private final RuntimeValue<ReactiveMongoClient> reactive;

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientNameBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientNameBuildItem.java
@@ -4,7 +4,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.mongodb.MongoClientName;
 
 /**
- * Represents the values of the {@link MongoClientName}
+ * Represents the values of the {@link MongoClientName}.
  */
 public final class MongoClientNameBuildItem extends MultiBuildItem {
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoConnectionNameBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoConnectionNameBuildItem.java
@@ -3,7 +3,7 @@ package io.quarkus.mongodb.deployment;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Holds a Mongo connection name
+ * Holds a MongoDB connection name.
  */
 final class MongoConnectionNameBuildItem extends MultiBuildItem {
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoConnectionPoolListenerBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoConnectionPoolListenerBuildItem.java
@@ -6,7 +6,11 @@ import com.mongodb.event.ConnectionPoolListener;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Register additional {@link ConnectionPoolListener}s.
+ */
 public final class MongoConnectionPoolListenerBuildItem extends MultiBuildItem {
+
     private Supplier<ConnectionPoolListener> connectionPoolListener;
 
     public MongoConnectionPoolListenerBuildItem(Supplier<ConnectionPoolListener> connectionPoolListener) {

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/PropertyCodecProviderBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/PropertyCodecProviderBuildItem.java
@@ -2,8 +2,13 @@ package io.quarkus.mongodb.deployment;
 
 import java.util.List;
 
+import org.bson.codecs.pojo.PropertyCodecProvider;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Register additional {@link PropertyCodecProvider}s for the MongoDB clients.
+ */
 public final class PropertyCodecProviderBuildItem extends SimpleBuildItem {
 
     private List<String> propertyCodecProviderClassNames;

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MockCommandListener.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MockCommandListener.java
@@ -1,0 +1,18 @@
+package io.quarkus.mongodb;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+
+public class MockCommandListener implements CommandListener {
+
+    public static final List<String> EVENTS = new ArrayList<>();
+
+    @Override
+    public void commandStarted(CommandStartedEvent startedEvent) {
+        EVENTS.add(startedEvent.getCommandName());
+    }
+
+}

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoCommandListenerTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoCommandListenerTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MongoCommandListenerTest extends MongoTestBase {
+
+    @Inject
+    MongoClient client;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(MongoTestBase.class, MockCommandListener.class))
+            .withConfigurationResource("default-mongoclient.properties");
+
+    @AfterEach
+    void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClientInitialization() {
+        assertThat(client.listDatabaseNames().first()).isNotEmpty();
+        assertThat(MockCommandListener.EVENTS, hasSize(1));
+        assertThat(MockCommandListener.EVENTS, hasItems(equalTo("listDatabases")));
+    }
+
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -22,18 +22,19 @@ import io.quarkus.runtime.annotations.Recorder;
 public class MongoClientRecorder {
 
     public Supplier<MongoClientSupport> mongoClientSupportSupplier(List<String> codecProviders,
-            List<String> propertyCodecProviders, List<String> bsonDiscriminators,
+            List<String> propertyCodecProviders, List<String> bsonDiscriminators, List<String> commandListeners,
             List<Supplier<ConnectionPoolListener>> connectionPoolListenerSuppliers, boolean disableSslSupport) {
 
         return new Supplier<MongoClientSupport>() {
             @Override
             public MongoClientSupport get() {
+
                 List<ConnectionPoolListener> connectionPoolListeners = new ArrayList<>(connectionPoolListenerSuppliers.size());
                 for (Supplier<ConnectionPoolListener> item : connectionPoolListenerSuppliers) {
                     connectionPoolListeners.add(item.get());
                 }
 
-                return new MongoClientSupport(codecProviders, propertyCodecProviders, bsonDiscriminators,
+                return new MongoClientSupport(codecProviders, propertyCodecProviders, bsonDiscriminators, commandListeners,
                         connectionPoolListeners, disableSslSupport);
             }
         };

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientSupport.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientSupport.java
@@ -10,14 +10,16 @@ public class MongoClientSupport {
     private final List<String> propertyCodecProviders;
     private final List<String> bsonDiscriminators;
     private final List<ConnectionPoolListener> connectionPoolListeners;
+    private final List<String> commandListeners;
     private final boolean disableSslSupport;
 
     public MongoClientSupport(List<String> codecProviders, List<String> propertyCodecProviders, List<String> bsonDiscriminators,
-            List<ConnectionPoolListener> connectionPoolListeners, boolean disableSslSupport) {
+            List<String> commandListeners, List<ConnectionPoolListener> connectionPoolListeners, boolean disableSslSupport) {
         this.codecProviders = codecProviders;
         this.propertyCodecProviders = propertyCodecProviders;
         this.bsonDiscriminators = bsonDiscriminators;
         this.connectionPoolListeners = connectionPoolListeners;
+        this.commandListeners = commandListeners;
         this.disableSslSupport = disableSslSupport;
     }
 
@@ -35,6 +37,10 @@ public class MongoClientSupport {
 
     public List<ConnectionPoolListener> getConnectionPoolListeners() {
         return connectionPoolListeners;
+    }
+
+    public List<String> getCommandListeners() {
+        return commandListeners;
     }
 
     public boolean isDisableSslSupport() {

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -45,6 +45,7 @@ import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
+import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
 
 import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
@@ -255,6 +256,8 @@ public class MongoClients {
                 CodecRegistries.fromProviders(providers));
         settings.codecRegistry(registry);
 
+        settings.commandListenerList(getCommandListeners(mongoClientSupport.getCommandListeners()));
+
         config.applicationName.ifPresent(settings::applicationName);
 
         if (config.credentials != null) {
@@ -403,6 +406,21 @@ public class MongoClients {
         }
 
         return providers;
+    }
+
+    private List<CommandListener> getCommandListeners(List<String> classNames) {
+        List<CommandListener> listeners = new ArrayList<>();
+        for (String name : classNames) {
+            try {
+                Class<?> clazz = Class.forName(name, true, Thread.currentThread().getContextClassLoader());
+                Constructor<?> clazzConstructor = clazz.getConstructor();
+                listeners.add((CommandListener) clazzConstructor.newInstance());
+            } catch (Exception e) {
+                LOGGER.warnf(e, "Unable to load the command listener class %s", name);
+            }
+        }
+
+        return listeners;
     }
 
     @PreDestroy


### PR DESCRIPTION
This implementation allows injecting a CommandListener to the current MongoDB client configuration via CDI bean definition.
The idea came from using the MP opentracing library and trying to include the mongodb tracing spans.

Following the instructions in the [OpenTracing Mongo Driver Instrumentation](https://github.com/opentracing-contrib/java-mongo-driver#opentracing-mongo-driver-instrumentation) there is a way to include the tracing information simply adding a CommandListener to the mongoclient settings.

I prepared an example to show the MongoDB tracing: 
https://github.com/juazugas/quarkus-mongodb-opentracing/blob/master/src/main/java/com/example/mongodb/tracing/TracingCommandListenerProducer.java
on project sample https://github.com/juazugas/quarkus-mongodb-opentracing/ 