### PR TITLE
Disable kubernetes http2 in kubernetes mock server

### DIFF
--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -20,6 +20,7 @@ public class KubernetesMockServerTestResource implements QuarkusTestResourceLife
         systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
         systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
         systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+        systemProps.put(Config.KUBERNETES_HTTP2_DISABLE, "true");
 
         mockServer = createMockServer();
         mockServer.init();


### PR DESCRIPTION
I've been struggling with building test cases for an application that uses the watcher pattern. 

Seems that adding:
        systemProps.put(Config.KUBERNETES_HTTP2_DISABLE, "true");

fixes the issues locally, at least in my build (sorry I don't have a reproducer). 

Also looks like that is common practice other places:

https://www.programcreek.com/java-api-examples/?api=io.fabric8.kubernetes.client.Config