### PR TITLE
Prevent potential infinite loop in AutoAddScopeProcessor

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoAddScopeProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoAddScopeProcessor.java
@@ -98,12 +98,14 @@ public class AutoAddScopeProcessor {
         if (index != null) {
             DotName superName = clazz.superName();
             while (superName != null && !superName.equals(DotNames.OBJECT)) {
-                ClassInfo superClass = index.getClassByName(superName);
+                final ClassInfo superClass = index.getClassByName(superName);
                 if (superClass != null) {
-                    if (hasContainerAnnotation(clazz, containerAnnotationNames)) {
+                    if (hasContainerAnnotation(superClass, containerAnnotationNames)) {
                         return true;
                     }
                     superName = superClass.superName();
+                } else {
+                    superName = null;
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/12102

As rightly identified by @doctau, the current code in `AutoAddScopeProcessor#requiresContainerServices` can potentially run into an infinite loop. The commit in this PR fixes that issue.