### PR TITLE
Defaults for kubernetes mock server

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -140,6 +140,37 @@ Note that to take advantage of these features, the `quarkus-test-kubernetes-clie
 </dependency>
 ----
 
+You can create a `CustomKubernetesMockServerTestResource.java` to ensure all you `@QuarkusTest` enabled test classes share the same mock server setup:
+
+[source%nowrap,java]
+----
+public class CustomKubernetesMockServerTestResource extends KubernetesMockServerTestResource {
+
+    @Override
+    public void configureMockServer(KubernetesMockServer mockServer) {
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods")
+                .andReturn(200, new PodList())
+                .always();
+    }
+}
+----
+
+and use this in your other test classes like this:
+[source%nowrap,java]
+----
+@QuarkusTestResource(KubernetesMockServerTestResource.class)
+@QuarkusTest
+public class KubernetesClientTest {
+
+    //tests will now use the configured server...
+}
+----
+
+Furthermore, to get a mock server that replies with empty lists per default (instead of getting 404 from the kubernetes api),
+you can use the `EmptyDefaultKubernetesMockServerTestResource.class` instead of
+`KubernetesMockServerTestResource.class`.
+
+
 == Note on implementing the Watcher interface
 
 Due to the restrictions imposed by GraalVM, extra care needs to be taken when implementing a `io.fabric8.kubernetes.client.Watcher` if the application is intended to work in native mode.

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -140,7 +140,7 @@ Note that to take advantage of these features, the `quarkus-test-kubernetes-clie
 </dependency>
 ----
 
-You can create a `CustomKubernetesMockServerTestResource.java` to ensure all you `@QuarkusTest` enabled test classes share the same mock server setup:
+You can create a `CustomKubernetesMockServerTestResource.java` to ensure all your `@QuarkusTest` enabled test classes share the same mock server setup:
 
 [source%nowrap,java]
 ----
@@ -155,7 +155,7 @@ public class CustomKubernetesMockServerTestResource extends KubernetesMockServer
 }
 ----
 
-and use this in your other test classes like this:
+and use this in your other test classes as follows:
 [source%nowrap,java]
 ----
 @QuarkusTestResource(KubernetesMockServerTestResource.class)
@@ -166,7 +166,7 @@ public class KubernetesClientTest {
 }
 ----
 
-Furthermore, to get a mock server that replies with empty lists per default (instead of getting 404 from the kubernetes api),
+Furthermore, to get a mock server that replies with empty lists by default (instead of getting 404 responses from the Kubernetes API),
 you can use the `EmptyDefaultKubernetesMockServerTestResource.class` instead of
 `KubernetesMockServerTestResource.class`.
 

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/EmptyDefaultKubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/EmptyDefaultKubernetesMockServerTestResource.java
@@ -1,0 +1,73 @@
+package io.quarkus.test.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.EventList;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+
+/**
+ * Kubernetes mock server, which responds to most of the basic api calls.
+ */
+public class EmptyDefaultKubernetesMockServerTestResource extends KubernetesMockServerTestResource {
+
+    @Override
+    public void configureMockServer(KubernetesMockServer mockServer) {
+        final String ns = Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY;
+        final String basePath = "/api/v1/namespaces/" + ns;
+
+        mockServer.expect().get().withPath(basePath + "/configmaps")
+                .andReturn(200, new ConfigMapList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/configmaps?watch=true")
+                .andReturn(200, new ConfigMapList())
+                .always();
+
+        mockServer.expect().get().withPath(basePath + "/deployments")
+                .andReturn(200, new DeploymentList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/deployments?watch=true")
+                .andReturn(200, new DeploymentList())
+                .always();
+
+        mockServer.expect().get().withPath(basePath + "/events")
+                .andReturn(200, new EventList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/events?watch=true")
+                .andReturn(200, new EventList())
+                .always();
+
+        mockServer.expect().get().withPath("/apis/extensions/v1beta1/namespaces/" + ns + "/ingresses")
+                .andReturn(200, new IngressList())
+                .always();
+        mockServer.expect().get().withPath("/apis/extensions/v1beta1/namespaces/" + ns + "/ingresses?watch=true")
+                .andReturn(200, new IngressList())
+                .always();
+
+        mockServer.expect().get().withPath(basePath + "/pods")
+                .andReturn(200, new PodList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/pods?watch=true")
+                .andReturn(200, new PodList())
+                .always();
+
+        mockServer.expect().get().withPath(basePath + "/serviceaccounts")
+                .andReturn(200, new ServiceAccountList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/serviceaccounts?watch=true")
+                .andReturn(200, new ServiceAccountList())
+                .always();
+
+        mockServer.expect().get().withPath(basePath + "/services")
+                .andReturn(200, new ServiceList())
+                .always();
+        mockServer.expect().get().withPath(basePath + "/services?watch=true")
+                .andReturn(200, new ServiceList())
+                .always();
+    }
+
+}


### PR DESCRIPTION
When testing applications written with the quarkus-kubernetes-client extension, i find that the configuration of kubernetes objects sometimes becomes large very fast and I loose the overview of my tests. Especially, when working with watchers that are registered at application startup. 

I propose that we populate the mock server with empty defaults, which the developer can override when needed, instead of giving a 404. 

Overriding is still possible with configureMockServer in a subclass, so impact should be neglible, if any. 

Alternatively we could also make a new class called something like `KubernetesWatcherMockServerTestResource`, which extends `KubernetesMockServerTestResource` and override `configureMockServer` there.  