### PR TITLE
Changed Execute objcopy command log message to debug

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -670,7 +670,9 @@ public class NativeImageBuildStep {
         final List<String> command = new ArrayList<>(args.length + 1);
         command.add("objcopy");
         command.addAll(Arrays.asList(args));
-        log.infof("Execute %s", command);
+        if (log.isDebugEnabled()) {
+            log.debugf("Execute %s", String.join(" ", command));
+        }
         Process process = null;
         try {
             process = new ProcessBuilder(command).start();


### PR DESCRIPTION
This is what was present in the logs:

```java
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Execute [objcopy, --strip-debug, /tmp/greeting-quarkus/target/greeting-quarkus-0.1.0-runner]
```

Also removed the list delimiters