### PR TITLE
Docs: update s3 docs localstack instructions

### DIFF
--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -39,9 +39,11 @@ The easiest way to start working with S3 is to run a local instance as a contain
 
 [source,shell,subs="verbatim,attributes"]
 ----
-docker run -it --publish 8008:4572 -e SERVICES=s3 -e START_WEB=0 localstack/localstack
+docker run -it --publish 8008:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack
 ----
 This starts a S3 instance that is accessible on port `8008`.
+
+**Note**: Versions of localstack newer than v0.11.5 require port `4566` instead of port `4572`. See this https://github.com/localstack/localstack/issues/2983[GitHub issue] for details on this change
 
 Create an AWS profile for your local instance using AWS CLI:
 [source,shell,subs="verbatim,attributes"]


### PR DESCRIPTION
On the newest version of localstack, all APIs are exposed via a single edge service, which is accessible on port 4566.