### PR TITLE
Update SmallRye Reactive Messaging to 2.4.0 and Mutiny to 0.9.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -130,7 +130,7 @@
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
-        <mutiny.version>0.8.1</mutiny.version>
+        <mutiny.version>0.9.0</mutiny.version>
         <axle-client.version>1.2.1</axle-client.version>
         <mutiny-client.version>1.2.1</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.1.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.3.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.4.0</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.34.0</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
@@ -9,12 +9,14 @@ public final class EmitterBuildItem extends MultiBuildItem {
      * Creates a new instance of {@link EmitterBuildItem} setting the overflow strategy.
      *
      * @param name the name of the stream
+     * @param isMutinyEmitter if the emitter is a {@link io.smallrye.reactive.messaging.MutinyEmitter}
      * @param overflow the overflow strategy
      * @param bufferSize the buffer size, if overflow is set to {@code BUFFER}
      * @return the new {@link EmitterBuildItem}
      */
-    static EmitterBuildItem of(String name, String overflow, int bufferSize, boolean hasBroadcast, int awaitSubscribers) {
-        return new EmitterBuildItem(name, overflow, bufferSize, hasBroadcast, awaitSubscribers);
+    static EmitterBuildItem of(String name, boolean isMutinyEmitter, String overflow, int bufferSize, boolean hasBroadcast,
+            int awaitSubscribers) {
+        return new EmitterBuildItem(name, isMutinyEmitter, overflow, bufferSize, hasBroadcast, awaitSubscribers);
     }
 
     /**
@@ -40,21 +42,28 @@ public final class EmitterBuildItem extends MultiBuildItem {
     private final boolean hasBroadcast;
 
     /**
+     * Whether the emitter is a {@link io.smallrye.reactive.messaging.MutinyEmitter} or a regular (non-mutiny) emitter.
+     */
+    private final boolean isMutinyEmitter;
+
+    /**
      * If the emitter uses the {@link io.smallrye.reactive.messaging.annotations.Broadcast} annotation, indicates the
      * number of subscribers to be expected before subscribing upstream.
      */
     private final int awaitSubscribers;
 
-    public EmitterBuildItem(String name, String overflow, int bufferSize, boolean hasBroadcast, int awaitSubscribers) {
+    public EmitterBuildItem(String name, boolean isMutinyEmitter, String overflow, int bufferSize, boolean hasBroadcast,
+            int awaitSubscribers) {
         this.name = name;
         this.overflow = overflow;
+        this.isMutinyEmitter = isMutinyEmitter;
         this.bufferSize = bufferSize;
         this.hasBroadcast = hasBroadcast;
         this.awaitSubscribers = hasBroadcast ? awaitSubscribers : -1;
     }
 
     public EmitterConfiguration getEmitterConfig() {
-        return new EmitterConfiguration(name, OnOverflowLiteral.create(overflow, bufferSize),
+        return new EmitterConfiguration(name, isMutinyEmitter, OnOverflowLiteral.create(overflow, bufferSize),
                 hasBroadcast ? new BroadcastLiteral(awaitSubscribers) : null);
     }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -77,7 +77,7 @@ public final class QuarkusMediatorConfigurationUtil {
                 acknowledgment);
         configuration.setProduction(validationOutput.getProduction());
         configuration.setConsumption(validationOutput.getConsumption());
-        configuration.setIngestedPayload(validationOutput.getIngestedPayloadType());
+        configuration.setIngestedPayloadType(validationOutput.getIngestedPayloadType());
         if (validationOutput.getUseBuilderTypes()) {
             configuration.setUseBuilderTypes(validationOutput.getUseBuilderTypes());
         } else {

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -1,5 +1,18 @@
 package io.quarkus.smallrye.reactivemessaging.deployment;
 
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.*;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusMediatorConfiguration;
@@ -8,18 +21,6 @@ import io.smallrye.reactive.messaging.MediatorConfigurationSupport;
 import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Merge;
-import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.Type;
-
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.*;
 
 public final class QuarkusMediatorConfigurationUtil {
 
@@ -90,7 +91,8 @@ public final class QuarkusMediatorConfigurationUtil {
         }
 
         configuration.setMerge(mediatorConfigurationSupport.processMerge(incomingValues, new Supplier<Merge.Mode>() {
-            @Override public Merge.Mode get() {
+            @Override
+            public Merge.Mode get() {
                 AnnotationInstance instance = methodInfo.annotation(MERGE);
                 if (instance != null) {
                     AnnotationValue value = instance.value();
@@ -105,7 +107,8 @@ public final class QuarkusMediatorConfigurationUtil {
 
         configuration.setBroadcastValue(mediatorConfigurationSupport.processBroadcast(outgoingValue,
                 new Supplier<Integer>() {
-                    @Override public Integer get() {
+                    @Override
+                    public Integer get() {
                         AnnotationInstance instance = methodInfo.annotation(BROADCAST);
                         if (instance != null) {
                             AnnotationValue value = instance.value();

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -1,22 +1,5 @@
 package io.quarkus.smallrye.reactivemessaging.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.ACKNOWLEDGMENT;
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BLOCKING;
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BROADCAST;
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.INCOMING;
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.MERGE;
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.OUTGOING;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.Type;
-
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusMediatorConfiguration;
@@ -25,13 +8,25 @@ import io.smallrye.reactive.messaging.MediatorConfigurationSupport;
 import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Merge;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 
-final class QuarkusMediatorConfigurationUtil {
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.*;
+
+public final class QuarkusMediatorConfigurationUtil {
 
     private QuarkusMediatorConfigurationUtil() {
     }
 
-    static QuarkusMediatorConfiguration create(MethodInfo methodInfo, BeanInfo bean,
+    public static QuarkusMediatorConfiguration create(MethodInfo methodInfo, BeanInfo bean,
             String generatedInvokerName, RecorderContext recorderContext, ClassLoader cl) {
 
         Class<?> returnTypeClass = load(methodInfo.returnType().name().toString(), cl);
@@ -81,7 +76,8 @@ final class QuarkusMediatorConfigurationUtil {
                 acknowledgment);
         configuration.setProduction(validationOutput.getProduction());
         configuration.setConsumption(validationOutput.getConsumption());
-        if (validationOutput.getUseBuilderTypes() != null) {
+        configuration.setIngestedPayload(validationOutput.getIngestedPayloadType());
+        if (validationOutput.getUseBuilderTypes()) {
             configuration.setUseBuilderTypes(validationOutput.getUseBuilderTypes());
         } else {
             configuration.setUseBuilderTypes(false);
@@ -89,33 +85,38 @@ final class QuarkusMediatorConfigurationUtil {
 
         if (acknowledgment == null) {
             acknowledgment = mediatorConfigurationSupport.processDefaultAcknowledgement(shape,
-                    validationOutput.getConsumption());
+                    validationOutput.getConsumption(), validationOutput.getProduction());
             configuration.setAcknowledgment(acknowledgment);
         }
 
-        configuration.setMerge(mediatorConfigurationSupport.processMerge(incomingValues, () -> {
-            AnnotationInstance instance = methodInfo.annotation(MERGE);
-            if (instance != null) {
-                AnnotationValue value = instance.value();
-                if (value == null) {
-                    return Merge.Mode.MERGE; // the default value of @Merge
+        configuration.setMerge(mediatorConfigurationSupport.processMerge(incomingValues, new Supplier<Merge.Mode>() {
+            @Override public Merge.Mode get() {
+                AnnotationInstance instance = methodInfo.annotation(MERGE);
+                if (instance != null) {
+                    AnnotationValue value = instance.value();
+                    if (value == null) {
+                        return Merge.Mode.MERGE; // the default value of @Merge
+                    }
+                    return Merge.Mode.valueOf(value.asEnum());
                 }
-                return Merge.Mode.valueOf(value.asEnum());
+                return null;
             }
-            return null;
         }));
 
-        configuration.setBroadcastValue(mediatorConfigurationSupport.processBroadcast(outgoingValue, () -> {
-            AnnotationInstance instance = methodInfo.annotation(BROADCAST);
-            if (instance != null) {
-                AnnotationValue value = instance.value();
-                if (value == null) {
-                    return 0; // the default value of @Broadcast
-                }
-                return value.asInt();
-            }
-            return null;
-        }));
+        configuration.setBroadcastValue(mediatorConfigurationSupport.processBroadcast(outgoingValue,
+                new Supplier<Integer>() {
+                    @Override public Integer get() {
+                        AnnotationInstance instance = methodInfo.annotation(BROADCAST);
+                        if (instance != null) {
+                            AnnotationValue value = instance.value();
+                            if (value == null) {
+                                return 0; // the default value of @Broadcast
+                            }
+                            return value.asInt();
+                        }
+                        return null;
+                    }
+                }));
 
         AnnotationInstance blockingAnnotation = methodInfo.annotation(BLOCKING);
         if (blockingAnnotation != null) {
@@ -192,7 +193,7 @@ final class QuarkusMediatorConfigurationUtil {
         return methodInfo.declaringClass() + "#" + methodInfo.name();
     }
 
-    private static class ReturnTypeGenericTypeAssignable extends JandexGenericTypeAssignable {
+    public static class ReturnTypeGenericTypeAssignable extends JandexGenericTypeAssignable {
 
         public ReturnTypeGenericTypeAssignable(MethodInfo method, ClassLoader classLoader) {
             super(method.returnType(), classLoader);
@@ -223,18 +224,68 @@ final class QuarkusMediatorConfigurationUtil {
                 return Result.InvalidIndex;
             }
         }
+
+        @Override
+        public java.lang.reflect.Type getType(int index) {
+            Type t = extract(type, index);
+            if (t != null) {
+                return load(t.name().toString(), classLoader);
+            }
+            return null;
+        }
+
+        private Type extract(Type type, int index) {
+            if (type.kind() != Type.Kind.PARAMETERIZED_TYPE) {
+                return null;
+            } else {
+                List<Type> arguments = type.asParameterizedType().arguments();
+                if (arguments.size() >= index + 1) {
+                    Type result = arguments.get(index);
+                    if (result.kind() == Type.Kind.WILDCARD_TYPE) {
+                        return null;
+                    }
+                    return result;
+                } else {
+                    return null;
+                }
+            }
+        }
+
+        @Override
+        public java.lang.reflect.Type getType(int index, int subIndex) {
+            Type generic = extract(type, index);
+            if (generic != null) {
+                Type t = extract(generic, subIndex);
+                if (t != null) {
+                    return load(t.name().toString(), classLoader);
+                }
+                return null;
+            } else {
+                return null;
+            }
+        }
     }
 
-    private static class AlwaysInvalidIndexGenericTypeAssignable
+    public static class AlwaysInvalidIndexGenericTypeAssignable
             implements MediatorConfigurationSupport.GenericTypeAssignable {
 
         @Override
         public Result check(Class<?> target, int index) {
             return Result.InvalidIndex;
         }
+
+        @Override
+        public java.lang.reflect.Type getType(int index) {
+            return null;
+        }
+
+        @Override
+        public java.lang.reflect.Type getType(int index, int subIndex) {
+            return null;
+        }
     }
 
-    private static class MethodParamGenericTypeAssignable extends JandexGenericTypeAssignable {
+    public static class MethodParamGenericTypeAssignable extends JandexGenericTypeAssignable {
 
         public MethodParamGenericTypeAssignable(MethodInfo method, int paramIndex, ClassLoader classLoader) {
             super(getGenericParameterType(method, paramIndex), classLoader);

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
@@ -5,6 +5,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.jandex.DotName;
 
+import io.smallrye.reactive.messaging.MutinyEmitter;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Channel;
@@ -21,6 +22,7 @@ public final class ReactiveMessagingDotNames {
     static final DotName CHANNEL = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Channel.class.getName());
     static final DotName LEGACY_CHANNEL = DotName.createSimple(Channel.class.getName());
     static final DotName EMITTER = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Emitter.class.getName());
+    static final DotName MUTINY_EMITTER = DotName.createSimple(MutinyEmitter.class.getName());
     static final DotName LEGACY_EMITTER = DotName.createSimple(Emitter.class.getName());
     static final DotName ON_OVERFLOW = DotName
             .createSimple(org.eclipse.microprofile.reactive.messaging.OnOverflow.class.getName());

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -3,11 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
@@ -168,18 +164,8 @@ public class SmallRyeReactiveMessagingProcessor {
 
         for (InjectionPointInfo injectionPoint : validationPhase.getContext()
                 .get(BuildExtension.Key.INJECTION_POINTS)) {
-
-            Optional<AnnotationInstance> broadcast = annotationStore.getAnnotations(injectionPoint.getTarget())
-                    .stream()
-                    .filter(ai -> ReactiveMessagingDotNames.BROADCAST.equals(ai.name()))
-                    .filter(ai -> {
-                        if (ai.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER && injectionPoint
-                                .isParam()) {
-                            return ai.target().asMethodParameter().position() == injectionPoint.getPosition();
-                        }
-                        return true;
-                    })
-                    .findAny();
+            Optional<AnnotationInstance> broadcast = getAnnotation(annotationStore, injectionPoint,
+                    ReactiveMessagingDotNames.BROADCAST);
 
             // New emitter from the spec.
             if (injectionPoint.getRequiredType().name().equals(
@@ -193,19 +179,10 @@ public class SmallRyeReactiveMessagingProcessor {
                                             .getTargetInfo()));
                 } else {
                     String channelName = instance.value().asString();
-                    Optional<AnnotationInstance> overflow = annotationStore.getAnnotations(injectionPoint.getTarget())
-                            .stream()
-                            .filter(ai -> ReactiveMessagingDotNames.ON_OVERFLOW
-                                    .equals(ai.name()))
-                            .filter(ai -> {
-                                if (ai.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER && injectionPoint
-                                        .isParam()) {
-                                    return ai.target().asMethodParameter().position() == injectionPoint.getPosition();
-                                }
-                                return true;
-                            })
-                            .findAny();
-                    createEmitter(emitters, injectionPoint, channelName, overflow, broadcast);
+                    Optional<AnnotationInstance> overflow = getAnnotation(annotationStore, injectionPoint,
+                            ReactiveMessagingDotNames.ON_OVERFLOW);
+                    createEmitter(emitters,
+                            injectionPoint, channelName, overflow, broadcast);
                 }
             }
 
@@ -221,23 +198,32 @@ public class SmallRyeReactiveMessagingProcessor {
                                             .getTargetInfo()));
                 } else {
                     String channelName = instance.value().asString();
-                    Optional<AnnotationInstance> overflow = annotationStore.getAnnotations(injectionPoint.getTarget())
-                            .stream()
-                            .filter(ai -> ReactiveMessagingDotNames.LEGACY_ON_OVERFLOW
-                                    .equals(ai.name()))
-                            .filter(ai -> {
-                                if (ai.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER && injectionPoint
-                                        .isParam()) {
-                                    return ai.target().asMethodParameter().position() == injectionPoint.getPosition();
-                                }
-                                return true;
-                            })
-                            .findAny();
+                    Optional<AnnotationInstance> overflow = getAnnotation(annotationStore, injectionPoint,
+                            ReactiveMessagingDotNames.LEGACY_ON_OVERFLOW);
 
                     createEmitter(emitters, injectionPoint, channelName, overflow, broadcast);
                 }
             }
         }
+    }
+
+    private Optional<AnnotationInstance> getAnnotation(AnnotationStore annotationStore, InjectionPointInfo injectionPoint,
+            DotName onOverflowAnnotation) {
+        Collection<AnnotationInstance> annotations = annotationStore.getAnnotations(injectionPoint.getTarget());
+        for (AnnotationInstance annotation : annotations) {
+            if (onOverflowAnnotation.equals(annotation.name())) {
+                // For method parameter we must check the position
+                if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER
+                        && injectionPoint.isParam()
+                        && annotation.target().asMethodParameter().position() == injectionPoint.getPosition()) {
+                    return Optional.of(annotation);
+                } else if (annotation.target().kind() != AnnotationTarget.Kind.METHOD_PARAMETER) {
+                    // For other kind, no need to check anything else
+                    return Optional.of(annotation);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
@@ -1,11 +1,16 @@
 package io.quarkus.smallrye.reactivemessaging;
 
-import io.quarkus.smallrye.reactivemessaging.deployment.QuarkusMediatorConfigurationUtil;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.reactive.messaging.MediatorConfiguration;
-import io.smallrye.reactive.messaging.MediatorConfigurationSupport;
-import io.smallrye.reactive.messaging.Shape;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -21,15 +26,12 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
-import javax.enterprise.inject.spi.DefinitionException;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
+import io.quarkus.smallrye.reactivemessaging.deployment.QuarkusMediatorConfigurationUtil;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.MediatorConfigurationSupport;
+import io.smallrye.reactive.messaging.Shape;
 
 @SuppressWarnings("ConstantConditions")
 public class MediatorConfigurationSupportTest {
@@ -41,7 +43,7 @@ public class MediatorConfigurationSupportTest {
     static void index() throws IOException {
         Indexer indexer = new Indexer();
         indexer.index(MediatorConfigurationSupportTest.class.getClassLoader().getResourceAsStream(
-                    "io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest$ClassContainingAllSortsOfMethods.class"));
+                "io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest$ClassContainingAllSortsOfMethods.class"));
         Index index = indexer.complete();
         classInfo = index
                 .getClassByName(DotName.createSimple(ClassContainingAllSortsOfMethods.class.getName()));
@@ -59,10 +61,8 @@ public class MediatorConfigurationSupportTest {
                         list.toArray(new Class[0]),
                         new QuarkusMediatorConfigurationUtil.ReturnTypeGenericTypeAssignable(m, classLoader),
                         m.parameters().size() == 0
-                                ?
-                                new QuarkusMediatorConfigurationUtil.AlwaysInvalidIndexGenericTypeAssignable()
-                                :
-                                new QuarkusMediatorConfigurationUtil.MethodParamGenericTypeAssignable(m, 0,
+                                ? new QuarkusMediatorConfigurationUtil.AlwaysInvalidIndexGenericTypeAssignable()
+                                : new QuarkusMediatorConfigurationUtil.MethodParamGenericTypeAssignable(m, 0,
                                         classLoader));
             }
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
@@ -1,0 +1,656 @@
+package io.quarkus.smallrye.reactivemessaging;
+
+import io.quarkus.smallrye.reactivemessaging.deployment.QuarkusMediatorConfigurationUtil;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.MediatorConfigurationSupport;
+import io.smallrye.reactive.messaging.Shape;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import javax.enterprise.inject.spi.DefinitionException;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+@SuppressWarnings("ConstantConditions")
+public class MediatorConfigurationSupportTest {
+
+    private static ClassInfo classInfo;
+    private static ClassLoader classLoader;
+
+    @BeforeAll
+    static void index() throws IOException {
+        Indexer indexer = new Indexer();
+        indexer.index(MediatorConfigurationSupportTest.class.getClassLoader().getResourceAsStream(
+                    "io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest$ClassContainingAllSortsOfMethods.class"));
+        Index index = indexer.complete();
+        classInfo = index
+                .getClassByName(DotName.createSimple(ClassContainingAllSortsOfMethods.class.getName()));
+        classLoader = ClassContainingAllSortsOfMethods.class.getClassLoader();
+    }
+
+    private MediatorConfigurationSupport create(String method) {
+        for (MethodInfo m : classInfo.methods()) {
+            if (m.name().equalsIgnoreCase(method)) {
+                List<? extends Class<?>> list = m.parameters().stream().map(t -> load(t.name().toString()))
+                        .collect(Collectors.toList());
+                return new MediatorConfigurationSupport(
+                        method,
+                        load(m.returnType().name().toString()),
+                        list.toArray(new Class[0]),
+                        new QuarkusMediatorConfigurationUtil.ReturnTypeGenericTypeAssignable(m, classLoader),
+                        m.parameters().size() == 0
+                                ?
+                                new QuarkusMediatorConfigurationUtil.AlwaysInvalidIndexGenericTypeAssignable()
+                                :
+                                new QuarkusMediatorConfigurationUtil.MethodParamGenericTypeAssignable(m, 0,
+                                        classLoader));
+            }
+        }
+        fail("Unable to find method " + method);
+        return null;
+    }
+
+    public Class<?> load(String className) {
+        try {
+            if (className.equalsIgnoreCase("void")) {
+                return void.class;
+            }
+            return Class.forName(className, false, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    public void testPublishers() {
+        MediatorConfigurationSupport support = create("publisherPublisherOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherMultiOfMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherPublisherOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherMultiOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherPublisherBuilderOfMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("publisherPublisherBuilderOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("publisherGeneratePayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateCompletionStagePayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateCompletionStageMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateUniPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateUniMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testSubscribers() {
+        MediatorConfigurationSupport support = create("subscriberSubscriberOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSubscriberOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSubscriberBuilderOfMessage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("subscriberSubscriberBuilderOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        assertThatThrownBy(() -> create("subscriberSinkOfMessage").validate(Shape.SUBSCRIBER, null))
+                .isInstanceOf(DefinitionException.class);
+
+        support = create("subscriberSinkOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfPayloadCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfMessageUni");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfPayloadUni");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfRawMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfWildcardMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testProcessors() {
+        MediatorConfigurationSupport support = create("processorProcessorOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessorOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessorBuilderOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorProcessorBuilderOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorPublisherOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorPublisherOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorPublisherBuilderOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorPublisherBuilderOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorProcessMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageCompletionStage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayloadCompletionStage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUni");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayloadUni");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUniRaw");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUniWildcard");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testStreamTransformers() {
+        MediatorConfigurationSupport support = create("transformerPublisherOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerMultiOfMessage");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerMultiOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherBuilderOfMessage");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("transformerPublisherBuilderOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("transformerPublisherOfMessageRaw");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherOfMessageWildcard");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        assertThatThrownBy(() -> create("transformerPublisherOfPayloadRaw").validate(Shape.STREAM_TRANSFORMER, null))
+                .isInstanceOf(DefinitionException.class);
+
+        support = create("transformerPublisherOfPayloadWildcard");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    static class ClassContainingAllSortsOfMethods {
+
+        // Publishers
+        Publisher<Message<Person>> publisherPublisherOfMessage() {
+            return null;
+        }
+
+        Multi<Message<Person>> publisherMultiOfMessage() {
+            return null;
+        }
+
+        Publisher<Person> publisherPublisherOfPayload() {
+            return null;
+        }
+
+        Multi<Person> publisherMultiOfPayload() {
+            return null;
+        }
+
+        PublisherBuilder<Message<Person>> publisherPublisherBuilderOfMessage() {
+            return null;
+        }
+
+        PublisherBuilder<Person> publisherPublisherBuilderOfPayload() {
+            return null;
+        }
+
+        Person publisherGeneratePayload() {
+            return null;
+        }
+
+        Message<Person> publisherGenerateMessage() {
+            return null;
+        }
+
+        CompletionStage<Person> publisherGenerateCompletionStagePayload() {
+            return null;
+        }
+
+        CompletionStage<Message<Person>> publisherGenerateCompletionStageMessage() {
+            return null;
+        }
+
+        Uni<Person> publisherGenerateUniPayload() {
+            return null;
+        }
+
+        Uni<Message<Person>> publisherGenerateUniMessage() {
+            return null;
+        }
+
+        // Subscribers
+        Subscriber<Message<Person>> subscriberSubscriberOfMessage() {
+            return null;
+        }
+
+        Subscriber<Person> subscriberSubscriberOfPayload() {
+            return null;
+        }
+
+        SubscriberBuilder<Message<Person>, Void> subscriberSubscriberBuilderOfMessage() {
+            return null;
+        }
+
+        SubscriberBuilder<Person, Void> subscriberSubscriberBuilderOfPayload() {
+            return null;
+        }
+
+        void subscriberSinkOfMessage(Message<Person> p) {
+            // Invalid
+        }
+
+        void subscriberSinkOfPayload(Person p) {
+
+        }
+
+        CompletionStage<Void> subscriberSinkOfMessageCompletionStage(Message<Person> p) {
+            return null;
+        }
+
+        CompletionStage<Void> subscriberSinkOfPayloadCompletionStage(Person p) {
+            return null;
+        }
+
+        Uni<Void> subscriberSinkOfMessageUni(Message<Person> p) {
+            return null;
+        }
+
+        Uni<Void> subscriberSinkOfPayloadUni(Person p) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        CompletionStage<Void> subscriberSinkOfRawMessageCompletionStage(Message p) {
+            return null;
+        }
+
+        CompletionStage<Void> subscriberSinkOfWildcardMessageCompletionStage(Message<?> p) {
+            return null;
+        }
+
+        // Processors
+
+        Processor<Message<String>, Message<Person>> processorProcessorOfMessage() {
+            return null;
+        }
+
+        Processor<String, Person> processorProcessorOfPayload() {
+            return null;
+        }
+
+        ProcessorBuilder<Message<String>, Message<Person>> processorProcessorBuilderOfMessage() {
+            return null;
+        }
+
+        ProcessorBuilder<String, Person> processorProcessorBuilderOfPayload() {
+            return null;
+        }
+
+        Publisher<Message<Person>> processorPublisherOfMessage(Message<String> in) {
+            return null;
+        }
+
+        Publisher<Person> processorPublisherOfPayload(String in) {
+            return null;
+        }
+
+        PublisherBuilder<Message<Person>> processorPublisherBuilderOfMessage(Message<String> in) {
+            return null;
+        }
+
+        PublisherBuilder<Person> processorPublisherBuilderOfPayload(String in) {
+            return null;
+        }
+
+        Message<String> processorProcessMessage(Message<Person> in) {
+            return null;
+        }
+
+        String processorProcessPayload(Person in) {
+            return null;
+        }
+
+        CompletionStage<Message<String>> processorProcessMessageCompletionStage(Message<Person> in) {
+            return null;
+        }
+
+        CompletionStage<String> processorProcessPayloadCompletionStage(Person in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUni(Message<Person> in) {
+            return null;
+        }
+
+        Uni<String> processorProcessPayloadUni(Person in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUniRaw(Message in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUniWildcard(Message<?> in) {
+            return null;
+        }
+
+        // Transformers
+
+        Publisher<Message<String>> transformerPublisherOfMessage(Publisher<Message<Person>> in) {
+            return null;
+        }
+
+        Multi<Message<String>> transformerMultiOfMessage(Multi<Message<Person>> in) {
+            return null;
+        }
+
+        PublisherBuilder<Message<String>> transformerPublisherBuilderOfMessage(PublisherBuilder<Message<Person>> in) {
+            return null;
+        }
+
+        Publisher<String> transformerPublisherOfPayload(Publisher<Person> in) {
+            return null;
+        }
+
+        Multi<String> transformerMultiOfPayload(Multi<Person> in) {
+            return null;
+        }
+
+        PublisherBuilder<String> transformerPublisherBuilderOfPayload(PublisherBuilder<Person> in) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        Publisher<Message<String>> transformerPublisherOfMessageRaw(Publisher<Message> in) {
+            return null;
+        }
+
+        Publisher<Message<String>> transformerPublisherOfMessageWildcard(Publisher<Message<?>> in) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        Publisher<String> transformerPublisherOfPayloadRaw(Publisher in) {
+            // invalid
+            return null;
+        }
+
+        Publisher<String> transformerPublisherOfPayloadWildcard(Publisher<?> in) {
+            return null;
+        }
+
+    }
+
+    static class Person {
+
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/ReactiveMessagingTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/ReactiveMessagingTest.java
@@ -12,6 +12,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.smallrye.reactivemessaging.channels.ChannelConsumer;
+import io.quarkus.smallrye.reactivemessaging.channels.EmitterExample;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ReactiveMessagingTest {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelConsumer.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelConsumer.java
@@ -1,17 +1,17 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.reactivex.Flowable;
-import io.smallrye.reactive.messaging.annotations.Channel;
 
 @ApplicationScoped
-public class DeprecatedChannelConsumer {
+public class ChannelConsumer {
 
     @Inject
     @Channel("source")

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflow.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflow.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -11,34 +11,27 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 
-import io.smallrye.reactive.messaging.annotations.Broadcast;
-
 @ApplicationScoped
-public class ChannelEmitterWithOverflowAndBroadcast {
+public class ChannelEmitterWithOverflow {
 
     @Inject
     @Channel("sink")
     @OnOverflow(value = OnOverflow.Strategy.BUFFER)
-    @Broadcast
     Emitter<String> emitter;
 
     private Emitter<String> emitterForSink2;
     private Emitter<String> emitterForSink1;
 
     @Inject
-    public void setEmitter(@Channel("sink-1") @Broadcast Emitter<String> sink1,
-            @Channel("sink-2") @Broadcast @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 4) Emitter<String> sink2) {
+    public void setEmitter(@Channel("sink-1") Emitter<String> sink1,
+            @Channel("sink-2") @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 4) Emitter<String> sink2) {
         this.emitterForSink1 = sink1;
         this.emitterForSink2 = sink2;
     }
 
-    private List<String> list = new CopyOnWriteArrayList<>();
-    private List<String> sink1 = new CopyOnWriteArrayList<>();
-    private List<String> sink2 = new CopyOnWriteArrayList<>();
-
-    private List<String> list2 = new CopyOnWriteArrayList<>();
-    private List<String> sink12 = new CopyOnWriteArrayList<>();
-    private List<String> sink22 = new CopyOnWriteArrayList<>();
+    private final List<String> list = new CopyOnWriteArrayList<>();
+    private final List<String> sink1 = new CopyOnWriteArrayList<>();
+    private final List<String> sink2 = new CopyOnWriteArrayList<>();
 
     public void run() {
         emitter.send("a");
@@ -56,57 +49,30 @@ public class ChannelEmitterWithOverflowAndBroadcast {
     }
 
     @Incoming("sink")
-    public void consume1(String s) {
+    public void consume(String s) {
         list.add(s);
     }
 
-    @Incoming("sink")
-    public void consume2(String s) {
-        list2.add(s);
-    }
-
     @Incoming("sink-1")
-    public void sink11(String s) {
+    public void consume1(String s) {
         sink1.add(s);
     }
 
-    @Incoming("sink-1")
-    public void sink12(String s) {
-        sink12.add(s);
-    }
-
     @Incoming("sink-2")
-    public void sink21(String s) {
+    public void consume2(String s) {
         sink2.add(s);
-    }
-
-    @Incoming("sink-2")
-    public void sink22(String s) {
-        sink22.add(s);
     }
 
     public List<String> list() {
         return list;
     }
 
-    public List<String> list2() {
-        return list2;
-    }
-
-    public List<String> sink11() {
+    public List<String> sink1() {
         return sink1;
     }
 
-    public List<String> sink12() {
-        return sink12;
-    }
-
-    public List<String> sink21() {
+    public List<String> sink2() {
         return sink2;
-    }
-
-    public List<String> sink22() {
-        return sink22;
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflowAndBroadcast.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/ChannelEmitterWithOverflowAndBroadcast.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -11,27 +11,34 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
 @ApplicationScoped
-public class ChannelEmitterWithOverflow {
+public class ChannelEmitterWithOverflowAndBroadcast {
 
     @Inject
     @Channel("sink")
     @OnOverflow(value = OnOverflow.Strategy.BUFFER)
+    @Broadcast
     Emitter<String> emitter;
 
     private Emitter<String> emitterForSink2;
     private Emitter<String> emitterForSink1;
 
     @Inject
-    public void setEmitter(@Channel("sink-1") Emitter<String> sink1,
-            @Channel("sink-2") @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 4) Emitter<String> sink2) {
+    public void setEmitter(@Channel("sink-1") @Broadcast Emitter<String> sink1,
+            @Channel("sink-2") @Broadcast @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 4) Emitter<String> sink2) {
         this.emitterForSink1 = sink1;
         this.emitterForSink2 = sink2;
     }
 
-    private List<String> list = new CopyOnWriteArrayList<>();
-    private List<String> sink1 = new CopyOnWriteArrayList<>();
-    private List<String> sink2 = new CopyOnWriteArrayList<>();
+    private final List<String> list = new CopyOnWriteArrayList<>();
+    private final List<String> sink1 = new CopyOnWriteArrayList<>();
+    private final List<String> sink2 = new CopyOnWriteArrayList<>();
+
+    private final List<String> list2 = new CopyOnWriteArrayList<>();
+    private final List<String> sink12 = new CopyOnWriteArrayList<>();
+    private final List<String> sink22 = new CopyOnWriteArrayList<>();
 
     public void run() {
         emitter.send("a");
@@ -49,30 +56,57 @@ public class ChannelEmitterWithOverflow {
     }
 
     @Incoming("sink")
-    public void consume(String s) {
+    public void consume1(String s) {
         list.add(s);
     }
 
+    @Incoming("sink")
+    public void consume2(String s) {
+        list2.add(s);
+    }
+
     @Incoming("sink-1")
-    public void consume1(String s) {
+    public void sink11(String s) {
         sink1.add(s);
     }
 
+    @Incoming("sink-1")
+    public void sink12(String s) {
+        sink12.add(s);
+    }
+
     @Incoming("sink-2")
-    public void consume2(String s) {
+    public void sink21(String s) {
         sink2.add(s);
+    }
+
+    @Incoming("sink-2")
+    public void sink22(String s) {
+        sink22.add(s);
     }
 
     public List<String> list() {
         return list;
     }
 
-    public List<String> sink1() {
+    public List<String> list2() {
+        return list2;
+    }
+
+    public List<String> sink11() {
         return sink1;
     }
 
-    public List<String> sink2() {
+    public List<String> sink12() {
+        return sink12;
+    }
+
+    public List<String> sink21() {
         return sink2;
+    }
+
+    public List<String> sink22() {
+        return sink22;
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedChannelConsumer.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedChannelConsumer.java
@@ -1,17 +1,17 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.reactivex.Flowable;
+import io.smallrye.reactive.messaging.annotations.Channel;
 
 @ApplicationScoped
-public class ChannelConsumer {
+public class DeprecatedChannelConsumer {
 
     @Inject
     @Channel("source")

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedEmitterExample.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedEmitterExample.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/DeprecatedInjectionTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,6 +11,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.smallrye.reactivemessaging.SimpleBean;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class DeprecatedInjectionTest {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterExample.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterExample.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -10,18 +10,14 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
-import io.smallrye.reactive.messaging.annotations.Broadcast;
-
 @ApplicationScoped
-public class EmitterWithBroadcastExample {
+public class EmitterExample {
 
     @Inject
     @Channel("sink")
-    @Broadcast
     Emitter<String> emitter;
 
-    private List<String> list = new CopyOnWriteArrayList<>();
-    private List<String> list2 = new CopyOnWriteArrayList<>();
+    private final List<String> list = new CopyOnWriteArrayList<>();
 
     public void run() {
         emitter.send("a");
@@ -35,17 +31,8 @@ public class EmitterWithBroadcastExample {
         list.add(s);
     }
 
-    @Incoming("sink")
-    public void consume2(String s) {
-        list2.add(s);
-    }
-
     public List<String> list() {
         return list;
-    }
-
-    public List<String> list2() {
-        return list2;
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastAndSubscriberExample.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastAndSubscriberExample.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastAndSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastAndSubscriberTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,15 +13,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class EmitterWithOverflowTest {
+public class EmitterWithBroadcastAndSubscriberTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(ChannelEmitterWithOverflow.class));
+                    .addClasses(EmitterWithBroadcastAndSubscriberExample.class));
 
     @Inject
-    ChannelEmitterWithOverflow bean;
+    EmitterWithBroadcastAndSubscriberExample bean;
 
     @Test
     public void testEmitter() {
@@ -32,17 +32,11 @@ public class EmitterWithOverflowTest {
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
 
-        List<String> sink1 = bean.sink1();
-        assertEquals(3, sink1.size());
-        assertEquals("a1", sink1.get(0));
-        assertEquals("b1", sink1.get(1));
-        assertEquals("c1", sink1.get(2));
-
-        List<String> sink2 = bean.sink2();
-        assertEquals(3, sink2.size());
-        assertEquals("a2", sink2.get(0));
-        assertEquals("b2", sink2.get(1));
-        assertEquals("c2", sink2.get(2));
+        List<String> list2 = bean.list2();
+        assertEquals(3, list2.size());
+        assertEquals("a", list2.get(0));
+        assertEquals("b", list2.get(1));
+        assertEquals("c", list2.get(2));
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastExample.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastExample.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -10,14 +10,18 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
 @ApplicationScoped
-public class EmitterExample {
+public class EmitterWithBroadcastExample {
 
     @Inject
     @Channel("sink")
+    @Broadcast
     Emitter<String> emitter;
 
     private List<String> list = new CopyOnWriteArrayList<>();
+    private List<String> list2 = new CopyOnWriteArrayList<>();
 
     public void run() {
         emitter.send("a");
@@ -31,8 +35,17 @@ public class EmitterExample {
         list.add(s);
     }
 
+    @Incoming("sink")
+    public void consume2(String s) {
+        list2.add(s);
+    }
+
     public List<String> list() {
         return list;
+    }
+
+    public List<String> list2() {
+        return list2;
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithBroadcastTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,15 +13,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class EmitterWithBroadcastAndSubscriberTest {
+public class EmitterWithBroadcastTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(EmitterWithBroadcastAndSubscriberExample.class));
+                    .addClasses(EmitterWithBroadcastExample.class));
 
     @Inject
-    EmitterWithBroadcastAndSubscriberExample bean;
+    EmitterWithBroadcastExample bean;
 
     @Test
     public void testEmitter() {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithOverflowAndBroadcastTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithOverflowAndBroadcastTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithOverflowTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/EmitterWithOverflowTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.reactivemessaging;
+package io.quarkus.smallrye.reactivemessaging.channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,15 +13,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class EmitterWithBroadcastTest {
+public class EmitterWithOverflowTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(EmitterWithBroadcastExample.class));
+                    .addClasses(ChannelEmitterWithOverflow.class));
 
     @Inject
-    EmitterWithBroadcastExample bean;
+    ChannelEmitterWithOverflow bean;
 
     @Test
     public void testEmitter() {
@@ -32,11 +32,17 @@ public class EmitterWithBroadcastTest {
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
 
-        List<String> list2 = bean.list2();
-        assertEquals(3, list2.size());
-        assertEquals("a", list2.get(0));
-        assertEquals("b", list2.get(1));
-        assertEquals("c", list2.get(2));
+        List<String> sink1 = bean.sink1();
+        assertEquals(3, sink1.size());
+        assertEquals("a1", sink1.get(0));
+        assertEquals("b1", sink1.get(1));
+        assertEquals("c1", sink1.get(2));
+
+        List<String> sink2 = bean.sink2();
+        assertEquals(3, sink2.size());
+        assertEquals("a2", sink2.get(0));
+        assertEquals("b2", sink2.get(1));
+        assertEquals("c2", sink2.get(2));
     }
 
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterTest.java
@@ -34,13 +34,11 @@ public class MutinyEmitterTest {
     public void testMutinyEmitter() {
         example.run();
         List<String> list = example.list();
-        assertEquals(6, list.size());
+        assertEquals(4, list.size());
         assertEquals("a", list.get(0));
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
         assertEquals("d", list.get(3));
-        assertEquals("e", list.get(4));
-        assertEquals("f", list.get(5));
     }
 
     @ApplicationScoped
@@ -59,9 +57,7 @@ public class MutinyEmitterTest {
             emitter.sendAndAwait("c");
 
             // Message
-            emitter.send(Message.of("d")).await().atMost(Duration.ofSeconds(1));
-            emitter.sendAndForget(Message.of("e"));
-            emitter.sendAndAwait(Message.of("f"));
+            emitter.send(Message.of("d"));
 
             emitter.complete();
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.smallrye.reactivemessaging.channels;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.smallrye.reactivemessaging.SimpleBean;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+public class MutinyEmitterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleBean.class, MutinyEmitterExample.class));
+
+    @Inject
+    MutinyEmitterExample example;
+
+    @Test
+    public void testMutinyEmitter() {
+        example.run();
+        List<String> list = example.list();
+        assertEquals(6, list.size());
+        assertEquals("a", list.get(0));
+        assertEquals("b", list.get(1));
+        assertEquals("c", list.get(2));
+        assertEquals("d", list.get(3));
+        assertEquals("e", list.get(4));
+        assertEquals("f", list.get(5));
+    }
+
+    @ApplicationScoped
+    public static class MutinyEmitterExample {
+
+        @Inject
+        @Channel("sink")
+        MutinyEmitter<String> emitter;
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        public void run() {
+            // Payloads
+            emitter.send("a").await().atMost(Duration.ofSeconds(1));
+            emitter.sendAndForget("b");
+            emitter.sendAndAwait("c");
+
+            // Message
+            emitter.send(Message.of("d")).await().atMost(Duration.ofSeconds(1));
+            emitter.sendAndForget(Message.of("e"));
+            emitter.sendAndAwait(Message.of("f"));
+
+            emitter.complete();
+        }
+
+        @Incoming("sink")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithConstructorInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithConstructorInjectionTest.java
@@ -19,16 +19,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.vertx.core.Vertx;
 
-public class MutinyEmitterTest {
+public class MutinyEmitterWithConstructorInjectionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(MutinyEmitterExample.class));
+                    .addClasses(MutinyEmitterExampleWithConstructorInjection.class));
 
     @Inject
-    MutinyEmitterExample example;
+    MutinyEmitterExampleWithConstructorInjection example;
 
     @Test
     public void testMutinyEmitter() {
@@ -44,11 +45,17 @@ public class MutinyEmitterTest {
     }
 
     @ApplicationScoped
-    public static class MutinyEmitterExample {
+    public static class MutinyEmitterExampleWithConstructorInjection {
 
-        @Inject
-        @Channel("sink")
         MutinyEmitter<String> emitter;
+
+        @SuppressWarnings("unused")
+        @Inject
+        public MutinyEmitterExampleWithConstructorInjection(
+                Vertx vertx, // Not used on purpose
+                @Channel("sink") MutinyEmitter<String> e) {
+            emitter = e;
+        }
 
         private final List<String> list = new CopyOnWriteArrayList<>();
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithConstructorInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithConstructorInjectionTest.java
@@ -35,13 +35,11 @@ public class MutinyEmitterWithConstructorInjectionTest {
     public void testMutinyEmitter() {
         example.run();
         List<String> list = example.list();
-        assertEquals(6, list.size());
+        assertEquals(4, list.size());
         assertEquals("a", list.get(0));
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
         assertEquals("d", list.get(3));
-        assertEquals("e", list.get(4));
-        assertEquals("f", list.get(5));
     }
 
     @ApplicationScoped
@@ -66,9 +64,7 @@ public class MutinyEmitterWithConstructorInjectionTest {
             emitter.sendAndAwait("c");
 
             // Message
-            emitter.send(Message.of("d")).await().atMost(Duration.ofSeconds(1));
-            emitter.sendAndForget(Message.of("e"));
-            emitter.sendAndAwait(Message.of("f"));
+            emitter.send(Message.of("d"));
 
             emitter.complete();
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithParameterInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithParameterInjectionTest.java
@@ -19,16 +19,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.vertx.core.Vertx;
 
-public class MutinyEmitterTest {
+public class MutinyEmitterWithParameterInjectionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(MutinyEmitterExample.class));
+                    .addClasses(MutinyEmitterExampleWithParameterInjection.class));
 
     @Inject
-    MutinyEmitterExample example;
+    MutinyEmitterExampleWithParameterInjection example;
 
     @Test
     public void testMutinyEmitter() {
@@ -44,11 +45,17 @@ public class MutinyEmitterTest {
     }
 
     @ApplicationScoped
-    public static class MutinyEmitterExample {
+    public static class MutinyEmitterExampleWithParameterInjection {
 
-        @Inject
-        @Channel("sink")
         MutinyEmitter<String> emitter;
+
+        @SuppressWarnings("unused")
+        @Inject
+        public void inject(
+                Vertx vertx, // Not used on purpose
+                @Channel("sink") MutinyEmitter<String> e) {
+            emitter = e;
+        }
 
         private final List<String> list = new CopyOnWriteArrayList<>();
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithParameterInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/channels/MutinyEmitterWithParameterInjectionTest.java
@@ -35,13 +35,11 @@ public class MutinyEmitterWithParameterInjectionTest {
     public void testMutinyEmitter() {
         example.run();
         List<String> list = example.list();
-        assertEquals(6, list.size());
+        assertEquals(4, list.size());
         assertEquals("a", list.get(0));
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
         assertEquals("d", list.get(3));
-        assertEquals("e", list.get(4));
-        assertEquals("f", list.get(5));
     }
 
     @ApplicationScoped
@@ -66,9 +64,7 @@ public class MutinyEmitterWithParameterInjectionTest {
             emitter.sendAndAwait("c");
 
             // Message
-            emitter.send(Message.of("d")).await().atMost(Duration.ofSeconds(1));
-            emitter.sendAndForget(Message.of("e"));
-            emitter.sendAndAwait(Message.of("f"));
+            emitter.send(Message.of("d"));
 
             emitter.complete();
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/converters/ConverterTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/converters/ConverterTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.smallrye.reactivemessaging.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MessageConverter;
+
+public class ConverterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Person.class, MyAppUsingConverter.class, MyPersonConverter.class));
+
+    @Inject
+    MyAppUsingConverter app;
+
+    @Test
+    public void testConverter() {
+        assertThat(app.list()).hasSize(4);
+        assertThat(app.list().stream().map(new Function<Person, String>() {
+            @Override
+            public String apply(Person p) {
+                return p.name;
+            }
+        }).collect(Collectors.toList()))
+                .containsExactly("john", "paul", "ringo", "george");
+    }
+
+    public static class Person {
+        public final String name;
+
+        public Person(String name) {
+            this.name = name;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyAppUsingConverter {
+        List<Person> list = new ArrayList<>();
+
+        @Outgoing("people")
+        public Multi<String> getPeople() {
+            return Multi.createFrom().items("john", "paul", "ringo", "george");
+        }
+
+        @Incoming("people")
+        public void consume(Person p) {
+            list.add(p);
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyPersonConverter implements MessageConverter {
+
+        @Override
+        public boolean canConvert(Message<?> in, Type target) {
+            return target.equals(Person.class) && in.getPayload().getClass().equals(String.class);
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new Person((String) in.getPayload()));
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
@@ -202,7 +202,7 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
         return ingestedPayload;
     }
 
-    public void setIngestedPayload(Type ingestedPayload) {
+    public void setIngestedPayloadType(Type ingestedPayload) {
         this.ingestedPayload = ingestedPayload;
     }
 

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +50,8 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
     private boolean blockingExecutionOrdered;
 
     private String workerPoolName;
+
+    private Type ingestedPayload;
 
     public String getBeanId() {
         return beanId;
@@ -192,6 +195,15 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
     @Override
     public Class<? extends Invoker> getInvokerClass() {
         return invokerClass;
+    }
+
+    @Override
+    public Type getIngestedPayloadType() {
+        return ingestedPayload;
+    }
+
+    public void setIngestedPayload(Type ingestedPayload) {
+        this.ingestedPayload = ingestedPayload;
     }
 
     public void setInvokerClass(Class<? extends Invoker> invokerClass) {


### PR DESCRIPTION
This PR updates SmallRye Reactive Messaging to version 2.4.0.

Noteworthy changes:

* Core
  - Health checks improvements
  - Message converter support to transform messages on the fly
  - Mutiny emitter (#11572)

* Kafka
  - New Kafka `Record` payload type to simplify the reception and sending of key/value pair
  - Disable auto commit by default
  - New commit strategy (auto-commit, latest, throttled)
  - Cloud Event support
  - Tracing support with Open Telemetry (#9449)

* AMQP
  - AMQP TTL fix

Full release note: https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/2.4.0


- Fixes #11572
- Fixes #12454
- Fixes #10265