### PR TITLE
Support vertx-web and micrometer

### DIFF
--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
+            <artifactId>quarkus-resteasy-common-spi</artifactId>
         </dependency>
 
         <!-- Registry providers (optional) -->

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/RequestMetric.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/RequestMetric.java
@@ -1,17 +1,34 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
+import io.micrometer.core.instrument.Timer;
 import io.vertx.core.Context;
 import io.vertx.ext.web.RoutingContext;
 
-public class RequestMetric extends HashMap<String, Object> {
+public class RequestMetric {
     static final String METRICS_CONTEXT = "HTTP_REQUEST_METRICS_CONTEXT";
-
     static final String HTTP_REQUEST_PATH = "HTTP_REQUEST_PATH";
-    static final String HTTP_REQUEST_SAMPLE = "HTTP_REQUEST_SAMPLE";
+    static final String HTTP_REQUEST_PATH_MATCHED = "HTTP_REQUEST_MATCHED_PATH";
+    static final Pattern VERTX_ROUTE_PARAM = Pattern.compile("^:(.*)$");
+
+    /** Cache of vert.x resolved paths: /item/:id --> /item/{id} */
+    final static ConcurrentHashMap<String, String> vertxRoutePath = new ConcurrentHashMap<>();
 
     volatile RoutingContext routingContext;
+
+    /** Do not measure requests until/unless a uri path is set */
+    boolean measure = false;
+
+    /** URI path used as a tag value for non-error requests */
+    String path;
+
+    /** True IFF the path was revised by a matcher expression */
+    boolean pathMatched = false;
+
+    /** Store the sample used to measure the request */
+    Timer.Sample sample;
 
     /**
      * Stash the RequestMetric in the Vertx Context
@@ -42,15 +59,33 @@ public class RequestMetric extends HashMap<String, Object> {
         return null;
     }
 
-    <T> T getFromRoutingContext(String key) {
-        if (routingContext != null) {
-            return routingContext.get(key);
+    String getHttpRequestPath() {
+        // Vertx binder configuration, see VertxMetricsTags
+        if (pathMatched) {
+            return path;
         }
-        return null;
-    }
-
-    <T> T getValue(String key) {
-        Object o = this.get(key);
-        return o == null ? null : (T) o;
+        if (routingContext != null) {
+            // JAX-RS or Servlet container filter
+            String rcPath = routingContext.get(HTTP_REQUEST_PATH);
+            if (rcPath != null) {
+                return rcPath;
+            }
+            // vertx-web or reactive route
+            String matchedPath = routingContext.currentRoute().getPath();
+            if (matchedPath != null) {
+                if (matchedPath.contains(":")) {
+                    // Convert /item/:id to /item/{id} and save it for next time
+                    matchedPath = vertxRoutePath.computeIfAbsent(matchedPath, k -> {
+                        String segments[] = k.split("/");
+                        for (int i = 0; i < segments.length; i++) {
+                            segments[i] = VERTX_ROUTE_PARAM.matcher(segments[i]).replaceAll("{$1}");
+                        }
+                        return String.join("/", segments);
+                    });
+                }
+                return matchedPath;
+            }
+        }
+        return path;
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/VertxConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/VertxConfig.java
@@ -10,18 +10,28 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "micrometer.binder.vertx", phase = ConfigPhase.RUN_TIME)
 public class VertxConfig {
     /**
-     * Comma-separated case-sensitive list of regular expressions defining Paths
-     * that should be matched and used as tags. By default, the first path
-     * segment will be used. This default behavior will also apply to any
-     * URI path that is found (2xx or 5xx) but doesn't match elements
-     * in this list.
+     * Comma-separated list of regular expressions used to specify uri
+     * labels in http metrics.
+     *
+     * Vertx instrumentation will attempt to transform parameterized
+     * resource paths, `/item/123`, into a generic form, `/item/{id}`,
+     * to reduce the cardinality of uri label values.
+     *
+     * Patterns specified here will take precedence over those computed
+     * values.
+     *
+     * For example, if `/item/\\d+=/item/custom` is specified in this list,
+     * a request to a matching path (`/item/123`) will use the specified
+     * replacement value (`/item/custom`) as the value for the uri label.
+     *
+     * @asciidoclet
      */
     @ConfigItem
     public Optional<List<String>> matchPatterns = Optional.empty();
 
     /**
-     * Comma-separated case-sensitive list of regular expressions defining Paths
-     * that should be ignored / not measured.
+     * Comma-separated list of regular expressions defining uri paths
+     * that should be ignored (not measured).
      */
     @ConfigItem
     public Optional<List<String>> ignorePatterns = Optional.empty();

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/RequestMetricTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/RequestMetricTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.micrometer.runtime.binder.vertx;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.mockito.Mockito;
+
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Disabled on Java 8 because of Mocks
+ */
+@DisabledOnJre(JRE.JAVA_8)
+public class RequestMetricTest {
+
+    @Test
+    public void testReturnPathFromHttpRequestPath() {
+        RequestMetric requestMetric = new RequestMetric();
+        requestMetric.routingContext = Mockito.mock(RoutingContext.class);
+
+        Mockito.when(requestMetric.routingContext.get(RequestMetric.HTTP_REQUEST_PATH))
+                .thenReturn("/item/{id}");
+
+        Assertions.assertEquals("/item/{id}", requestMetric.getHttpRequestPath());
+    }
+
+    @Test
+    public void testReturnPathFromRoutingContext() {
+        RequestMetric requestMetric = new RequestMetric();
+        requestMetric.routingContext = Mockito.mock(RoutingContext.class);
+        Route currentRoute = Mockito.mock(Route.class);
+
+        Mockito.when(requestMetric.routingContext.currentRoute()).thenReturn(currentRoute);
+        Mockito.when(currentRoute.getPath()).thenReturn("/item");
+
+        Assertions.assertEquals("/item", requestMetric.getHttpRequestPath());
+    }
+
+    @Test
+    public void testReturnGenericPathFromRoutingContext() {
+        RequestMetric requestMetric = new RequestMetric();
+        requestMetric.routingContext = Mockito.mock(RoutingContext.class);
+        Route currentRoute = Mockito.mock(Route.class);
+
+        Mockito.when(requestMetric.routingContext.currentRoute()).thenReturn(currentRoute);
+        Mockito.when(currentRoute.getPath()).thenReturn("/item/:id");
+
+        Assertions.assertEquals("/item/{id}", requestMetric.getHttpRequestPath());
+        // Make sure conversion is cached
+        Assertions.assertEquals("/item/{id}", RequestMetric.vertxRoutePath.get("/item/:id"));
+    }
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.micrometer.runtime.binder.vertx;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
+
+public class VertxHttpServerMetricsTest {
+
+    @Test
+    public void testHttpServerMetricsIgnorePatterns() {
+        VertxConfig runtimeConfig = new VertxConfig();
+        runtimeConfig.ignorePatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/.*")));
+        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), runtimeConfig);
+
+        Assertions.assertFalse(metrics.ignorePatterns.isEmpty());
+        Pattern p = metrics.ignorePatterns.get(0);
+        Assertions.assertEquals("/item/.*", p.pattern());
+        Assertions.assertTrue(p.matcher("/item/123").matches());
+    }
+
+    @Test
+    public void testHttpServerMetricsMatchPatterns() {
+        VertxConfig runtimeConfig = new VertxConfig();
+        runtimeConfig.matchPatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/\\d+=/item/{id}")));
+        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), runtimeConfig);
+
+        Assertions.assertFalse(metrics.matchPatterns.isEmpty());
+        Map.Entry<Pattern, String> entry = metrics.matchPatterns.entrySet().iterator().next();
+        Assertions.assertEquals("/item/\\d+", entry.getKey().pattern());
+        Assertions.assertEquals("/item/{id}", entry.getValue());
+        Assertions.assertTrue(entry.getKey().matcher("/item/123").matches());
+    }
+}

