### PR TITLE
Create default OIDC TokenStateManager

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -26,6 +26,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.runtime.DefaultTenantConfigResolver;
+import io.quarkus.oidc.runtime.DefaultTokenStateManager;
 import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
 import io.quarkus.oidc.runtime.OidcBuildTimeConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
@@ -74,7 +75,8 @@ public class OidcBuildStep {
                 .addBeanClass(OidcJsonWebTokenProducer.class)
                 .addBeanClass(OidcTokenCredentialProducer.class)
                 .addBeanClass(OidcIdentityProvider.class)
-                .addBeanClass(DefaultTenantConfigResolver.class);
+                .addBeanClass(DefaultTenantConfigResolver.class)
+                .addBeanClass(DefaultTokenStateManager.class);
         additionalBeans.produce(builder.build());
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, JwtProviderImpl.class));

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -26,7 +26,8 @@ public class CodeFlowDevModeTestCase {
     private static Class<?>[] testClasses = {
             ProtectedResource.class,
             UnprotectedResource.class,
-            CustomTenantConfigResolver.class
+            CustomTenantConfigResolver.class,
+            CustomTokenStateManager.class
     };
 
     @RegisterExtension
@@ -81,6 +82,9 @@ public class CodeFlowDevModeTestCase {
             page = loginForm.getInputByName("login").click();
 
             assertEquals("alice-dev-mode", page.getBody().asText());
+
+            assertEquals("custom", page.getWebClient().getCookieManager().getCookie("q_session").getValue().split("\\|")[3]);
+
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTokenStateManager.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTokenStateManager.java
@@ -1,0 +1,42 @@
+package io.quarkus.oidc.test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.quarkus.arc.AlternativePriority;
+import io.quarkus.oidc.AuthorizationCodeTokens;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TokenStateManager;
+import io.quarkus.oidc.runtime.DefaultTokenStateManager;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+@AlternativePriority(1)
+public class CustomTokenStateManager implements TokenStateManager {
+
+    @Inject
+    DefaultTokenStateManager tokenStateManager;
+
+    @Override
+    public String createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            AuthorizationCodeTokens sessionContent) {
+        return tokenStateManager.createTokenState(routingContext, oidcConfig, sessionContent) + "|custom";
+    }
+
+    @Override
+    public AuthorizationCodeTokens getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            String tokenState) {
+        if (!tokenState.endsWith("|custom")) {
+            throw new IllegalStateException();
+        }
+        String defaultState = tokenState.substring(0, tokenState.length() - 7);
+        return tokenStateManager.getTokens(routingContext, oidcConfig, defaultState);
+    }
+
+    @Override
+    public void deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
+        if (!tokenState.endsWith("|custom")) {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
@@ -1,0 +1,44 @@
+package io.quarkus.oidc;
+
+/**
+ * Authorization Code Flow Session State
+ */
+public class AuthorizationCodeTokens {
+
+    private String idToken;
+    private String accessToken;
+    private String refreshToken;
+
+    public AuthorizationCodeTokens() {
+    }
+
+    public AuthorizationCodeTokens(String idToken, String accessToken, String refreshToken) {
+        this.setIdToken(idToken);
+        this.setAccessToken(accessToken);
+        this.setRefreshToken(refreshToken);
+    }
+
+    public String getIdToken() {
+        return idToken;
+    }
+
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -164,6 +164,12 @@ public class OidcTenantConfig {
     @ConfigItem
     public Logout logout = new Logout();
 
+    /**
+     * Default token state manager configuration
+     */
+    @ConfigItem
+    public TokenStateManager tokenStateManager = new TokenStateManager();
+
     @ConfigGroup
     public static class Tls {
         public enum Verification {
@@ -226,6 +232,56 @@ public class OidcTenantConfig {
 
         public Optional<String> getPostLogoutPath() {
             return postLogoutPath;
+        }
+    }
+
+    /**
+     * Default Authorization Code token state manager configuration
+     */
+    @ConfigGroup
+    public static class TokenStateManager {
+
+        public enum Strategy {
+            /**
+             * Keep ID, access and refresh tokens.
+             */
+            KEEP_ALL_TOKENS,
+
+            /**
+             * Keep ID token only
+             */
+            ID_TOKEN
+        }
+
+        /**
+         * Default TokenStateManager strategy.
+         */
+        @ConfigItem(defaultValue = "keep_all_tokens")
+        public Strategy strategy;
+
+        /**
+         * Default TokenStateManager keeps all tokens (ID, access and refresh)
+         * returned in the authorization code grant response in a single session cookie by default.
+         * 
+         * Enable this property to minimize a session cookie size
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean splitTokens;
+
+        public boolean isSplitTokens() {
+            return splitTokens;
+        }
+
+        public void setSplitTokens(boolean spliTokens) {
+            this.splitTokens = spliTokens;
+        }
+
+        public Strategy getStrategy() {
+            return strategy;
+        }
+
+        public void setStrategy(Strategy strategy) {
+            this.strategy = strategy;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc;
+
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Authorization Code Flow Token State Manager.
+ * It converts the ID, access and refresh tokens returned in the authorization code grant response into a token state
+ * for OIDC Code AuthenticationMechanism to keep it as a session cookie.
+ * 
+ * For example, default TokenStateManager concatenates all 3 tokens into a single String but does not persist it.
+ * Custom TokenStateManager may choose to keep the tokens in the external storage (DB, file system, etc) and return
+ * a reference to this storage.
+ */
+public interface TokenStateManager {
+
+    String createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig, AuthorizationCodeTokens tokens);
+
+    AuthorizationCodeTokens getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState);
+
+    void deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState);
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -1,0 +1,85 @@
+package io.quarkus.oidc.runtime;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.AuthorizationCodeTokens;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TokenStateManager;
+import io.vertx.core.http.Cookie;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class DefaultTokenStateManager implements TokenStateManager {
+
+    private static final String SESSION_AT_COOKIE_NAME = CodeAuthenticationMechanism.SESSION_COOKIE_NAME + "_at";
+    private static final String SESSION_RT_COOKIE_NAME = CodeAuthenticationMechanism.SESSION_COOKIE_NAME + "_rt";
+
+    @Override
+    public String createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            AuthorizationCodeTokens tokens) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(tokens.getIdToken());
+        if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
+            if (!oidcConfig.tokenStateManager.splitTokens) {
+                sb.append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                        .append(tokens.getAccessToken())
+                        .append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                        .append(tokens.getRefreshToken());
+            } else {
+                CodeAuthenticationMechanism.createCookie(routingContext,
+                        oidcConfig,
+                        getAccessTokenCookieName(oidcConfig.getTenantId().get()),
+                        tokens.getAccessToken(),
+                        routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
+                if (tokens.getRefreshToken() != null) {
+                    CodeAuthenticationMechanism.createCookie(routingContext,
+                            oidcConfig,
+                            getRefreshTokenCookieName(oidcConfig.getTenantId().get()),
+                            tokens.getRefreshToken(),
+                            routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public AuthorizationCodeTokens getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
+        String[] tokens = CodeAuthenticationMechanism.COOKIE_PATTERN.split(tokenState);
+        String idToken = tokens[0];
+
+        String accessToken = null;
+        String refreshToken = null;
+        if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
+            if (!oidcConfig.tokenStateManager.splitTokens) {
+                accessToken = tokens[1];
+                refreshToken = tokens[2];
+            } else {
+                Cookie atCookie = routingContext.request().getCookie(getAccessTokenCookieName(oidcConfig.getTenantId().get()));
+                if (atCookie != null) {
+                    accessToken = atCookie.getValue();
+                }
+                Cookie rtCookie = routingContext.request().getCookie(getRefreshTokenCookieName(oidcConfig.getTenantId().get()));
+                if (rtCookie != null) {
+                    refreshToken = rtCookie.getValue();
+                }
+            }
+        }
+
+        return new AuthorizationCodeTokens(idToken, accessToken, refreshToken);
+    }
+
+    @Override
+    public void deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
+    }
+
+    private static String getAccessTokenCookieName(String tenantId) {
+        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(tenantId);
+        return SESSION_AT_COOKIE_NAME + cookieSuffix;
+    }
+
+    private static String getRefreshTokenCookieName(String tenantId) {
+        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(tenantId);
+        return SESSION_RT_COOKIE_NAME + cookieSuffix;
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
@@ -62,7 +62,7 @@ public class OidcJsonWebTokenProducer {
             return (JsonWebToken) identity.getPrincipal();
         }
         TokenCredential credential = identity.getCredential(type);
-        if (credential != null) {
+        if (credential != null && credential.getToken() != null) {
             if (credential instanceof AccessTokenCredential && ((AccessTokenCredential) credential).isOpaque()) {
                 throw new OIDCException("Opaque access token can not be converted to JsonWebToken");
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
@@ -28,8 +28,8 @@ public class OidcTokenCredentialProducer {
     @RequestScoped
     IdTokenCredential currentIdToken() {
         IdTokenCredential cred = identity.getCredential(IdTokenCredential.class);
-        if (cred == null) {
-            LOG.trace("IdTokenCredential is null");
+        if (cred == null || cred.getToken() == null) {
+            LOG.trace("IdToken is null");
             cred = new IdTokenCredential();
         }
         return cred;
@@ -39,8 +39,8 @@ public class OidcTokenCredentialProducer {
     @RequestScoped
     AccessTokenCredential currentAccessToken() {
         AccessTokenCredential cred = identity.getCredential(AccessTokenCredential.class);
-        if (cred == null) {
-            LOG.trace("AccessTokenCredential is null");
+        if (cred == null || cred.getToken() == null) {
+            LOG.trace("AccessToken is null");
             cred = new AccessTokenCredential();
         }
         return cred;

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -27,6 +27,14 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-listener";
         }
 
+        if (path.contains("tenant-idtoken-only")) {
+            return "tenant-idtoken-only";
+        }
+
+        if (path.contains("tenant-split-tokens")) {
+            return "tenant-split-tokens";
+        }
+
         if (path.contains("tenant-autorefresh")) {
             return "tenant-autorefresh";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -52,6 +52,18 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("tenant-idtoken-only")
+    public String getNameIdTokenOnly() {
+        return "tenant-idtoken-only:" + getName();
+    }
+
+    @GET
+    @Path("tenant-split-tokens")
+    public String getNameSplitTokens() {
+        return "tenant-split-tokens:" + getName();
+    }
+
+    @GET
     @Path("callback-before-redirect")
     public String getNameCallbackBeforeRedirect() {
         throw new InternalServerErrorException("This method must not be invoked");
@@ -96,16 +108,29 @@ public class ProtectedResource {
     @GET
     @Path("access")
     public String getAccessToken() {
-        if (!accessTokenCredential.getToken().equals(accessToken.getRawToken())) {
+        if (accessToken.getRawToken() != null && !accessTokenCredential.getToken().equals(accessToken.getRawToken())) {
             throw new OIDCException("Access token values are not equal");
         }
-        return accessToken.getRawToken() != null && !accessToken.getRawToken().isEmpty() ? "AT injected" : "";
+        return accessToken.getRawToken() != null && !accessToken.getRawToken().isEmpty() ? "AT injected" : "no access";
+    }
+
+    @GET
+    @Path("access/tenant-idtoken-only")
+    public String getAccessTokenIdTokenOnly() {
+        return "tenant-idtoken-only:" + getAccessToken();
+    }
+
+    @GET
+    @Path("access/tenant-split-tokens")
+    public String getAccessTokenSplitTokens() {
+        return "tenant-split-tokens:" + getAccessToken();
     }
 
     @GET
     @Path("refresh")
-    public String refresh() {
-        if (!accessTokenCredential.getRefreshToken().getToken().equals(refreshToken.getToken())) {
+    public String getRefreshToken() {
+        if (refreshToken.getToken() != null
+                && !accessTokenCredential.getRefreshToken().getToken().equals(refreshToken.getToken())) {
             throw new OIDCException("Refresh token values are not equal");
         }
         if (refreshToken.getToken() != null && !refreshToken.getToken().isEmpty()) {
@@ -121,14 +146,26 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("refresh/tenant-idtoken-only")
+    public String getRefreshTokenIdTokenOnly() {
+        return "tenant-idtoken-only:" + getRefreshToken();
+    }
+
+    @GET
+    @Path("refresh/tenant-split-tokens")
+    public String getRefreshTokenSplitTokens() {
+        return "tenant-split-tokens:" + getRefreshToken();
+    }
+
+    @GET
     @Path("refresh/tenant-listener")
-    public String refreshTenantListener() {
-        return refresh();
+    public String getRefreshTokenTenantListener() {
+        return getRefreshToken();
     }
 
     @GET
     @Path("refresh-query")
-    public String refresh(@QueryParam("a") String aValue) {
-        return refresh() + ":" + aValue;
+    public String getRefreshTokenQuery(@QueryParam("a") String aValue) {
+        return getRefreshToken() + ":" + aValue;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -111,6 +111,18 @@ quarkus.oidc.tenant-javascript.credentials.secret=secret
 quarkus.oidc.tenant-javascript.authentication.java-script-auto-redirect=false
 quarkus.oidc.tenant-javascript.application-type=web-app
 
+quarkus.oidc.tenant-idtoken-only.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-idtoken-only.client-id=quarkus-app
+quarkus.oidc.tenant-idtoken-only.credentials.secret=secret
+quarkus.oidc.tenant-idtoken-only.token-state-manager.strategy=id-token
+quarkus.oidc.tenant-idtoken-only.application-type=web-app
+
+quarkus.oidc.tenant-split-tokens.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-split-tokens.client-id=quarkus-app
+quarkus.oidc.tenant-split-tokens.credentials.secret=secret
+quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true
+quarkus.oidc.tenant-split-tokens.application-type=web-app
+
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
 


### PR DESCRIPTION
Fixes #12254

This PR is a new attempt to resolve #12254, following the discussion at the closed #12290.
So, what it does it:
- introduces `SessionManager` interface
- All the existing code dealing with the session cookie is moved to `DefaultSessionManager`
- Added an option for DefaultSessionManager to keep an id token only: if the users don't need access or refresh tokens then the session cookie length is reduced by `/3`. I've been thinking if it can be deduced (for ex we already have a `refresh-expired` property) but came to a conclusion that it will be too messy - for example, even if we check all the injection points for AT and RT, we still won't be able to detect `SecurityIdentity.getCredential(AccessTokenCredential)` etc. So the users can just set the `keep-id-token-only`.

- However, there will always be cases where all 3 tokens are needed, so if a combined cookie value becomes too large then DefaultSessionManager can be configured to create a cookie per token, id-token is still bound to the `q_session` token (the #12290 idea).

- tests are added (custom session manager, DefaultSessionManager keeping the id token only and creating 3 cookies)

I'll follow up with creating an enhancement request to create a DB-based SessionManager - and in total we'll have a very comprehensive support for the OIDC adapter session state management