### PR TITLE
Add Freemarker extension

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -523,7 +523,7 @@ jobs:
               virtual-http
               rest-client
           - category: Misc1
-            timeout: 65
+            timeout: 70
             test-modules: >
               maven
               jackson
@@ -533,6 +533,7 @@ jobs:
               quartz
               qute
               consul-config
+              freemarker
           - category: Misc2
             timeout: 65
             test-modules: >

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -206,6 +206,7 @@
         <log4j2-jboss-logmanager.version>1.0.0.Beta1</log4j2-jboss-logmanager.version>
         <log4j-jboss-logmanager.version>1.2.0.Final</log4j-jboss-logmanager.version>
         <avro.version>1.10.0</avro.version>
+        <freemarker.version>2.3.30</freemarker.version>
     </properties>
 
     <dependencyManagement>
@@ -2048,6 +2049,16 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-qute-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-freemarker</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-freemarker-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/docs/src/main/asciidoc/freemarker.adoc
+++ b/docs/src/main/asciidoc/freemarker.adoc
@@ -1,0 +1,171 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Freemarker Templating Engine
+:extension-status: preview
+
+include::./attributes.adoc[]
+
+Freemarker is a very popular and mature templating engine. Its integration as a Quarkus extension
+provides developers ease of configuration, and offers support for native images.
+In this guide, you will learn how to easily render Freemarker templates in your application.
+
+include::./status-include.adoc[]
+
+== Hello World
+
+If you want to use Freemarker you need to add the `quarkus-freemarker` extension first.
+In your `pom.xml` file, add:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-freemarker</artifactId>
+</dependency>
+----
+
+We'll start with a very simple template:
+
+.hello.ftl
+[source]
+----
+Hello ${name}! <1>
+----
+<1> `${name}` is a value expression that is evaluated when the template is rendered.
+
+Now let's inject the template in the resource class.
+
+.HelloResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import freemarker.template.Template;
+import io.quarkus.freemarker.runtime.TemplatePath;
+
+@Path("hello")
+public class HelloResource {
+
+    @Inject
+    @TemplatePath("hello.ftl") <1>
+    Template hello;
+
+    @GET
+    @Produces(TEXT_PLAIN)
+    public String hello(@QueryParam("name") String name) throws IOException, TemplateException {
+        StringWriter stringWriter = new StringWriter();
+        hello.process(Map.of("name", name), stringWriter); <2>
+        return stringWriter.toString();
+    }
+}
+----
+<1> The `@TemplatePath` qualifier specifies the template name, found in either jar resource paths or external file paths.
+<2> `Map.of("name", name)` provides the model.
+
+If your application is running, you can request the endpoint:
+
+[source, shell]
+----
+$ curl -w "\n" http://localhost:8080/hello?name=bob
+Hello bob!
+----
+
+== Usage
+
+The application code can either directly inject a Freemarker `Template` bean as we saw above.
+In that case it must provide a `TemplatePath` qualifier annotation with the name
+of the template to select.
+
+Or it can inject a Freemarker `Configuration` bean, from which templates
+can be obtained programmatically. The `Configuration` is a `Singleton`
+`DefaultBean` that can be replaced by an application provided implementation.
+
+The default `Configuration` bean is configured from quarkus exposed
+properties. Among those, 2 are build time:
+
+ - `resource-paths` is a list of resource paths contained in the classpath (e.g.
+typically in jars of the application). Each path is traversed recursively, and
+all files get added as native resources when building a native image.
+ - `directive` is a map of _directive alias_ to _directive class name_. Each directive
+class is added as a shared variable in the `Configuration` bean.
+
+Here is an example of using a `Configuration` bean instead of a `Template` bean:
+[source,java]
+----
+    @Inject
+    Configuration configuration;
+
+    @GET
+    @Produces(TEXT_PLAIN)
+    public String hello(@QueryParam("name") String name) throws IOException, TemplateException {
+        StringWriter stringWriter = new StringWriter();
+        configuration.getTemplate(ftl).process(model, stringWriter);
+        return stringWriter.toString();
+    }
+----
+
+The rest of the configuration properties can be provided at runtime, such as
+a list of external filesystem paths where to find additional templates,
+and optional properties that can be configured on the Freemarker `Configuration` class.
+
+== Directives
+
+Freemarker can be extended using custom directives. For instance if we wanted
+to transform some text in `base64`, we could write:
+
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+public class Base64Directive implements TemplateDirectiveModel {
+    @Override
+    public void execute(Environment environment, Map map, TemplateModel[] templateModels, TemplateDirectiveBody body)
+            throws TemplateException, IOException {
+        StringWriter sw = new StringWriter();
+        body.render(sw);
+        byte[] bytes = Base64.getEncoder().encode(sw.toString().getBytes(UTF_8));
+        environment.getOut().write(new String(bytes, UTF_8));
+    }
+}
+----
+
+Then we would have to configure the application with:
+[source,properties]
+----
+quarkus.freemarker.directive.base64=org.acme.quarkus.sample.Base64Directive
+----
+
+And finally, we would use it in templates such as:
+[source]
+----
+Hello <@base64>${name}</@base64>!
+----
+
+This would be rendered as:
+[source]
+----
+Hello Ym9i!
+----
+
+== Data model
+
+Freemarker supports `Map` or `Object` based data models.
+When using objects, it is important to configure
+`quarkus.freemarker.object-wrapper-expose-fields=true` if model classes
+do not have getters.
+
+Additionnaly, they should be annotated with
+`@RegisterForReflection` to support native images.
+
+[[freemarker-configuration-reference]]
+== Freemarker Configuration Reference
+
+include::{generated-dir}/config/quarkus-freemarker.adoc[leveloffset=+1, opts=optional]

