### PR TITLE
Do not rely on svm scope set to provided in the BoM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3100,6 +3100,7 @@
                 <groupId>org.graalvm.nativeimage</groupId>
                 <artifactId>svm</artifactId>
                 <version>${graal-sdk.version}</version>
+                <!-- TODO: declaring a provided or test scope in BoM is not necessarily a good practice. We should think of removing it -->
                 <scope>provided</scope>
                 <!-- We only want the included annotations -->
                 <exclusions>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -81,6 +81,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus.http</groupId>

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->

--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -31,10 +31,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda-http</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/amazon-lambda-xray/deployment/pom.xml
+++ b/extensions/amazon-lambda-xray/deployment/pom.xml
@@ -23,10 +23,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda-xray</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/amazon-lambda-xray/runtime/pom.xml
+++ b/extensions/amazon-lambda-xray/runtime/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/artemis-core/runtime/pom.xml
+++ b/extensions/artemis-core/runtime/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/avro/runtime/pom.xml
+++ b/extensions/avro/runtime/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/azure-functions-http/deployment/pom.xml
+++ b/extensions/azure-functions-http/deployment/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/azure-functions-http/runtime/pom.xml
+++ b/extensions/azure-functions-http/runtime/pom.xml
@@ -26,6 +26,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/extensions/caffeine/runtime/pom.xml
+++ b/extensions/caffeine/runtime/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/elasticsearch-rest-client-common/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-client-common/runtime/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/elytron-security-common/runtime/pom.xml
+++ b/extensions/elytron-security-common/runtime/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>

--- a/extensions/flyway/runtime/pom.xml
+++ b/extensions/flyway/runtime/pom.xml
@@ -32,6 +32,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
@@ -30,10 +30,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/funqy/funqy-http/deployment/pom.xml
+++ b/extensions/funqy/funqy-http/deployment/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/funqy/funqy-knative-events/deployment/pom.xml
+++ b/extensions/funqy/funqy-knative-events/deployment/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/funqy/funqy-server-common/deployment/pom.xml
+++ b/extensions/funqy/funqy-server-common/deployment/pom.xml
@@ -26,10 +26,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/google-cloud-functions-http/deployment/pom.xml
+++ b/extensions/google-cloud-functions-http/deployment/pom.xml
@@ -22,10 +22,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/google-cloud-functions-http/runtime/pom.xml
+++ b/extensions/google-cloud-functions-http/runtime/pom.xml
@@ -26,6 +26,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.functions</groupId>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -115,6 +115,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -65,6 +65,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -95,6 +95,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-db2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-db2/runtime/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>quarkus-jdbc-db2</artifactId>
     <name>Quarkus - JDBC - DB2 - Runtime</name>
 	<description>Connect to the DB2 database via JDBC</description>
-	
+
     <dependencies>
         <dependency>
             <groupId>com.ibm.db2</groupId>
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
@@ -25,6 +25,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -73,6 +73,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-mysql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/runtime/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
@@ -25,6 +25,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jgit/runtime/pom.xml
+++ b/extensions/jgit/runtime/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jsch/runtime/pom.xml
+++ b/extensions/jsch/runtime/pom.xml
@@ -18,6 +18,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/kafka-streams/runtime/pom.xml
+++ b/extensions/kafka-streams/runtime/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/extensions/liquibase/runtime/pom.xml
+++ b/extensions/liquibase/runtime/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/extensions/logging-gelf/runtime/pom.xml
+++ b/extensions/logging-gelf/runtime/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -99,7 +100,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>

--- a/extensions/narayana-stm/runtime/pom.xml
+++ b/extensions/narayana-stm/runtime/pom.xml
@@ -25,6 +25,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -26,6 +26,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -30,10 +30,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -39,10 +39,6 @@
             <artifactId>quarkus-security-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
             <scope>test</scope>

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>

--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -69,6 +69,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -18,6 +18,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus.http</groupId>

--- a/extensions/vertx-core/runtime/pom.xml
+++ b/extensions/vertx-core/runtime/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR does the following:

* Sets an explicit `<scope>provided</scope>` on every `svm` dependency
* Removed `svm` dependencies from deployment modules where it is redundant

Motivation: 

Relying on a `provided` or `test` scope defined in BoM is not necessarily a good practice. People seeing 

```
        <dependency>
            <groupId>org.graalvm.nativeimage</groupId>
            <artifactId>svm</artifactId>
        </dependency>
```

may naturally expect that the scope is `compile`, but it is not because it is set in the BoM. When people see this in Quarkus they may think that `svm` should actually have the `compile` scope and they may wrongly copy it in that way to their extension projects. That may lead to bugs like https://github.com/apache/camel-quarkus/issues/1182. 

I think it is safer for all parties to have an explicit `<scope>provided</scope>` on all  places where the dependency is used.