### PR TITLE
build-tree mojo should take the POM artifact as the root instead of the JAR

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/AbstractTreeMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/AbstractTreeMojo.java
@@ -20,7 +20,8 @@ public class AbstractTreeMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final AppArtifact appArtifact = new AppArtifact(project.getGroupId(), project.getArtifactId(), project.getVersion());
+        final AppArtifact appArtifact = new AppArtifact(project.getGroupId(), project.getArtifactId(), null, "pom",
+                project.getVersion());
         final BootstrapAppModelResolver modelResolver;
         try {
             modelResolver = new BootstrapAppModelResolver(resolver());

--- a/independent-projects/bootstrap/maven-plugin/src/test/resources/test-app-1.jar.build-tree
+++ b/independent-projects/bootstrap/maven-plugin/src/test/resources/test-app-1.jar.build-tree
@@ -1,4 +1,4 @@
-[info] io.quarkus.bootstrap.test:test-app:jar:1
+[info] io.quarkus.bootstrap.test:test-app:pom:1
 [info] ├─ io.quarkus.bootstrap.test:artifact-with-classifier:jar:classifier:1 (compile)
 [info] ├─ io.quarkus.bootstrap.test:test-ext2-deployment:jar:1 (compile)
 [info] │  ├─ io.quarkus.bootstrap.test:test-ext2:jar:1 (compile)

--- a/independent-projects/bootstrap/maven-plugin/src/test/resources/test-app-1.jar.dev-mode-tree
+++ b/independent-projects/bootstrap/maven-plugin/src/test/resources/test-app-1.jar.dev-mode-tree
@@ -1,4 +1,4 @@
-[info] io.quarkus.bootstrap.test:test-app:jar:1
+[info] io.quarkus.bootstrap.test:test-app:pom:1
 [info] ├─ io.quarkus.bootstrap.test:artifact-with-classifier:jar:classifier:1 (compile)
 [info] ├─ io.quarkus.bootstrap.test:test-ext2-deployment:jar:1 (compile)
 [info] │  ├─ io.quarkus.bootstrap.test:test-ext2:jar:1 (compile)


### PR DESCRIPTION
The JAR may not always be resolvable (e.g. in case the project has not yet been built and not available in the local maven repo), while the POM is always available.

Fixes #12257