### PR TITLE
Introduce @RunOnWorkerThread

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RunOnWorkerThread.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RunOnWorkerThread.java
@@ -13,9 +13,12 @@ import javax.inject.Qualifier;
 /**
  * Annotation used to indicate that the annotated element should not be executed on the IO thread but on
  * a worker thread.
+ *
  * This annotation is used to allow <em>blocking</em> processing in a reactive application.
  * For example, use this annotation if your reactive route or gRPC service need to use blocking APIs such
  * as <em>blocking</em> database access.
+ *
+ * This annotation is also a CDI Qualifier, must can also be used as a marker annotation.
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RunOnWorkerThread.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RunOnWorkerThread.java
@@ -1,0 +1,24 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Annotation used to indicate that the annotated element should not be executed on the IO thread but on
+ * a worker thread.
+ * This annotation is used to allow <em>blocking</em> processing in a reactive application.
+ * For example, use this annotation if your reactive route or gRPC service need to use blocking APIs such
+ * as <em>blocking</em> database access.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ TYPE, FIELD, METHOD })
+public @interface RunOnWorkerThread {
+}

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -188,6 +188,11 @@ The main differences are the following:
 * it extends the `ImplBase` from `MutinyGreeterGrpc` instead of `GreeterGrpc`
 * the signature of the method is using Mutiny types
 
+NOTE: If your service implementation logic is blocking (use blocking I/O for example), annotate your class with
+`@RunOnWorkerThread`.
+The `io.quarkus.runtime.annotations.RunOnWorkerThread` annotation instructs the framework to invoke the
+service methods on a worker thread instead of the I/O thread (event-loop).
+
 === The gRPC server
 
 The services are _served_ by a _server_.

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -584,6 +584,10 @@ public class PriceResource {
 You often need to combine Reactive Messaging with blocking processing such as database interactions.
 For this, you need to use the `@Blocking` annotation indicating that the processing is _blocking_ and cannot be run on the caller thread.
 
+NOTE: Alternatively, you can use the `@RunOnWorkerThread` annotation instead of `@Blocking`.
+`@Blocking` provides more fine-grain tuning such as the worker pool to use and whether it preserves the order.
+`@RunOnWorkerThread` uses the default worker pool and preserves order.
+
 For example, The following code illustrates how you can store incoming payloads to a database using Hibernate with Panache:
 
 [source,java]

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -88,7 +88,20 @@ void consumeBlocking(String message) {
     // Something blocking
 }
 ----
+
+Alternatively, you can annotate your method with `@RunOnWorkerThread`:
+
+[source, java]
+----
+@ConsumeEvent(value = "blocking-consumer")
+@RunOnWorkerThread
+void consumeBlocking(String message) {
+    // Something blocking
+}
+----
 ====
+
+When using `@RunOnWorkerThread`, it ignores the value of the `blocking` attribute of `@ConsumeEvent`.
 
 Asynchronous processing is also possible by returning either an `io.smallrye.mutiny.Uni` or a `java.util.concurrent.CompletionStage`:
 

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -101,6 +101,20 @@ public void blocking(RoutingContext rc) {
 }
 ----
 
+[NOTE]
+====
+Alternatively, you can use `@RunOnWorkerThread` and omit the `type = Route.HandlerType.BLOCKING`:
+[source, java]
+----
+@Route(methods = HttpMethod.POST, path = "/post")
+@RunOnWorkerThread
+public void blocking(RoutingContext rc) {
+    // ...
+}
+----
+When `@RunOnWorkerThread` is used, it ignores the `type` attribute of `@Route`.
+====
+
 The `@Route` annotation is repeatable and so you can declare several routes for a single method:
 
 [source,java]
@@ -322,7 +336,7 @@ String helloSync(RoutingContext context) {
 ----
 
 Be aware, the processing must be **non-blocking** as reactive routes are invoked on the IO Thread.
-Otherwise, use the `blocking` attribute of the `@Route` annotation.
+Otherwise, use the `blocking` attribute of the `@Route` annotation or the `@RunOnWorkerThread` annotation.
 
 The method can return:
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.EmptyProtos;
+
+import grpc.health.v1.HealthGrpc;
+import grpc.health.v1.HealthOuterClass;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.reflection.v1alpha.MutinyServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.reflection.v1alpha.ServiceResponse;
+import io.grpc.testing.integration.Messages;
+import io.grpc.testing.integration.TestServiceGrpc;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
+import io.quarkus.grpc.server.services.TestService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class BlockingAndNonBlockingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HealthGrpc.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addPackage(TestServiceGrpc.class.getPackage())
+                    .addPackage(EmptyProtos.class.getPackage())
+                    .addClasses(BlockingMutinyHelloService.class, TestService.class))
+            .withConfigurationResource("blocking-config.properties");
+
+    @Inject
+    GrpcHealthStorage healthService;
+
+    @Inject
+    @GrpcService("reflection-service")
+    MutinyServerReflectionGrpc.MutinyServerReflectionStub reflection;
+
+    @Inject
+    @GrpcService("test-service")
+    TestServiceGrpc.TestServiceBlockingStub test;
+
+    @Inject
+    @GrpcService("greeter-service")
+    GreeterGrpc.GreeterBlockingStub greeter;
+
+    @Test
+    public void testInvokingABlockingService() {
+        HelloReply reply = greeter.sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+    }
+
+    @Test
+    public void testInvokingANonBlockingService() {
+        Messages.SimpleResponse reply = test.unaryCall(Messages.SimpleRequest.newBuilder().build());
+        assertThat(reply).isNotNull();
+    }
+
+    @Test
+    public void testHealth() {
+        assertThat(healthService.getStatuses()).contains(
+                entry(GreeterGrpc.SERVICE_NAME, HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING),
+                entry(TestServiceGrpc.SERVICE_NAME, HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING)
+
+        );
+    }
+
+    @Test
+    public void testReflection() {
+        ServerReflectionRequest request = ServerReflectionRequest.newBuilder().setHost("localhost")
+                .setListServices("").build();
+
+        ServerReflectionResponse response = invoke(request);
+        List<ServiceResponse> list = response.getListServicesResponse().getServiceList();
+        assertThat(list).hasSize(3)
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo(GreeterGrpc.SERVICE_NAME))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo(TestServiceGrpc.SERVICE_NAME))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("grpc.health.v1.Health"));
+    }
+
+    private ServerReflectionResponse invoke(ServerReflectionRequest request) {
+        return reflection.serverReflectionInfo(Multi.createFrom().item(request))
+                .collectItems().first()
+                .await().indefinitely();
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMutinyHelloService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMutinyHelloService.java
@@ -1,0 +1,21 @@
+package io.quarkus.grpc.server.blocking;
+
+import javax.inject.Singleton;
+
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+@RunOnWorkerThread
+public class BlockingMutinyHelloService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        return Uni.createFrom().item(request.getName())
+                .map(s -> Thread.currentThread().getName() + " " + s)
+                .map(s -> HelloReply.newBuilder().setMessage(s).build());
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import grpc.health.v1.HealthGrpc;
+import grpc.health.v1.HealthOuterClass;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.reflection.v1alpha.MutinyServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.reflection.v1alpha.ServiceResponse;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class BlockingServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HealthGrpc.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClasses(BlockingMutinyHelloService.class))
+            .withConfigurationResource("reflection-config.properties");
+
+    protected ManagedChannel channel;
+
+    @Inject
+    GrpcHealthStorage healthService;
+
+    @Inject
+    @GrpcService("reflection-service")
+    MutinyServerReflectionGrpc.MutinyServerReflectionStub reflection;
+
+    @BeforeEach
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingABlockingService() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+    }
+
+    @Test
+    public void testHealth() {
+        assertThat(healthService.getStatuses())
+                .contains(entry("helloworld.Greeter", HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING));
+    }
+
+    @Test
+    public void testReflection() {
+        ServerReflectionRequest request = ServerReflectionRequest.newBuilder().setHost("localhost")
+                .setListServices("").build();
+
+        ServerReflectionResponse response = invoke(request);
+        List<ServiceResponse> list = response.getListServicesResponse().getServiceList();
+        assertThat(list).hasSize(2)
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("helloworld.Greeter"))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("grpc.health.v1.Health"));
+    }
+
+    private ServerReflectionResponse invoke(ServerReflectionRequest request) {
+        return reflection.serverReflectionInfo(Multi.createFrom().item(request))
+                .collectItems().first()
+                .await().indefinitely();
+    }
+}

--- a/extensions/grpc/deployment/src/test/resources/blocking-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/blocking-config.properties
@@ -1,0 +1,4 @@
+quarkus.grpc.clients.reflection-service.host=localhost
+quarkus.grpc.clients.test-service.host=localhost
+quarkus.grpc.clients.greeter-service.host=localhost
+quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
@@ -13,12 +13,24 @@ import javax.inject.Inject;
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
 import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
 
 @ApplicationScoped
 public class GrpcContainer {
 
+    /**
+     * The list of {@link BindableService} that runs on the I/O thread.
+     */
     @Inject
     Instance<BindableService> services;
