### PR TITLE
Replaced eclipse-minimal-json with Jackson

### DIFF
--- a/independent-projects/tools/platform-descriptor-resolver-json/pom.xml
+++ b/independent-projects/tools/platform-descriptor-resolver-json/pom.xml
@@ -15,10 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.eclipsesource.minimal-json</groupId>
-            <artifactId>minimal-json</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
         </dependency>

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
@@ -2,8 +2,8 @@ package io.quarkus.platform.descriptor.resolver.json;
 
 import static io.quarkus.platform.tools.ToolsUtils.getProperty;
 
-import com.eclipsesource.json.Json;
-import com.eclipsesource.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
@@ -190,8 +190,8 @@ public class QuarkusJsonPlatformDescriptorResolver {
         // Resolve the Quarkus version used by the platform
         final String quarkusCoreVersion;
         try (BufferedReader reader = Files.newBufferedReader(jsonFile)) {
-            final JsonObject jsonObject = Json.parse(reader).asObject();
-            quarkusCoreVersion = jsonObject.getString("quarkus-core-version", null);
+            JsonNode node = new ObjectMapper().readTree(reader);
+            quarkusCoreVersion = node.get("quarkus-core-version").asText(null);
             if (quarkusCoreVersion == null) {
                 throw new IllegalStateException("Failed to determine the Quarkus Core version for " + jsonFile);
             }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -38,7 +38,6 @@
 
         <!-- Versions -->
         <assertj.version>3.17.2</assertj.version>
-        <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jackson.version>2.11.2</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
@@ -69,11 +68,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.eclipsesource.minimal-json</groupId>
-                <artifactId>minimal-json</artifactId>
-                <version>${eclipse-minimal-json.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Since jackson is resolved transitively from quarkus-devtools-common, there is no need for another JSON parser