### PR TITLE
Deprecate OIDC xhr-auto-redirect and add java-script-auto-redirect properties

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -340,14 +340,14 @@ Additionally a custom `SecurityIdentityAugmentor` can also be used to add the ro
 
 Please check if implementing SPAs the way it is suggested in the link:security-openid-connect#single-page-applications[Single Page Applications for Service Applications] section can meet your requirements.
 
-If you prefer to use SPA and `XMLHttpRequest`(XHR) with Quarkus web applications, please be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
+If you prefer to use SPA and JavaScript API such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, please be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
 
-In such cases, set the `quarkus.oidc.authentication.xhr-auto-redirect` property to `false` which will instruct Quarkus to return a `499` status code and `WWW-Authenticate` header with the `OIDC` value. The browser script also needs to be updated to set `X-Requested-With` header with the `XMLHttpRequest` value and reload the last requested page in case of `499`, for example:
+In such cases, set the `quarkus.oidc.authentication.java-script-auto-redirect` property to `false` which will instruct Quarkus to return a `499` status code and `WWW-Authenticate` header with the `OIDC` value. The browser script also needs to be updated to set `X-Requested-With` header with the `JavaScript` value and reload the last requested page in case of `499`, for example:
 
 [source,javascript]
 ----
 Future<void> callQuarkusService() async {
-    Map<String, String> headers = Map.fromEntries([MapEntry("X-Requested-With", "XMLHttpRequest")]);
+    Map<String, String> headers = Map.fromEntries([MapEntry("X-Requested-With", "JavaScript")]);
 
     await http
         .get("https://localhost:443/serviceCall")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -698,7 +698,10 @@ public class OidcTenantConfig {
          * authorization endpoints typically do not support CORS.
          * If this property is set to `false` then a status code of '499' will be returned to allow
          * the client to handle the redirect manually
+         *
+         * This property is deprecated. Please use a 'javaScriptAutoRedirect' property instead.
          */
+        @Deprecated
         @ConfigItem(defaultValue = "true")
         public boolean xhrAutoRedirect = true;
 
@@ -708,6 +711,26 @@ public class OidcTenantConfig {
 
         public void setXhrAutoredirect(boolean autoRedirect) {
             this.xhrAutoRedirect = autoRedirect;
+        }
+
+        /**
+         * If this property is set to 'true' then a normal 302 redirect response will be returned
+         * if the request was initiated via JavaScript API such as XMLHttpRequest or Fetch and the current user needs to be
+         * (re)authenticated which may not be desirable for Single Page Applications since
+         * it automatically following the redirect may not work given that OIDC authorization endpoints typically do not support
+         * CORS.
+         * If this property is set to `false` then a status code of '499' will be returned to allow
+         * the client to handle the redirect manually
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean javaScriptAutoRedirect = true;
+
+        public boolean isJavaScriptAutoRedirect() {
+            return javaScriptAutoRedirect;
+        }
+
+        public void setJavaScriptAutoredirect(boolean autoRedirect) {
+            this.javaScriptAutoRedirect = autoRedirect;
         }
 
         public Optional<String> getRedirectPath() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -148,8 +148,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         return performCodeFlow(identityProviderManager, context, resolver);
     }
 
-    private boolean isXHR(RoutingContext context) {
-        return "XMLHttpRequest".equals(context.request().getHeader("X-Requested-With"));
+    private boolean isJavaScript(RoutingContext context) {
+        String value = context.request().getHeader("X-Requested-With");
+        return "JavaScript".equals(value) || "XMLHttpRequest".equals(value);
     }
 
     // This test determines if the default behavior of returning a 302 should go forward
@@ -157,7 +158,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     // user has set the auto direct application property to false indicating that
     // the client application will manually handle the redirect to account for SPA behavior
     private boolean shouldAutoRedirect(TenantConfigContext configContext, RoutingContext context) {
-        return isXHR(context) ? configContext.oidcConfig.authentication.xhrAutoRedirect : true;
+        return isJavaScript(context)
+                ? configContext.oidcConfig.authentication.javaScriptAutoRedirect
+                        && configContext.oidcConfig.authentication.xhrAutoRedirect
+                : true;
     }
 
     public Uni<ChallengeData> getChallenge(RoutingContext context, DefaultTenantConfigResolver resolver) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -237,17 +237,16 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         } catch (Throwable ex) {
             return Uni.createFrom().failure(new AuthenticationFailedException(ex));
         }
-        if (jwt.isExpired(tokenJson, auth.getConfig().getJWTOptions())) {
-            return Uni.createFrom().failure(new AuthenticationFailedException());
-        } else {
-            try {
-                return Uni.createFrom()
-                        .item(validateAndCreateIdentity(null, request.getToken(), resolvedContext.oidcConfig, tokenJson,
-                                tokenJson,
-                                null));
-            } catch (Throwable ex) {
-                return Uni.createFrom().failure(ex);
+        try {
+            if (jwt.isExpired(tokenJson, auth.getConfig().getJWTOptions())) {
+                return Uni.createFrom().failure(new AuthenticationFailedException());
             }
+            return Uni.createFrom()
+                    .item(validateAndCreateIdentity(null, request.getToken(), resolvedContext.oidcConfig, tokenJson,
+                            tokenJson,
+                            null));
+        } catch (Throwable ex) {
+            return Uni.createFrom().failure(new AuthenticationFailedException(ex));
         }
     }
 

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -35,6 +35,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-xhr";
         }
 
+        if (path.contains("tenant-javascript")) {
+            return "tenant-javascript";
+        }
+
         return path.contains("callback-after-redirect") || path.contains("callback-before-redirect") ? "tenant-1"
                 : path.contains("callback-jwt-after-redirect") || path.contains("callback-jwt-before-redirect") ? "tenant-jwt"
                         : path.contains("callback-jwt-not-used-after-redirect")

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -95,17 +95,26 @@ quarkus.oidc.tenant-xhr.credentials.secret=secret
 quarkus.oidc.tenant-xhr.authentication.xhr-auto-redirect=false
 quarkus.oidc.tenant-xhr.application-type=web-app
 
+quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-javascript.client-id=quarkus-app
+quarkus.oidc.tenant-javascript.credentials.secret=secret
+quarkus.oidc.tenant-javascript.authentication.java-script-auto-redirect=false
+quarkus.oidc.tenant-javascript.application-type=web-app
+
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
 
 quarkus.http.auth.permission.logout.paths=/tenant-logout
 quarkus.http.auth.permission.logout.policy=authenticated
 
-quarkus.http.auth.permission.logout.paths=/tenant-autorefresh
-quarkus.http.auth.permission.logout.policy=authenticated
+quarkus.http.auth.permission.autorefresh.paths=/tenant-autorefresh
+quarkus.http.auth.permission.autorefresh.policy=authenticated
 
 quarkus.http.auth.permission.xhr.paths=/tenant-xhr
 quarkus.http.auth.permission.xhr.policy=authenticated
+
+quarkus.http.auth.permission.javascript.paths=/tenant-javascript
+quarkus.http.auth.permission.javascript.policy=authenticated
 
 quarkus.http.auth.permission.post-logout.paths=/tenant-logout/post-logout
 quarkus.http.auth.permission.post-logout.policy=permit

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -587,6 +587,22 @@ public class CodeFlowTest {
     }
 
     @Test
+    public void testJavaScriptRequest() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            try {
+                webClient.addRequestHeader("X-Requested-With", "JavaScript");
+                webClient.getPage("http://localhost:8081/tenant-javascript");
+                fail("499 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(499, ex.getStatusCode());
+                assertEquals("OIDC", ex.getResponse().getResponseHeaderValue("WWW-Authenticate"));
+            }
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testNoCodeFlowUnprotected() {
         RestAssured.when().get("/public-web-app/access")
                 .then()

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.keycloak;
 
 import java.io.IOException;
+import java.time.Instant;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,16 @@ public class ServicePublicKeyTestCase {
         // the last section of the jwt token is a signature
         Response r = RestAssured.given().auth()
                 .oauth2(jwt + "1")
+                .get("/service/tenant-public-key");
+        Assertions.assertEquals(401, r.getStatusCode());
+    }
+
+    @Test
+    public void testExpiredToken() throws IOException, InterruptedException {
+        String jwt = Jwt.claims().preferredUserName("alice").expiresAt(Instant.EPOCH).sign();
+        // the last section of the jwt token is a signature
+        Response r = RestAssured.given().auth()
+                .oauth2(jwt)
                 .get("/service/tenant-public-key");
         Assertions.assertEquals(401, r.getStatusCode());
     }


### PR DESCRIPTION
Some users who need to manually handle redirects in their SPA applications use `Fetch`, [see this Zulip thread](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/OIDC.20web-app.20-.20Single.20Page.20Applications), so asking them to set `quarkus.oidc.authentication.xhr-auto-redirect=false` is not nice :-),
so this PR deprecates `quarkus.oidc.authentication.xhr-auto-redirect` and adds `quarkus.oidc.authentication.javascript-auto-redirect` which should be general enough for all the cases where SPA which use some JavaScript API need to disable the auto-redirect.

Also, this PR adds a minor update related to the non-OIDC server case (where only public-key is configured), so it  Fixes #12395 