### PR TITLE
UserInfo support for OIDC service endpoints

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -272,10 +272,12 @@ Note that `AccessTokenCredential` will have to be used if the Access Token issue
 
 Injection of the `JsonWebToken` and `AccessTokenCredential` is supported in both `@RequestScoped` and `@ApplicationScoped` contexts.
 
+[[user-info]]
 == User Info
 
 Set `quarkus.oidc.user-info-required=true` if a UserInfo JSON object from the OIDC userinfo endpoint has to be requested.
-This will make an `io.quarkus.oidc.UserInfo` (which is a simple `javax.json.JsonObject` wrapper) object accessible as a SecurityIdentity `userinfo` attribute.
+A request will be sent to the OpenId Provider UserInfo endpont and  an `io.quarkus.oidc.UserInfo` (a simple `javax.json.JsonObject` wrapper) object will be created.
+`io.quarkus.oidc.UserInfo` can be either injected or accessed as a SecurityIdentity `userinfo` attribute.
 
 == Token Claims And SecurityIdentity Roles
 
@@ -285,7 +287,9 @@ Note if you use Keycloak then you should set a Microprofile JWT client scope for
 
 If only the access token contains the roles and this access token is not meant to be propagated to the downstream endpoints then set `quarkus.oidc.roles.source=accesstoken`.
 
-If UserInfo is the source of the roles then set `quarkus.oidc.user-info-required=true` and `quarkus.oidc.roles.source=userinfo`, and if needed, `quarkus.oidc.roles.role-claim-path`.
+If UserInfo is the source of the roles then set `quarkus.oidc.authentication.user-info-required=true` and `quarkus.oidc.roles.source=userinfo`, and if needed, `quarkus.oidc.roles.role-claim-path`.
+
+Additionally a custom `SecurityIdentityAugmentor` can also be used to add the roles as documented link:security#security-identity-customization[here].
 
 == Single Page Applications
 

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -329,6 +329,13 @@ export access_token=$(\
  )
 ----
 
+[[user-info]]
+== User Info
+
+Set `quarkus.oidc.user-info-required=true` if a UserInfo JSON object from the OIDC userinfo endpoint has to be requested.
+A request will be sent to the OpenId Provider UserInfo endpont and  an `io.quarkus.oidc.UserInfo` (a simple `javax.json.JsonObject` wrapper) object will be created.
+`io.quarkus.oidc.UserInfo` can be either injected or accessed as a SecurityIdentity `userinfo` attribute.
+
 == Token Claims And SecurityIdentity Roles
 
 SecurityIdentity roles can be mapped from the verified JWT access tokens as follows:
@@ -340,6 +347,8 @@ SecurityIdentity roles can be mapped from the verified JWT access tokens as foll
   This check supports the tokens issued by Keycloak
 
 If the token is opaque (binary) then a `scope` property from the remote token introspection response will be used.
+
+If UserInfo is the source of the roles then set `quarkus.oidc.authentication.user-info-required=true` and `quarkus.oidc.roles.source=userinfo`, and if needed, `quarkus.oidc.roles.role-claim-path`.
 
 Additionally a custom `SecurityIdentityAugmentor` can also be used to add the roles as documented link:security#security-identity-customization[here].
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -582,13 +582,13 @@ public class OidcTenantConfig {
             idtoken,
 
             /**
-             * Access Token - the default and only supported value for the 'service' applications;
+             * Access Token - the default value for the 'service' applications;
              * can also be used as the source of roles for the 'web-app' applications.
              */
             accesstoken,
 
             /**
-             * User Info - only supported for the "web-app" applications
+             * User Info
              */
             userinfo
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -185,10 +185,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             TokenCredential tokenCred,
             JsonObject tokenJson, JsonObject userInfo) {
         JsonObject rolesJson = tokenJson;
-        if (tokenCred instanceof IdTokenCredential && resolvedContext.oidcConfig.roles.source.isPresent()) {
+        if (resolvedContext.oidcConfig.roles.source.isPresent()) {
             if (resolvedContext.oidcConfig.roles.source.get() == Source.userinfo) {
                 rolesJson = userInfo;
-            } else if (resolvedContext.oidcConfig.roles.source.get() == Source.accesstoken) {
+            } else if (tokenCred instanceof IdTokenCredential
+                    && resolvedContext.oidcConfig.roles.source.get() == Source.accesstoken) {
                 AccessToken result = (AccessToken) vertxContext.get("code_flow_access_token_result");
                 rolesJson = result.accessToken();
                 if (rolesJson == null) {
@@ -256,7 +257,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 new Consumer<UniEmitter<? super JsonObject>>() {
                     @Override
                     public void accept(UniEmitter<? super JsonObject> uniEmitter) {
-                        tokenImpl.principal().put("access_token", opaqueAccessToken);
+                        if (opaqueAccessToken != null) {
+                            tokenImpl.principal().put("access_token", opaqueAccessToken);
+                        }
                         tokenImpl.userInfo(new Handler<AsyncResult<JsonObject>>() {
                             @Override
                             public void handle(AsyncResult<JsonObject> event) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -126,10 +126,10 @@ public class OidcRecorder {
                 if (oidcConfig.getTokenPath().isPresent()) {
                     options.setTokenPath(authServerUrl + prependSlash(oidcConfig.getTokenPath().get()));
                 }
+            }
 
-                if (oidcConfig.getUserInfoPath().isPresent()) {
-                    options.setUserInfoPath(authServerUrl + prependSlash(oidcConfig.getUserInfoPath().get()));
-                }
+            if (oidcConfig.getUserInfoPath().isPresent()) {
+                options.setUserInfoPath(authServerUrl + prependSlash(oidcConfig.getUserInfoPath().get()));
             }
 
             // JWK and introspection endpoints have to be set for both 'web-app' and 'service' applications  
@@ -169,9 +169,9 @@ public class OidcRecorder {
                         "The 'logout.path' property can only be enabled for " + ApplicationType.WEB_APP
                                 + " application types");
             }
-            if (oidcConfig.roles.source.isPresent() && oidcConfig.roles.source.get() != Source.accesstoken) {
+            if (oidcConfig.roles.source.isPresent() && oidcConfig.roles.source.get() == Source.idtoken) {
                 throw new RuntimeException(
-                        "The 'roles.source' property can only be set to 'accesstoken' for " + ApplicationType.SERVICE
+                        "The 'roles.source' property can only be set to 'idtoken' for " + ApplicationType.WEB_APP
                                 + " application types");
             }
         }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -19,6 +19,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setClientId("quarkus-d");
             config.getCredentials().setSecret("secret");
             config.getToken().setIssuer(getIssuerUrl() + "/realms/quarkus-d");
+            config.getAuthentication().setUserInfoRequired(true);
             return config;
         } else if ("tenant-oidc".equals(tenantId)) {
             OidcTenantConfig config = new OidcTenantConfig();

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -150,7 +150,7 @@ public class BearerTokenAuthorizationTest {
                 .when().get("/tenant/tenant-d/api/user")
                 .then()
                 .statusCode(200)
-                .body(equalTo("tenant-d:alice"));
+                .body(equalTo("tenant-d:alice.alice"));
 
         // should give a 401 given that access token from issuer b can not access tenant c
         RestAssured.given().auth().oauth2(getAccessToken("alice", "b"))


### PR DESCRIPTION
Fixes #12227

I've originally restricted retrieving `UserInfo` for `web-app` applications only but if a bearer token has been issued to allow it as well then indeed it makes sense to support it in Quarkus OIDC as well. 