### PR TITLE
Clean jandex index after test

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -134,6 +134,19 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleWrapperTestBase {
     }
 
     @Test
+    public void canDetectUpToDateTests() throws Exception {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runGradleWrapper(projectRoot, "test");
+
+        assertThat(firstBuild.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+
+        BuildResult secondBuild = runGradleWrapper(projectRoot, "test");
+
+        assertThat(secondBuild.getTasks().get(":test")).isEqualTo(BuildResult.UPTODATE_OUTCOME);
+    }
+
+    @Test
     public void canDetectSystemPropertyChangeWhenBuilding() throws Exception {
         createProject(SourceType.JAVA);
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
@@ -106,4 +106,15 @@ public final class TestClassIndexer {
             }
         });
     }
+
+    public static void removeIndex(Class<?> requiredTestClass) {
+        Path indexPath = indexPath(requiredTestClass);
+        if (Files.exists(indexPath)) {
+            try {
+                Files.delete(indexPath);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to delete file index", e);
+            }
+        }
+    }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -261,6 +261,10 @@ public class QuarkusTestExtension
                             }
                             tm.close();
                         }
+                        try {
+                            TestClassIndexer.removeIndex(requiredTestClass);
+                        } catch (Exception ignored) {
+                        }
                     }
                 }
             };


### PR DESCRIPTION
This branch aims to remove the jandex index containing test in the shutdown hook. 
This allow gradle test task to be up-to-date after the first run.

close #11406  