### PR TITLE
Fix Gradle test-fixtures class loading issues

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -1,5 +1,7 @@
 package io.quarkus.gradle.builder;
 
+import static io.quarkus.bootstrap.resolver.model.impl.ArtifactCoordsImpl.TYPE_JAR;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -22,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -31,9 +34,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.plugins.JavaTestFixturesPlugin;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.internal.component.external.model.TestFixturesSupport;
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
 
 import io.quarkus.bootstrap.BootstrapConstants;
@@ -128,14 +129,6 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
                 project.getVersion().toString());
         final SourceSet mainSourceSet = QuarkusGradleUtils.getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME);
         final SourceSetImpl modelSourceSet = convert(mainSourceSet);
-
-        // If the project exposes test fixtures, we must add them as source directory
-        if (mode.equals(LaunchMode.TEST) && project.getPlugins().hasPlugin(JavaTestFixturesPlugin.class)) {
-            final SourceSet fixtureSourceSet = QuarkusGradleUtils.getSourceSet(project,
-                    TestFixturesSupport.TEST_FIXTURE_SOURCESET_NAME);
-            modelSourceSet.addSourceDirectories(fixtureSourceSet.getOutput().getClassesDirs().getFiles());
-        }
-
         return new WorkspaceModuleImpl(appArtifactCoords, project.getProjectDir().getAbsoluteFile(),
                 project.getBuildDir().getAbsoluteFile(), getSourceSourceSet(mainSourceSet), modelSourceSet);
     }
@@ -162,25 +155,30 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             Map<ArtifactCoords, Dependency> appDependencies, Set<org.gradle.api.artifacts.Dependency> extensionDeps,
             Set<ArtifactCoords> visited) {
         for (ResolvedDependency d : dependencies) {
-            ArtifactCoords key = new ArtifactCoordsImpl(d.getModuleGroup(), d.getModuleName(), "");
-            if (!visited.add(key)) {
-                continue;
-            }
-
-            Dependency appDep = appDependencies.get(key);
-            if (appDep == null) {
-                continue;
-            }
-            final org.gradle.api.artifacts.Dependency deploymentArtifact = getDeploymentArtifact(appDep);
-
             boolean addChildExtension = true;
-            if (deploymentArtifact != null && addChildExtension) {
-                extensionDeps.add(deploymentArtifact);
-                addChildExtension = false;
-            }
+            boolean wasDependencyVisited = false;
+            for (ResolvedArtifact artifact : d.getModuleArtifacts()) {
+                ModuleVersionIdentifier moduleIdentifier = artifact.getModuleVersion().getId();
+                ArtifactCoords key = toAppDependenciesKey(moduleIdentifier.getGroup(), moduleIdentifier.getName(),
+                        artifact.getClassifier());
+                if (!visited.add(key)) {
+                    continue;
+                }
 
+                Dependency appDep = appDependencies.get(key);
+                if (appDep == null) {
+                    continue;
+                }
+
+                wasDependencyVisited = true;
+                final org.gradle.api.artifacts.Dependency deploymentArtifact = getDeploymentArtifact(appDep);
+                if (deploymentArtifact != null) {
+                    extensionDeps.add(deploymentArtifact);
+                    addChildExtension = false;
+                }
+            }
             final Set<ResolvedDependency> resolvedChildren = d.getChildren();
-            if (addChildExtension && !resolvedChildren.isEmpty()) {
+            if (wasDependencyVisited && addChildExtension && !resolvedChildren.isEmpty()) {
                 collectFirstMetDeploymentDeps(resolvedChildren, appDependencies, extensionDeps, visited);
             }
         }
@@ -260,7 +258,7 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             } else {
                 dep.addPath(a.getFile());
             }
-            appDependencies.put((ArtifactCoords) new ArtifactCoordsImpl(dep.getGroupId(), dep.getName(), ""), dep);
+            appDependencies.put(toAppDependenciesKey(dep.getGroupId(), dep.getName(), dep.getClassifier()), dep);
             if (artifactFiles != null) {
                 artifactFiles.add(a.getFile());
             }
@@ -288,8 +286,8 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
                 }
                 // hash could be a better way to represent the version
                 final String version = String.valueOf(f.lastModified());
-                final ArtifactCoords key = new ArtifactCoordsImpl(group, name, "");
-                final DependencyImpl dep = new DependencyImpl(name, group, version, "copmile", type, null);
+                final ArtifactCoords key = toAppDependenciesKey(group, name, "");
+                final DependencyImpl dep = new DependencyImpl(name, group, version, "compile", type, null);
                 dep.addPath(f);
                 appDependencies.put(key, dep);
             }
