### PR TITLE
Support OIDC hybrid application type

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -30,7 +30,7 @@ public class OidcTenantConfig {
      * The application type, which can be one of the following values from enum {@link ApplicationType}.
      */
     @ConfigItem(defaultValue = "service")
-    public ApplicationType applicationType;
+    public ApplicationType applicationType = ApplicationType.SERVICE;
 
     /**
      * The base URL of the OpenID Connect (OIDC) server, for example, 'https://host:port/auth'.
@@ -999,6 +999,13 @@ public class OidcTenantConfig {
          * RESTful Architectural Design. For this type of client, the Bearer Authorization method is defined as the preferred
          * method for authenticating and authorizing users.
          */
-        SERVICE
+        SERVICE,
+
+        /**
+         * A combined {@code SERVICE} and {@code WEB_APP} client.
+         * For this type of client, the Bearer Authorization method will be used if the Authorization header is set
+         * and Authorization Code Flow - if not.
+         */
+        HYBRID
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -33,7 +33,7 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
         if (tenantContext.oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(tenantContext) ? codeAuth.authenticate(context, identityProviderManager, resolver)
+        return isWebApp(context, tenantContext) ? codeAuth.authenticate(context, identityProviderManager, resolver)
                 : bearerAuth.authenticate(context, identityProviderManager, resolver);
     }
 
@@ -43,7 +43,7 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
         if (tenantContext.oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(tenantContext) ? codeAuth.getChallenge(context, resolver)
+        return isWebApp(context, tenantContext) ? codeAuth.getChallenge(context, resolver)
                 : bearerAuth.getChallenge(context, resolver);
     }
 
@@ -55,7 +55,10 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
         return tenantContext;
     }
 
