### PR TITLE
Only clear the DriverManager if a driver was loaded

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DriverRemover.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DriverRemover.java
@@ -10,13 +10,21 @@ public class DriverRemover implements Runnable {
 
     private static final Logger log = Logger.getLogger(DriverRemover.class);
 
+    final ClassLoader goingAwayCl;
+
+    public DriverRemover(ClassLoader goingAwayCl) {
+        this.goingAwayCl = goingAwayCl;
+    }
+
     @Override
     public void run() {
         Enumeration<Driver> drivers = DriverManager.getDrivers();
         while (drivers.hasMoreElements()) {
             Driver driver = drivers.nextElement();
             try {
-                DriverManager.deregisterDriver(driver);
+                if (driver.getClass().getClassLoader() == goingAwayCl) {
+                    DriverManager.deregisterDriver(driver);
+                }
             } catch (SQLException t) {
                 log.error("Failed to deregister driver", t);
             }


### PR DESCRIPTION
The act of clearing the manager could result in
the drivers being initialized, which can change
the runtime behaviour.

Fixes #12116