### PR TITLE
Throw a build exception if the deprecated datasource config is used

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -72,6 +72,12 @@ class AgroalProcessor {
             BuildProducer<NativeImageResourceBuildItem> resource,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
             BuildProducer<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedConfig) throws Exception {
+        if (dataSourcesBuildTimeConfig.driver.isPresent() || dataSourcesBuildTimeConfig.url.isPresent()) {
+            throw new ConfigurationException(
+                    "quarkus.datasource.url and quarkus.datasource.driver have been deprecated in Quarkus 1.3 and removed in 1.9. "
+                            + "Please use the new datasource configuration as explained in https://quarkus.io/guides/datasource.");
+        }
+
         List<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedDataSourceBuildTimeConfigs = getAggregatedConfigBuildItems(
                 dataSourcesBuildTimeConfig,
                 dataSourcesJdbcBuildTimeConfig,
@@ -252,7 +258,6 @@ class AgroalProcessor {
             List<JdbcDriverBuildItem> jdbcDriverBuildItems) {
         List<AggregatedDataSourceBuildTimeConfigBuildItem> dataSources = new ArrayList<>();
 
-        // New configuration
         if (dataSourcesBuildTimeConfig.defaultDataSource.dbKind.isPresent()) {
             if (dataSourcesJdbcBuildTimeConfig.jdbc.enabled) {
                 dataSources.add(new AggregatedDataSourceBuildTimeConfigBuildItem(DataSourceUtil.DEFAULT_DATASOURCE_NAME,

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DeprecatedDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DeprecatedDataSourceConfigTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.agroal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DeprecatedDataSourceConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-deprecated-config.properties")
+            .assertException(e -> {
+                assertThat(e).isInstanceOf(ConfigurationException.class);
+                assertThat(e)
+                        .hasMessageStartingWith("quarkus.datasource.url and quarkus.datasource.driver have been deprecated");
+            });
+
+    @Test
+    public void deprecatedConfigThrowsException() {
+        // Should not be reached: verify
+        assertTrue(false);
+    }
+
+}

--- a/extensions/agroal/deployment/src/test/resources/application-deprecated-config.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-deprecated-config.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=username-default
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:default
+quarkus.datasource.max-size=13

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.datasource.runtime;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -43,5 +44,23 @@ public class DataSourcesBuildTimeConfig {
      */
     @ConfigItem(name = "metrics.enabled")
     public boolean metricsEnabled;
+
+    /**
+     * Only here to detect configuration errors.
+     * <p>
+     * This used to be runtime but we don't really care, we just want to catch invalid configurations.
+     *
+     * @deprecated
+     */
+    @Deprecated
+    public Optional<String> url;
+
+    /**
+     * Only here to detect configuration errors.
+     *
+     * @deprecated
+     */
+    @Deprecated
+    public Optional<String> driver;
 
 }


### PR DESCRIPTION
Otherwise errors could be a bit cryptic with CDI injection errors and so
on.