+
+    /**
+     * The list of {@link BindableService} that runs on a worker thread.
+     */
+    @Inject
+    @RunOnWorkerThread
+    Instance<BindableService> blockingServices;
+
     @Inject
     Instance<ServerInterceptor> interceptors;
     @Inject
@@ -52,7 +64,12 @@ public class GrpcContainer {
         return healthStorage;
     }
 
-    public Instance<BindableService> getServices() {
+    public Instance<BindableService> getNonBlockingServices() {
         return services;
     }
+
+    public Instance<BindableService> getBlockingServices() {
+        return blockingServices;
+    }
+
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
@@ -1,0 +1,102 @@
+package io.quarkus.grpc.runtime.supports;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.grpc.*;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class BlockingServerInterceptor implements ServerInterceptor {
+
+    private final Vertx vertx;
+
+    public BlockingServerInterceptor(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        ReplayListener<ReqT> replay = new ReplayListener<>();
+
+        vertx.executeBlocking(new Handler<Promise<Object>>() {
+            @Override
+            public void handle(Promise<Object> f) {
+                ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
+                replay.setDelegate(listener);
+                f.complete(null);
+            }
+        }, null);
+
+        return replay;
+    }
+
+    /**
+     * Stores the incoming events until the listener is injected.
+     * When injected, replay the events.
+     *
+     * Note that event must be executed in order, explaining the `ordered:true`.
+     */
+    private class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
+        private ServerCall.Listener<ReqT> delegate;
+        private final List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
+
+        synchronized void setDelegate(ServerCall.Listener<ReqT> delegate) {
+            this.delegate = delegate;
+            for (Consumer<ServerCall.Listener<ReqT>> event : incomingEvents) {
+                event.accept(delegate);
+            }
+            incomingEvents.clear();
+        }
+
+        private synchronized void executeOnContextOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
+            if (this.delegate != null) {
+                vertx.executeBlocking(new Handler<Promise<Object>>() {
+                    @Override
+                    public void handle(Promise<Object> f) {
+                        consumer.accept(delegate);
+                        f.complete();
+                    }
+                }, true, null);
+            } else {
+                incomingEvents.add(consumer);
+            }
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            executeOnContextOrEnqueue(new Consumer<ServerCall.Listener<ReqT>>() {
+                @Override
+                public void accept(ServerCall.Listener<ReqT> t) {
+                    t.onMessage(message);
+                }
+            });
+        }
+
+        @Override
+        public void onHalfClose() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onHalfClose);
+        }
+
+        @Override
+        public void onCancel() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onCancel);
+        }
+
+        @Override
+        public void onComplete() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onComplete);
+        }
+
+        @Override
+        public void onReady() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onReady);
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -1,6 +1,12 @@
 package io.quarkus.smallrye.reactivemessaging.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.*;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.ACKNOWLEDGMENT;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BLOCKING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BROADCAST;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.INCOMING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.MERGE;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.OUTGOING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.RUN_ON_WORKER_THREAD;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -122,15 +128,20 @@ public final class QuarkusMediatorConfigurationUtil {
                 }));
 
         AnnotationInstance blockingAnnotation = methodInfo.annotation(BLOCKING);