--- a/extensions/freemarker/deployment/pom.xml
+++ b/extensions/freemarker/deployment/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-freemarker-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-freemarker-deployment</artifactId>
+    <name>Quarkus - Freemarker - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-freemarker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/freemarker/deployment/src/main/java/io/quarkus/freemarker/FreemarkerProcessor.java
+++ b/extensions/freemarker/deployment/src/main/java/io/quarkus/freemarker/FreemarkerProcessor.java
@@ -1,0 +1,160 @@
+package io.quarkus.freemarker;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.jboss.logging.Logger;
+
+import freemarker.ext.jython.JythonModel;
+import freemarker.ext.jython.JythonWrapper;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.freemarker.runtime.FreemarkerBuildConfig;
+import io.quarkus.freemarker.runtime.FreemarkerConfigurationProducer;
+import io.quarkus.freemarker.runtime.FreemarkerTemplateProducer;
+import io.quarkus.freemarker.runtime.TemplatePath;
+
+public class FreemarkerProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(FreemarkerProcessor.class);
+
+    private static final String FEATURE = "freemarker";
+
+    private static final String CLASSPATH_PROTOCOL = "classpath";
+
+    private static final String JAR_PROTOCOL = "jar";
+
+    private static final String FILE_PROTOCOL = "file";
+
+    private static final String ADD_MSG = "Adding application freemarker templates in path ''{0}'' using protocol ''{1}''";
+
+    private static final String UNSUPPORTED_MSG = "Unsupported URL protocol ''{0}'' for path ''{1}''. Freemarker files will not be discovered.";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void runtimeInit(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitialized) {
+
+        Stream.of(JythonWrapper.class, JythonModel.class)
+                .map(Class::getCanonicalName)
+                .map(RuntimeInitializedClassBuildItem::new)
+                .forEach(runtimeInitialized::produce);
+    }
+
+    @BuildStep
+    void discoverTemplates(BuildProducer<NativeImageResourceBuildItem> resourceProducer, FreemarkerBuildConfig config)
+            throws IOException, URISyntaxException {
+
+        final List<String> nativeResources = discoverTemplates(config.resourcePaths);
+        resourceProducer.produce(new NativeImageResourceBuildItem(nativeResources.toArray(new String[0])));
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem additionalBeans() {
+        return AdditionalBeanBuildItem.builder()
+                .setUnremovable()
+                .addBeanClasses(FreemarkerConfigurationProducer.class, TemplatePath.class, FreemarkerTemplateProducer.class,
+                        FreemarkerTemplateProducer.class)
+                .build();
+    }
+
+    @BuildStep
+    public void reflection(BuildProducer<ReflectiveClassBuildItem> additionalBeanBuildItemProducer,
+            FreemarkerBuildConfig config) {
+
+        LOGGER.info("Adding directives " + config.directive.values());
+        config.directive.values().stream()
+                .map(classname -> new ReflectiveClassBuildItem(false, false, classname))
+                .forEach(additionalBeanBuildItemProducer::produce);
+    }
+
+    private List<String> discoverTemplates(List<String> locations) throws IOException, URISyntaxException {
+
+        List<String> resources = new ArrayList<>();
+
+        for (String location : locations) {
+
+            // Strip any 'classpath:' protocol prefixes because they are assumed
+            // but not recognized by ClassLoader.getResources()
+            if (location.startsWith(CLASSPATH_PROTOCOL + ':')) {
+                location = location.substring(CLASSPATH_PROTOCOL.length() + 1);
+            }
+
+            Enumeration<URL> templates = Thread.currentThread().getContextClassLoader().getResources(location);
+
+            while (templates.hasMoreElements()) {
+                URL path = templates.nextElement();
+                LOGGER.infov(ADD_MSG, path.getPath(), path.getProtocol());
+                final Set<String> freemarkerTemplates;
+                if (JAR_PROTOCOL.equals(path.getProtocol())) {
+                    try (final FileSystem fileSystem = initFileSystem(path.toURI())) {
+                        freemarkerTemplates = getTemplatesFromPath(location, path);
+                    }
+                } else if (FILE_PROTOCOL.equals(path.getProtocol())) {
+                    freemarkerTemplates = getTemplatesFromPath(location, path);
+                } else {
+                    LOGGER.warnv(UNSUPPORTED_MSG, path.getProtocol(), path.getPath());
+                    freemarkerTemplates = null;
+                }
+
+                if (freemarkerTemplates != null) {
+                    resources.addAll(freemarkerTemplates);
+                }
+            }
+        }
+        return resources;
+    }
+
+    private Set<String> getTemplatesFromPath(final String location, final URL pathURL)
+            throws IOException, URISyntaxException {
+
+        try (final Stream<Path> pathStream = Files.walk(Paths.get(pathURL.toURI()))) {
+            return pathStream
+                    .filter(Files::isRegularFile)
+                    .map(path -> getSubpath(location, path))
+                    .peek(subpath -> LOGGER.info("Discovered: " + subpath))
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private String getSubpath(String location, Path path) {
+        String file = FilenameUtils.separatorsToUnix(path.toString());
+        int indexOf = file.lastIndexOf("/" + location + "/");
+        if (indexOf == -1) {
+            indexOf = file.lastIndexOf("/" + location);
+        }
+        String substring = file.substring(indexOf + 1);
+        return FilenameUtils.separatorsToUnix(substring);
+    }
+
+    private FileSystem initFileSystem(final URI uri) throws IOException {
+        final Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        return FileSystems.newFileSystem(uri, env);
+    }
+
+}

--- a/extensions/freemarker/pom.xml
+++ b/extensions/freemarker/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-freemarker-parent</artifactId>
+    <name>Quarkus - Freemarker</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/freemarker/runtime/pom.xml
+++ b/extensions/freemarker/runtime/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-freemarker-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-freemarker</artifactId>
+    <name>Quarkus - Freemarker - Runtime</name>
+    <description>Freemarker templating engine</description>
+    <dependencies>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.arc</groupId>
+            <artifactId>arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerBuildConfig.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerBuildConfig.java
@@ -1,0 +1,30 @@
+package io.quarkus.freemarker.runtime;
+
+import java.util.List;
+import java.util.Map;
+
+import freemarker.template.TemplateModel;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "freemarker", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class FreemarkerBuildConfig {
+
+    /**
+     * Comma-separated list of absolute resource paths to scan recursively for templates.
+     * All tree folder from 'resource-paths' will be added as a resource.
+     * Unprefixed locations or locations starting with classpath will be processed in the same way.
+     */
+    @ConfigItem(defaultValue = "freemarker/templates")
+    public List<String> resourcePaths;
+
+    /**
+     * List of directives to register with format name=classname
+     * 
+     * @see freemarker.template.Configuration#setSharedVariable(String, TemplateModel)
+     */
+    @ConfigItem
+    public Map<String, String> directive;
+
+}

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerConfig.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerConfig.java
@@ -1,0 +1,83 @@
+package io.quarkus.freemarker.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import freemarker.template.TemplateExceptionHandler;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "freemarker", phase = ConfigPhase.RUN_TIME)
+public class FreemarkerConfig {
+
+    /**
+     * Comma-separated of file system paths where freemarker templates are located
+     */
+    @ConfigItem
+    public Optional<List<String>> filePaths;
+
+    /**
+     * Set the preferred charset template files are stored in.
+     */
+    @ConfigItem
+    public Optional<String> defaultEncoding;
+
+    /**
+     * Sets how errors will appear. rethrow, debug, html-debug, ignore.
+     * 
+     * @see freemarker.template.Configuration#setTemplateExceptionHandler(TemplateExceptionHandler)
+     */
+    @ConfigItem
+    public Optional<String> templateExceptionHandler;
+
+    /**
+     * If false, don't log exceptions inside FreeMarker that it will be thrown at you anyway.
+     * 
+     * @see freemarker.template.Configuration#setLogTemplateExceptions(boolean)
+     */
+    @ConfigItem
+    public Optional<Boolean> logTemplateExceptions;
+
+    /**
+     * Wrap unchecked exceptions thrown during template processing into TemplateException-s.
+     * 
+     * @see freemarker.template.Configuration#setWrapUncheckedExceptions(boolean)
+     */
+    @ConfigItem
+    public Optional<Boolean> wrapUncheckedExceptions;
+
+    /**
+     * If false, do not fall back to higher scopes when reading a null loop variable.
+     * 
+     * @see freemarker.template.Configuration#setFallbackOnNullLoopVariable(boolean)
+     */
+    @ConfigItem
+    public Optional<Boolean> fallbackOnNullLoopVariable;
+
+    /**
+     * The string value for the boolean {@code true} and {@code false} values, usually intended for human consumption (not for a
+     * computer language), separated with comma.
+     * 
+     * @see freemarker.template.Configuration#setBooleanFormat(String)
+     */
+    @ConfigItem
+    public Optional<String> booleanFormat;
+
+    /**
+     * Sets the default number format used to convert numbers to strings.
+     * 
+     * @see freemarker.template.Configuration#setNumberFormat(String)
+     */
+    @ConfigItem
+    public Optional<String> numberFormat;
+
+    /**
+     * If true, the object wrapper will be configured to expose fields.
+     * 
+     * @see freemarker.ext.beans.BeansWrapper#setExposeFields(boolean)
+     */
+    @ConfigItem
+    public Optional<Boolean> objectWrapperExposeFields;
+
+}

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerConfigurationProducer.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerConfigurationProducer.java
@@ -1,0 +1,100 @@
+package io.quarkus.freemarker.runtime;
+
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateExceptionHandler;
+import io.quarkus.arc.DefaultBean;
+
+@Singleton
+public class FreemarkerConfigurationProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(FreemarkerConfigurationProducer.class);
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    public Configuration configuration(FreemarkerBuildConfig buildConfig, FreemarkerConfig config)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_30);
+
+        List<TemplateLoader> loaders = new ArrayList<>();
+        log.info("Adding build time locations " + buildConfig.resourcePaths);
+        loaders.addAll(buildConfig.resourcePaths.stream().map(this::newClassTemplateLoader).collect(toList()));
+
+        log.info("Adding runtime locations " + config.filePaths.orElse(emptyList()));
+        loaders.addAll(config.filePaths.orElse(emptyList()).stream().map(this::newFileTemplateLoader).collect(toList()));
+
+        MultiTemplateLoader mtl = new MultiTemplateLoader(loaders.toArray(new TemplateLoader[0]));
+        cfg.setTemplateLoader(mtl);
+
+        config.defaultEncoding.ifPresent(cfg::setDefaultEncoding);
+        config.templateExceptionHandler.ifPresent(s -> cfg.setTemplateExceptionHandler(getExceptionHandler(s)));
+        config.logTemplateExceptions.ifPresent(cfg::setLogTemplateExceptions);
+        config.wrapUncheckedExceptions.ifPresent(cfg::setWrapUncheckedExceptions);
+        config.fallbackOnNullLoopVariable.ifPresent(cfg::setFallbackOnNullLoopVariable);
+        config.booleanFormat.ifPresent(cfg::setBooleanFormat);
+        config.numberFormat.ifPresent(cfg::setNumberFormat);
+
+        if (config.objectWrapperExposeFields.isPresent()) {
+            DefaultObjectWrapper objectWrapper = new DefaultObjectWrapper(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+            objectWrapper.setExposeFields(config.objectWrapperExposeFields.get());
+            cfg.setObjectWrapper(objectWrapper);
+        }
+
+        for (Map.Entry<String, String> directive : buildConfig.directive.entrySet()) {
+            Class<?> directiveClass = Thread.currentThread().getContextClassLoader().loadClass(directive.getValue());
+            cfg.setSharedVariable(directive.getKey(), (TemplateDirectiveModel) directiveClass.newInstance());
+        }
+
+        return cfg;
+    }
+
+    private TemplateExceptionHandler getExceptionHandler(String templateExceptionHandler) {
+        if (templateExceptionHandler.equals("rethrow")) {
+            return TemplateExceptionHandler.RETHROW_HANDLER;
+        } else if (templateExceptionHandler.equals("debug")) {
+            return TemplateExceptionHandler.DEBUG_HANDLER;
+        } else if (templateExceptionHandler.equals("html-debug")) {
+            return TemplateExceptionHandler.HTML_DEBUG_HANDLER;
+        } else if (templateExceptionHandler.equals("ignore")) {
+            return TemplateExceptionHandler.IGNORE_HANDLER;
+        } else {
+            return null;
+        }
+    }
+
+    private ClassTemplateLoader newClassTemplateLoader(String location) {
+        // assuming an absolute location (i.e. starts with a '/')
+        return new ClassTemplateLoader(getClass(), "/" + location);
+    }
+
+    private FileTemplateLoader newFileTemplateLoader(String path) {
+        try {
+            return new FileTemplateLoader(new File(path));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerTemplateProducer.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/FreemarkerTemplateProducer.java
@@ -1,0 +1,35 @@
+package io.quarkus.freemarker.runtime;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+
+@Singleton
+public class FreemarkerTemplateProducer {
+
+    @Inject
+    Configuration configuration;
+
+    @Produces
+    @TemplatePath("ignored")
+    Template getTemplate(InjectionPoint injectionPoint) throws IOException {
+        TemplatePath path = null;
+        for (Annotation qualifier : injectionPoint.getQualifiers()) {
+            if (qualifier.annotationType().equals(TemplatePath.class)) {
+                path = (TemplatePath) qualifier;
+                break;
+            }
+        }
+        if (path == null || path.value().isEmpty()) {
+            throw new IllegalStateException("No template reource path specified");
+        }
+        return configuration.getTemplate(path.value());
+    }
+}

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/Log4jOverSLF4JTesterSubstitue.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/Log4jOverSLF4JTesterSubstitue.java
@@ -1,0 +1,18 @@
+package io.quarkus.freemarker.runtime;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import freemarker.log._Log4jOverSLF4JTester;
+
+/**
+ * avoid a class not found on org.apache.log4j.MDC
+ */
+@TargetClass(_Log4jOverSLF4JTester.class)
+final class Log4jOverSLF4JTesterSubstitue {
+
+    @Substitute
+    public static final boolean test() {
+        return false;
+    }
+}

--- a/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/TemplatePath.java
+++ b/extensions/freemarker/runtime/src/main/java/io/quarkus/freemarker/runtime/TemplatePath.java
@@ -1,0 +1,45 @@
+package io.quarkus.freemarker.runtime;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, METHOD })
+public @interface TemplatePath {
+
+    /**
+     * @return the path relative from the base path, must not be an empty string
+     */
+    @Nonbinding
+    String value();
+
+    /**
+     * Supports inline instantiation of this qualifier.
+     */
+    public static final class Literal extends AnnotationLiteral<TemplatePath> implements TemplatePath {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+    }
+}

