### PR TITLE
quarkus:create-extension Support external parent POMs

### DIFF
--- a/devtools/maven/src/main/resources/create-extension-templates/parent-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/parent-pom.xml
@@ -7,11 +7,13 @@
         <groupId>[=grandParentGroupId]</groupId>
         <artifactId>[=grandParentArtifactId]</artifactId>
         <version>[=grandParentVersion]</version>
-        <relativePath>[=grandParentRelativePath]</relativePath>
+[#if grandParentRelativePath?? ]        <relativePath>[=grandParentRelativePath]</relativePath>
+[/#if]
     </parent>
 [/#if]
 
-[#if grandParentGroupId?? ][#if groupId != grandParentGroupId ]    <groupId>[=groupId]</groupId>[/#if][#else ]    <groupId>[=groupId]</groupId>
+[#if grandParentGroupId?? ][#if groupId != grandParentGroupId ]    <groupId>[=groupId]</groupId>
+[/#if][#else ]    <groupId>[=groupId]</groupId>
 [/#if]
     <artifactId>[=artifactId]-parent</artifactId>
 [#if groupId?? && (!grandParentGroupId?? || groupId != grandParentGroupId) && version?? && (!grandParentVersion?? || version != grandParentVersion) ]    <version>[=version]</version>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -168,8 +168,8 @@ public class CreateExtensionMojoTest {
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
         final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "myproject-(with-grand-parent)";
-        mojo.grandParentArtifactId = "grand-parent";
-        mojo.grandParentRelativePath = "../pom.xml";
+        mojo.parentArtifactId = "grand-parent";
+        mojo.parentRelativePath = "../pom.xml";
         mojo.templatesUriBase = "file:templates";
 
         mojo.bomPath = Paths.get("bom/pom.xml");
@@ -189,6 +189,22 @@ public class CreateExtensionMojoTest {
         mojo.execute();
         assertTreesMatch(
                 Paths.get("target/test-classes/expected/new-extension-project"),
+                mojo.basedir.toPath());
+    }
+
+    @Test
+    void createNewExtensionProjectWithJBossParent() throws Exception {
+        final CreateExtensionMojo mojo = initMojo(newProjectDir("new-ext-project-with-jboss-parent"));
+        mojo.parentGroupId = "org.jboss";
+        mojo.parentArtifactId = "jboss-parent";
+        mojo.parentVersion = "37";
+        mojo.groupId = "org.acme";
+        mojo.artifactId = "my-ext";
+        mojo.version = "1.0-SNAPSHOT";
+        mojo.assumeManaged = null;
+        mojo.execute();
+        assertTreesMatch(
+                Paths.get("target/test-classes/expected/new-extension-project-with-jboss-parent"),
                 mojo.basedir.toPath());
     }
 

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.acme</groupId>
         <artifactId>grand-parent</artifactId>
         <version>0.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>my-project-add-to-bom-parent</artifactId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.acme</groupId>
         <artifactId>grand-parent</artifactId>
         <version>0.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>my-project-itest-parent</artifactId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.acme</groupId>
         <artifactId>grand-parent</artifactId>
         <version>0.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>my-project-minimal-extension-parent</artifactId>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>my-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-ext-deployment</artifactId>
+    <name>My Ext - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>my-ext</artifactId>
+            <version>\${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/main/java/org/acme/my/ext/deployment/MyExtProcessor.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/main/java/org/acme/my/ext/deployment/MyExtProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.my.ext.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class MyExtProcessor {
+
+    private static final String FEATURE = "my-ext";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>37</version>
+    </parent>
+
+    <groupId>org.acme</groupId>
+    <artifactId>my-ext-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>My Ext - Parent</name>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <quarkus.version>${project.version}</quarkus.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    </properties>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/runtime/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>my-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-ext</artifactId>
+    <name>My Ext - Runtime</name>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>\${project.groupId}:\${project.artifactId}-deployment:\${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #12499 

This adds support for external (not in-tree) parent POMs. I also took the opportunity to deprecate `quarkus.grandParentXXX` parameters in favor of `parentXXX` ones.