### PR TITLE
Avoid copying sources directly in the source cache

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -75,6 +75,7 @@ public class NativeImageBuildStep {
     private static final String CONTAINER_BUILD_VOLUME_PATH = "/project";
     private static final String TRUST_STORE_SYSTEM_PROPERTY_MARKER = "-Djavax.net.ssl.trustStore=";
     private static final String MOVED_TRUST_STORE_NAME = "trustStore";
+    public static final String APP_SOURCES = "app-sources";
 
     @BuildStep(onlyIf = NativeBuild.class)
     ArtifactResultBuildItem result(NativeImageBuildItem image) {
@@ -231,6 +232,7 @@ public class NativeImageBuildStep {
             if (nativeConfig.debug.enabled) {
                 if (graalVMVersion.isMandrel() || graalVMVersion.isNewerThan(GraalVM.Version.VERSION_20_1)) {
                     command.add("-g");
+                    command.add("-H:DebugInfoSourceSearchPath=" + APP_SOURCES);
                 }
             }
             if (nativeConfig.debugBuildProcess) {
@@ -337,6 +339,7 @@ public class NativeImageBuildStep {
         } finally {
             if (nativeConfig.debug.enabled) {
                 removeJarSourcesFromLib(outputTargetBuildItem);
+                IoUtils.recursiveDelete(outputDir.resolve(Paths.get(APP_SOURCES)));
             }
         }
     }
@@ -447,7 +450,7 @@ public class NativeImageBuildStep {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
 
-        final Path targetSrc = targetDirectory.resolve(Paths.get("sources", "src"));
+        final Path targetSrc = targetDirectory.resolve(Paths.get(APP_SOURCES));
         final File targetSrcFile = targetSrc.toFile();
         if (!targetSrcFile.exists())
             targetSrcFile.mkdirs();


### PR DESCRIPTION
This has the following benefits:
1. Quarkus code doesn't make any assumptions about the source-cache
structure or its name. Previously it assumed that the source-cache is
called sources and it contains a subfolder src with the applicatino
sources, which no longer holds for Mandrel 20.1.0.2 and won't hold for
GraalVM CE 20.3+.
2. The source-cache doesn't need to contain all the source files of the
application, only the ones being referenced by the debug info. As a
result, letting Graal construct the source cache we might end up with
less files in the source-cache.

cc: @Karm @galderz @rsvoboda 