--- a/extensions/freemarker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/freemarker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "Quarkus Freemarker"
+description: "Freemarker support"
+metadata:
+  keywords:
+    - "freemarker"
+    - "template"
+  guide: "https://quarkus.io/guides/freemarker"
+  categories:
+    - "miscellaneous"
+  status: "preview"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -183,6 +183,7 @@
 
         <!-- Templating -->
         <module>qute</module>
+        <module>freemarker</module>
 
         <!-- Command line -->
         <module>picocli</module>

--- a/integration-tests/freemarker/pom.xml
+++ b/integration-tests/freemarker/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>quarkus-integration-tests-parent</artifactId>
+		<groupId>io.quarkus</groupId>
+		<version>999-SNAPSHOT</version>
+		<relativePath>../</relativePath>
+	</parent>
+
+	<artifactId>quarkus-integration-test-freemarker</artifactId>
+	<name>Quarkus - Integration Tests - Freemarker</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-resteasy</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-arc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-freemarker</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-junit5-internal</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-resteasy-deployment</artifactId>
+			<version>${project.version}</version>
+			<type>pom</type>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		
+		<!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-arc-deployment</artifactId>
+			<version>${project.version}</version>
+			<type>pom</type>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		
+		<!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-freemarker-deployment</artifactId>
+			<version>${project.version}</version>
+			<type>pom</type>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.quarkus</groupId>
+				<artifactId>quarkus-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>native-image</id>
+			<activation>
+				<property>
+					<name>native</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<skipTests>${native.surefire.skip}</skipTests>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+								<configuration>
+									<systemPropertyVariables>
+										<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+									</systemPropertyVariables>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>io.quarkus</groupId>
+						<artifactId>quarkus-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>native-image</id>
+								<goals>
+									<goal>native-image</goal>
+								</goals>
+								<configuration>
+									<cleanupServer>true</cleanupServer>
+									<enableHttpUrlHandler>true</enableHttpUrlHandler>
+									<graalvmHome>${graalvmHome}</graalvmHome>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/Base64Directive.java
+++ b/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/Base64Directive.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.freemarker;
+
+import static java.nio.charset.StandardCharsets.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Base64;
+import java.util.Map;
+
+import freemarker.core.Environment;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+
+public class Base64Directive implements TemplateDirectiveModel {
+    @Override
+    public void execute(Environment environment, Map map, TemplateModel[] templateModels, TemplateDirectiveBody body)
+            throws TemplateException, IOException {
+        StringWriter sw = new StringWriter();
+        body.render(sw);
+        byte[] bytes = Base64.getEncoder().encode(sw.toString().getBytes(UTF_8));
+        environment.getOut().write(new String(bytes, UTF_8));
+    }
+}

