### PR TITLE
Update to Tika 1.24.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.12.9</scala.version>
-        <tika.version>1.22</tika.version>
+        <tika.version>1.24.1</tika.version>
         <ooxml-schemas.version>1.4</ooxml-schemas.version>
         <aws-lambda-java.version>1.2.1</aws-lambda-java.version>
         <aws-lambda-java-events.version>3.3.1</aws-lambda-java-events.version>
@@ -2475,6 +2475,10 @@
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
                         <artifactId>cxf-rt-rs-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
                 <version>${tika.version}</version>

--- a/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
+++ b/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
@@ -78,13 +78,13 @@ public class TikaProcessorTest {
 
     @Test
     public void testAllSupportedParserNames() throws Exception {
-        assertEquals(69, getParserNames(null, null).size());
+        assertEquals(72, getParserNames(null, null).size());
     }
 
     @Test
     public void testSupportedParserNamesWithTikaConfigPath() throws Exception {
         Set<String> names = getParserNames("tika-config.xml", "pdf");
-        assertEquals(69, names.size());
+        assertEquals(72, names.size());
     }
 
     @Test

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -73,6 +73,11 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/graalvm/CleanerNotSupportedSubstitution.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/graalvm/CleanerNotSupportedSubstitution.java
@@ -1,0 +1,29 @@
+package io.quarkus.tika.graalvm;
+
+@com.oracle.svm.core.annotate.Substitute
+@com.oracle.svm.core.annotate.TargetClass(className = "org.apache.poi.poifs.nio.CleanerUtil")
+public final class CleanerNotSupportedSubstitution {
+
+    /**
+     * <code>true</code>, if this platform supports unmapping mmapped files.
+     */
+    public static final boolean UNMAP_SUPPORTED = false;
+
+    /**
+     * if {@link #UNMAP_SUPPORTED} is {@code false}, this contains the reason
+     * why unmapping is not supported.
+     */
+    public static final String UNMAP_NOT_SUPPORTED_REASON = "Not supported on GraalVM native-image";
+
+    private static final org.apache.poi.poifs.nio.CleanerUtil.BufferCleaner CLEANER = null;
+
+    /**
+     * Reference to a BufferCleaner that does unmapping.
+     * 
+     * @return {@code null} if not supported.
+     */
+    public static org.apache.poi.poifs.nio.CleanerUtil.BufferCleaner getCleaner() {
+        return CLEANER;
+    }
+
+}


### PR DESCRIPTION
I had to add `--report-unsupported-elements-at-runtime` to bypass an Apache POI issue I commented at:
see https://github.com/quarkusio/quarkus/issues/6549#issuecomment-703283700
and in Zulip, https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Native.20issue.
This is not introducing any new issues since Apache POI does not currently work in the native mode (#6549)
