### PR TITLE
Remove lambdas from runtime metrics code

### DIFF
--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsFactory.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsFactory.java
@@ -102,26 +102,39 @@ public class SmallRyeMetricsFactory implements MetricsFactory {
         public Runnable buildTimer(Runnable f) {
             builder.withType(MetricType.SIMPLE_TIMER);
             SimpleTimer timer = registry.simpleTimer(builder.build(), tags.toArray(new Tag[0]));
-            return () -> timer.time(f);
+            return new Runnable() {
+                @Override
+                public void run() {
+                    timer.time(f);
+                }
+            };
         }
 
         @Override
         public <T> Callable<T> buildTimer(Callable<T> f) {
             builder.withType(MetricType.SIMPLE_TIMER);
             SimpleTimer timer = registry.simpleTimer(builder.build(), tags.toArray(new Tag[0]));
-            return () -> timer.time(f);
+            return new Callable<T>() {
+                @Override
+                public T call() throws Exception {
+                    return timer.time(f);
+                }
+            };
         }
 
         @Override
         public <T> Supplier<T> buildTimer(Supplier<T> f) {
             builder.withType(MetricType.SIMPLE_TIMER);
             SimpleTimer timer = registry.simpleTimer(builder.build(), tags.toArray(new Tag[0]));
-            return () -> {
-                SimpleTimer.Context ctx = timer.time();
-                try {
-                    return f.get();
-                } finally {
-                    ctx.stop();
+            return new Supplier<T>() {
+                @Override
+                public T get() {
+                    SimpleTimer.Context ctx = timer.time();
+                    try {
+                        return f.get();
+                    } finally {
+                        ctx.stop();
+                    }
                 }
             };
         }

--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsHandler.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsHandler.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.metrics.runtime;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import javax.enterprise.inject.spi.CDI;
@@ -33,10 +34,15 @@ public class SmallRyeMetricsHandler implements Handler<RoutingContext> {
 
         try {
             internalHandler.handleRequest(request.path(), metricsPath, request.rawMethod(), acceptHeaders,
-                    (status, message, headers) -> {
-                        response.setStatusCode(status);
-                        headers.forEach(response::putHeader);
-                        response.end(Buffer.buffer(message));
+                    new MetricsRequestHandler.Responder() {
+                        @Override
+                        public void respondWith(int status, String message, Map<String, String> headers) throws IOException {
+                            response.setStatusCode(status);
+                            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                                response.putHeader(entry.getKey(), entry.getValue());
+                            }
+                            response.end(Buffer.buffer(message));
+                        }
                     });
         } catch (IOException e) {
             response.setStatusCode(503);


### PR DESCRIPTION
Just came across it while looking at some JAX-RS related things