--- a/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/FreemarkerTestResource.java
+++ b/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/FreemarkerTestResource.java
@@ -1,0 +1,118 @@
+package io.quarkus.it.freemarker;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import io.quarkus.freemarker.runtime.TemplatePath;
+
+@Path("/freemarker")
+public class FreemarkerTestResource {
+
+    public static final String FOLDER_SUB_FTL = "folder/sub.ftl";
+
+    public static final String OTHER_FTL = "other.ftl";
+
+    public static final String EXTERNAL_EXTERNAL_FTL = "external/external.ftl";
+
+    @Inject
+    Configuration configuration;
+
+    @Inject
+    @TemplatePath(FOLDER_SUB_FTL)
+    Template subTemplate;
+
+    @Inject
+    @TemplatePath(OTHER_FTL)
+    Template otherTemplate;
+
+    @Inject
+    @TemplatePath("hello.ftl")
+    Template hello;
+
+    @GET
+    @Path("/hello")
+    @Produces(TEXT_PLAIN)
+    public String hello(@QueryParam("name") String name) throws IOException, TemplateException {
+        Map<String, String> model = new HashMap<>();
+        model.put("name", name);
+        StringWriter stringWriter = new StringWriter();
+        hello.process(model, stringWriter);
+        return stringWriter.toString();
+    }
+
+    @GET
+    @Path("/hello_ftl")
+    @Produces(TEXT_PLAIN)
+    public String hello(@QueryParam("name") String name, @QueryParam("ftl") String ftl) throws IOException, TemplateException {
+        Map<String, String> model = new HashMap<>();
+        model.put("name", name);
+        StringWriter stringWriter = new StringWriter();
+        configuration.getTemplate(ftl).process(model, stringWriter);
+        return stringWriter.toString();
+    }
+
+    @GET
+    @Path("/sub")
+    @Produces(TEXT_PLAIN)
+    public String sub() throws IOException, TemplateException {
+        return process(FOLDER_SUB_FTL, null);
+    }
+
+    @GET
+    @Path("/subInject")
+    @Produces(TEXT_PLAIN)
+    public String subInject() throws IOException, TemplateException {
+        return process(subTemplate, null);
+    }
+
+    @GET
+    @Path("/person")
+    @Produces(TEXT_PLAIN)
+    public String person() throws IOException, TemplateException {
+        return process(OTHER_FTL, createPersonModel());
+    }
+
+    @GET
+    @Path("/personInject")
+    @Produces(TEXT_PLAIN)
+    public String personInject() throws IOException, TemplateException {
+        return process(otherTemplate, createPersonModel());
+    }
+
+    @GET
+    @Path("/personext")
+    @Produces(TEXT_PLAIN)
+    public String personext() throws IOException, TemplateException {
+        return process(EXTERNAL_EXTERNAL_FTL, createPersonModel());
+    }
+
+    private String process(String templateName, Object model) throws IOException, TemplateException {
+        return process(configuration.getTemplate(templateName), model);
+    }
+
+    private String process(Template template, Object model) throws TemplateException, IOException {
+        StringWriter out = new StringWriter();
+        template.process(model, out);
+        return out.toString();
+    }
+
+    private Map<Object, Object> createPersonModel() {
+        Map<Object, Object> model = new HashMap<>();
+        model.put("person", new Person().setName("bob"));
+        return model;
+    }
+
+}