-        if (blockingAnnotation != null) {
+        AnnotationInstance runOnWorkerThread = methodInfo.annotation(RUN_ON_WORKER_THREAD);
+        if (blockingAnnotation != null || runOnWorkerThread != null) {
             mediatorConfigurationSupport.validateBlocking(validationOutput);
             configuration.setBlocking(true);
-            AnnotationValue ordered = blockingAnnotation.value("ordered");
-            configuration.setBlockingExecutionOrdered(ordered == null || ordered.asBoolean());
-            String poolName;
-            if (blockingAnnotation.value() != null &&
-                    !(poolName = blockingAnnotation.value().asString()).equals(Blocking.DEFAULT_WORKER_POOL)) {
-                configuration.setWorkerPoolName(poolName);
+            if (blockingAnnotation != null) {
+                AnnotationValue ordered = blockingAnnotation.value("ordered");
+                configuration.setBlockingExecutionOrdered(ordered == null || ordered.asBoolean());
+                String poolName;
+                if (blockingAnnotation.value() != null &&
+                        !(poolName = blockingAnnotation.value().asString()).equals(Blocking.DEFAULT_WORKER_POOL)) {
+                    configuration.setWorkerPoolName(poolName);
+                }
+            } else {
+                configuration.setBlockingExecutionOrdered(true);
             }
         }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
@@ -5,6 +5,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
@@ -19,6 +20,7 @@ public final class ReactiveMessagingDotNames {
     static final DotName INCOMING = DotName.createSimple(Incoming.class.getName());
     static final DotName OUTGOING = DotName.createSimple(Outgoing.class.getName());
     static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
+    static final DotName RUN_ON_WORKER_THREAD = DotName.createSimple(RunOnWorkerThread.class.getName());
     static final DotName CHANNEL = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Channel.class.getName());
     static final DotName LEGACY_CHANNEL = DotName.createSimple(Channel.class.getName());
     static final DotName EMITTER = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Emitter.class.getName());

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -337,9 +337,15 @@ public class SmallRyeReactiveMessagingProcessor {
              */
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, generatedInvokerName));
 
