### PR TITLE
Add OIDC SecurityEvent

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -336,6 +336,31 @@ If UserInfo is the source of the roles then set `quarkus.oidc.authentication.use
 
 Additionally a custom `SecurityIdentityAugmentor` can also be used to add the roles as documented link:security#security-identity-customization[here].
 
+== Listening to important authentication events
+
+One can register `@ApplicationScoped` bean which will observe important OIDC authentication events. The listener will be updated when a user has logged in for the first time or re-authenticated, as well as when the session has been refreshed. More events may be reported in the future. For example:
+
+[source, java]
+----
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.SecurityEvent;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class SecurityEventListener {
+
+    public void event(@Observes SecurityEvent event) {
+        String tenantId = event.getSecurityIdentity().getAttribute("tenant-id");
+        RoutingContext vertxContext = event.getSecurityIdentity().getCredential(IdTokenCredential.class).getRoutingContext();
+        vertxContext.put("listener-message", String.format("event:%s,tenantId:%s", event.getEventType().name(), tenantId));
+    }
+}
+----
+
 == Single Page Applications
 
 Please check if implementing SPAs the way it is suggested in the link:security-openid-connect#single-page-applications[Single Page Applications for Service Applications] section can meet your requirements.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1011,9 +1011,8 @@ public class OidcTenantConfig {
 
     public static enum ApplicationType {
         /**
-         * A {@code WEB_APP} is a client that server pages, usually a frontend application. For this type of client the
-         * Authorization Code Flow is
-         * defined as the preferred method for authenticating users.
+         * A {@code WEB_APP} is a client that serves pages, usually a frontend application. For this type of client the
+         * Authorization Code Flow is defined as the preferred method for authenticating users.
          */
         WEB_APP,
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
@@ -1,0 +1,47 @@
+package io.quarkus.oidc;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+/**
+ * Security event.
+ *
+ */
+public class SecurityEvent {
+    public enum Type {
+        /**
+         * OIDC Login event which is reported after the first user authentication but also when the user's session
+         * has expired and the user has re-authenticated at the OIDC provider site.
+         */
+        OIDC_LOGIN,
+        /**
+         * OIDC Session refreshed event is reported if it has been detected that an ID token will expire shortly and the session
+         * has been successfully auto-refreshed without the user having to re-authenticate again at the OIDC site.
+         */
+        OIDC_SESSION_REFRESHED,
+        /**
+         * OIDC Session expired and refreshed event is reported if a session has expired but been successfully refreshed
+         * without the user having to re-authenticate again at the OIDC site.
+         */
+        OIDC_SESSION_EXPIRED_AND_REFRESHED,
+        /**
+         * OIDC Logout event is reported when the current user has started an RP-initiated OIDC logout flow.
+         */
+        OIDC_LOGOUT_RP_INITIATED
+    }
+
+    private final Type eventType;
+    private final SecurityIdentity securityIdentity;
+
+    public SecurityEvent(Type eventType, SecurityIdentity securityIdentity) {
+        this.eventType = eventType;
+        this.securityIdentity = securityIdentity;
+    }
+
+    public Type getEventType() {
+        return eventType;
+    }
+
+    public SecurityIdentity getSecurityIdentity() {
+        return securityIdentity;
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractOidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractOidcAuthenticationMechanism.java
@@ -7,8 +7,15 @@ import io.quarkus.security.identity.request.TokenAuthenticationRequest;
 import io.smallrye.mutiny.Uni;
 
 abstract class AbstractOidcAuthenticationMechanism {
+    protected DefaultTenantConfigResolver resolver;
+
     protected Uni<SecurityIdentity> authenticate(IdentityProviderManager identityProviderManager,
             TokenCredential token) {
         return identityProviderManager.authenticate(new TokenAuthenticationRequest(token));
     }
+
+    void setResolver(DefaultTenantConfigResolver resolver) {
+        this.resolver = resolver;
+    }
+
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -18,8 +18,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             null, null);
 
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
-            IdentityProviderManager identityProviderManager,
-            DefaultTenantConfigResolver resolver) {
+            IdentityProviderManager identityProviderManager) {
         String token = extractBearerToken(context, resolver.resolve(context, false).oidcConfig);
 
         // if a bearer token is provided try to authenticate
@@ -29,7 +28,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         return Uni.createFrom().nullItem();
     }
 
-    public Uni<ChallengeData> getChallenge(RoutingContext context, DefaultTenantConfigResolver resolver) {
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
         return Uni.createFrom().item(UNAUTHORIZED_CHALLENGE);
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -12,6 +13,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.quarkus.oidc.TenantResolver;
 import io.vertx.ext.web.RoutingContext;
@@ -32,6 +34,11 @@ public class DefaultTenantConfigResolver {
 
     @Inject
     TenantConfigBean tenantConfigBean;
+
+    @Inject
+    Event<SecurityEvent> securityEvent;
+
+    private volatile boolean securityEventObserved;
 
     @PostConstruct
     public void verifyResolvers() {
@@ -89,6 +96,18 @@ public class DefaultTenantConfigResolver {
         return resolver != null
                 && (resolver.auth == null || resolver.oidcConfig.token.refreshExpired
                         || resolver.oidcConfig.authentication.userInfoRequired);
+    }
+
+    boolean isSecurityEventObserved() {
+        return securityEventObserved;
+    }
+
+    void setSecurityEventObserved(boolean securityEventObserved) {
+        this.securityEventObserved = securityEventObserved;
+    }
+
+    Event<SecurityEvent> getSecurityEvent() {
+        return securityEvent;
     }
 
     private TenantConfigContext getTenantConfigFromConfigResolver(RoutingContext context, boolean create) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -23,8 +24,15 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     @Inject
     DefaultTenantConfigResolver resolver;
+
     private BearerAuthenticationMechanism bearerAuth = new BearerAuthenticationMechanism();
     private CodeAuthenticationMechanism codeAuth = new CodeAuthenticationMechanism();
+
+    @PostConstruct
+    public void init() {
+        bearerAuth.setResolver(resolver);
+        codeAuth.setResolver(resolver);
+    }
 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
@@ -33,8 +41,8 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
         if (tenantContext.oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(context, tenantContext) ? codeAuth.authenticate(context, identityProviderManager, resolver)
-                : bearerAuth.authenticate(context, identityProviderManager, resolver);
+        return isWebApp(context, tenantContext) ? codeAuth.authenticate(context, identityProviderManager)
+                : bearerAuth.authenticate(context, identityProviderManager);
     }
 
     @Override
@@ -43,8 +51,8 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
         if (tenantContext.oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(context, tenantContext) ? codeAuth.getChallenge(context, resolver)
-                : bearerAuth.getChallenge(context, resolver);
+        return isWebApp(context, tenantContext) ? codeAuth.getChallenge(context)
+                : bearerAuth.getChallenge(context);
     }
 
     private TenantConfigContext resolve(RoutingContext context) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -47,6 +47,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             AuthenticationRequestContext context) {
         OidcTokenCredential credential = (OidcTokenCredential) request.getToken();
         RoutingContext vertxContext = credential.getRoutingContext();
+        vertxContext.put(AuthenticationRequestContext.class.getName(), context);
         return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
             @Override
             public Uni<SecurityIdentity> get() {
@@ -159,6 +160,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                     if (userInfo != null) {
                                         OidcUtils.setSecurityIdentityRoles(builder, resolvedContext.oidcConfig, userInfo);
                                     }
+                                    OidcUtils.setBlockinApiAttribute(builder, vertxContext);
+                                    OidcUtils.setTenantIdAttribute(builder, resolvedContext.oidcConfig);
                                     uniEmitter.complete(builder.build());
                                 }
                             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
@@ -332,5 +333,10 @@ public class OidcRecorder {
             jsonOptions.put("password", proxyConfig.password.get());
         }
         return Optional.of(new ProxyOptions(jsonOptions));
+    }
+
+    public void setSecurityEventObserved(boolean isSecurityEventObserved) {
+        DefaultTenantConfigResolver bean = Arc.container().instance(DefaultTenantConfigResolver.class).get();
+        bean.setSecurityEventObserved(isSecurityEventObserved);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -21,6 +21,7 @@ import io.quarkus.oidc.UserInfo;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.credential.TokenCredential;
+import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -176,6 +177,8 @@ public final class OidcUtils {
         builder.setPrincipal(jwtPrincipal);
         setSecurityIdentityRoles(builder, config, rolesJson);
         setSecurityIdentityUserInfo(builder, userInfo);
+        setBlockinApiAttribute(builder, vertxContext);
+        setTenantIdAttribute(builder, config);
         return builder.build();
     }
 
@@ -189,6 +192,17 @@ public final class OidcUtils {
         } catch (Exception e) {
             throw new ForbiddenException(e);
         }
+    }
+
+    public static void setBlockinApiAttribute(QuarkusSecurityIdentity.Builder builder, RoutingContext vertxContext) {
+        if (vertxContext != null) {
+            builder.addAttribute(AuthenticationRequestContext.class.getName(),
+                    vertxContext.get(AuthenticationRequestContext.class.getName()));
+        }
+    }
+
+    public static void setTenantIdAttribute(QuarkusSecurityIdentity.Builder builder, OidcTenantConfig config) {
+        builder.addAttribute("tenant-id", config.tenantId.orElse("Default"));
     }
 
     public static void setSecurityIdentityUserInfo(QuarkusSecurityIdentity.Builder builder, JsonObject userInfo) {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -23,6 +23,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-logout";
         }
 
+        if (path.contains("tenant-listener")) {
+            return "tenant-listener";
+        }
+
         if (path.contains("tenant-autorefresh")) {
             return "tenant-autorefresh";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -108,7 +108,22 @@ public class ProtectedResource {
         if (!accessTokenCredential.getRefreshToken().getToken().equals(refreshToken.getToken())) {
             throw new OIDCException("Refresh token values are not equal");
         }
-        return refreshToken.getToken() != null && !refreshToken.getToken().isEmpty() ? "RT injected" : "no refresh";
+        if (refreshToken.getToken() != null && !refreshToken.getToken().isEmpty()) {
+            String message = "RT injected";
+            String listenerMessage = idTokenCredential.getRoutingContext().get("listener-message");
+            if (listenerMessage != null) {
+                message += ("(" + listenerMessage + ")");
+            }
+            return message;
+        } else {
+            return "no refresh";
+        }
+    }
+
+    @GET
+    @Path("refresh/tenant-listener")
+    public String refreshTenantListener() {
+        return refresh();
     }
 
     @GET

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/SecurityEventListener.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/SecurityEventListener.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.keycloak;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.SecurityEvent;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class SecurityEventListener {
+
+    public void event(@Observes SecurityEvent event) {
+        String tenantId = event.getSecurityIdentity().getAttribute("tenant-id");
+        boolean blockingApiAvailable = event.getSecurityIdentity()
+                .getAttribute(AuthenticationRequestContext.class.getName()) != null;
+
+        RoutingContext vertxContext = event.getSecurityIdentity().getCredential(IdTokenCredential.class).getRoutingContext();
+        vertxContext.put("listener-message",
+                String.format("event:%s,tenantId:%s,blockingApi:%b", event.getEventType().name(), tenantId,
+                        blockingApiAvailable));
+    }
+
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -12,6 +12,16 @@ quarkus.oidc.authentication.cookie-domain=localhost
 quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.oidc.application-type=web-app
 
+# Tenant listener configuration for testing that the login event has been captured
+quarkus.oidc.tenant-listener.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-listener.client-id=quarkus-app
+quarkus.oidc.tenant-listener.credentials.secret=secret
+quarkus.oidc.tenant-listener.authentication.cookie-path=/
+# Redirect parameters are dropped by redirecting the authenticated user but this final redirect loses the login event message
+# on Vertx context; so disabling it for the test endpoint to confirm the login event has been accepted
+quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
+quarkus.oidc.tenant-listener.application-type=web-app
+
 
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
 quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -551,6 +551,25 @@ public class CodeFlowTest {
     }
 
     @Test
+    public void testAccessAndRefreshTokenInjectionWithoutIndexHtmlAndListener() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-listener");
+
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("RT injected(event:OIDC_LOGIN,tenantId:tenant-listener,blockingApi:true)", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testAccessAndRefreshTokenInjectionWithoutIndexHtmlWithQuery() throws Exception {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh-query?a=aValue");


### PR DESCRIPTION
Fixes #12145 

This PR adds a listener which can capture some important login/session/logout events based on the conversation with the user. `Login` (i.e creating a new session after a successful code flow) is of primary interest, but other events (4 of them for now, more can be added easily) will let users have a better view into what is going on.
Note I'm passing a blocking API ref as a context attribute (in case some expensive action will need to be done), @stuartwdouglas, if you prefer, I can have a dedicated parameter. 

Also updated the RP-initiated doc section as the user could not make it work (was not obvious the logout path had to be authenticated)