-    private boolean isWebApp(TenantConfigContext tenantContext) {
+    private boolean isWebApp(RoutingContext context, TenantConfigContext tenantContext) {
+        if (OidcTenantConfig.ApplicationType.HYBRID == tenantContext.oidcConfig.applicationType) {
+            return context.request().getHeader("Authorization") == null;
+        }
         return OidcTenantConfig.ApplicationType.WEB_APP == tenantContext.oidcConfig.applicationType;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -119,7 +119,7 @@ public class OidcRecorder {
         options.setSite(authServerUrl);
 
         if (!oidcConfig.discoveryEnabled) {
-            if (ApplicationType.WEB_APP.equals(oidcConfig.applicationType)) {
+            if (oidcConfig.applicationType != ApplicationType.SERVICE) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
                     throw new OIDCException("'web-app' applications must have 'authorization-path' and 'token-path' properties "
                             + "set when the discovery is disabled.");
@@ -298,7 +298,7 @@ public class OidcRecorder {
     @SuppressWarnings("deprecation")
     private static TenantConfigContext createdTenantContextFromPublicKey(OAuth2ClientOptions options,
             OidcTenantConfig oidcConfig) {
-        if (oidcConfig.applicationType == ApplicationType.WEB_APP) {
+        if (oidcConfig.applicationType != ApplicationType.SERVICE) {
             throw new ConfigurationException("'public-key' property can only be used with the 'service' applications");
         }
         LOG.debug("'public-key' property for the local token verification is set,"

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -13,6 +13,11 @@ public class CustomTenantResolver implements TenantResolver {
         if (context.request().path().endsWith("/tenant-public-key")) {
             return "tenant-public-key";
         }
-        return context.request().path().split("/")[2];
+        String tenantId = context.request().path().split("/")[2];
+        if ("tenant-hybrid".equals(tenantId)) {
+            return context.request().getHeader("Authorization") != null ? "tenant-hybrid-service" : "tenant-hybrid-webapp";
+        }
+        return tenantId;
+
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantHybridResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantHybridResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+
+@Path("/tenants")
+public class TenantHybridResource {
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+    @Inject
+    JsonWebToken accessToken;
+
+    @GET
+    @Path("/{tenant-hybrid}/api/user")
+    @RolesAllowed("user")
+    public String userNameService() {
+        return idToken.getName() != null ? (idToken.getName() + ":web-app") : (accessToken.getName() + ":service");
+    }
+}

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -35,6 +35,24 @@ quarkus.oidc.tenant-web-app2.credentials.secret=secret
 quarkus.oidc.tenant-web-app2.application-type=web-app
 quarkus.oidc.tenant-web-app2.roles.source=accesstoken
 
+# Tenant Hybrid Service
+quarkus.oidc.tenant-hybrid-service.auth-server-url=${keycloak.url}/realms/quarkus-hybrid
+quarkus.oidc.tenant-hybrid-service.client-id=quarkus-app-hybrid
+quarkus.oidc.tenant-hybrid-service.credentials.secret=secret
+quarkus.oidc.tenant-hybrid-service.application-type=service
+
+# Tenant Hybrid Web-App
+quarkus.oidc.tenant-hybrid-webapp.auth-server-url=${keycloak.url}/realms/quarkus-hybrid
+quarkus.oidc.tenant-hybrid-webapp.client-id=quarkus-app-hybrid
+quarkus.oidc.tenant-hybrid-webapp.credentials.secret=secret
+quarkus.oidc.tenant-hybrid-webapp.application-type=web-app
+
+# Tenant Hybrid Web-App Service
+quarkus.oidc.tenant-hybrid-webapp-service.auth-server-url=${keycloak.url}/realms/quarkus-hybrid
+quarkus.oidc.tenant-hybrid-webapp-service.client-id=quarkus-app-hybrid
+quarkus.oidc.tenant-hybrid-webapp-service.credentials.secret=secret
+quarkus.oidc.tenant-hybrid-webapp-service.application-type=hybrid
+
 # Custom header
 quarkus.oidc.tenant-customheader.auth-server-url=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-customheader.client-id=quarkus-app-b

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -26,7 +26,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
     @Override
     public Map<String, String> start() {
-        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2")) {
+        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2", "hybrid")) {
             RealmRepresentation realm = createRealm(KEYCLOAK_REALM + realmId);
 
             realm.getClients().add(createClient("quarkus-app-" + realmId));
@@ -92,10 +92,10 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         client.setDirectAccessGrantsEnabled(true);
         client.setEnabled(true);
         client.setDefaultRoles(new String[] { "role-" + clientId });
-        if (clientId.startsWith("quarkus-app-webapp")) {
+        if (clientId.startsWith("quarkus-app-webapp") || clientId.equals("quarkus-app-hybrid")) {
             client.setRedirectUris(Arrays.asList("*"));
         }
-        if (clientId.equals("quarkus-app-webapp")) {
+        if (clientId.equals("quarkus-app-webapp") || clientId.equals("quarkus-app-hybrid")) {
             // This instructs Keycloak to include the roles with the ID token too
             client.setDefaultClientScopes(Arrays.asList("microprofile-jwt"));
         }
@@ -123,7 +123,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
     @Override
     public void stop() {
-        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2")) {
+        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2", "hybrid")) {
             RestAssured
                     .given()
                     .auth().oauth2(getAdminAccessToken())


### PR DESCRIPTION
Fixes #12297 

This PR introduces a `hybrid` application type. Effectively it allows the users to optimize the configuration, collapse 2 nearly identical tenant configuration into one, see the test, `tenant-hybrid-webapp` + `tenant-hybrid-service` vs a single `tenant-hybrid-webapp-service` in the situations where a user wants to drive the authentication based on the presence of the `Authorization` header. If it is set - it is Bearer auth, if not - code flow.

This is a visible optimization and to be honest I'd not be too keen on it because one can just avoid this static configuration duplication with `TenantConfigResolver` but the main saving comes from sharing a single Keycloak connection. 

When we have 2 tenants then per every tenant there will be its own Vert.X OAuth connection - which is fine when one has different realms, but in this case, one would also have a duplicate local JWT set copy, which is sub-optimal.

So, `hybrid` does not introduce any new flow, it simply allows to optimize the way the 2 tenants which differ only by its type (`service` vs `web-app`) can be configured