--- a/integration-tests/micrometer-jmx/pom.xml
+++ b/integration-tests/micrometer-jmx/pom.xml
@@ -26,14 +26,10 @@
             <artifactId>micrometer-registry-jmx</artifactId>
         </dependency>
 
-        <!-- JAX-RS -->
+        <!-- Do not use Resteasy! Deliberately focused on vertx-web alone -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-vertx-web</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -69,20 +65,7 @@
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-resteasy-deployment</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+        <artifactId>quarkus-vertx-web-deployment</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>test</scope>

--- a/integration-tests/micrometer-jmx/src/main/java/io/quarkus/it/micrometer/jmx/MessageResource.java
+++ b/integration-tests/micrometer-jmx/src/main/java/io/quarkus/it/micrometer/jmx/MessageResource.java
@@ -4,14 +4,15 @@ import java.lang.management.ManagementFactory;
 import java.util.Set;
 
 import javax.management.*;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.core.http.HttpMethod;
 
-@Path("/message")
+@RouteBase(path = "/message")
 public class MessageResource {
 
     private final MeterRegistry registry;
@@ -21,27 +22,24 @@ public class MessageResource {
         this.registry = registry;
     }
 
-    @GET
+    @Route(path = "ping", methods = HttpMethod.GET)
     public String message() {
         CompositeMeterRegistry compositeMeterRegistry = (CompositeMeterRegistry) registry;
         Set<MeterRegistry> subRegistries = compositeMeterRegistry.getRegistries();
         return subRegistries.iterator().next().getClass().getName();
     }
 
-    @GET
-    @Path("fail")
+    @Route(path = "fail", methods = HttpMethod.GET)
     public String fail() {
         throw new RuntimeException("Failed on purpose");
     }
 
-    @GET
-    @Path("item/{id}")
-    public String item(@PathParam("id") String id) {
+    @Route(path = "item/:id", methods = HttpMethod.GET)
+    public String item(@Param("id") String id) {
         return "return message with id " + id;
     }
 
-    @GET
-    @Path("mbeans")
+    @Route(path = "mbeans", methods = HttpMethod.GET)
     public String metrics() throws IntrospectionException, InstanceNotFoundException, ReflectionException {
         Set<ObjectName> mbeans = mBeanServer.queryNames(null, null);
         StringBuilder sb = new StringBuilder();

--- a/integration-tests/micrometer-jmx/src/test/java/io/quarkus/it/micrometer/jmx/JmxMetricsRegistryTest.java
+++ b/integration-tests/micrometer-jmx/src/test/java/io/quarkus/it/micrometer/jmx/JmxMetricsRegistryTest.java
@@ -24,7 +24,7 @@ class JmxMetricsRegistryTest {
     @Order(1)
     void testRegistryInjection() {
         given()
-                .when().get("/message")
+                .when().get("/message/ping")
                 .then()
                 .statusCode(200)
                 .body(containsString("io.micrometer.jmx.JmxMeterRegistry"));
@@ -49,7 +49,7 @@ class JmxMetricsRegistryTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void testPathParameter() {
         given()
                 .when().get("/message/item/123")
@@ -64,6 +64,7 @@ class JmxMetricsRegistryTest {
         given()
                 .when().get("/message/mbeans")
                 .then()
+                .log().all()
                 .statusCode(200)
 
                 // JMX endpoint is returning a subset of mbean objects to inspect
@@ -78,7 +79,7 @@ class JmxMetricsRegistryTest {
                         "metrics:name=httpServerRequests.env.test.method.GET.outcome.SERVER_ERROR.registry.jmx.status.500.uri./message/fail"))
 
                 .body(containsString(
-                        "metrics:name=httpServerRequests.env.test.method.GET.outcome.SUCCESS.registry.jmx.status.200.uri./message"))
+                        "metrics:name=httpServerRequests.env.test.method.GET.outcome.SUCCESS.registry.jmx.status.200.uri./message/ping"))
                 .body(containsString(
                         "metrics:name=httpServerRequests.env.test.method.GET.outcome.SUCCESS.registry.jmx.status.200.uri./message/item/{id}"))
 


### PR DESCRIPTION
Correct micrometer deployment dependencies
Update micrometer-jmx IT to use vertx-web and not resteasy
Ensure vertx-web routes are matched to micrometer uri tag format
Resolves #12182