### PR TITLE
Kubernetes - Don't create a service account if not needed

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -781,8 +781,7 @@ class KubernetesProcessor {
                 .forEach(p -> session.configurators().add(new AddPort(p)));
 
         //Handle RBAC
-        // TODO why this condition?
-        if (!kubernetesPorts.isEmpty()) {
+        if (!kubernetesRoleBindings.isEmpty()) {
             session.resources().decorate(new ApplyServiceAccountNamedDecorator());
             session.resources().decorate(new AddServiceAccountResourceDecorator());
             kubernetesRoles.forEach(r -> session.resources().decorate(new AddRoleResourceDecorator(r)));

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
@@ -61,7 +60,7 @@ public class BasicKubernetesTest {
         List<HasMetadata> kubernetesList = DeserializationUtil
                 .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
 
-        assertThat(kubernetesList).hasSize(3);
+        assertThat(kubernetesList).hasSize(2);
 
         assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
             assertThat(d.getMetadata()).satisfies(m -> {
@@ -99,12 +98,6 @@ public class BasicKubernetesTest {
                 assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
                     assertThat(p.getPort()).isEqualTo(8080);
                 });
-            });
-        });
-
-        assertThat(kubernetesList.get(2)).isInstanceOfSatisfying(ServiceAccount.class, sa -> {
-            assertThat(sa.getMetadata()).satisfies(m -> {
-                assertThat(m.getNamespace()).isNull();
             });
         });
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.quarkus.test.ProdBuildResults;
@@ -45,7 +44,7 @@ public class KubernetesWithApplicationPropertiesTest {
         List<HasMetadata> kubernetesList = DeserializationUtil
                 .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
 
-        assertThat(kubernetesList).hasSize(4);
+        assertThat(kubernetesList).hasSize(3);
 
         assertThat(kubernetesList).filteredOn(i -> "Deployment".equals(i.getKind())).singleElement().satisfies(i -> {
             assertThat(i).isInstanceOfSatisfying(Deployment.class, d -> {
@@ -100,9 +99,6 @@ public class KubernetesWithApplicationPropertiesTest {
                 });
             });
         });
-
-        assertThat(kubernetesList).filteredOn(i -> "ServiceAccount".equals(i.getKind())).hasSize(1)
-                .hasOnlyElementsOfType(ServiceAccount.class);
 
         assertThat(kubernetesList).filteredOn(i -> "Ingress".equals(i.getKind())).singleElement().satisfies(i -> {
             assertThat(i).isInstanceOfSatisfying(Ingress.class, in -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDefaultsTest.java
@@ -46,6 +46,7 @@ public class KubernetesWithDefaultsTest {
                     assertThat(deploymentSpec.getReplicas()).isEqualTo(1);
                     assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                         assertThat(t.getSpec()).satisfies(podSpec -> {
+                            assertThat(podSpec.getServiceAccount()).isNull();
                             assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                                 assertThat(container.getImagePullPolicy()).isEqualTo("Always");
                             });


### PR DESCRIPTION
Resolves: #9283 

The pull request fixes the condition under which we generate a service account.