### PR TITLE
Improve error reporting in OIDC extension

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -99,9 +99,15 @@ public class OidcRecorder {
             return createdTenantContextFromPublicKey(options, oidcConfig);
         }
 
-        if (!oidcConfig.getAuthServerUrl().isPresent() || !oidcConfig.getClientId().isPresent()) {
+        if (!oidcConfig.getAuthServerUrl().isPresent()) {
             throw new ConfigurationException(
-                    "Both 'auth-server-url' and 'client-id' or alternatively 'public-key' must be configured"
+                    "'auth-server-url' is not present. Both 'auth-server-url' and 'client-id' or alternatively 'public-key' must be configured"
+                            + " when the quarkus-oidc extension is enabled");
+        }
+
+        if (!oidcConfig.getClientId().isPresent()) {
+            throw new ConfigurationException(
+                    "'client-id' is not present. Both 'auth-server-url' and 'client-id' or alternatively 'public-key' must be configured"
                             + " when the quarkus-oidc extension is enabled");
         }
 


### PR DESCRIPTION
added additional info added  in case 'client-id' or 'auth-server-url' are note available

currently the error message looks like:

io.quarkus.runtime.configuration.ConfigurationException: Both 'auth-server-url' and 'client-id' or alternatively 'public-key' must be configured when the quarkus-oidc extension is enabled
	at io.quarkus.oidc.runtime.OidcRecorder.createTenantContext(OidcRecorder.java:103)
	at io.quarkus.oidc.runtime.OidcRecorder.setup(OidcRecorder.java:54)
