### PR TITLE
Mutiny 0.8.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -130,7 +130,7 @@
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <mutiny.version>0.8.0</mutiny.version>
+        <mutiny.version>0.8.1</mutiny.version>
         <axle-client.version>1.1.0</axle-client.version>
         <mutiny-client.version>1.1.0</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -130,7 +130,7 @@
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <mutiny.version>0.7.0</mutiny.version>
+        <mutiny.version>0.8.0</mutiny.version>
         <axle-client.version>1.1.0</axle-client.version>
         <mutiny-client.version>1.1.0</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -23,4 +23,10 @@ public class MutinyProcessor {
         ExecutorService executor = executorBuildItem.getExecutorProxy();
         recorder.configureMutinyInfrastructure(executor);
     }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void defineDroppedExceptionHandler(ExecutorBuildItem executorBuildItem, MutinyInfrastructure recorder) {
+        recorder.configureDroppedExceptionHandler();
+    }
 }

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -26,13 +26,7 @@ public class MutinyProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    public void defineDroppedExceptionHandler(MutinyInfrastructure recorder) {
-        recorder.configureDroppedExceptionHandler();
-    }
-
-    @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
-    public void defineThreadBlockingChecker(MutinyInfrastructure recorder) {
-        recorder.configureThreadBlockingChecker();
+    public void configureDroppedExceptionHandlerAndThreadBlockingChecker(MutinyInfrastructure recorder) {
+        recorder.configureDroppedExceptionHandlerAndThreadBlockingChecker();
     }
 }

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -25,13 +25,13 @@ public class MutinyProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.STATIC_INIT)
     public void defineDroppedExceptionHandler(MutinyInfrastructure recorder) {
         recorder.configureDroppedExceptionHandler();
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.STATIC_INIT)
     public void defineThreadBlockingChecker(MutinyInfrastructure recorder) {
         recorder.configureThreadBlockingChecker();
     }

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -26,7 +26,13 @@ public class MutinyProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void defineDroppedExceptionHandler(ExecutorBuildItem executorBuildItem, MutinyInfrastructure recorder) {
+    public void defineDroppedExceptionHandler(MutinyInfrastructure recorder) {
         recorder.configureDroppedExceptionHandler();
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void defineThreadBlockingChecker(MutinyInfrastructure recorder) {
+        recorder.configureThreadBlockingChecker();
     }
 }

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -17,11 +17,10 @@ public class MutinyInfrastructure {
     }
 
     public void configureDroppedExceptionHandler() {
-        Logger logger = Logger.getLogger(MutinyInfrastructure.class);
         Infrastructure.setDroppedExceptionHandler(new Consumer<Throwable>() {
             @Override
             public void accept(Throwable throwable) {
-                logger.error("Mutiny had to drop the following exception", throwable);
+                Logger.getLogger(MutinyInfrastructure.class).error("Mutiny had to drop the following exception", throwable);
             }
         });
     }

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -16,19 +16,25 @@ public class MutinyInfrastructure {
         Infrastructure.setDefaultExecutor(exec);
     }
 
-    public void configureDroppedExceptionHandler() {
+    public void configureDroppedExceptionHandlerAndThreadBlockingChecker() {
+        Logger logger = Logger.getLogger(MutinyInfrastructure.class);
         Infrastructure.setDroppedExceptionHandler(new Consumer<Throwable>() {
             @Override
             public void accept(Throwable throwable) {
-                Logger.getLogger(MutinyInfrastructure.class).error("Mutiny had to drop the following exception", throwable);
+                logger.error("Mutiny had to drop the following exception", throwable);
             }
         });
-    }
 
-    public void configureThreadBlockingChecker() {
         Infrastructure.setCanCallerThreadBeBlockedSupplier(new BooleanSupplier() {
             @Override
             public boolean getAsBoolean() {
+                /*
+                 * So far all threads and Vert.x worker threads can block, but Vert.x event-loop threads must not block.
+                 * It is safe to detect Vert.x event-loop threads by naming convention.
+                 *
+                 * It also avoids adding a dependency of this extension on the Vert.x APIs to check if we are
+                 * calling from a Vert.x event-loop context / thread.
+                 */
                 String threadName = Thread.currentThread().getName();
                 return !threadName.contains("vertx-eventloop-thread-");
             }

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -1,6 +1,7 @@
 package io.quarkus.mutiny.runtime;
 
 import java.util.concurrent.ExecutorService;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
@@ -21,6 +22,16 @@ public class MutinyInfrastructure {
             @Override
             public void accept(Throwable throwable) {
                 logger.error("Mutiny had to drop the following exception", throwable);
+            }
+        });
+    }
+
+    public void configureThreadBlockingChecker() {
+        Infrastructure.setCanCallerThreadBeBlockedSupplier(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() {
+                String threadName = Thread.currentThread().getName();
+                return !threadName.contains("vertx-eventloop-thread-");
             }
         });
     }

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -1,6 +1,9 @@
 package io.quarkus.mutiny.runtime;
 
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -10,5 +13,15 @@ public class MutinyInfrastructure {
 
     public void configureMutinyInfrastructure(ExecutorService exec) {
         Infrastructure.setDefaultExecutor(exec);
+    }
+
+    public void configureDroppedExceptionHandler() {
+        Logger logger = Logger.getLogger(MutinyInfrastructure.class);
+        Infrastructure.setDroppedExceptionHandler(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable throwable) {
+                logger.error("Mutiny had to drop the following exception", throwable);
+            }
+        });
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -46,7 +46,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             AuthenticationRequestContext context) {
         OidcTokenCredential credential = (OidcTokenCredential) request.getToken();
         RoutingContext vertxContext = credential.getRoutingContext();
-        return Uni.createFrom().deferred(new Supplier<Uni<SecurityIdentity>>() {
+        return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
             @Override
             public Uni<SecurityIdentity> get() {
                 if (tenantResolver.isBlocking(vertxContext)) {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusIdentityProviderManagerImpl.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusIdentityProviderManagerImpl.java
@@ -37,7 +37,7 @@ public class QuarkusIdentityProviderManagerImpl implements IdentityProviderManag
     private final AuthenticationRequestContext blockingRequestContext = new AuthenticationRequestContext() {
         @Override
         public Uni<SecurityIdentity> runBlocking(Supplier<SecurityIdentity> function) {
-            return Uni.createFrom().deferred(new Supplier<Uni<SecurityIdentity>>() {
+            return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
                 @Override
                 public Uni<SecurityIdentity> get() {
                     if (BlockingOperationControl.isBlockingAllowed()) {
@@ -137,7 +137,7 @@ public class QuarkusIdentityProviderManagerImpl implements IdentityProviderManag
         }
         IdentityProvider<T> current = providers.get(pos);
         Uni<SecurityIdentity> cs = current.authenticate(request, context)
-                .onItem().transformToUni(new Function<SecurityIdentity, Uni<SecurityIdentity>>() {
+                .onItem().transformToUni(new Function<SecurityIdentity, Uni<? extends SecurityIdentity>>() {
                     @Override
                     public Uni<SecurityIdentity> apply(SecurityIdentity securityIdentity) {
                         if (securityIdentity != null) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -100,7 +100,7 @@ public class HttpAuthenticator {
         Uni<SecurityIdentity> result = mechanisms[0].authenticate(routingContext, identityProviderManager);
         for (int i = 1; i < mechanisms.length; ++i) {
             HttpAuthenticationMechanism mech = mechanisms[i];
-            result = result.onItem().transformToUni(new Function<SecurityIdentity, Uni<SecurityIdentity>>() {
+            result = result.onItem().transformToUni(new Function<SecurityIdentity, Uni<? extends SecurityIdentity>>() {
                 @Override
                 public Uni<SecurityIdentity> apply(SecurityIdentity data) {
                     if (data != null) {


### PR DESCRIPTION
Upgrading to Mutiny 0.8.1:

* fix compilation errors against parametric types,
* install a dropped exception handler/logger,
* configure a thread blocking checker that reports blocking Vert.x event-loops.

Fixes #11614 