### PR TITLE
Adds new property to configure "hibernate.format_sql" in the application.properties

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -376,13 +376,19 @@ public class HibernateOrmConfigPersistenceUnit {
         public boolean sql;
 
         /**
+         * Format the SQL logs if SQL log is enabled
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean formatSql;
+
+        /**
          * Whether JDBC warnings should be collected and logged.
          */
         @ConfigItem(defaultValueDocumentation = "depends on dialect")
         public Optional<Boolean> jdbcWarnings;
 
         public boolean isAnyPropertySet() {
-            return sql || jdbcWarnings.isPresent();
+            return sql || !formatSql || jdbcWarnings.isPresent();
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -811,7 +811,10 @@ public final class HibernateOrmProcessor {
         // Logging
         if (persistenceUnitConfig.log.sql) {
             descriptor.getProperties().setProperty(AvailableSettings.SHOW_SQL, "true");
-            descriptor.getProperties().setProperty(AvailableSettings.FORMAT_SQL, "true");
+
+            if (persistenceUnitConfig.log.formatSql) {
+                descriptor.getProperties().setProperty(AvailableSettings.FORMAT_SQL, "true");
+            }
         }
 
         if (persistenceUnitConfig.log.jdbcWarnings.isPresent()) {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/logsql/LogSqlFormatSqlDefaultValueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/logsql/LogSqlFormatSqlDefaultValueTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.hibernate.orm.logsql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LogSqlFormatSqlDefaultValueTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class)
+                    .addAsResource("application-log-sql-format-sql-default.properties", "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @BeforeEach
+    public void activateRequestContext() {
+        Arc.container().requestContext().activate();
+    }
+
+    @Test
+    public void testFormattedDefaultValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+        assertEquals("true", properties.get(AvailableSettings.FORMAT_SQL));
+    }
+
+    @AfterEach
+    public void terminateRequestContext() {
+        Arc.container().requestContext().terminate();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/logsql/LogSqlFormatSqlFalseTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/logsql/LogSqlFormatSqlFalseTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.logsql;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LogSqlFormatSqlFalseTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class)
+                    .addAsResource("application-log-sql-format-sql-false.properties", "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @BeforeEach
+    public void activateRequestContext() {
+        Arc.container().requestContext().activate();
+    }
+
+    @Test
+    public void testFormattedValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+        assertNull(properties.get(AvailableSettings.FORMAT_SQL));
+    }
+
+    @AfterEach
+    public void terminateRequestContext() {
+        Arc.container().requestContext().terminate();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-default.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-default.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-false.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-log-sql-format-sql-false.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.format-sql=false

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -243,7 +243,10 @@ public final class HibernateReactiveProcessor {
         // Logging
         if (persistenceUnitConfig.log.sql) {
             desc.getProperties().setProperty(AvailableSettings.SHOW_SQL, "true");
-            desc.getProperties().setProperty(AvailableSettings.FORMAT_SQL, "true");
+
+            if (persistenceUnitConfig.log.formatSql) {
+                desc.getProperties().setProperty(AvailableSettings.FORMAT_SQL, "true");
+            }
         }
 
         // Statistics


### PR DESCRIPTION
`quarkus.hibernate-orm.log.format-sql=false`

This allows to configure hibernate's `hibernate.format_sql` property in the application.properties.

Fixes: #12204 