### PR TITLE
Fix i18n documentation

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1422,7 +1422,7 @@ import io.quarkus.qute.i18n.Localized;
 import io.quarkus.qute.i18n.Message;
 
 @Localized("de") <1>
-public interface GermanAppMessages {
+public interface GermanAppMessages extends AppMessages {
 
     @Override
     @Message("Hallo {name}!") <2>


### PR DESCRIPTION
There is a missing `extends` for the Localized Message Bundle so the `@Override` doesn't make much sense right now.

There should be additional information somewhere also on setting the Locale, which I had to find in the unit tests:
```
templateInstance.setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag(locale)
```