### PR TITLE
Trim spaces in CORS config

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/TrimmedStringConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/TrimmedStringConverter.java
@@ -1,0 +1,17 @@
+package io.quarkus.runtime.configuration;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+public class TrimmedStringConverter implements Converter<String> {
+
+    public TrimmedStringConverter() {
+    }
+
+    @Override
+    public String convert(String s) {
+        if (s == null) {
+            return s;
+        }
+        return s.trim();
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config-full.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config-full.properties
@@ -1,5 +1,5 @@
 quarkus.http.cors=true
-quarkus.http.cors.origins=http://custom.origin.quarkus,http://www.quarkus.io
+quarkus.http.cors.origins=http://custom.origin.quarkus, http://www.quarkus.io
 quarkus.http.cors.methods=GET,PUT,POST
 quarkus.http.cors.headers=X-Custom
 quarkus.http.cors.exposed-headers=Content-Disposition

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.vertx.core.http.HttpMethod;
 
 @ConfigGroup
@@ -20,6 +22,7 @@ public class CORSConfig {
      * default: returns any requested origin as valid
      */
     @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
     public Optional<List<String>> origins;
 
     /**
@@ -42,6 +45,7 @@ public class CORSConfig {
      * default: returns any requested header as valid
      */
     @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
     public Optional<List<String>> headers;
 
     /**
@@ -52,6 +56,7 @@ public class CORSConfig {
      * default: empty
      */
     @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
     public Optional<List<String>> exposedHeaders;
 
     /**


### PR DESCRIPTION
Adding spaces to the lists causes hard to debug
errors.