### PR TITLE
Removing jsr305 as dependency to verify if the grpc extension works fine without it

### DIFF
--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -18,10 +18,6 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc</artifactId>
             <exclusions>


### PR DESCRIPTION
Removing jsr305 as dependency to verify if the grpc extension works fine