--- a/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/IndentDirective.java
+++ b/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/IndentDirective.java
@@ -1,0 +1,58 @@
+package io.quarkus.it.freemarker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+import freemarker.core.Environment;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+
+public class IndentDirective implements TemplateDirectiveModel {
+
+    @Override
+    public void execute(Environment environment, Map params, TemplateModel[] templateModels, TemplateDirectiveBody body)
+            throws TemplateException, IOException {
+        if (body != null) {
+            int length = getIndentLength(params);
+            StringWriter sw = new StringWriter();
+            body.render(sw);
+            environment.getOut().write(indent(sw.toString(), length));
+        }
+    }
+
+    private String indent(String original, int length) {
+        StringBuilder indentString = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            indentString.append(" ");
+        }
+        StringWriter out = new StringWriter();
+        PrintWriter pw = new PrintWriter(out);
+
+        try (BufferedReader reader = new BufferedReader(new StringReader(original))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.length() > 0) {
+                    pw.println(indentString + line);
+                } else {
+                    pw.println();
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return out.toString();
+    }
+
+    private int getIndentLength(Map params) {
+        return params.containsKey("indent") ? Integer.parseInt(((SimpleScalar) params.get("indent")).getAsString()) : 0;
+    }
+
+}

--- a/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/Person.java
+++ b/integration-tests/freemarker/src/main/java/io/quarkus/it/freemarker/Person.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.freemarker;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Person {
+
+    public String name;
+
+    public Person setName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/integration-tests/freemarker/src/main/resources/application.properties
+++ b/integration-tests/freemarker/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+# runtime
+quarkus.freemarker.default-encoding=UTF-8
+quarkus.freemarker.template-exception-handler=rethrow
+quarkus.freemarker.log-template-exceptions=false
+quarkus.freemarker.wrap-unchecked-exceptions=true
+quarkus.freemarker.fallback-on-null-loop-variable=false
+quarkus.freemarker.boolean-format=c
+quarkus.freemarker.number-format=computer
+quarkus.freemarker.object-wrapper-expose-fields=true
+
+quarkus.freemarker.file-paths=src/test/external-templates
+
+quarkus.log.level=INFO
+quarkus.log.category."org.freemarker".level=DEBUG
+
+# build time 
+quarkus.freemarker.resource-paths=freemarker/mytemplates,myothertemplates
+quarkus.freemarker.directive.base64=io.quarkus.it.freemarker.Base64Directive
+quarkus.freemarker.directive.indent=io.quarkus.it.freemarker.IndentDirective
+

--- a/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/base.ftl
+++ b/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/base.ftl
@@ -1,0 +1,1 @@
+<@indent indent="4">hello in base64 is <@base64>hello</@base64></@indent>

--- a/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/folder/sub.ftl
+++ b/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/folder/sub.ftl
@@ -1,0 +1,1 @@
+<#include "../base.ftl"/>

--- a/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/hello.ftl
+++ b/integration-tests/freemarker/src/main/resources/freemarker/mytemplates/hello.ftl
@@ -1,0 +1,1 @@
+Hello ${name}!

--- a/integration-tests/freemarker/src/main/resources/myothertemplates/other.ftl
+++ b/integration-tests/freemarker/src/main/resources/myothertemplates/other.ftl
@@ -1,0 +1,1 @@
+my name is ${person.name}

--- a/integration-tests/freemarker/src/test/external-templates/external/external.ftl
+++ b/integration-tests/freemarker/src/test/external-templates/external/external.ftl
@@ -1,0 +1,1 @@
+my name is ${person.name}

--- a/integration-tests/freemarker/src/test/java/io/quarkus/it/freemarker/FreemarkerIT.java
+++ b/integration-tests/freemarker/src/test/java/io/quarkus/it/freemarker/FreemarkerIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.freemarker;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class FreemarkerIT extends FreemarkerTest {
+
+}

--- a/integration-tests/freemarker/src/test/java/io/quarkus/it/freemarker/FreemarkerTest.java
+++ b/integration-tests/freemarker/src/test/java/io/quarkus/it/freemarker/FreemarkerTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.freemarker;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class FreemarkerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(FreemarkerTest.class);
+
+    public static final String BASE64_EXPECTED_VALUE = "    hello in base64 is aGVsbG8=";
+
+    public static final String NAME_EXPECTED_VALUE = "my name is bob";
+
+    @Test
+    public void hello() {
+        RestAssured.when().get("/freemarker/hello/?name=bob").then().body(is("Hello bob!"));
+    }
+
+    @Test
+    public void hello_ftl() {
+        RestAssured.when().get("/freemarker/hello_ftl/?name=bob&ftl=hello.ftl").then().body(is("Hello bob!"));
+    }
+
+    @Test
+    public void sub() {
+        RestAssured.when().get("/freemarker/sub").then().body(containsString(BASE64_EXPECTED_VALUE));
+    }
+
+    @Test
+    public void subInject() {
+        RestAssured.when().get("/freemarker/subInject").then().body(containsString(BASE64_EXPECTED_VALUE));
+    }
+
+    @Test
+    public void person() {
+        RestAssured.when().get("/freemarker/person").then().body(is(NAME_EXPECTED_VALUE));
+    }
+
+    @Test
+    public void personInject() {
+        RestAssured.when().get("/freemarker/personInject").then().body(is(NAME_EXPECTED_VALUE));
+    }
+
+    @Test
+    public void personext() {
+        RestAssured.when().get("/freemarker/personext").then().body(is(NAME_EXPECTED_VALUE));
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -120,6 +120,7 @@
         <module>logging-gelf</module>
         <module>cache</module>
         <module>qute</module>
+        <module>freemarker</module>
         <module>bootstrap-config</module>
         <module>injectmock</module>
         <module>reactive-messaging-amqp</module>


### PR DESCRIPTION
This adds an extension providing support for _Freemarker_, including native support.
It brings 2 CDI beans: _Freemarker_ `Configuration` and `Template`, expose common configuration options plus support for custom directives.
This work has been largely inspired by (including copying some snippets of code) from @carlosthe19916 's work in the context of https://github.com/apache/camel-quarkus/issues/223.
The PR is complete with integration testing and a new documentation guide.
see also https://groups.google.com/g/quarkus-dev/c/M8EcFBFkj-o/m/Sv6RW_ZeBgAJ

/cc @ppalaga 