### PR TITLE
Startup of Hibernate ORM was not registered as a ServiceStartBuildItem

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -95,6 +95,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -506,16 +507,17 @@ public final class HibernateOrmProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public void startPersistenceUnits(HibernateOrmRecorder recorder, BeanContainerBuildItem beanContainer,
+    public ServiceStartBuildItem startPersistenceUnits(HibernateOrmRecorder recorder, BeanContainerBuildItem beanContainer,
             List<JdbcDataSourceBuildItem> dataSourcesConfigured,
             JpaEntitiesBuildItem jpaEntities, List<NonJpaModelBuildItem> nonJpaModels,
             List<HibernateOrmIntegrationRuntimeConfiguredBuildItem> integrationsRuntimeConfigured,
             List<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) throws Exception {
-        if (!hasEntities(jpaEntities, nonJpaModels)) {
-            return;
+        if (hasEntities(jpaEntities, nonJpaModels)) {
+            recorder.startAllPersistenceUnits(beanContainer.getValue());
         }
 
-        recorder.startAllPersistenceUnits(beanContainer.getValue());
+        return new ServiceStartBuildItem("Hibernate ORM");
+
     }
 
     @BuildStep


### PR DESCRIPTION
This is to address a possible bug identified by @famod . Seems we don't register the SessionFactory startup as a dependency for the Start event - my bad, I didn't know about this.

Marking as a draft as I didn't test this at all - althought it seems harmless.

Hopefully @famod might be able to confirm that this fixes his problem? Or we just merge it, it seems this was just missing - but let's create the issue first.

Fixes #12463 