### PR TITLE
Ability to handle both exit code and exception when running CLI applications

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -285,9 +285,6 @@ public class MainClassBuildStep {
                 activeProfile,
                 tryBlock.load(LaunchMode.DEVELOPMENT.equals(launchMode.getLaunchMode())));
         cb = tryBlock.addCatch(Throwable.class);
-        cb.invokeVirtualMethod(ofMethod(Logger.class, "errorv", void.class, Throwable.class, String.class, Object.class),
-                cb.readStaticField(logField.getFieldDescriptor()), cb.getCaughtException(),
-                cb.load("Failed to start application (with profile {0})"), activeProfile);
 
         // an exception was thrown before logging was actually setup, we simply dump everything to the console
         ResultHandle delayedHandler = cb

--- a/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 
@@ -23,7 +22,7 @@ import io.quarkus.bootstrap.BootstrapConstants;
  */
 public class QuarkusLauncher {
 
-    public static void launch(String callingClass, String quarkusApplication, Consumer<Integer> exitHandler, String... args) {
+    public static void launch(String callingClass, String quarkusApplication, String... args) {
         try {
             String classResource = callingClass.replace(".", "/") + ".class";
             URL resource = Thread.currentThread().getContextClassLoader().getResource(classResource);

--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -1,6 +1,6 @@
 package io.quarkus.runtime;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.LogManager;
@@ -46,10 +46,11 @@ public class Quarkus {
      * go into the QuarkusApplication.
      *
      * @param quarkusApplication The application to run, or null
-     * @param exitHandler The handler that is called with the exit code when the application has finished
+     * @param exitHandler The handler that is called with the exit code and any exception (if any) thrown when the application
+     *        has finished
      * @param args The command line parameters
      */
-    public static void run(Class<? extends QuarkusApplication> quarkusApplication, Consumer<Integer> exitHandler,
+    public static void run(Class<? extends QuarkusApplication> quarkusApplication, BiConsumer<Integer, Throwable> exitHandler,
             String... args) {
         try {
             System.setProperty("java.util.logging.manager", LogManager.class.getName());
@@ -63,12 +64,11 @@ public class Quarkus {
         } catch (ClassNotFoundException e) {
             //ignore, this happens when running in dev mode
         } catch (Exception e) {
-            //TODO: exception mappers
-            Logger.getLogger(Quarkus.class).error("Error running Quarkus", e);
             if (exitHandler != null) {
-                exitHandler.accept(1);
+                exitHandler.accept(1, e);
             } else {
-                ApplicationLifecycleManager.getDefaultExitCodeHandler().accept(1);
+                Logger.getLogger(Quarkus.class).error("Error running Quarkus", e);
+                ApplicationLifecycleManager.getDefaultExitCodeHandler().accept(1, e);
             }
             return;
         }
@@ -76,12 +76,11 @@ public class Quarkus {
         //dev mode path, i.e. launching from the IDE
         //this is not the quarkus:dev path as it will augment before
         //calling this method
-        launchFromIDE(quarkusApplication, exitHandler, args);
+        launchFromIDE(quarkusApplication, args);
 
     }
 
-    private static void launchFromIDE(Class<? extends QuarkusApplication> quarkusApplication, Consumer<Integer> exitHandler,
-            String... args) {
+    private static void launchFromIDE(Class<? extends QuarkusApplication> quarkusApplication, String... args) {
         //some trickery, get the class that has invoked us, and use this to figure out the
         //classes root
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
@@ -90,8 +89,7 @@ public class Quarkus {
             pos++;
         }
         String callingClass = stackTrace[pos].getClassName();
-        QuarkusLauncher.launch(callingClass, quarkusApplication == null ? null : quarkusApplication.getName(), exitHandler,
-                args);
+        QuarkusLauncher.launch(callingClass, quarkusApplication == null ? null : quarkusApplication.getName(), args);
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/QuarkusSubstitution.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/QuarkusSubstitution.java
@@ -1,7 +1,5 @@
 package io.quarkus.runtime.graal;
 
-import java.util.function.Consumer;
-
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
@@ -12,8 +10,7 @@ import io.quarkus.runtime.QuarkusApplication;
 final class QuarkusSubstitution {
 
     @Substitute
-    private static void launchFromIDE(Class<? extends QuarkusApplication> quarkusApplication, Consumer<Integer> exitHandler,
-            String... args) {
+    private static void launchFromIDE(Class<? extends QuarkusApplication> quarkusApplication, String... args) {
         throw new RuntimeException("Should never be hit");
     }
 

--- a/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ExceptionHandlingCommandModeTestCase.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ExceptionHandlingCommandModeTestCase.java
@@ -1,0 +1,29 @@
+package io.quarkus.commandmode;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class ExceptionHandlingCommandModeTestCase {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties")
+                    .addClasses(ThrowExceptionApplicationMain.class, ThrowExceptionApplication.class))
+            .setApplicationName("exception-handling")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true);
+
+    @Test
+    public void testRun() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("exception-handling").contains("Exception and exit code [1] handled by application");
+        Assertions.assertThat(config.getExitCode()).isEqualTo(10);
+    }
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
@@ -2,7 +2,7 @@ package io.quarkus.commandmode;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -25,12 +25,13 @@ public class ExitCodeTestCase {
     @Test
     public void testReturnedExitCode() throws ExecutionException, InterruptedException {
         CompletableFuture<Integer> future = new CompletableFuture<>();
-        ApplicationLifecycleManager.run(Application.currentApplication(), ExitCodeApplication.class, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer integer) {
-                future.complete(integer);
-            }
-        }, "5");
+        ApplicationLifecycleManager.run(Application.currentApplication(), ExitCodeApplication.class,
+                new BiConsumer<Integer, Throwable>() {
+                    @Override
+                    public void accept(Integer integer, Throwable cause) {
+                        future.complete(integer);
+                    }
+                }, "5");
         Assertions.assertEquals(5, future.get());
     }
 
@@ -41,9 +42,9 @@ public class ExitCodeTestCase {
             @Override
             public void run() {
                 ApplicationLifecycleManager.run(Application.currentApplication(), WaitToExitApplication.class,
-                        new Consumer<Integer>() {
+                        new BiConsumer<Integer, Throwable>() {
                             @Override
-                            public void accept(Integer integer) {
+                            public void accept(Integer integer, Throwable cause) {
                                 future.complete(integer);
                             }
                         });
@@ -62,9 +63,9 @@ public class ExitCodeTestCase {
             @Override
             public void run() {
                 ApplicationLifecycleManager.run(Application.currentApplication(), WaitToExitApplication.class,
-                        new Consumer<Integer>() {
+                        new BiConsumer<Integer, Throwable>() {
                             @Override
-                            public void accept(Integer integer) {
+                            public void accept(Integer integer, Throwable cause) {
                                 future.complete(integer);
                             }
                         });

--- a/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ThrowExceptionApplication.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ThrowExceptionApplication.java
@@ -1,0 +1,11 @@
+package io.quarkus.commandmode;
+
+import io.quarkus.runtime.QuarkusApplication;
+
+public class ThrowExceptionApplication implements QuarkusApplication {
+
+    @Override
+    public int run(String... args) throws Exception {
+        throw new RuntimeException("Exception thrown from application");
+    }
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ThrowExceptionApplicationMain.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/commandmode/ThrowExceptionApplicationMain.java
@@ -1,0 +1,20 @@
+package io.quarkus.commandmode;
+
+import java.util.function.BiConsumer;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class ThrowExceptionApplicationMain {
+
+    public static void main(String... args) {
+        Quarkus.run(ThrowExceptionApplication.class, new BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer exitCode, Throwable cause) {
+                System.out.println("Exception and exit code [" + exitCode + "] handled by application");
+                System.exit(10);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixes #12397
A few points:

* Basically, if an exit handler is provided we don't do any logging but leave to the custom exit handler to deal with both exit code and exception
* I've removed logging from `Application` so that any logging can be done depending on whether or not an exit handler is provided.

I'm not sure if that is the best approach but it helps to allow CLI applications to better handle messages to their users without necessarily show Quarkus messages and stack traces.