### PR TITLE
Enable quarkus:list-extensions in an empty dir

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
@@ -130,6 +130,9 @@ public class MavenBuildFile extends BuildFile {
     }
 
     private Model initModel() throws IOException {
+        if (!hasProjectFile(BuildTool.MAVEN.getDependenciesFile())) {
+            return null;
+        }
         byte[] content = readProjectFile(BuildTool.MAVEN.getDependenciesFile());
         return MojoUtils.readPom(new ByteArrayInputStream(content));
     }


### PR DESCRIPTION
This change allows to execute list-extensions in an empty directory.