### PR TITLE
JUnit 5 version should match in ArC too

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -38,7 +38,7 @@
         <version.cdi>2.0.2</version.cdi>
         <version.jta>1.3.3</version.jta>
         <version.jandex>2.2.1.Final</version.jandex>
-        <version.junit5>5.6.1</version.junit5>
+        <version.junit5>5.7.0</version.junit5>
         <version.maven>3.6.3</version.maven>
         <version.assertj>3.17.2</version.assertj>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
@@ -90,12 +90,15 @@
                 <version>${version.gizmo}</version>
             </dependency>
 
+            <!-- JUnit 5 dependencies, imported as a BOM -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${version.junit5}</version>
-                <scope>test</scope>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
+
 
             <dependency>
                 <groupId>org.apache.maven</groupId>

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Follow-up to https://github.com/quarkusio/quarkus/pull/12096

Using the BOM is necessary so Dependabot can update properly