### PR TITLE
Integrate AzureMonitorRegistry into Micrometer Extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4597,6 +4597,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-azure-monitor</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
 
             <!-- Picocli -->
             <dependency>

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -65,7 +65,11 @@
             <artifactId>micrometer-registry-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-azure-monitor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- test -->
 
         <dependency>

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/AzureMonitorRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/AzureMonitorRegistryProcessor.java
@@ -1,0 +1,47 @@
+package io.quarkus.micrometer.deployment.export;
+
+import java.util.function.BooleanSupplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
+import io.quarkus.micrometer.runtime.MicrometerRecorder;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+import io.quarkus.micrometer.runtime.export.AzureMonitorMeterRegistryProvider;
+
+/**
+ * Add support for the Azure Monitor Meter Registry. Note that the registry may not
+ * be available at deployment time for some projects: Avoid direct class
+ * references.
+ */
+public class AzureMonitorRegistryProcessor {
+    private static final Logger log = Logger.getLogger(AzureMonitorRegistryProcessor.class);
+
+    static final String REGISTRY_CLASS_NAME = "io.micrometer.azuremonitor.AzureMonitorMeterRegistry";
+    static final Class<?> REGISTRY_CLASS = MicrometerRecorder.getClassForName(REGISTRY_CLASS_NAME);
+
+    public static class AzureMonitorEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+
+        @Override
+        public boolean getAsBoolean() {
+            return REGISTRY_CLASS != null && mConfig.checkRegistryEnabledWithDefault(mConfig.export.azuremonitor);
+        }
+    }
+
+    @BuildStep(onlyIf = AzureMonitorEnabled.class)
+    MicrometerRegistryProviderBuildItem createAzureMonitorRegistry(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+        // Add the AzureMonitor Registry Producer
+        additionalBeans.produce(
+                AdditionalBeanBuildItem.builder()
+                        .addBeanClass(AzureMonitorMeterRegistryProvider.class)
+                        .setUnremovable().build());
+
+        // Include the AzureMonitorMeterRegistry in a possible CompositeMeterRegistry
+        return new MicrometerRegistryProviderBuildItem(REGISTRY_CLASS);
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
@@ -23,6 +23,7 @@ public class AllRegistriesDisabledTest {
             .withConfigurationResource("test-logging.properties")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
             .overrideConfigKey("quarkus.micrometer.export.datadog.enabled", "false")
+            .overrideConfigKey("quarkus.micrometer.export.azuremonitor.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.jmx.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.stackdriver.enabled", "false")

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AzureMonitorEnabledInvalidTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AzureMonitorEnabledInvalidTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.deployment.export;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.validate.ValidationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureMonitorEnabledInvalidTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.export.azuremonitor.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(AzureMonitorRegistryProcessor.REGISTRY_CLASS))
+            .assertException(t -> {
+                Assertions.assertEquals(ValidationException.class.getName(), t.getClass().getName());
+            });
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    public void testMeterRegistryPresent() {
+        Assertions.fail("Runtime should not have initialized with missing instrumentationKey");
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AzureMonitorEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AzureMonitorEnabledTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.micrometer.deployment.export;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.quarkus.micrometer.runtime.MicrometerRecorder;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureMonitorEnabledTest {
+    static final String REGISTRY_CLASS_NAME = "io.micrometer.azuremonitor.AzureMonitorMeterRegistry";
+    static final Class<?> REGISTRY_CLASS = MicrometerRecorder.getClassForName(REGISTRY_CLASS_NAME);
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.export.azuremonitor.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.export.azuremonitor.instrumentation-key", "TEST")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(AzureMonitorRegistryProcessor.REGISTRY_CLASS));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    public void testMeterRegistryPresent() {
+        // AzureMonitor is enabled (alone, all others disabled)
+        Assertions.assertNotNull(registry, "A registry should be configured");
+        Set<MeterRegistry> subRegistries = ((CompositeMeterRegistry) registry).getRegistries();
+        Assertions.assertEquals(
+                REGISTRY_CLASS, subRegistries.iterator().next().getClass(),
+                "Should be AzureMonitorMeterRegistry");
+    }
+}

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -65,7 +65,11 @@
             <artifactId>micrometer-registry-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-azure-monitor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Dependencies for Binding (optional) -->
 
         <dependency>

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/AzureMonitorConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/AzureMonitorConfig.java
@@ -1,0 +1,39 @@
+package io.quarkus.micrometer.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class AzureMonitorConfig implements MicrometerConfig.CapabilityEnabled {
+    /**
+     * Support for export to AzureMonitor.
+     * <p>
+     * Support for AzureMonitor will be enabled if micrometer
+     * support is enabled, the AzureMonitorMeterRegistry is on the classpath
+     * and either this value is true, or this value is unset and
+     * {@code quarkus.micrometer.registry-enabled-default} is true.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled;
+
+    /**
+     * The path for the azure monitor instrumentationKey
+     */
+    @ConfigItem
+    public Optional<String> instrumentationKey;
+
+    @Override
+    public Optional<Boolean> getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName()
+                + "{instrumentationKey='" + instrumentationKey
+                + ",enabled=" + enabled
+                + '}';
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
@@ -119,6 +119,7 @@ public final class MicrometerConfig {
         public PrometheusConfig prometheus;
         public StackdriverConfig stackdriver;
         public JsonConfig json;
+        public AzureMonitorConfig azuremonitor;
     }
 
     public static interface CapabilityEnabled {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/ExportConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/ExportConfig.java
@@ -82,6 +82,31 @@ public class ExportConfig {
 
     // @formatter:off
     /**
+     * Azure Monitor registry configuration properties.
+     * <p>
+     * A property source for configuration of the AzureMonitor MeterRegistry,
+     *
+     * Available values:
+     *
+     * [cols=2]
+     * !===
+     * h!Property=Default
+     * h!Description
+     *
+     * !`instrumentation-key`
+     * !Define the instrumentationKey used to push data to Azure Insights Monitor
+     *
+     * !===
+     *
+     * Other micrometer configuration attributes can also be specified.
+     *
+     * @asciidoclet
+     */
+    // @formatter:on
+    @ConfigItem
+    Map<String, String> azuremonitor;
+    // @formatter:off
+    /**
      * Stackdriver registry configuration properties.
      * <p>
      * A property source for configuration of the Stackdriver MeterRegistry,

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/AzureMonitorMeterRegistryProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/AzureMonitorMeterRegistryProvider.java
@@ -1,0 +1,46 @@
+package io.quarkus.micrometer.runtime.export;
+
+import java.util.Map;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.config.Config;
+
+import io.micrometer.azuremonitor.AzureMonitorConfig;
+import io.micrometer.azuremonitor.AzureMonitorMeterRegistry;
+import io.micrometer.azuremonitor.AzureMonitorNamingConvention;
+import io.micrometer.core.instrument.Clock;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.micrometer.runtime.MicrometerRecorder;
+
+@Singleton
+public class AzureMonitorMeterRegistryProvider {
+    static final String PREFIX = "quarkus.micrometer.export.azuremonitor.";
+
+    @Produces
+    @Singleton
+    @DefaultBean
+    public AzureMonitorConfig configure(Config config) {
+        final Map<String, String> properties = MicrometerRecorder.captureProperties(config, PREFIX);
+
+        return new AzureMonitorConfig() {
+            @Override
+            public String get(String key) {
+                return properties.get(key);
+            }
+        };
+    }
+
+    @Produces
+    @DefaultBean
+    public AzureMonitorNamingConvention namingConvention() {
+        return new AzureMonitorNamingConvention();
+    }
+
+    @Produces
+    @Singleton
+    public AzureMonitorMeterRegistry registry(AzureMonitorConfig config, Clock clock) {
+        return new AzureMonitorMeterRegistry(config, clock);
+    }
+}


### PR DESCRIPTION
Integration of the existing micrometer implementation for Azure Insights Monitor into the quarkus-micrometer extension.