-            if (methodInfo.hasAnnotation(ReactiveMessagingDotNames.BLOCKING)) {
-                AnnotationInstance blocking = methodInfo.annotation(ReactiveMessagingDotNames.BLOCKING);
-                String poolName = blocking.value() == null ? Blocking.DEFAULT_WORKER_POOL : blocking.value().asString();
+            if (methodInfo.hasAnnotation(ReactiveMessagingDotNames.BLOCKING)
+                    || methodInfo.hasAnnotation(ReactiveMessagingDotNames.RUN_ON_WORKER_THREAD)) {
+
+                // Just in case both annotation are used, use @Blocking value.
+                String poolName = Blocking.DEFAULT_WORKER_POOL;
+                if (methodInfo.hasAnnotation(ReactiveMessagingDotNames.BLOCKING)) {
+                    AnnotationInstance blocking = methodInfo.annotation(ReactiveMessagingDotNames.BLOCKING);
+                    poolName = blocking.value() == null ? Blocking.DEFAULT_WORKER_POOL : blocking.value().asString();
+                }
 
                 recorder.configureWorkerPool(beanContainer.getValue(), methodInfo.declaringClass().toString(),
                         methodInfo.name(), poolName);

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/RunOnWorkerThreadPublisherTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/RunOnWorkerThreadPublisherTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.smallrye.reactivemessaging.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.BeanReturningMessagesUsingRunOnWorkerThread;
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.BeanReturningPayloadsUsingRunOnWorkerThread;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+
+public class RunOnWorkerThreadPublisherTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanReturningPayloadsUsingRunOnWorkerThread.class,
+                            BeanReturningMessagesUsingRunOnWorkerThread.class));
+
+    @Inject
+    BeanReturningPayloadsUsingRunOnWorkerThread beanReturningPayloads;
+    @Inject
+    BeanReturningMessagesUsingRunOnWorkerThread beanReturningMessages;
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @Test
+    public void testBlockingWhenProducingPayload() {
+        List<PublisherBuilder<? extends Message<?>>> producer = channelRegistry.getPublishers("infinite-producer-payload");
+        assertThat(producer).isNotEmpty();
+        List<Integer> list = producer.get(0).map(Message::getPayload)
+                .limit(5)
+                .map(i -> (Integer) i)
+                .toList().run().toCompletableFuture().join();
+        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+
+        List<String> threadNames = beanReturningPayloads.threads().stream().distinct().collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+
+    @Test
+    public void testBlockingWhenProducingMessages() {
+        List<PublisherBuilder<? extends Message<?>>> producer = channelRegistry.getPublishers("infinite-producer-msg");
+        assertThat(producer).isNotEmpty();
+        List<Integer> list = producer.get(0).map(Message::getPayload)
+                .limit(5)
+                .map(i -> (Integer) i)
+                .toList().run().toCompletableFuture().join();
+        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+
+        List<String> threadNames = beanReturningMessages.threads().stream().distinct().collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/RunOnWorkerThreadSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/RunOnWorkerThreadSubscriberTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.smallrye.reactivemessaging.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.IncomingUsingRunOnWorkerThread;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class RunOnWorkerThreadSubscriberTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProduceIn.class, IncomingUsingRunOnWorkerThread.class)
+                    .addAsResource(
+                            new File("src/test/resources/config/worker-config.properties"),
+                            "application.properties"));
+
+    @Inject
+    IncomingUsingRunOnWorkerThread incoming;
+
+    @Test
+    public void testIncomingUsingRunOnWorkerThread() {
+        await().until(() -> incoming.list().size() == 6);
+        assertThat(incoming.list()).contains("a", "b", "c", "d", "e", "f");
+
+        List<String> threadNames = incoming.threads().stream().distinct()
+                .collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProduceIn {
+        @Outgoing("in")
+        public Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningMessagesUsingRunOnWorkerThread.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningMessagesUsingRunOnWorkerThread.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
+
+@ApplicationScoped
+public class BeanReturningMessagesUsingRunOnWorkerThread {
+    private final AtomicInteger count = new AtomicInteger();
+    private final List<String> threads = new CopyOnWriteArrayList<>();
+
+    @RunOnWorkerThread
+    @Outgoing("infinite-producer-msg")
+    public Message<Integer> create() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        threads.add(Thread.currentThread().getName());
+        return Message.of(count.incrementAndGet());
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningPayloadsUsingRunOnWorkerThread.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningPayloadsUsingRunOnWorkerThread.java
@@ -1,0 +1,33 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
+
+@ApplicationScoped
+public class BeanReturningPayloadsUsingRunOnWorkerThread {
+    private AtomicInteger count = new AtomicInteger();
+    private List<String> threads = new CopyOnWriteArrayList<>();
+
+    @RunOnWorkerThread
+    @Outgoing("infinite-producer-payload")
+    public int create() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        threads.add(Thread.currentThread().getName());
+        return count.incrementAndGet();
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/IncomingUsingRunOnWorkerThread.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/IncomingUsingRunOnWorkerThread.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
+
+@ApplicationScoped
+public class IncomingUsingRunOnWorkerThread {
+    private final List<String> list = new CopyOnWriteArrayList<>();
+    private final List<String> threads = new CopyOnWriteArrayList<>();
+
+    @Incoming("in")
+    @RunOnWorkerThread()
+    public void consume(String s) {
+        if (s.equals("b") || s.equals("d") || s.equals("f")) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        threads.add(Thread.currentThread().getName());
+        list.add(s);
+    }
+
+    public List<String> list() {
+        return list;
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
 import io.quarkus.vertx.web.Body;
 import io.quarkus.vertx.web.Header;
 import io.quarkus.vertx.web.Param;
@@ -49,5 +50,6 @@ final class DotNames {
     static final DotName LIST = DotName.createSimple(List.class.getName());
     static final DotName EXCEPTION = DotName.createSimple(Exception.class.getName());
     static final DotName THROWABLE = DotName.createSimple(Throwable.class.getName());
+    static final DotName RUN_ON_WORKER_THREAD = DotName.createSimple(RunOnWorkerThread.class.getName());
 
 }

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -327,6 +327,16 @@ class VertxWebProcessor {
                     }
                 }
 
+                if (businessMethod.getMethod().annotation(DotNames.RUN_ON_WORKER_THREAD) != null) {
+                    if (handlerType == HandlerType.NORMAL) {
+                        handlerType = HandlerType.BLOCKING;
+                    } else if (handlerType == HandlerType.FAILURE) {
+                        throw new IllegalStateException(
+                                "Invalid combination - a reactive route cannot use @RunOnWorkerThread and be of type `failure` at the same time: "
+                                        + businessMethod.getMethod().toString());
+                    }
+                }
+
                 if (routeHandler == null) {
                     String handlerClass = generateHandler(
                             new HandlerDescriptor(businessMethod.getMethod(), beanValidationAnnotations.orElse(null),

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.vertx.web.blocking;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.containsString;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.annotations.RunOnWorkerThread;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.vertx.core.http.HttpMethod;
+
+public class BlockingRouteTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyRoutes.class));
+
+    @Test
+    public void testBlockingRoutes() {
+        get("/non-blocking")
+                .then().statusCode(200)
+                .body(containsString("nonBlocking-"), containsString("eventloop"));
+
+        get("/blocking")
+                .then().statusCode(200)
+                .body(containsString("blocking-"), containsString("worker"));
+
+        get("/worker")
+                .then().statusCode(200)
+                .body(containsString("worker-"), containsString("worker"));
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        @Route(methods = HttpMethod.GET, path = "/non-blocking")
+        public String nonBlocking() {
+            return "nonBlocking-" + Thread.currentThread().getName();
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/blocking", type = Route.HandlerType.BLOCKING)
+        public String blocking() {
+            return "blocking-" + Thread.currentThread().getName();
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/worker")
+        @RunOnWorkerThread
+        public String worker() {
+            return "worker-" + Thread.currentThread().getName();
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/12077.

* introduce the new annotation
* add support into the gRPC extension (for services)
* add support into the reactive messaging extension - equivalent to @Blocking
* add support into the vertx extension (@ConsumeEvent) - equivalent to `blocking=true`
* add support into the vertx-web extension (@Route) - equivalent to `type=BLOCKING`

The documentation of these extensions has been updated.