### PR TITLE
Workaround MongoDB JsonReader NPE with different locale to EN

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -320,4 +320,17 @@ public class MongoClientProcessor {
         return new HealthBuildItem("io.quarkus.mongodb.health.MongoHealthCheck",
                 buildTimeConfig.healthEnabled);
     }
+
+    @BuildStep
+    List<ReflectiveClassBuildItem> addJsonClasses() {
+        List<String> reflectiveClassNames = new ArrayList<>();
+        reflectiveClassNames.add("org.bson.json.JsonTokenType");
+        reflectiveClassNames.add("org.bson.json.JsonToken");
+        reflectiveClassNames.add("org.bson.json.JsonReader");
+
+        // TODO temporary so no rush to fine tune constructors, methods and fields to add
+        return reflectiveClassNames.stream()
+                .map(s -> new ReflectiveClassBuildItem(true, true, true, s))
+                .collect(Collectors.toList());
+    }
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/BsonSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/BsonSubstitutions.java
@@ -1,0 +1,77 @@
+package io.quarkus.mongodb.runtime.graal;
+
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.bson.json.JsonParseException;
+import org.bson.json.JsonReader;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.arc.impl.Reflections;
+
+public final class BsonSubstitutions {
+}
+
+@TargetClass(JsonReader.class)
+final class JsonReaderSubstitution {
+    @Substitute
+    private long visitISODateTimeConstructor() {
+        final Class<?> jsonTokenTypeClass = classForName("org.bson.json.JsonTokenType");
+        Reflections.invokeMethod(JsonReader.class, "verifyToken", new Class<?>[] {}, this,
+                new Object[] { Reflections.getEnumConstant("LEFT_PAREN", jsonTokenTypeClass) });
+        // verifyToken(JsonTokenType.LEFT_PAREN);
+
+        Object token = Reflections.invokeMethod(JsonReader.class, "popToken", new Class<?>[] {}, this, new Object[] {});
+        // JsonToken token = popToken();
+        final Class<?> jsonTokenClass = classForName("org.bson.json.JsonToken");
+        Object tokenType = Reflections.invokeMethod(jsonTokenClass, "getType", new Class<?>[] {}, token, new Object[] {});
+        if (tokenType == Reflections.getEnumConstant("RIGHT_PAREN", jsonTokenTypeClass)) {
+            return new Date().getTime();
+        } else if (tokenType != Reflections.getEnumConstant("String", jsonTokenTypeClass)) {
+            throw new JsonParseException("JSON reader expected a string but found '%s'.",
+                    Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] {}, token, new Object[] {}));
+            // throw new JsonParseException("JSON reader expected a string but found '%s'.", token.getValue());
+        }
+
+        Reflections.invokeMethod(JsonReader.class, "verifyToken", new Class<?>[] {}, this,
+                new Object[] { Reflections.getEnumConstant("RIGHT_PAREN", jsonTokenTypeClass) });
+        // verifyToken(JsonTokenType.RIGHT_PAREN);
+        String[] patterns = { "yyyy-MM-dd", "yyyy-MM-dd'T'HH:mm:ssz", "yyyy-MM-dd'T'HH:mm:ss.SSSz" };
+
+        SimpleDateFormat format = new SimpleDateFormat(patterns[0], Locale.ENGLISH);
+        ParsePosition pos = new ParsePosition(0);
+        String s = (String) Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] { Class.class }, token,
+                new Object[] { String.class });
+        // String s = token.getValue(String.class);
+
+        if (s.endsWith("Z")) {
+            s = s.substring(0, s.length() - 1) + "GMT-00:00";
+        }
+
+        for (final String pattern : patterns) {
+            format.applyPattern(pattern);
+            format.setLenient(true);
+            pos.setIndex(0);
+
+            Date date = format.parse(s, pos);
+
+            // Substitution: skip checking length, return as soon as a date is available
+            if (date != null) {
+                return date.getTime();
+            }
+        }
+        throw new JsonParseException("Invalid date format.");
+    }
+
+    private Class<?> classForName(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/BsonSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/BsonSubstitutions.java
@@ -20,32 +20,26 @@ public final class BsonSubstitutions {
 final class JsonReaderSubstitution {
     @Substitute
     private long visitISODateTimeConstructor() {
-        final Class<?> jsonTokenTypeClass = classForName("org.bson.json.JsonTokenType");
-        Reflections.invokeMethod(JsonReader.class, "verifyToken", new Class<?>[] {}, this,
-                new Object[] { Reflections.getEnumConstant("LEFT_PAREN", jsonTokenTypeClass) });
+        Util.jsonReaderVerifyToken("LEFT_PAREN", this);
         // verifyToken(JsonTokenType.LEFT_PAREN);
 
-        Object token = Reflections.invokeMethod(JsonReader.class, "popToken", new Class<?>[] {}, this, new Object[] {});
+        Object token = Util.jsonReaderPopToken(this);
         // JsonToken token = popToken();
-        final Class<?> jsonTokenClass = classForName("org.bson.json.JsonToken");
-        Object tokenType = Reflections.invokeMethod(jsonTokenClass, "getType", new Class<?>[] {}, token, new Object[] {});
-        if (tokenType == Reflections.getEnumConstant("RIGHT_PAREN", jsonTokenTypeClass)) {
+        Object tokenType = Util.jsonTokenGetType(token);
+        if (tokenType == Util.jsonTokenType("RIGHT_PAREN")) {
             return new Date().getTime();
-        } else if (tokenType != Reflections.getEnumConstant("String", jsonTokenTypeClass)) {
-            throw new JsonParseException("JSON reader expected a string but found '%s'.",
-                    Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] {}, token, new Object[] {}));
+        } else if (tokenType != Util.jsonTokenType("STRING")) {
+            throw new JsonParseException("JSON reader expected a string but found '%s'.", Util.jsonTokenGetValue(token));
             // throw new JsonParseException("JSON reader expected a string but found '%s'.", token.getValue());
         }
 
-        Reflections.invokeMethod(JsonReader.class, "verifyToken", new Class<?>[] {}, this,
-                new Object[] { Reflections.getEnumConstant("RIGHT_PAREN", jsonTokenTypeClass) });
+        Util.jsonReaderVerifyToken("RIGHT_PAREN", this);
         // verifyToken(JsonTokenType.RIGHT_PAREN);
         String[] patterns = { "yyyy-MM-dd", "yyyy-MM-dd'T'HH:mm:ssz", "yyyy-MM-dd'T'HH:mm:ss.SSSz" };
 
         SimpleDateFormat format = new SimpleDateFormat(patterns[0], Locale.ENGLISH);
         ParsePosition pos = new ParsePosition(0);
-        String s = (String) Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] { Class.class }, token,
-                new Object[] { String.class });
+        String s = Util.jsonTokenGetValueString(token);
         // String s = token.getValue(String.class);
 
         if (s.endsWith("Z")) {
@@ -67,11 +61,46 @@ final class JsonReaderSubstitution {
         throw new JsonParseException("Invalid date format.");
     }
 
-    private Class<?> classForName(String className) {
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
+    // Holder class to keep helper methods (they cannot be added directly to the substituted class)
+    private static class Util {
+        static String jsonTokenGetValueString(Object token) {
+            final Class<?> jsonTokenClass = Util.classForName("org.bson.json.JsonToken");
+            return (String) Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] { Class.class }, token,
+                    new Object[] { String.class });
+        }
+
+        static Object jsonTokenGetValue(Object token) {
+            final Class<?> jsonTokenClass = Util.classForName("org.bson.json.JsonToken");
+            return Reflections.invokeMethod(jsonTokenClass, "getValue", new Class<?>[] {}, token, new Object[] {});
+        }
+
+        static Object jsonTokenGetType(Object token) {
+            final Class<?> jsonTokenClass = Util.classForName("org.bson.json.JsonToken");
+            return Reflections.invokeMethod(jsonTokenClass, "getType", new Class<?>[] {}, token, new Object[] {});
+        }
+
+        static Object jsonReaderPopToken(Object reader) {
+            return Reflections.invokeMethod(JsonReader.class, "popToken", new Class<?>[] {}, reader, new Object[] {});
+        }
+
+        static Object jsonTokenType(String name) {
+            final Class<?> jsonTokenTypeClass = Util.classForName("org.bson.json.JsonTokenType");
+            return Reflections.getEnumConstant(name, jsonTokenTypeClass);
+        }
+
+        static void jsonReaderVerifyToken(String tokenName, Object reader) {
+            final Class<?> jsonTokenTypeClass = Util.classForName("org.bson.json.JsonTokenType");
+            Reflections.invokeMethod(JsonReader.class, "verifyToken", new Class<?>[] { jsonTokenTypeClass }, reader,
+                    new Object[] { Reflections.getEnumConstant(tokenName, jsonTokenTypeClass) });
+        }
+
+        static Class<?> classForName(String className) {
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
+
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
@@ -15,8 +15,10 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Neither the class nor its methods are considered a public API and should only be used internally.
@@ -174,6 +176,18 @@ public final class Reflections {
         } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
             throw new RuntimeException("Cannot invoke method: " + clazz.getName() + "#" + name + " on " + instance, e);
         }
+    }
+
+    public static <T> T getEnumConstant(String name, Class<T> clazz) {
+        Optional<T> found = Stream.of(clazz.getEnumConstants())
+                .filter(e -> name.equals(e.toString()))
+                .findFirst();
+
+        if (found.isPresent())
+            return found.get();
+
+        throw new RuntimeException(String.format(
+                "Enum value '%s' not found in %s", name, clazz));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Added a substitution that returns a date as soon as it's found, which avoids the NPE.

Closes https://github.com/quarkusio/quarkus/issues/11524.