@@ -369,4 +367,11 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         return new DependencyImpl(split[1], split[0], split.length > 2 ? split[2] : null,
                 "compile", a.getType(), a.getClassifier());
     }
+
+    private static ArtifactCoords toAppDependenciesKey(String groupId, String artifactId, String classifier) {
+        // Default classifier is empty string and not null value, lets keep it that way
+        classifier = classifier == null ? "" : classifier;
+        return new ArtifactCoordsImpl(groupId, artifactId, classifier, "", TYPE_JAR);
+    }
+
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
@@ -1,6 +1,8 @@
 package io.quarkus.bootstrap.utils;
 
 import static io.quarkus.bootstrap.util.QuarkusModelHelper.DEVMODE_REQUIRED_TASKS;
+import static io.quarkus.bootstrap.util.QuarkusModelHelper.ENABLE_JAR_PACKAGING;
+import static io.quarkus.bootstrap.util.QuarkusModelHelper.TEST_REQUIRED_TASKS;
 
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.QuarkusGradleModelFactory;
@@ -9,6 +11,7 @@ import io.quarkus.bootstrap.util.QuarkusModelHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Helper class used to expose build tool used by the project
@@ -82,13 +85,18 @@ public class BuildToolHelper {
         return null;
     }
 
-    public static QuarkusModel enableGradleAppModel(Path projectRoot, String mode, String... tasks)
+    public static QuarkusModel enableGradleAppModelForTest(Path projectRoot) throws IOException, AppModelResolverException {
+        // We enable jar packaging since we want test-fixtures as jars
+        return enableGradleAppModel(projectRoot, "TEST", ENABLE_JAR_PACKAGING, TEST_REQUIRED_TASKS);
+    }
+
+    public static QuarkusModel enableGradleAppModel(Path projectRoot, String mode, List<String> jvmArgs, String... tasks)
             throws IOException, AppModelResolverException {
         if (isMavenProject(projectRoot)) {
             return null;
         }
         final QuarkusModel model = QuarkusGradleModelFactory.create(getBuildFile(projectRoot, BuildTool.GRADLE).toFile(),
-                mode, tasks);
+                mode, jvmArgs, tasks);
         QuarkusModelHelper.exportModel(model);
         return model;
     }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -2,6 +2,8 @@ package io.quarkus.bootstrap.resolver;
 
 import io.quarkus.bootstrap.resolver.model.QuarkusModel;
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
@@ -9,10 +11,14 @@ import org.gradle.tooling.ProjectConnection;
 public class QuarkusGradleModelFactory {
 
     public static QuarkusModel create(File projectDir, String mode, String... tasks) {
+        return create(projectDir, mode, Collections.emptyList(), tasks);
+    }
+
+    public static QuarkusModel create(File projectDir, String mode, List<String> jvmArgs, String... tasks) {
         try (ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(projectDir)
                 .connect()) {
-            connection.newBuild().forTasks(tasks).run();
+            connection.newBuild().forTasks(tasks).addJvmArguments(jvmArgs).run();
             return connection.action(new QuarkusModelBuildAction(mode)).run();
         }
     }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,8 @@ public class QuarkusModelHelper {
     public final static String SERIALIZED_QUARKUS_MODEL = "quarkus-internal.serialized-quarkus-model.path";
     public final static String[] DEVMODE_REQUIRED_TASKS = new String[] { "classes" };
     public final static String[] TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses" };
+    public final static List<String> ENABLE_JAR_PACKAGING = Collections
+            .singletonList("-Dorg.gradle.java.compile-classpath-packaging=true");
 
     public static void exportModel(QuarkusModel model) throws AppModelResolverException, IOException {
         Path serializedModel = QuarkusModelHelper

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+public class TestFixtureMultiModuleTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("test-fixtures-multi-module");
+        final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
+        assertThat(result.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'io.quarkus:quarkus-resteasy-jsonb'
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    // Library-2 has to be dependency as implementation and test fixture
+    implementation(project(':library-2'))
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation(testFixtures(project(':library-2')))
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/src/main/java/org/example/Main.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/src/main/java/org/example/Main.java
@@ -1,0 +1,9 @@
+package org.example;
+
+public class Main {
+
+    // Here just because we want dependency
+    // to production code and test-fixtures of the same module
+    private MainLibrary2 mainLibrary2 = new MainLibrary2();
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/src/test/java/org/example/TestFixturesTest.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/src/test/java/org/example/TestFixturesTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TestFixturesTest extends TestBase {
+
+    @Test
+    void testTestFixtures() {
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/build.gradle
@@ -1,0 +1,9 @@
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+allprojects {
+    group 'my-groupId'
+    version 'my-version'
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'java-test-fixtures'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":static-init-library"))
+    testFixturesImplementation(project(":static-init-library"))
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/main/java/org/example/MainLibrary1.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/main/java/org/example/MainLibrary1.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class MainLibrary1 {
+
+    public void hereJustForDependency() {
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/main/java/org/example/OfyFactory.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/main/java/org/example/OfyFactory.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class OfyFactory extends ObjectFactory {
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/testFixtures/java/org/example/TestHelper.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/src/testFixtures/java/org/example/TestHelper.java
@@ -1,0 +1,10 @@
+package org.example;
+
+
+public class TestHelper {
+
+    public void setUp() {
+        StaticInitLibrary.init(new OfyFactory());
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'java-test-fixtures'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    testFixturesImplementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    testFixturesImplementation 'io.quarkus:quarkus-junit5'
+
+    // Library-1 has to be dependency as implementation and test fixture
+    testFixturesImplementation(project(':library-1'))
+    testFixturesImplementation(testFixtures(project(':library-1')))
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/src/main/java/org/example/MainLibrary2.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/src/main/java/org/example/MainLibrary2.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class MainLibrary2 {
+
+    public void hereJustForDependency() {
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/src/testFixtures/java/org/example/TestBase.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/src/testFixtures/java/org/example/TestBase.java
@@ -1,0 +1,22 @@
+package org.example;
+
+import org.junit.jupiter.api.BeforeEach;
+
+
+public class TestBase {
+
+    private final TestHelper helper;
+    private final MainLibrary1 mainLibrary1;
+
+    public TestBase() {
+        this.helper = new TestHelper();
+        this.mainLibrary1 = new MainLibrary1();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        helper.setUp();
+        mainLibrary1.hereJustForDependency();
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+include ':application', ':library-1', ':library-2', ':static-init-library'
+
+rootProject.name='io.quarkus.reproducer'
+

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java'
+}
+
+dependencies {
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/src/main/java/org/example/ObjectFactory.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/src/main/java/org/example/ObjectFactory.java
@@ -1,0 +1,9 @@
+package org.example;
+
+public class ObjectFactory {
+
+    private String returnValue() {
+        return "value";
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/src/main/java/org/example/StaticInitLibrary.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/static-init-library/src/main/java/org/example/StaticInitLibrary.java
@@ -1,0 +1,11 @@
+package org.example;
+
+public class StaticInitLibrary {
+
+    private static ObjectFactory factory;
+
+    public static void init(ObjectFactory f) {
+        factory = f;
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
@@ -59,7 +58,6 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.runner.Timing;
-import io.quarkus.bootstrap.util.QuarkusModelHelper;
 import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
@@ -134,9 +132,6 @@ public class QuarkusTestExtension
                     rootBuilder.add(testResourcesLocation);
                 }
             }
-            if (Files.exists(testClassLocation.getParent().resolve("testFixtures"))) {
-                rootBuilder.add(testClassLocation.getParent().resolve("testFixtures"));
-            }
 
             originalCl = Thread.currentThread().getContextClassLoader();
             Map<String, String> sysPropRestore = new HashMap<>();
@@ -196,7 +191,7 @@ public class QuarkusTestExtension
 
             // If gradle project running directly with IDE
             if (System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL) == null) {
-                BuildToolHelper.enableGradleAppModel(projectRoot, "TEST", QuarkusModelHelper.TEST_REQUIRED_TASKS);
+                BuildToolHelper.enableGradleAppModelForTest(projectRoot);
             }
 
             runnerBuilder.setApplicationRoot(rootBuilder.build());


### PR DESCRIPTION
Fixes Classloader issues from #11318 for test fixtures.

It looks like dependencies are not correctly collected when test-fixtures are used, since they have same coordinates as main artifact and app dependencies are collected as a map of `Map<ArtifactCoords, Dependency> appDependencies`. 

So this fix also takes into account classifier when it's generating `ArtifactCoords`.

Alternative is, to use `Map<ArtifactCoords, List<Dependency>> appDependencies` and not classifier, but I think classifier solution is better.