### PR TITLE
Bump RESTEasy to 4.5.8.Final 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <jandex.version>2.2.1.Final</jandex.version>
-        <resteasy.version>4.5.6.Final</resteasy.version>
+        <resteasy.version>4.5.8.Final</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
@@ -7,9 +7,9 @@ import javax.ws.rs.core.UriInfo;
 
 import org.jboss.resteasy.core.ResourceMethodRegistry;
 import org.jboss.resteasy.core.ResteasyContext;
-import org.jboss.resteasy.links.ClassLinksProvider;
-import org.jboss.resteasy.links.ObjectLinksProvider;
 import org.jboss.resteasy.links.RESTServiceDiscovery;
+import org.jboss.resteasy.links.impl.ClassLinksProvider;
+import org.jboss.resteasy.links.impl.ObjectLinksProvider;
 import org.jboss.resteasy.spi.Registry;
 
 public final class ResourceLinksProvider {

--- a/extensions/resteasy-mutiny-common/runtime/src/main/java/io/quarkus/resteasy/mutiny/common/runtime/MultiRxInvokerImpl.java
+++ b/extensions/resteasy-mutiny-common/runtime/src/main/java/io/quarkus/resteasy/mutiny/common/runtime/MultiRxInvokerImpl.java
@@ -219,8 +219,7 @@ public class MultiRxInvokerImpl implements MultiRxInvoker {
         if (executorService != null) {
             builder.executor(executorService);
         }
-        SseEventSourceImpl sseEventSource = (SseEventSourceImpl) builder.build();
-        sseEventSource.setAlwaysReconnect(false);
+        SseEventSourceImpl sseEventSource = (SseEventSourceImpl) builder.alwaysReconnect(false).build();
         return sseEventSource;
     }
 


### PR DESCRIPTION
This is https://github.com/quarkusio/quarkus/pull/12232 but with RESTEasy version 4.5.8.Final. I don't have permission to edit https://github.com/quarkusio/quarkus/pull/12232 directly.

Fixes: #10133