### PR TITLE
Make sasl.mechanism configurable in Kafka Streams extension

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -189,6 +189,8 @@ public class KafkaStreamsProducer {
         // sasl
         SaslConfig sc = runtimeConfig.sasl;
         if (sc != null) {
+            setProperty(sc.mechanism, streamsProperties, SaslConfigs.SASL_MECHANISM);
+
             setProperty(sc.jaasConfig, streamsProperties, SaslConfigs.SASL_JAAS_CONFIG);
 
             setProperty(sc.clientCallbackHandlerClass, streamsProperties, SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS);

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/SaslConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/SaslConfig.java
@@ -10,6 +10,12 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class SaslConfig {
 
     /**
+     * SASL mechanism used for client connections
+     */
+    @ConfigItem
+    public Optional<String> mechanism;
+
+    /**
      * JAAS login context parameters for SASL connections in the format used by JAAS configuration files
      */
     @ConfigItem


### PR DESCRIPTION
The Kafka Streams extension allows to configure some SASL properties of the underlying Kafka Streams library. However, it doesn't allow to configure the `sasl.mechanism` option which defines the SASL mechanism which will be used. Because of this, the `sasl.mechanism` is always set to `GSSAPI` (Kerberos) and it cannot do anything else (such as `PLAIN` or `SCRAM-SHA-512`). This Pr makes the `sasl.mechanism` field configurable and makes it possible to use also other SASL mechanisms than Kerberos.