### PR TITLE
Remove unnecessary var assignement breaking snapshot ci job 

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
@@ -16,7 +16,7 @@ public class GrpcMultiModuleQuarkusBuildTest extends QuarkusGradleWrapperTestBas
 
         final File projectDir = getProjectDir("grpc-multi-module-project");
 
-        final var buildResult = runGradleWrapper(projectDir, ":application:quarkusBuild", ":application:test");
+        runGradleWrapper(projectDir, ":application:quarkusBuild", ":application:test");
 
         final Path commonLibs = projectDir.toPath().resolve("common").resolve("build").resolve("libs");
         assertThat(commonLibs).exists();


### PR DESCRIPTION
My last commit introduced a useless assignement using the `var` keyword. This broke the `snapshot-ci` job last night. 
This branch fix it. 