### PR TITLE
No more runtime / deployment BOMs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
@@ -384,7 +384,7 @@ public class CreateExtensionMojo extends AbstractMojo {
     String encoding;
 
     /**
-     * Path relative to {@link #basedir} pointing at a {@code pom.xml} file containing the BOM (Bill of Materials) that
+     * Path relative to {@link #basedir} pointing at a {@code pom.xml} file containing the platform BOM (Bill of Materials) that
      * manages extension artifacts. If set, the newly created runtime and deployment modules will be added to
      * {@code <dependencyManagement>} section of this bom; otherwise the newly created modules will not be added
      * to any BOM.
@@ -395,8 +395,8 @@ public class CreateExtensionMojo extends AbstractMojo {
     Path bomPath;
 
     /**
-     * A version for the entries added to the runtime BOM (see {@link #runtimeBomPath}) and to the deployment BOM (see
-     * {@link #deploymentBomPath}). If you want to pass a property placeholder, use {@code @} instead if {@code $} so
+     * A version for the entries added to the platform BOM (see {@link #bomPath}).
+     * If you want to pass a property placeholder, use {@code @} instead if {@code $} so
      * that the property is not evaluated by the current mojo - e.g. <code>@{my-project.version}</code>
      *
      * @since 0.25.0
@@ -406,15 +406,15 @@ public class CreateExtensionMojo extends AbstractMojo {
 
     /**
      * A list of strings of the form {@code groupId:artifactId:version[:type[:classifier[:scope]]]} representing the
-     * dependencies that should be added to the generated runtime module and to the runtime BOM if it is specified via
-     * {@link #runtimeBomPath}.
+     * dependencies that should be added to the generated runtime module and to the platform BOM if it is specified via
+     * {@link #bomPath}.
      * <p>
      * In case the built-in Maven <code>${placeholder}</code> expansion does not work well for you (because you e.g.
      * pass {@link #additionalRuntimeDependencies}) via CLI, the Mojo supports a custom <code>@{placeholder}</code>
      * expansion:
      * <ul>
      * <li><code>@{$}</code> will be expanded to {@code $} - handy for escaping standard placeholders. E.g. to insert
-     * <code>${quarkus.version}</code> to the BOM, you need to pass <code>@{$}{quarkus.version}</code></li>
+     * <code>${quarkus.version}</code> to the platform BOM, you need to pass <code>@{$}{quarkus.version}</code></li>
      * <li><code>@{quarkus.field}</code> will be expanded to whatever value the given {@code field} of this mojo has at
      * runtime.</li>
      * <li>Any other <code>@{placeholder}</code> will be resolved using the current project's properties</li>
@@ -552,7 +552,7 @@ public class CreateExtensionMojo extends AbstractMojo {
         if (bomPath != null) {
             bomPath = basedir.toPath().resolve(bomPath);
             if (!Files.exists(bomPath)) {
-                throw new MojoFailureException("runtimeBomPath does not exist: " + bomPath);
+                throw new MojoFailureException("bomPath does not exist: " + bomPath);
             }
         }
 
@@ -835,7 +835,7 @@ public class CreateExtensionMojo extends AbstractMojo {
         templateParams.javaPackageBase = javaPackageBase != null ? javaPackageBase
                 : getJavaPackage(templateParams.groupId, javaPackageInfix, artifactId);
         templateParams.additionalRuntimeDependencies = getAdditionalRuntimeDependencies();
-        templateParams.runtimeBomPathSet = bomPath != null;
+        templateParams.bomPathSet = bomPath != null;
         return templateParams;
     }
 
@@ -1068,7 +1068,7 @@ public class CreateExtensionMojo extends AbstractMojo {
         boolean assumeManaged;
         String quarkusVersion;
         List<Gavtcs> additionalRuntimeDependencies;
-        boolean runtimeBomPathSet;
+        boolean bomPathSet;
         String bomEntryVersion;
 
         public String getJavaPackageBase() {
@@ -1139,8 +1139,8 @@ public class CreateExtensionMojo extends AbstractMojo {
             return additionalRuntimeDependencies;
         }
 
-        public boolean isRuntimeBomPathSet() {
-            return runtimeBomPathSet;
+        public boolean isBomPathSet() {
+            return bomPathSet;
         }
 
         public String getItestParentRelativePath() {

--- a/devtools/maven/src/main/resources/create-extension-templates/runtime-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/runtime-pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>[=dep.groupId]</groupId>
             <artifactId>[=dep.artifactId]</artifactId>
-[#if !runtimeBomPathSet ]            <version>[=dep.version]</version>
+[#if !bomPathSet ]            <version>[=dep.version]</version>
 [/#if]
 [#if dep.type?? ]            <type>[=dep.type]</type>
 [/#if]

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -164,7 +164,7 @@ Your extension is a multi-module project. So let's start by checking out the par
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId> #<2>
+                <artifactId>quarkus-bom</artifactId> #<2>
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -186,7 +186,7 @@ Your extension is a multi-module project. So let's start by checking out the par
 ----
 
 <1> Your extension declares 2 sub-modules `deployment` and `runtime`.
-<2> The `quarkus-bom-deployment` aligns your dependencies with those used by Quarkus during the augmentation phase.
+<2> The `quarkus-bom` aligns your dependencies with those used by Quarkus during the augmentation phase.
 <3> Quarkus requires a recent version of the Maven compiler plugin supporting the annotationProcessorPaths configuration.
 
 === The Deployment module
@@ -356,7 +356,7 @@ To do so, our extension will deploy, in the user application, a Servlet exposing
 The `runtime` module is where you develop the feature you want to propose to your users, so it's time to create our Web Servlet.
 
 To use Servlets in your applications you need to have a Servlet Container such as http://undertow.io[Undertow].
-Luckily, `quarkus-bom-deployment` imported by our parent `pom.xml` already includes the Undertow Quarkus extension.
+Luckily, `quarkus-bom` imported by our parent `pom.xml` already includes the Undertow Quarkus extension.
 All we need to do is add
 [source, xml]
 ----

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -495,8 +495,8 @@ The above sequence of commands does the following:
 ** `quarkus-my-ext-integration-test` in the `integration-tests/my-ext/deployment` directory; an empty JAX-RS Resource class and two test classes (for JVM mode and native mode) are generated in this module.
 * Links these three modules where necessary:
 ** `quarkus-my-ext-parent` is added to the `<modules>` of `quarkus-extensions-parent`
-** `quarkus-my-ext` is added to the `<dependencyManagement>` of the runtime BOM (Bill of Materials) `bom/runtime/pom.xml`
-** `quarkus-my-ext-deployment` is added to the `<dependencyManagement>` of the deployment BOM (Bill of Materials) `bom/deployment/pom.xml`
+** `quarkus-my-ext` is added to the `<dependencyManagement>` of the Quarkus BOM (Bill of Materials) `bom/application/pom.xml`
+** `quarkus-my-ext-deployment` is added to the `<dependencyManagement>` of the Quarkus BOM (Bill of Materials) `bom/application/pom.xml`
 ** `quarkus-my-ext-integration-test` is added to the `<modules>` of `quarkus-integration-tests-parent`
 
 A Maven build performed immediately after generating the modules should fail due to a `fail()` assertion in one of the test classes.
@@ -535,8 +535,7 @@ Note that the parameters of the mojo that will be constant for all the extension
     -->
     <configuration>
         <namePrefix xml:space="preserve">Quarkus - </namePrefix>
-        <runtimeBomPath>../bom/runtime/pom.xml</runtimeBomPath>
-        <deploymentBomPath>../bom/deployment/pom.xml</deploymentBomPath>
+        <bomPath>../bom/application/pom.xml</bomPath>
         <itestParentPath>../integration-tests/pom.xml</itestParentPath>
     </configuration>
 </plugin>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -206,7 +206,7 @@
                     <artifactIdPrefix>quarkus-</artifactIdPrefix>
                     <namePrefix xml:space="preserve">Quarkus - </namePrefix>
                     <quarkusVersion>@{project.version}</quarkusVersion>
-                    <bomPath>../bom/application/pom.xml</runtimeBomPath>
+                    <bomPath>../bom/application/pom.xml</bomPath>
                     <itestParentPath>../integration-tests/pom.xml</itestParentPath>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Multiple correction due to the replacement of the runtime/deployment BOM to the application one.

The changes on create extension template needs to be checked carefully as I don't know how this part works.