### PR TITLE
Update to Vert.x 3.9.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -105,7 +105,7 @@
         <wildfly-elytron.version>1.13.0.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.1.1.Final</jboss-threads.version>
-        <vertx.version>3.9.2</vertx.version>
+        <vertx.version>3.9.3</vertx.version>
         <httpclient.version>4.5.12</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -73,7 +73,11 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         if (event.failure() instanceof AuthenticationFailedException) {
             return; //handled elsewhere
         }
-        event.response().setStatusCode(event.statusCode() > 0 ? event.statusCode() : 500);
+
+        if (!event.response().headWritten()) {
+            event.response().setStatusCode(event.statusCode() > 0 ? event.statusCode() : 500);
+        }
+
         String uuid = BASE_ID + ERROR_COUNT.incrementAndGet();
         String details = "";
         String stack = "";


### PR DESCRIPTION
Update Vert.x version to 3.9.3.

Mutiny clients are going to be updated in another PR, as it depends on #11614. 