### PR TITLE
Fix the blocked thread issue caused by combining OIDC introspection and userinfo requests

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -174,6 +174,13 @@ public final class OidcUtils {
             throw new AuthenticationFailedException(e);
         }
         builder.setPrincipal(jwtPrincipal);
+        setSecurityIdentityRoles(builder, config, rolesJson);
+        setSecurityIdentityUserInfo(builder, userInfo);
+        return builder.build();
+    }
+
+    public static void setSecurityIdentityRoles(QuarkusSecurityIdentity.Builder builder, OidcTenantConfig config,
+            JsonObject rolesJson) {
         try {
             String clientId = config.getClientId().isPresent() ? config.getClientId().get() : null;
             for (String role : findRoles(clientId, config.getRoles(), rolesJson)) {
@@ -182,8 +189,6 @@ public final class OidcUtils {
         } catch (Exception e) {
             throw new ForbiddenException(e);
         }
-        setSecurityIdentityUserInfo(builder, userInfo);
-        return builder.build();
     }
 
     public static void setSecurityIdentityUserInfo(QuarkusSecurityIdentity.Builder builder, JsonObject userInfo) {

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -38,7 +38,7 @@ public class TenantResource {
             throw new OIDCException("Wrong tenant");
         }
         String name = getNameServiceType();
-        if ("tenant-d".equals(tenant)) {
+        if ("tenant-d".equals(tenant) || "tenant-b-no-discovery".equals(tenant)) {
             UserInfo userInfo = getUserInfo();
             name = name + "." + userInfo.getString("preferred_username");
         }
@@ -46,10 +46,17 @@ public class TenantResource {
     }
 
     @GET
+    @RolesAllowed("user")
+    @Path("no-discovery")
+    public String userNameServiceNoDiscovery(@PathParam("tenant") String tenant) {
+        return userNameService(tenant);
+    }
+
+    @GET
     @Path("webapp")
     @RolesAllowed("user")
     public String userNameWebApp(@PathParam("tenant") String tenant) {
-        if (!tenant.equals("tenant-web-app")) {
+        if (!tenant.equals("tenant-web-app") && !tenant.equals("tenant-web-app-no-discovery")) {
             throw new OIDCException("Wrong tenant");
         }
         UserInfo userInfo = getUserInfo();
@@ -57,6 +64,13 @@ public class TenantResource {
             throw new OIDCException("Groups expected");
         }
         return tenant + ":" + getNameWebAppType(userInfo.getString("upn"), "upn", "preferred_username");
+    }
+
+    @GET
+    @Path("webapp-no-discovery")
+    @RolesAllowed("user")
+    public String userNameWebAppNoDiscovery(@PathParam("tenant") String tenant) {
+        return userNameWebApp(tenant);
     }
 
     private UserInfo getUserInfo() {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -13,6 +13,16 @@ quarkus.oidc.tenant-b.credentials.secret=secret
 quarkus.oidc.tenant-b.token.issuer=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-b.application-type=service
 
+# Tenant B Service No Discovery (Introspection + User Info)
+quarkus.oidc.tenant-b-no-discovery.auth-server-url=${keycloak.url}/realms/quarkus-b
+quarkus.oidc.tenant-b-no-discovery.discovery-enabled=false
+quarkus.oidc.tenant-b-no-discovery.user-info-path=/protocol/openid-connect/userinfo
+quarkus.oidc.tenant-b-no-discovery.introspection-path=protocol/openid-connect/token/introspect
+quarkus.oidc.tenant-b-no-discovery.client-id=quarkus-app-b
+quarkus.oidc.tenant-b-no-discovery.credentials.secret=secret
+quarkus.oidc.tenant-b-no-discovery.application-type=service
+quarkus.oidc.tenant-b-no-discovery.authentication.user-info-required=true
+
 # Tenant C
 quarkus.oidc.tenant-c.auth-server-url=${keycloak.url}/realms/quarkus-c
 quarkus.oidc.tenant-c.client-id=quarkus-app-c
@@ -27,6 +37,20 @@ quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
 quarkus.oidc.tenant-web-app.authentication.user-info-required=true
 quarkus.oidc.tenant-web-app.roles.source=userinfo
+
+# Tenant Web App No Discovery (Introspection + User Info)
+quarkus.oidc.tenant-web-app-no-discovery.auth-server-url=${keycloak.url}/realms/quarkus-webapp
+quarkus.oidc.tenant-web-app-no-discovery.discovery-enabled=false
+quarkus.oidc.tenant-web-app-no-discovery.authorization-path=/protocol/openid-connect/auth
+quarkus.oidc.tenant-web-app-no-discovery.token-path=/protocol/openid-connect/token
+quarkus.oidc.tenant-web-app-no-discovery.user-info-path=/protocol/openid-connect/userinfo
+quarkus.oidc.tenant-web-app-no-discovery.introspection-path=protocol/openid-connect/token/introspect
+#quarkus.oidc.tenant-web-app-no-discovery.jwks-path=/protocol/openid-connect/certs
+quarkus.oidc.tenant-web-app-no-discovery.client-id=quarkus-app-webapp
+quarkus.oidc.tenant-web-app-no-discovery.credentials.secret=secret
+quarkus.oidc.tenant-web-app-no-discovery.application-type=web-app
+quarkus.oidc.tenant-web-app-no-discovery.authentication.user-info-required=true
+quarkus.oidc.tenant-web-app-no-discovery.roles.source=userinfo
 
 # Tenant Web App2
 quarkus.oidc.tenant-web-app2.auth-server-url=${keycloak.url}/realms/quarkus-webapp2


### PR DESCRIPTION
Fixes #12394 

This issue was reported in [this Zulip thread](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/OIDC.20empty.20IntrospectionPath).

So far the user info requests have been done from inside the async Vert.x handler after the ID (code flow) or Bearer access (in the master only) JWT tokens have been verified locally, but it was confirmed that if such a userinfo call follows a nested async introspection call then Vert.x blocks. 

So this PR just makes the userinfo call independent.

Also, while working on the tests, I came accross the issue to do with the Vert.x reinitializing its current `OAuth2TokenImpl` content, thus, in case of the code flow, losing the id, refresh tokens. FYI the introspection of the ID token will happen if not only ID token requires it (it is JWE-encrypted for example) but also if the local JWK set has no matching `kid` in which case Vert.x does the remote introspection while the JWK set is being refreshed.
This explains `CodeAuthenticationMechanism` updates - they are simply about keeping the token values before (re)authenticating them so as to avoid losing them in case of the introspection.
  