### PR TITLE
Update SmallRye GraphQL to 1.0.12

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -38,7 +38,7 @@
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.4</smallrye-metrics.version>
         <smallrye-open-api.version>2.0.10</smallrye-open-api.version>
-        <smallrye-graphql.version>1.0.11</smallrye-graphql.version>
+        <smallrye-graphql.version>1.0.12</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.3.0</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.graphql.deployment;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 
 @ConfigRoot(name = "smallrye-graphql")
 public class SmallRyeGraphQLConfig {
@@ -18,6 +19,12 @@ public class SmallRyeGraphQLConfig {
      */
     @ConfigItem(name = "metrics.enabled", defaultValue = "false")
     boolean metricsEnabled;
+
+    /**
+     * Change the type naming strategy.
+     */
+    @ConfigItem(defaultValue = "Default")
+    TypeAutoNameStrategy autoNameStrategy;
 
     /**
      * UI configuration

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -69,6 +69,7 @@ import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.Field;
+import io.smallrye.graphql.schema.model.Group;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.schema.model.InterfaceType;
 import io.smallrye.graphql.schema.model.Operation;
@@ -155,7 +156,8 @@ public class SmallRyeGraphQLProcessor {
             CombinedIndexBuildItem combinedIndex) {
 
         IndexView index = combinedIndex.getIndex();
-        Schema schema = SchemaBuilder.build(index);
+
+        Schema schema = SchemaBuilder.build(index, quarkusConfig.autoNameStrategy);
 
         recorder.createExecutionService(beanContainer.getValue(), schema);
 
@@ -251,7 +253,9 @@ public class SmallRyeGraphQLProcessor {
         Set<String> classes = new HashSet<>();
 
         classes.addAll(getOperationClassNames(schema.getQueries()));
+        classes.addAll(getOperationClassNames(schema.getGroupedQueries()));
         classes.addAll(getOperationClassNames(schema.getMutations()));
+        classes.addAll(getOperationClassNames(schema.getGroupedMutations()));
         classes.addAll(getTypeClassNames(schema.getTypes().values()));
         classes.addAll(getInputClassNames(schema.getInputs().values()));
         classes.addAll(getInterfaceClassNames(schema.getInterfaces().values()));
@@ -289,6 +293,15 @@ public class SmallRyeGraphQLProcessor {
                 classes.addAll(getAllReferenceClasses(argument.getReference()));
             }
             classes.addAll(getAllReferenceClasses(operation.getReference()));
+        }
+        return classes;
+    }
+
+    private Set<String> getOperationClassNames(Map<Group, Set<Operation>> groupedOperations) {
+        Set<String> classes = new HashSet<>();
+        Collection<Set<Operation>> operations = groupedOperations.values();
+        for (Set<Operation> operationSet : operations) {
+            classes.addAll(getOperationClassNames(operationSet));
         }
         return classes;
     }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
@@ -2,6 +2,7 @@ package io.quarkus.smallrye.graphql.deployment;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.Properties;
 
 import javax.json.Json;
@@ -61,8 +62,15 @@ public abstract class AbstractGraphQLTest {
     }
 
     protected static String getPropertyAsString() {
+        return getPropertyAsString(null);
+    }
+
+    protected static String getPropertyAsString(Map<String, String> otherProperties) {
         try {
             StringWriter writer = new StringWriter();
+            if (otherProperties != null) {
+                PROPERTIES.putAll(otherProperties);
+            }
             PROPERTIES.store(writer, "Test Properties");
             return writer.toString();
         } catch (IOException ex) {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/Book.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/Book.java
@@ -1,0 +1,23 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+public class Book {
+    public String isbn;
+    public String title;
+    public LocalDate published;
+    public List<String> authors;
+
+    public Book() {
+    }
+
+    public Book(String isbn, String title, LocalDate published, String... authors) {
+        this.isbn = isbn;
+        this.title = title;
+        this.published = published;
+        this.authors = Arrays.asList(authors);
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/BookGraphQLApi.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/BookGraphQLApi.java
@@ -1,0 +1,45 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+@Name("books")
+@Description("Allow all book releated APIs")
+public class BookGraphQLApi {
+
+    @Query
+    public List<Book> getAllBooks() {
+        return new ArrayList<>(BOOKS.values());
+    }
+
+    @Query
+    public Book getBook(String name) {
+        return BOOKS.get(name);
+    }
+
+    @Mutation
+    public Book addBook(Book book) {
+        BOOKS.put(book.title, book);
+        return book;
+    }
+
+    private static Map<String, Book> BOOKS = new HashMap<>();
+    static {
+        Book book1 = new Book("0-571-05686-5", "Lord of the Flies", LocalDate.of(1954, Month.SEPTEMBER, 17), "William Golding");
+        BOOKS.put(book1.title, book1);
+
+        Book book2 = new Book("0-582-53008-3", "Animal Farm", LocalDate.of(1945, Month.AUGUST, 17), "George Orwell");
+        BOOKS.put(book2.title, book2);
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLGroupedTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLGroupedTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Basic tests for Grouping.
+ */
+public class GraphQLGroupedTest extends AbstractGraphQLTest {
+
+    private static final Logger LOG = Logger.getLogger(GraphQLGroupedTest.class);
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BookGraphQLApi.class, Book.class)
+                    .addAsResource(new StringAsset(getPropertyAsString()), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testSourcePost() {
+        String booksRequest = getPayload("{\n" +
+                "  books{\n" +
+                "    book(name:\"Lord of the Flies\"){\n" +
+                "      title\n" +
+                "      authors\n" +
+                "      published\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(booksRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("Lord of the Flies"));
+
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLNamingTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLNamingTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+/**
+ * Basic tests. POST
+ */
+public class GraphQLNamingTest extends AbstractGraphQLTest {
+
+    private static final Logger LOG = Logger.getLogger(GraphQLNamingTest.class);
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestResource.class, TestPojo.class, TestRandom.class, TestGenericsPojo.class)
+                    .addAsResource(new StringAsset(getPropertyAsString(configuration())), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testSchema() {
+        RequestSpecification request = RestAssured.given();
+        request.accept(MEDIATYPE_TEXT);
+        request.contentType(MEDIATYPE_TEXT);
+        Response response = request.get("/graphql/schema.graphql");
+        String body = response.body().asString();
+        LOG.error(body);
+
+        Assertions.assertEquals(200, response.statusCode());
+        Assertions.assertTrue(body.contains("\"Query root\""));
+        Assertions.assertTrue(body.contains("type Query {"));
+        Assertions.assertTrue(body.contains("ping: TestPojo"));
+        Assertions.assertTrue(body.contains("generics: TestGenericsPojo_String"));
+        Assertions.assertTrue(body.contains("type TestGenericsPojo_String {"));
+        Assertions.assertTrue(body.contains("enum SomeEnum {"));
+        Assertions.assertTrue(body.contains("enum TestPojoNumber {")); // This is the important part. TestPojo merged with Number
+    }
+
+    private static Map<String, String> configuration() {
+        Map<String, String> m = new HashMap<>();
+        m.put("quarkus.smallrye-graphql.auto-name-strategy", "MergeInnerClass");
+        return m;
+
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
@@ -47,6 +47,7 @@ public class GraphQLTest extends AbstractGraphQLTest {
         Assertions.assertTrue(body.contains("generics: TestGenericsPojo_String"));
         Assertions.assertTrue(body.contains("type TestGenericsPojo_String {"));
         Assertions.assertTrue(body.contains("enum SomeEnum {"));
+        Assertions.assertTrue(body.contains("enum Number {"));
     }
 
     @Test

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestPojo.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestPojo.java
@@ -10,6 +10,8 @@ public class TestPojo {
     private String message;
     private List<String> list = Arrays.asList("a", "b", "c");
 
+    private Number number;
+
     public TestPojo() {
         super();
     }
@@ -35,9 +37,22 @@ public class TestPojo {
         this.list = list;
     }
 
-    @Override
-    public String toString() {
-        return "TestPojo{" + "message=" + message + ", list=" + list + '}';
+    public Number getNumber() {
+        return number;
     }
 
+    public void setNumber(Number number) {
+        this.number = number;
+    }
+
+    @Override
+    public String toString() {
+        return "TestPojo{" + "message=" + message + ", list=" + list + ", number=" + number + '}';
+    }
+
+    enum Number {
+        ONE,
+        TWO,
+        THREE
+    }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -9,6 +9,7 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.smallrye.graphql.runtime.spi.QuarkusClassloadingService;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.graphql.cdi.config.GraphQLConfig;
 import io.smallrye.graphql.cdi.producer.GraphQLProducer;
 import io.smallrye.graphql.schema.model.Schema;
 import io.vertx.core.Handler;
@@ -21,7 +22,8 @@ public class SmallRyeGraphQLRecorder {
 
     public void createExecutionService(BeanContainer beanContainer, Schema schema) {
         GraphQLProducer graphQLProducer = beanContainer.instance(GraphQLProducer.class);
-        graphQLProducer.initialize(schema);
+        GraphQLConfig graphQLConfig = beanContainer.instance(GraphQLConfig.class);
+        graphQLProducer.initialize(schema, graphQLConfig);
     }
 
     public Handler<RoutingContext> executionHandler(boolean allowGet) {


### PR DESCRIPTION
This PR upgrades SmallRye GraphQL to 1.0.12.

The following is included:

- Fix #12452 - Native image problem with ValidationService (@jefrajames)
- Fix #12402 - Added naming strategies for types (@miador)
- Fix #12302 - Allow grouping of top-level endpoint with `@Name` (@mejlholm)
- Better support for generics (@velias)

Also see https://github.com/smallrye/smallrye-graphql/releases/tag/1.0.12

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>