### PR TITLE
Set 'Secured' property for Form authentication cookies

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthTestCase.java
@@ -18,6 +18,7 @@ import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.restassured.filter.cookie.CookieFilter;
+import io.restassured.matcher.RestAssuredMatchers;
 
 public class FormAuthTestCase {
 
@@ -60,7 +61,8 @@ public class FormAuthTestCase {
                 .assertThat()
                 .statusCode(302)
                 .header("location", containsString("/login"))
-                .cookie("quarkus-redirect-location", containsString("/admin"));
+                .cookie("quarkus-redirect-location",
+                        RestAssuredMatchers.detailedCookie().value(containsString("/admin")).secured(false));
 
         RestAssured
                 .given()
@@ -74,7 +76,8 @@ public class FormAuthTestCase {
                 .assertThat()
                 .statusCode(302)
                 .header("location", containsString("/admin"))
-                .cookie("quarkus-credential", notNullValue());
+                .cookie("quarkus-credential",
+                        RestAssuredMatchers.detailedCookie().value(notNullValue()).secured(false));
 
         RestAssured
                 .given()

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -75,7 +75,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
                                         @Override
                                         public void accept(SecurityIdentity identity) {
                                             try {
-                                                loginManager.save(identity, exchange, null);
+                                                loginManager.save(identity, exchange, null, exchange.request().isSSL());
                                                 if (redirectAfterLogin || exchange.getCookie(locationCookie) != null) {
                                                     handleRedirectBack(exchange);
                                                     //we  have authenticated, but we want to just redirect back to the original page
@@ -111,6 +111,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
         Cookie redirect = exchange.getCookie(locationCookie);
         String location;
         if (redirect != null) {
+            redirect.setSecure(exchange.request().isSSL());
             location = redirect.getValue();
             exchange.response().addCookie(redirect.setMaxAge(0));
         } else {
@@ -122,7 +123,8 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     protected void storeInitialLocation(final RoutingContext exchange) {
-        exchange.response().addCookie(Cookie.cookie(locationCookie, exchange.request().absoluteURI()).setPath("/"));
+        exchange.response().addCookie(Cookie.cookie(locationCookie, exchange.request().absoluteURI())
+                .setPath("/").setSecure(exchange.request().isSSL()));
     }
 
     protected void servePage(final RoutingContext exchange, final String location) {
@@ -152,7 +154,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
             return ret.onItem().invoke(new Consumer<SecurityIdentity>() {
                 @Override
                 public void accept(SecurityIdentity securityIdentity) {
-                    loginManager.save(securityIdentity, context, result);
+                    loginManager.save(securityIdentity, context, result, context.request().isSSL());
                 }
             });
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -37,10 +37,10 @@ public class PersistentLoginManager {
     private final long newCookieIntervalMillis;
 
     public PersistentLoginManager(String encryptionKey, String cookieName, long timeoutMillis, long newCookieIntervalMillis) {
+        this.cookieName = cookieName;
+        this.newCookieIntervalMillis = newCookieIntervalMillis;
+        this.timeoutMillis = timeoutMillis;
         try {
-            this.cookieName = cookieName;
-            this.newCookieIntervalMillis = newCookieIntervalMillis;
-            this.timeoutMillis = timeoutMillis;
             if (encryptionKey == null) {
                 this.secretKey = KeyGenerator.getInstance("AES").generateKey();
             } else if (encryptionKey.length() < 16) {
@@ -99,7 +99,7 @@ public class PersistentLoginManager {
         }
     }
 
-    public void save(SecurityIdentity identity, RoutingContext context, RestoreResult restoreResult) {
+    public void save(SecurityIdentity identity, RoutingContext context, RestoreResult restoreResult, boolean secureCookie) {
         if (restoreResult != null) {
             if (!restoreResult.newCookieNeeded) {
                 return;
@@ -122,7 +122,7 @@ public class PersistentLoginManager {
             message.put(iv);
             message.put(encrypted);
             String cookieValue = Base64.getEncoder().encodeToString(message.array());
-            context.addCookie(Cookie.cookie(cookieName, cookieValue).setPath("/"));
+            context.addCookie(Cookie.cookie(cookieName, cookieValue).setPath("/").setSecure(secureCookie));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixes #12441

@stuartwdouglas we do not set a same-site cookie in OIDC but only a `Secured` property, this should resolve the issue as OIDC users have never reported it.
The test does not use HTTPS (I believe it is not possible with RestAssured in Quarkus at the moment), so it just verifies that this property is disabled for non-SSL