### PR TITLE
Forward protoc log to console for gradle project

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenContext.java
@@ -9,12 +9,14 @@ public class CodeGenContext {
     private final Path outDir;
     private final Path workDir;
     private final Path inputDir;
+    private final boolean redirectIO;
 
-    public CodeGenContext(AppModel model, Path outDir, Path workDir, Path inputDir) {
+    public CodeGenContext(AppModel model, Path outDir, Path workDir, Path inputDir, boolean redirectIO) {
         this.model = model;
         this.outDir = outDir;
         this.workDir = workDir;
         this.inputDir = inputDir;
+        this.redirectIO = redirectIO;
     }
 
     public AppModel appModel() {
@@ -31,5 +33,9 @@ public class CodeGenContext {
 
     public Path inputDir() {
         return inputDir;
+    }
+
+    public boolean shouldRedirectIO() {
+        return redirectIO;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -26,6 +26,7 @@ public class CodeGenerator {
             AppModel appModel) throws CodeGenException {
         List<CodeGenData> generators = init(classLoader, sourceParentDirs, generatedSourcesDir, buildDir, sourceRegistrar);
         for (CodeGenData generator : generators) {
+            generator.setRedirectIO(true);
             trigger(classLoader, generator, appModel);
         }
     }
@@ -81,12 +82,11 @@ public class CodeGenerator {
             CodeGenData data,
             AppModel appModel) throws CodeGenException {
         return callWithClassloader(deploymentClassLoader, () -> {
-            Thread.currentThread().setContextClassLoader(deploymentClassLoader);
-
             CodeGenProvider provider = data.provider;
 
             return Files.isDirectory(data.sourceDir)
-                    && provider.trigger(new CodeGenContext(appModel, data.outPath, data.buildDir, data.sourceDir));
+                    && provider.trigger(
+                            new CodeGenContext(appModel, data.outPath, data.buildDir, data.sourceDir, data.redirectIO));
         });
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/codegen/CodeGenData.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/codegen/CodeGenData.java
@@ -9,11 +9,21 @@ public class CodeGenData {
     public final Path outPath;
     public final Path sourceDir;
     public final Path buildDir;
+    public boolean redirectIO;
 
     public CodeGenData(CodeGenProvider provider, Path outPath, Path sourceDir, Path buildDir) {
+        this(provider, outPath, sourceDir, buildDir, true);
+    }
+
+    public CodeGenData(CodeGenProvider provider, Path outPath, Path sourceDir, Path buildDir, boolean redirectIO) {
         this.provider = provider;
         this.outPath = outPath;
         this.sourceDir = sourceDir;
         this.buildDir = buildDir;
+        this.redirectIO = redirectIO;
+    }
+
+    public void setRedirectIO(boolean redirectIO) {
+        this.redirectIO = redirectIO;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -87,7 +87,7 @@ public class NativeImageBuildStep {
             PackageConfig packageConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
-            final Optional<ProcessInheritIODisabled> processInheritIODisabled) {
+            Optional<ProcessInheritIODisabled> processInheritIODisabled) {
         if (nativeConfig.debug.enabled) {
             copyJarSourcesToLib(outputTargetBuildItem, curateOutcomeBuildItem);
         }
@@ -164,7 +164,7 @@ public class NativeImageBuildStep {
                 cleanup.add("--server-shutdown");
                 final ProcessBuilder pb = new ProcessBuilder(cleanup.toArray(new String[0]));
                 pb.directory(outputDir.toFile());
-                final Process process = ProcessUtil.launchProcess(pb, processInheritIODisabled);
+                final Process process = ProcessUtil.launchProcess(pb, processInheritIODisabled.isPresent());
                 process.waitFor();
             }
             boolean enableSslNative = false;
@@ -310,7 +310,7 @@ public class NativeImageBuildStep {
             log.info(String.join(" ", command).replace("$", "\\$"));
             CountDownLatch errorReportLatch = new CountDownLatch(1);
             final ProcessBuilder processBuilder = new ProcessBuilder(command).directory(outputDir.toFile());
-            final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);
+            final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled.isPresent());
             ExecutorService executor = Executors.newSingleThreadExecutor();
             executor.submit(new ErrorReplacingProcessReader(process.getErrorStream(), outputDir.resolve("reports").toFile(),
                     errorReportLatch));
@@ -389,7 +389,7 @@ public class NativeImageBuildStep {
             try {
                 final ProcessBuilder pb = new ProcessBuilder(
                         Arrays.asList(containerRuntime, "pull", nativeConfig.builderImage));
-                pullProcess = ProcessUtil.launchProcess(pb, processInheritIODisabled);
+                pullProcess = ProcessUtil.launchProcess(pb, processInheritIODisabled.isPresent());
                 pullProcess.waitFor();
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Failed to pull builder image " + nativeConfig.builderImage, e);

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
@@ -6,11 +6,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 import org.jboss.logging.Logger;
-
-import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 
 /**
  * Utility for {@link Process} related operations
@@ -21,19 +18,19 @@ public class ProcessUtil {
 
     /**
      * Launches and returns a {@link Process} built from the {@link ProcessBuilder builder}.
-     * Before launching the process, this method checks if {@link ProcessInheritIODisabled inherit IO is disabled}
-     * and if so, streams both the {@code STDOUT} and {@code STDERR} of the launched process using
+     * Before launching the process, this method checks if inherit IO is disabled and if so,
+     * streams both the {@code STDOUT} and {@code STDERR} of the launched process using
      * {@link #streamToSysOutSysErr(Process)}. Else, it launches the process with {@link ProcessBuilder#inheritIO()}
      *
      * @param builder The process builder
-     * @param processInheritIODisabled Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
+     * @param shouldRedirectIO Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
      *        launching the process
      * @return Returns the newly launched process
      * @throws IOException
      */
     public static Process launchProcess(final ProcessBuilder builder,
-            final Optional<ProcessInheritIODisabled> processInheritIODisabled) throws IOException {
-        if (!processInheritIODisabled.isPresent()) {
+            final boolean shouldRedirectIO) throws IOException {
+        if (!shouldRedirectIO) {
             return builder.inheritIO().start();
         }
         final Process process = builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
@@ -46,19 +43,19 @@ public class ProcessUtil {
 
     /**
      * Launches and returns a {@link Process} built from the {@link ProcessBuilder builder}.
-     * Before launching the process, this method checks if {@link ProcessInheritIODisabled inherit IO is disabled}
+     * Before launching the process, this method checks if inheritIO is disabled
      * and if so, streams (only) the {@code STDOUT} of the launched process using {@link #streamOutputToSysOut(Process)}
      * (Process)}. Else, it launches the process with {@link ProcessBuilder#inheritIO()}
      *
      * @param builder The process builder
-     * @param processInheritIODisabled Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
+     * @param shouldRedirectIO Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
      *        launching the process
      * @return Returns the newly launched process
      * @throws IOException
      */
     public static Process launchProcessStreamStdOut(final ProcessBuilder builder,
-            final Optional<ProcessInheritIODisabled> processInheritIODisabled) throws IOException {
-        if (!processInheritIODisabled.isPresent()) {
+            boolean shouldRedirectIO) throws IOException {
+        if (!shouldRedirectIO) {
             return builder.inheritIO().start();
         }
         final Process process = builder.redirectOutput(ProcessBuilder.Redirect.PIPE)

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
@@ -21,6 +21,7 @@ import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.bootstrap.prebuild.CodeGenFailureException;
 import io.quarkus.deployment.CodeGenContext;
 import io.quarkus.deployment.CodeGenProvider;
+import io.quarkus.deployment.util.ProcessUtil;
 import io.quarkus.utilities.JavaBinFinder;
 import io.quarkus.utilities.OS;
 
@@ -77,10 +78,9 @@ public class GrpcCodeGen implements CodeGenProvider {
                             "--java_out=" + outDir));
                     command.addAll(protoFiles);
 
-                    Process process = new ProcessBuilder()
-                            .command(command)
-                            .inheritIO()
-                            .start();
+                    ProcessBuilder processBuilder = new ProcessBuilder(command);
+
+                    final Process process = ProcessUtil.launchProcess(processBuilder, context.shouldRedirectIO());
                     int resultCode = process.waitFor();
                     if (resultCode != 0) {
                         throw new CodeGenException("Failed to generate Java classes from proto files: " + protoFiles +

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.gradle;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -14,7 +16,7 @@ public class GrpcMultiModuleQuarkusBuildTest extends QuarkusGradleWrapperTestBas
 
         final File projectDir = getProjectDir("grpc-multi-module-project");
 
-        runGradleWrapper(projectDir, ":application:quarkusBuild", ":application:test");
+        final var buildResult = runGradleWrapper(projectDir, ":application:quarkusBuild", ":application:test");
 
         final Path commonLibs = projectDir.toPath().resolve("common").resolve("build").resolve("libs");
         assertThat(commonLibs).exists();
@@ -23,5 +25,20 @@ public class GrpcMultiModuleQuarkusBuildTest extends QuarkusGradleWrapperTestBas
         final Path applicationLib = projectDir.toPath().resolve("application").resolve("build").resolve("lib");
         assertThat(applicationLib).exists();
         assertThat(applicationLib.resolve("quarkus-grpc-multi-module-build.common.jar")).exists();
+    }
+
+    @Test
+    public void testProtocErrorOutput() throws Exception {
+        final File projectDir = getProjectDir("grpc-multi-module-project");
+
+        final Path protoDirectory = new File(projectDir, "application/src/main/proto/").toPath();
+        Files.copy(projectDir.toPath().resolve("invalid.proto"), protoDirectory.resolve("invalid.proto"));
+        try {
+            final BuildResult buildResult = runGradleWrapper(projectDir, ":application:quarkusBuild", "--info");
+            assertTrue(buildResult.getOutput().contains("invalid.proto:5:1: Missing field number."));
+        } finally {
+            Files.delete(protoDirectory.resolve("invalid.proto"));
+        }
+
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -31,6 +31,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
                 .command(command)
                 .redirectInput(ProcessBuilder.Redirect.INHERIT)
                 .redirectOutput(logOutput)
+                .redirectError(logOutput)
                 .start();
 
         p.waitFor(5, TimeUnit.MINUTES);

--- a/integration-tests/gradle/src/test/resources/grpc-multi-module-project/invalid.proto
+++ b/integration-tests/gradle/src/test/resources/grpc-multi-module-project/invalid.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+message DevModeRequest {
+  string service
+}
+
+
+message DevModeResponse {
+  enum Status {
+    UNKNOWN = 0;
+    NOT_SERVING = 1;
+    TEST_ONE = 2;
+  }
+  Status status = 1;
+}


### PR DESCRIPTION
This branch make sure `protoc` output are redirected to console when running a gradle build. 

This reuse the same `ProcessUtil` class used to forward `native-image` log to console. 

close #11552