### PR TITLE
Allow configuring the RestAssured timeouts and provide sensible defaults.

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -159,6 +159,16 @@ quarkus.http.test-ssl-port=8446
 Quarkus also provides RestAssured integration that updates the default port used by RestAssured before the tests are run,
 so no additional configuration should be required.
 
+=== Controlling HTTP interaction timeout
+
+When using REST Assured in your test, the connection and response timeouts are set to 30 seconds.
+You can override this setting with the `quarkus.http.test-timeout` property:
+
+[source]
+----
+quarkus.http.test-timeout=10s
+----
+
 === Injecting a URI
 
 It is also possible to directly inject the URL into the test which can make is easy to use a different client. This is

--- a/integration-tests/amazon-services/src/main/resources/application.properties
+++ b/integration-tests/amazon-services/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.http.test-timeout=1m
+
 quarkus.dynamodb.endpoint-override=${dynamodb.url}
 quarkus.dynamodb.interceptors=io.quarkus.it.amazon.dynamodb.DynamoDBModifyResponse
 quarkus.dynamodb.aws.region=us-east-1


### PR DESCRIPTION
Fix #11769.

At the moment, we do not configure the RestAssured timeout. ﻿As a consequence, tests can  _wait_ up to 45 minutes before failing. 

This PR configures the timeout to 30 seconds and provides a way to the user to configure them from the application properties.

