### PR TITLE
Missing publish option in kms docker + specify version of localhost i…

### DIFF
--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -41,7 +41,7 @@ The easiest way to start working with KMS is to run a local instance as a contai
 
 [source,shell,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-kms 8011:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-kms --publish 8011:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:0.11.1
 ----
 This starts a KMS instance that is accessible on port `8011`.
 

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -39,7 +39,7 @@ The easiest way to start working with S3 is to run a local instance as a contain
 
 [source,shell,subs="verbatim,attributes"]
 ----
-docker run -it --publish 8008:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack
+docker run -it --publish 8008:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:0.11.5
 ----
 This starts a S3 instance that is accessible on port `8008`.
 


### PR DESCRIPTION
Small fixes to the guides
- KMS guide had missing `--publish` when starting localhost docker
- Set localhost image tag to the latest version to avoid further issues with incompatibilities.