### PR TITLE
Improve Debugging experience by copying sources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -321,6 +321,15 @@ public class NativeImageBuildStep {
             Path finalPath = outputTargetBuildItem.getOutputDirectory().resolve(executableName);
             IoUtils.copy(generatedImage, finalPath);
             Files.delete(generatedImage);
+            if (nativeConfig.debug.enabled) {
+                if (graalVMVersion.isMandrel() || graalVMVersion.isNewerThan(GraalVM.Version.VERSION_20_1)) {
+                    final String sources = "sources";
+                    final Path generatedSources = outputDir.resolve(sources);
+                    final Path finalSources = outputTargetBuildItem.getOutputDirectory().resolve(sources);
+                    IoUtils.copy(generatedSources, finalSources);
+                    IoUtils.recursiveDelete(generatedSources);
+                }
+            }
             System.setProperty("native.image.path", finalPath.toAbsolutePath().toString());
 
             if (objcopyExists(env)) {


### PR DESCRIPTION
Copying sources next to the binary allows gdb to automatically detect
the sources. One still has to start up gdb from this directory though.

Follow up to #12294 

## Before this patch one needs to:

```
cd target/getting-started-1.0-SNAPSHOT-native-image-source-jar
gdb ../getting-started-1.0-SNAPSHOT-runner
```

To make `gdb` detect the sources without the need of executing gdb's `directory` or `set directories` commands.

## After this patch one needs to:

```
cd target
gdb getting-started-1.0-SNAPSHOT-runner
```

which should be more intuitive.

Since this is not a major improvement we might as well skip it.