### PR TITLE
Create source cache when building native in container #12283

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -90,6 +90,7 @@ public class NativeImageBuildStep {
             final Optional<ProcessInheritIODisabled> processInheritIODisabled) {
         if (nativeConfig.debug.enabled) {
             copyJarSourcesToLib(outputTargetBuildItem, curateOutcomeBuildItem);
+            copySourcesToSourceCache(outputTargetBuildItem);
         }
 
         Path runnerJar = nativeImageSourceJarBuildItem.getPath();
@@ -230,14 +231,6 @@ public class NativeImageBuildStep {
             if (nativeConfig.debug.enabled) {
                 if (graalVMVersion.isMandrel() || graalVMVersion.isNewerThan(GraalVM.Version.VERSION_20_1)) {
                     command.add("-g");
-
-                    final Path javaSourcesPath = Paths.get("..", "..", "src", "main", "java");
-                    if (outputDir.resolve(javaSourcesPath).toFile().exists()) {
-                        command.add("-H:DebugInfoSourceSearchPath=" + javaSourcesPath.toString());
-                    }
-
-                    final Path sourcesCachePath = outputDir.getParent().resolve("sources-cache");
-                    command.add("-H:DebugInfoSourceCacheRoot=" + sourcesCachePath.toString());
                 }
             }
             if (nativeConfig.debugBuildProcess) {
@@ -448,6 +441,33 @@ public class NativeImageBuildStep {
         final File[] jarSources = libDir.toFile()
                 .listFiles((file, name) -> name.endsWith("-sources.jar"));
         Stream.of(Objects.requireNonNull(jarSources)).forEach(File::delete);
+    }
+
+    private static void copySourcesToSourceCache(OutputTargetBuildItem outputTargetBuildItem) {
+        Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
+                .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
+
+        final Path targetSrc = targetDirectory.resolve(Paths.get("sources", "src"));
+        final File targetSrcFile = targetSrc.toFile();
+        if (!targetSrcFile.exists())
+            targetSrcFile.mkdirs();
+
+        final Path javaSourcesPath = outputTargetBuildItem.getOutputDirectory().resolve(
+                Paths.get("..", "src", "main", "java"));
+
+        try {
+            Files.walk(javaSourcesPath).forEach(path -> {
+                Path targetPath = Paths.get(targetSrc.toString(),
+                        path.toString().substring(javaSourcesPath.toString().length()));
+                try {
+                    Files.copy(path, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Unable to copy from " + path + " to " + targetPath, e);
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to walk path " + javaSourcesPath, e);
+        }
     }
 
     private void handleAdditionalProperties(NativeConfig nativeConfig, List<String> command, boolean isContainerBuild,

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -566,7 +566,7 @@ To include those, make sure you invoke `mvn dependency:sources` first.
 This step is required in order to pull the sources for these dependencies,
 and get them included in the source cache.
 
-The location of source cache is `target/sources-cache` folder.
+The location of source cache is `target/{project.name}-{project.version}-native-image-source-jar/sources` folder.
 
 [[configuration-reference]]
 == Configuring the Native Executable


### PR DESCRIPTION
* Let Mandrel/GraalVM decide where to put the source cache, which naturally leads to a folder that's stored within the module shared with container.
* Copy the application sources in advance, to avoid the need to make src/main/java available to the container.
* Update documentation.

Closes #12283.