### PR TITLE
Fix maven wrapper not working in codestarts

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/.mvn/wrapper/MavenWrapperDownloader.tpl.qute.java
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/.mvn/wrapper/MavenWrapperDownloader.tpl.qute.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2007-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader {
+
+    private static final String WRAPPER_VERSION = "{maven.wrapper-version}";
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
+     * use instead of the default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
+            ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH =
+            ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main(String args[]) {
+        System.out.println("- Downloader started");
+        File baseDirectory = new File(args[0]);
+        System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        String url = DEFAULT_DOWNLOAD_URL;
+        if(mavenWrapperPropertyFile.exists()) {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try {
+                mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
+                url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
+            } catch (IOException e) {
+                System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
+            } finally {
+                try {
+                    if(mavenWrapperPropertyFileInputStream != null) {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println("- Downloading from: " + url);
+
+        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        if(!outputFile.getParentFile().exists()) {
+            if(!outputFile.getParentFile().mkdirs()) {
+                System.out.println(
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+            }
+        }
+        System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
+        try {
+            downloadFileFromURL(url, outputFile);
+            System.out.println("Done");
+            System.exit(0);
+        } catch (Throwable e) {
+            System.out.println("- Error downloading");
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
+        URL website = new URL(urlString);
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destination);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/.mvn/wrapper/maven-wrapper.tpl.qute.properties
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/.mvn/wrapper/maven-wrapper.tpl.qute.properties
@@ -1,0 +1,2 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/{maven.version}/apache-maven-{maven.version}-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/{maven.wrapper-version}/maven-wrapper-{maven.wrapper-version}.jar

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/mvnw.tpl.qute
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/mvnw.tpl.qute
@@ -212,9 +212,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/{maven.version}/maven-wrapper-{maven.version}.jar"
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/{maven.wrapper-version}/maven-wrapper-{maven.wrapper-version}.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/{maven.version}/maven-wrapper-{maven.version}.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/{maven.wrapper-version}/maven-wrapper-{maven.wrapper-version}.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/mvnw.tpl.qute.cmd
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/base/mvnw.tpl.qute.cmd
@@ -120,7 +120,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/{maven.version}/maven-wrapper-{maven.version}.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/{maven.wrapper-version}/maven-wrapper-{maven.wrapper-version}.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
@@ -134,7 +134,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/{maven.version}/maven-wrapper-{maven.version}.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/{maven.wrapper-version}/maven-wrapper-{maven.wrapper-version}.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/codestart.yml
@@ -4,7 +4,8 @@ language:
   base:
     data:
       maven:
-        version: 0.5.6
+        version: 3.6.3
+        wrapper-version: 0.5.6
     shared-data:
       buildtool:
         cmd:


### PR DESCRIPTION
maven-wrapper.properties is necessary to automatically download the jar
it was working by luck when a parent folder contains a  directory