### PR TITLE
fix: use own AddEnvVarDecorator to prevent it from being skipped

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddEnvVarDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddEnvVarDecorator.java
@@ -1,0 +1,30 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.deps.kubernetes.api.model.ContainerBuilder;
+import io.dekorate.kubernetes.config.Env;
+import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.ContainerDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+
+/**
+ * Delegate to dekorate's version to sidestep the fact that the dekorate version of AddEnvVarDecorator inherits from
+ * ApplicationContainerDecorator which expects metadata to be present, which doesn't happen in our context. We sidestep the
+ * issue by wrapping the original behavior and calling its andThenVisit method, which does the work when not skipped.
+ */
+public class AddEnvVarDecorator extends Decorator<ContainerBuilder> {
+    private final io.dekorate.kubernetes.decorator.AddEnvVarDecorator delegate;
+
+    public AddEnvVarDecorator(Env env) {
+        delegate = new io.dekorate.kubernetes.decorator.AddEnvVarDecorator(env);
+    }
+
+    @Override
+    public void visit(ContainerBuilder containerBuilder) {
+        delegate.andThenVisit(containerBuilder);
+    }
+
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class, ContainerDecorator.class, AddSidecarDecorator.class };
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerAdapter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerAdapter.java
@@ -5,7 +5,6 @@ import io.dekorate.deps.kubernetes.api.model.ContainerBuilder;
 import io.dekorate.kubernetes.config.Env;
 import io.dekorate.kubernetes.config.Mount;
 import io.dekorate.kubernetes.config.Port;
-import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
@@ -137,7 +137,8 @@ public class ContainerConfig implements EnvVarHolder {
 
     public Collection<Env> convertToEnvs() {
         return convertToBuildItems().stream()
-                .map(kebi -> new Env(kebi.getName(), kebi.getValue(), kebi.getSecret(), kebi.getConfigMap(), kebi.getField()))
+                .map(kebi -> new Env(EnvConverter.convertName(kebi.getName()), kebi.getValue(), kebi.getSecret(),
+                        kebi.getConfigMap(), kebi.getField()))
                 .collect(Collectors.toList());
     }
 

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
@@ -70,9 +70,8 @@ public class KubernetesWithSidecarAndJibTest {
                     assertThat(c.getArgs()).isEmpty();
                     assertThat(c.getWorkingDir()).isNull();
                     assertThat(c.getVolumeMounts()).isEmpty();
-                    assertThat(c.getPorts()).singleElement().satisfies(p -> {
-                        assertThat(p.getContainerPort()).isEqualTo(8080);
-                    });
+                    assertThat(c.getPorts()).singleElement().satisfies(p -> assertThat(p.getContainerPort()).isEqualTo(8080));
+                    assertThat(c.getEnv()).allSatisfy(e -> assertThat(e.getName()).isNotEqualToIgnoringCase("foo"));
                 });
     }
 
@@ -90,6 +89,10 @@ public class KubernetesWithSidecarAndJibTest {
                     });
                     assertThat(c.getPorts()).singleElement().satisfies(p -> {
                         assertThat(p.getContainerPort()).isEqualTo(3000);
+                    });
+                    assertThat(c.getEnv()).singleElement().satisfies(e -> {
+                        assertThat(e.getName()).isEqualTo("FOO");
+                        assertThat(e.getValue()).isEqualTo("bar");
                     });
                 });
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-sidecar-and-jib.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-sidecar-and-jib.properties
@@ -8,3 +8,4 @@ quarkus.kubernetes.sidecars.sc.working-dir=/work
 quarkus.kubernetes.sidecars.sc.arguments=-l
 quarkus.kubernetes.sidecars.sc.mounts.app-config.path=/deployments/config
 quarkus.kubernetes.sidecars.sc.ports.http.container-port=3000
+quarkus.kubernetes.sidecars.sc.env-vars.foo.value=bar


### PR DESCRIPTION
Fixes #12063. This occurs because the dekorate version of
AddEnvVarDecorator inherits from ApplicationContainerDecorator
which expects metadata to be present, which doesn't happen in our
context. We sidestep the issue by wrapping the original behavior and
calling its andThenVisit method, which does the work when not skipped.