### PR TITLE
Fixed incorrect docs for recordDelimiter

### DIFF
--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
@@ -29,7 +29,7 @@ public class JsonConfig {
     @ConfigItem(defaultValue = "default")
     String dateFormat;
     /**
-     * The special end-of-record delimiter to be used. By default, no delimiter is used.
+     * The special end-of-record delimiter to be used. By default, newline is used as delimiter.
      */
     @ConfigItem
     Optional<String> recordDelimiter;


### PR DESCRIPTION
Fixed incorrect docs, for recordDelimiter, which have a default of newline in org.jboss.logmanager.formatters.StructuredFormatter.