### PR TITLE
Add grpc netty keep-alive-time configuration option

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -175,8 +175,8 @@ public class GrpcServerRecorder {
     }
 
     private void applyNettySettings(GrpcServerConfiguration configuration, VertxServerBuilder builder) {
-        if (configuration.nettyConfig != null) {
-            GrpcServerNettyConfig config = configuration.nettyConfig;
+        if (configuration.netty != null) {
+            GrpcServerNettyConfig config = configuration.netty;
             config.keepAliveTime.ifPresent(duration -> builder.nettyBuilder()
                     .keepAliveTime(duration.toNanos(), TimeUnit.NANOSECONDS));
         }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -73,4 +73,10 @@ public class GrpcServerConfiguration {
      */
     @ConfigItem(defaultValue = "1")
     public int instances;
+
+    /**
+     * Configures the netty server settings.
+     */
+    @ConfigItem
+    public GrpcServerNettyConfig nettyConfig;
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -78,5 +78,5 @@ public class GrpcServerConfiguration {
      * Configures the netty server settings.
      */
     @ConfigItem
-    public GrpcServerNettyConfig nettyConfig;
+    public GrpcServerNettyConfig netty;
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.grpc.runtime.config;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@ConfigGroup
+public class GrpcServerNettyConfig {
+
+    /**
+     * Sets a custom keepalive time, the delay time for sending next keepalive ping.
+     */
+    @ConfigItem
+    public Optional<Duration> keepAliveTime;
+
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
@@ -11,7 +11,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class GrpcServerNettyConfig {
 
     /**
-     * Sets a custom keepalive time, the delay time for sending next keepalive ping.
+     * Sets a custom keep-alive duration. This configures the time before sending a `keepalive` ping when there is no read activity.
      */
     @ConfigItem
     public Optional<Duration> keepAliveTime;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerNettyConfig.java
@@ -11,7 +11,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class GrpcServerNettyConfig {
 
     /**
-     * Sets a custom keep-alive duration. This configures the time before sending a `keepalive` ping when there is no read activity.
+     * Sets a custom keep-alive duration. This configures the time before sending a `keepalive` ping
+     * when there is no read activity.
      */
     @ConfigItem
     public Optional<Duration> keepAliveTime;


### PR DESCRIPTION
While using gRPC server side stream we are facing stream termination due to short tcp idle time on loadbalancer. There is configuration options in netty server which are not exposed presently.
With this the netty keep-alive is exposed as `quarkus.grpc.server.netty.keep-alive-time`where we can set a Duration.