### PR TITLE
Set HTTPS scheme in the final OIDC redirect URI

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -318,7 +318,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
                                         if (configContext.oidcConfig.authentication.isRemoveRedirectParameters()
                                                 && context.request().query() != null) {
-                                            String finalRedirectUri = buildUriWithoutQueryParams(context);
+                                            String finalRedirectUri = buildUriWithoutQueryParams(context,
+                                                    isForceHttps(configContext));
                                             if (finalUserQuery != null) {
                                                 finalRedirectUri += ("?" + finalUserQuery);
                                             }
@@ -429,9 +430,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 .toString();
     }
 
-    private String buildUriWithoutQueryParams(RoutingContext context) {
+    private String buildUriWithoutQueryParams(RoutingContext context, boolean forceHttps) {
+        final String scheme = forceHttps ? "https" : context.request().scheme();
         URI absoluteUri = URI.create(context.request().absoluteURI());
-        return new StringBuilder(context.request().scheme()).append("://")
+        return new StringBuilder(scheme).append("://")
                 .append(absoluteUri.getAuthority())
                 .append(absoluteUri.getRawPath())
                 .toString();

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/tenant-https")
+public class TenantHttps {
+
+    @Authenticated
+    @GET
+    public String getTenant() {
+        return "tenant-https";
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -83,7 +83,6 @@ quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-https.client-id=quarkus-app
 quarkus.oidc.tenant-https.credentials.secret=secret
 quarkus.oidc.tenant-https.authentication.scopes=profile,email,phone
-quarkus.oidc.tenant-https.authentication.redirect-path=/web-app
 quarkus.oidc.tenant-https.authentication.cookie-path=/
 quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
 quarkus.oidc.tenant-https.application-type=web-app
@@ -103,9 +102,6 @@ quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.http.auth.permission.logout.paths=/tenant-autorefresh
 quarkus.http.auth.permission.logout.policy=authenticated
-
-quarkus.http.auth.permission.https.paths=/tenant-https
-quarkus.http.auth.permission.https.policy=authenticated
 
 quarkus.http.auth.permission.xhr.paths=/tenant-xhr
 quarkus.http.auth.permission.xhr.policy=authenticated


### PR DESCRIPTION
Fixes #12130

This PR adds a tiny fix as explained in #12130 and updates the existing test to verify that the final redirect URI starts from `https`