### PR TITLE
Add support for custom formatter for file logging.

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -29,6 +29,15 @@ public class FileConfig {
     String format;
 
     /**
+     * Class name for custom formatter.
+     * <p>
+     * Setting a class name here will override settings in {@code format}.
+     * The class must extend org.jboss.logmanager.ExtFormatter.
+     */
+    @ConfigItem
+    Optional<String> formatter;
+
+    /**
      * The level of logs to be written into the file.
      */
     @ConfigItem(defaultValue = "ALL")

--- a/core/test-extension/deployment/src/main/resources/application-file-formatter-output-log.properties
+++ b/core/test-extension/deployment/src/main/resources/application-file-formatter-output-log.properties
@@ -1,0 +1,5 @@
+quarkus.log.level=INFO
+quarkus.log.file.enable=true
+quarkus.log.file.level=INFO
+quarkus.log.file.formatter=org.jboss.logmanager.formatters.JsonFormatter
+quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/core/test-extension/deployment/src/main/resources/application-file-formatter-wrong-class.properties
+++ b/core/test-extension/deployment/src/main/resources/application-file-formatter-wrong-class.properties
@@ -1,0 +1,5 @@
+quarkus.log.level=INFO
+quarkus.log.file.enable=true
+quarkus.log.file.level=INFO
+quarkus.log.file.formatter=does.not.exists.CustomFormatter
+quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerFormatterInvalidClassTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerFormatterInvalidClassTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.logging;
+
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FileHandlerFormatterInvalidClassTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-file-formatter-wrong-class.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(LoggingTestsHelper.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+
+    @Test
+    public void invalidFormatterClassTest() {
+        Handler handler = getHandler(FileHandler.class);
+
+        Formatter formatter = handler.getFormatter();
+        assertThat(formatter).isInstanceOf(PatternFormatter.class);
+    }
+
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerFormatterTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerFormatterTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.logging;
+
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+
+import org.jboss.logmanager.formatters.JsonFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FileHandlerFormatterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-file-formatter-output-log.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(LoggingTestsHelper.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+
+    @Test
+    public void customFileFormatterTest() {
+        Handler handler = getHandler(FileHandler.class);
+
+        Formatter formatter = handler.getFormatter();
+        assertThat(formatter).isInstanceOf(JsonFormatter.class);
+    }
+
+}


### PR DESCRIPTION
Make formatter instance for file logger configurable, so those
with specific needs can plug in their own formatter.
Fixes #12389.