### PR TITLE
Update the Axle and Mutiny Vert.x clients to version 1.2.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -131,8 +131,8 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <mutiny.version>0.8.1</mutiny.version>
-        <axle-client.version>1.1.0</axle-client.version>
-        <mutiny-client.version>1.1.0</mutiny-client.version>
+        <axle-client.version>1.2.1</axle-client.version>
+        <mutiny-client.version>1.2.1</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->


### PR DESCRIPTION
Update the Vert.x clients using the Axle and Mutiny APIs.
This version uses Vert.x 3.9.3 and Mutiny 0.8.1 so are aligned with Quarkus dependencies. 