### PR TITLE
Update KeycloakAuthorization tests to run with the disabled TLS verification

### DIFF
--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -18,6 +18,7 @@ import org.keycloak.representations.adapters.config.AdapterConfig;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.Tls.Verification;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
@@ -110,6 +111,10 @@ public class KeycloakPolicyEnforcerAuthorizer
         }
 
         adapterConfig.setPolicyEnforcerConfig(enforcerConfig);
+        if (oidcConfig.defaultTenant.tls.getVerification() == Verification.NONE) {
+            adapterConfig.setDisableTrustManager(true);
+            adapterConfig.setAllowAnyHostname(true);
+        }
 
         this.readTimeout = httpConfiguration.readTimeout.toMillis();
         this.delegate = new KeycloakAdapterPolicyEnforcer(

--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
     </properties>
 
     <dependencies>
@@ -170,7 +171,7 @@
                             <skip>false</skip>
                             <skipTests>${native.surefire.skip}</skipTests>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
+                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -179,7 +180,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
+                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -237,6 +238,7 @@
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
@@ -258,6 +260,7 @@
             </activation>
             <properties>
                 <keycloak.url>http://localhost:8180/auth</keycloak.url>
+                <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
             </properties>
             <build>
                 <plugins>
@@ -272,6 +275,7 @@
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
+                                            <port>8543:8443</port>
                                         </ports>
                                         <env>
                                             <KEYCLOAK_USER>admin</KEYCLOAK_USER>

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 
@@ -27,7 +28,9 @@ public class AdminClientResource {
                 .realm("master")
                 .clientId("admin-cli")
                 .username("admin")
-                .password("admin").build();
+                .password("admin")
+                .resteasyClient(new ResteasyClientBuilderImpl().disableTrustManager().build())
+                .build();
         return keycloak.realm("quarkus").toRepresentation().getRealm();
     }
 }

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 # Configuration file
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.auth-server-url=${keycloak.ssl.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
+quarkus.oidc.tls.verification=none
 quarkus.http.cors=true
 
 # Enable Policy Enforcement

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -24,7 +25,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.ssl.url", "https://localhost:8543/auth");
     private static final String KEYCLOAK_REALM = "quarkus";
 
     private Keycloak keycloak;
@@ -40,11 +41,12 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
         realm.getUsers().add(createUser("jdoe", "user", "confidential"));
 
         keycloak = KeycloakBuilder.builder()
-                .serverUrl(KEYCLOAK_SERVER_URL)
+        	    .serverUrl(KEYCLOAK_SERVER_URL)
                 .realm("master")
                 .clientId("admin-cli")
                 .username("admin")
                 .password("admin")
+                .resteasyClient(new ResteasyClientBuilderImpl().disableTrustManager().build())
                 .build();
         keycloak.realms().create(realm);
 

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -18,8 +18,12 @@ import io.restassured.http.ContentType;
 @QuarkusTest
 public class PolicyEnforcerTest {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.ssl.url", "https://localhost:8543/auth");
     private static final String KEYCLOAK_REALM = "quarkus";
+
+    static {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
 
     @BeforeAll
     public static void configureKeycloakRealm() throws IOException {


### PR DESCRIPTION
@pedroigor Hi Pedro, can you have a look please at this draft PR ? I've tried to update the `keycloak-authorization` test, exactly the way it is done for `integration-tests/oidc`, but getting stuck with trying to configure Keycloak Admin API to skip the verification (note I've also tried setting a SSL Context on the client builder), getting:

```
Caused by: javax.ws.rs.ProcessingException: java.lang.NullPointerException
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.filterRequest(ClientInvocation.java:696)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:485)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invokeSync(ClientInvoker.java:149)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invoke(ClientInvoker.java:112)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy.invoke(ClientProxy.java:76)
	at com.sun.proxy.$Proxy43.create(Unknown Source)
	at io.quarkus.it.keycloak.KeycloakTestResource.start(KeycloakTestResource.java:65)
	at io.quarkus.test.common.TestResourceManager.start(TestResourceManager.java:52)
	... 45 more
Caused by: java.lang.NullPointerException
	at org.keycloak.admin.client.resource.BearerAuthFilter.filter(BearerAuthFilter.java:53)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.filterRequest(ClientInvocation.java:683)

```

have you had to deal with disabling the SSL cert verification in Keycloak Admin API ?
thanks