### PR TITLE
Hot Reload Performance Improvements

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -340,6 +340,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-class-change-agent</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-ide-launcher</artifactId>
                 <version>${project.version}</version>
                 <exclusions>

--- a/core/class-change-agent/pom.xml
+++ b/core/class-change-agent/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-class-change-agent</artifactId>
+    <name>Quarkus - Core - Class Change Agent</name>
+    <description>
+        A Java Agent that exposes the instrumentation API. This allows for super fast
+        hot reloads if there have been no changes to the structure of the class files.
+
+        This agent is not required for hot reload, it just provides an optimisation in
+        some circumstances.
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Premain-Class>io.quarkus.changeagent.ClassChangeAgent</Premain-Class>
+                            <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/class-change-agent/src/main/java/io/quarkus/changeagent/ClassChangeAgent.java
+++ b/core/class-change-agent/src/main/java/io/quarkus/changeagent/ClassChangeAgent.java
@@ -1,0 +1,18 @@
+package io.quarkus.changeagent;
+
+import java.lang.instrument.Instrumentation;
+
+public class ClassChangeAgent {
+
+    private static volatile Instrumentation instrumentation;
+
+    public static Instrumentation getInstrumentation() {
+        return instrumentation;
+    }
+
+    public static void premain(java.lang.String s, Instrumentation i) {
+        instrumentation = i;
+
+    }
+
+}

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-class-change-agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
@@ -30,6 +30,8 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
      */
     final Set<String> requireConstPoolEntry;
 
+    final boolean cacheable;
+
     public BytecodeTransformerBuildItem(String classToTransform,
             BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
         this(classToTransform, visitorFunction, null);
@@ -46,11 +48,23 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
     }
 
     public BytecodeTransformerBuildItem(boolean eager, String classToTransform,
+            BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction, boolean cacheable) {
+        this(eager, classToTransform, visitorFunction, null, cacheable);
+    }
+
+    public BytecodeTransformerBuildItem(boolean eager, String classToTransform,
             BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction, Set<String> requireConstPoolEntry) {
+        this(eager, classToTransform, visitorFunction, requireConstPoolEntry, false);
+    }
+
+    public BytecodeTransformerBuildItem(boolean eager, String classToTransform,
+            BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction, Set<String> requireConstPoolEntry,
+            boolean cacheable) {
         this.eager = eager;
         this.classToTransform = classToTransform;
         this.visitorFunction = visitorFunction;
         this.requireConstPoolEntry = requireConstPoolEntry;
+        this.cacheable = cacheable;
     }
 
     public String getClassToTransform() {
@@ -67,5 +81,9 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
 
     public boolean isEager() {
         return eager;
+    }
+
+    public boolean isCacheable() {
+        return cacheable;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ChangedClassesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ChangedClassesBuildItem.java
@@ -1,0 +1,54 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Represents the differences between classes in a dev mode restart.
+ *
+ * This can be used to avoid repeating work on restart, e.g. re-using
+ * old proxy definitions if nothing has changed for a given class.
+ *
+ * This will not always be present, it must be injected as an
+ * optional dependency.
+ *
+ * This will never be generated if the previous restart was a failure
+ * to avoid issues with inconsistent application state.
+ */
+public class ChangedClassesBuildItem extends SimpleBuildItem {
+
+    private final Map<DotName, ClassInfo> changedClassesNewVersion;
+    private final Map<DotName, ClassInfo> changedClassesOldVersion;
+    private final Map<DotName, ClassInfo> deletedClasses;
+    private final Map<DotName, ClassInfo> addedClasses;
+
+    public ChangedClassesBuildItem(Map<DotName, ClassInfo> changedClassesNewVersion,
+            Map<DotName, ClassInfo> changedClassesOldVersion, Map<DotName, ClassInfo> deletedClasses,
+            Map<DotName, ClassInfo> addedClasses) {
+        this.changedClassesNewVersion = changedClassesNewVersion;
+        this.changedClassesOldVersion = changedClassesOldVersion;
+        this.deletedClasses = deletedClasses;
+        this.addedClasses = addedClasses;
+    }
+
+    public Map<DotName, ClassInfo> getChangedClassesNewVersion() {
+        return Collections.unmodifiableMap(changedClassesNewVersion);
+    }
+
+    public Map<DotName, ClassInfo> getChangedClassesOldVersion() {
+        return Collections.unmodifiableMap(changedClassesOldVersion);
+    }
+
+    public Map<DotName, ClassInfo> getDeletedClasses() {
+        return Collections.unmodifiableMap(deletedClasses);
+    }
+
+    public Map<DotName, ClassInfo> getAddedClasses() {
+        return Collections.unmodifiableMap(addedClasses);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.quarkus.bootstrap.app.ClassChangeInformation;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
@@ -18,6 +19,7 @@ public final class LiveReloadBuildItem extends SimpleBuildItem {
     private final boolean liveReload;
     private final Set<String> changedResources;
     private final Map<Class<?>, Object> reloadContext;
+    private final ClassChangeInformation changeInformation;
 
     /**
      * This constructor should only be used if live reload is not possible
@@ -26,12 +28,15 @@ public final class LiveReloadBuildItem extends SimpleBuildItem {
         liveReload = false;
         changedResources = Collections.emptySet();
         this.reloadContext = new ConcurrentHashMap<>();
+        this.changeInformation = null;
     }
 
-    public LiveReloadBuildItem(boolean liveReload, Set<String> changedResources, Map<Class<?>, Object> reloadContext) {
+    public LiveReloadBuildItem(boolean liveReload, Set<String> changedResources, Map<Class<?>, Object> reloadContext,
+            ClassChangeInformation changeInformation) {
         this.liveReload = liveReload;
         this.changedResources = changedResources;
         this.reloadContext = reloadContext;
+        this.changeInformation = changeInformation;
     }
 
     /**
@@ -70,5 +75,16 @@ public final class LiveReloadBuildItem extends SimpleBuildItem {
      */
     public <T> void setContextObject(Class<T> type, T val) {
         reloadContext.put(type, val);
+    }
+
+    /**
+     * Returns the change information from the last successful restart.
+     *
+     * Will be null if Quarkus has not previously successfully started, or if the
+     * previous attempt to start was a failure.
+     *
+     */
+    public ClassChangeInformation getChangeInformation() {
+        return changeInformation;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
@@ -1,0 +1,170 @@
+package io.quarkus.deployment.dev;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+public class ClassComparisonUtil {
+    static boolean isSameStructure(ClassInfo clazz, ClassInfo old) {
+        if (clazz.flags() != old.flags()) {
+            return false;
+        }
+        if (!clazz.typeParameters().equals(old.typeParameters())) {
+            return false;
+        }
+        if (!clazz.interfaceNames().equals(old.interfaceNames())) {
+            return false;
+        }
+        if (!compareAnnotations(clazz.classAnnotations(), old.classAnnotations())) {
+            return false;
+        }
+        if (old.fields().size() != clazz.fields().size()) {
+            return false;
+        }
+        Map<String, FieldInfo> oldFields = old.fields().stream()
+                .collect(Collectors.toMap(FieldInfo::name, Function.identity()));
+        for (FieldInfo field : clazz.fields()) {
+            FieldInfo of = oldFields.get(field.name());
+            if (of == null) {
+                return false;
+            }
+            if (of.flags() != field.flags()) {
+                return false;
+            }
+            if (!of.type().equals(field.type())) {
+                return false;
+            }
+            if (!compareAnnotations(of.annotations(), field.annotations())) {
+                return false;
+            }
+        }
+        for (MethodInfo method : clazz.methods()) {
+            MethodInfo om = null;
+            for (MethodInfo i : old.methods()) {
+                if (!i.name().equals(method.name())) {
+                    continue;
+                }
+                if (!i.returnType().equals(method.returnType())) {
+                    continue;
+                }
+                if (i.parameters().size() != method.parameters().size()) {
+                    continue;
+                }
+                if (i.flags() != method.flags()) {
+                    continue;
+                }
+                if (!Objects.equals(i.defaultValue(), method.defaultValue())) {
+                    continue;
+                }
+                if (!compareAnnotations(i.annotations(), method.annotations())) {
+                    continue;
+                }
+                boolean paramEqual = true;
+                for (int j = 0; j < method.parameters().size(); ++j) {
+                    Type a = method.parameters().get(j);
+                    Type b = i.parameters().get(j);
+                    if (!a.equals(b)) {
+                        paramEqual = false;
+                        break;
+                    }
+                }
+                if (!paramEqual) {
+                    continue;
+                }
+                if (!compareMethodAnnotations(i.annotations(), method.annotations())) {
+                    continue;
+                }
+                om = i;
+            }
+            //no further checks needed, we fully matched in the loop
+            if (om == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static boolean compareAnnotations(Collection<AnnotationInstance> a, Collection<AnnotationInstance> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        Map<DotName, AnnotationInstance> lookup = b.stream()
+                .collect(Collectors.toMap(AnnotationInstance::name, Function.identity()));
+
+        for (AnnotationInstance i1 : a) {
+            AnnotationInstance i2 = lookup.get(i1.name());
+            if (i2 == null) {
+                return false;
+            }
+            if (!compareAnnotation(i1, i2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static boolean compareMethodAnnotations(Collection<AnnotationInstance> a, Collection<AnnotationInstance> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        List<AnnotationInstance> method1 = new ArrayList<>();
+        Map<Integer, List<AnnotationInstance>> params1 = new HashMap<>();
+        methodMap(a, method1, params1);
+        List<AnnotationInstance> method2 = new ArrayList<>();
+        Map<Integer, List<AnnotationInstance>> params2 = new HashMap<>();
+        methodMap(b, method2, params2);
+        if (!compareAnnotations(method1, method2)) {
+            return false;
+        }
+        if (!params1.keySet().equals(params2.keySet())) {
+            return false;
+        }
+        for (Map.Entry<Integer, List<AnnotationInstance>> entry : params1.entrySet()) {
+            List<AnnotationInstance> other = params2.get(entry.getKey());
+            if (!compareAnnotations(other, entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void methodMap(Collection<AnnotationInstance> b, List<AnnotationInstance> method2,
+            Map<Integer, List<AnnotationInstance>> params2) {
+        for (AnnotationInstance i : b) {
+            if (i.target().kind() == AnnotationTarget.Kind.METHOD) {
+                method2.add(i);
+            } else {
+                int index = i.target().asMethodParameter().position();
+                List<AnnotationInstance> instances = params2.get(index);
+                if (instances == null) {
+                    params2.put(index, instances = new ArrayList<>());
+                }
+                instances.add(i);
+            }
+        }
+    }
+
+    private static boolean compareAnnotation(AnnotationInstance a, AnnotationInstance b) {
+        for (AnnotationValue i : a.values()) {
+            AnnotationValue j = b.value(i.name());
+            if (!i.equals(j)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassScanResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassScanResult.java
@@ -1,0 +1,39 @@
+package io.quarkus.deployment.dev;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ClassScanResult {
+    final Set<Path> changedClasses = new HashSet<>();
+    final Set<Path> deletedClasses = new HashSet<>();
+    final Set<Path> addedClasses = new HashSet<>();
+    final Set<String> changedClassNames = new HashSet<>();
+    final Set<String> deletedClassNames = new HashSet<>();
+    final Set<String> addedClassNames = new HashSet<>();
+
+    public boolean isChanged() {
+        return !changedClasses.isEmpty() || !deletedClasses.isEmpty() || !addedClasses.isEmpty();
+    }
+
+    public void addDeletedClass(Path moduleClassesPath, Path classFilePath) {
+        deletedClasses.add(classFilePath);
+        deletedClassNames.add(toName(moduleClassesPath, classFilePath));
+    }
+
+    public void addChangedClass(Path moduleClassesPath, Path classFilePath) {
+        changedClasses.add(classFilePath);
+        changedClassNames.add(toName(moduleClassesPath, classFilePath));
+    }
+
+    public void addAddedClass(Path moduleClassesPath, Path classFilePath) {
+        addedClasses.add(classFilePath);
+        addedClassNames.add(toName(moduleClassesPath, classFilePath));
+    }
+
+    private String toName(Path moduleClassesPath, Path classFilePath) {
+        String cf = moduleClassesPath.relativize(classFilePath).toString()
+                .replace(moduleClassesPath.getFileSystem().getSeparator(), ".");
+        return cf.substring(0, cf.length() - ".class".length());
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
@@ -142,7 +142,7 @@ public class IsolatedRemoteDevModeMain implements BiConsumer<CuratedApplication,
         return null;
     }
 
-    void regenerateApplication(Set<String> ignore) {
+    void regenerateApplication(Set<String> ignore, ClassScanResult ignore2) {
         generateApplication();
     }
 
@@ -256,7 +256,7 @@ public class IsolatedRemoteDevModeMain implements BiConsumer<CuratedApplication,
             boolean scanResult = RuntimeUpdatesProcessor.INSTANCE.doScan(true);
             if (!scanResult && !copiedStaticResources.isEmpty()) {
                 scanResult = true;
-                regenerateApplication(Collections.emptySet());
+                regenerateApplication(Collections.emptySet(), new ClassScanResult());
             }
             copiedStaticResources.clear();
             if (scanResult) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -19,12 +19,15 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import org.jboss.logging.Logger;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 
 import io.quarkus.gizmo.Gizmo;
 
 public class JavaCompilationProvider implements CompilationProvider {
+
+    private static final Logger log = Logger.getLogger(JavaCompilationProvider.class);
 
     // -g is used to make the java compiler generate all debugging info
     // -parameters is used to generate metadata for reflection on method parameters
@@ -71,12 +74,14 @@ public class JavaCompilationProvider implements CompilationProvider {
             }
 
             for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-                System.out.format("%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
+                log.logf(diagnostic.getKind() == Diagnostic.Kind.ERROR ? Logger.Level.ERROR : Logger.Level.WARN,
+                        "%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
                         diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
             }
             if (!fileManagerDiagnostics.getDiagnostics().isEmpty()) {
                 for (Diagnostic<? extends JavaFileObject> diagnostic : fileManagerDiagnostics.getDiagnostics()) {
-                    System.out.format("%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
+                    log.logf(diagnostic.getKind() == Diagnostic.Kind.ERROR ? Logger.Level.ERROR : Logger.Level.WARN,
+                            "%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
                             diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
                 }
                 fileManager.close();

--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -2,7 +2,13 @@ package io.quarkus.deployment.jbang;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -58,7 +64,8 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
 
         builder.setLaunchMode(LaunchMode.NORMAL);
         builder.setRebuild(quarkusBootstrap.isRebuild());
-        builder.setLiveReloadState(new LiveReloadBuildItem(false, Collections.emptySet(), new HashMap<>()));
+        builder.setLiveReloadState(
+                new LiveReloadBuildItem(false, Collections.emptySet(), new HashMap<>(), null));
         for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
             //this gets added to the class path either way
             //but we only need to add it to the additional app archives

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ChangedClassesBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ChangedClassesBuildStep.java
@@ -1,0 +1,70 @@
+package io.quarkus.deployment.steps;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ChangedClassesBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
+
+public class ChangedClassesBuildStep {
+
+    private static volatile IndexView oldIndex;
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    ChangedClassesBuildItem changedClassesBuildItem(CombinedIndexBuildItem combinedIndexBuildItem,
+            LiveReloadBuildItem liveReloadBuildItem) {
+        IndexView currentIndex = combinedIndexBuildItem.getIndex();
+        if (liveReloadBuildItem.getChangeInformation() == null) {
+            oldIndex = currentIndex;
+            return null;
+        }
+        Map<DotName, ClassInfo> changedClassesNewVersion = new HashMap<>();
+        Map<DotName, ClassInfo> changedClassesOldVersion = new HashMap<>();
+        Map<DotName, ClassInfo> deletedClasses = new HashMap<>();
+        Map<DotName, ClassInfo> addedClasses = new HashMap<>();
+        for (String added : liveReloadBuildItem.getChangeInformation().getAddedClasses()) {
+            DotName name = DotName.createSimple(added);
+            ClassInfo clazz = currentIndex.getClassByName(name);
+            if (clazz == null) {
+                //should never happen, but we bail out to be paranoid
+                return null;
+            }
+            addedClasses.put(name, clazz);
+        }
+        for (String deleted : liveReloadBuildItem.getChangeInformation().getDeletedClasses()) {
+            DotName name = DotName.createSimple(deleted);
+            ClassInfo clazz = oldIndex.getClassByName(name);
+            if (clazz == null) {
+                //should never happen, but we bail out to be paranoid
+                return null;
+            }
+            addedClasses.put(name, clazz);
+        }
+        for (String mod : liveReloadBuildItem.getChangeInformation().getChangedClasses()) {
+            DotName name = DotName.createSimple(mod);
+            ClassInfo clazz = oldIndex.getClassByName(name);
+            if (clazz == null) {
+                //should never happen, but we bail out to be paranoid
+                return null;
+            }
+            changedClassesOldVersion.put(name, clazz);
+            clazz = currentIndex.getClassByName(name);
+            if (clazz == null) {
+                //should never happen, but we bail out to be paranoid
+                return null;
+            }
+            changedClassesNewVersion.put(name, clazz);
+        }
+
+        oldIndex = currentIndex;
+        return new ChangedClassesBuildItem(changedClassesNewVersion, changedClassesOldVersion, deletedClasses, addedClasses);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
 import io.quarkus.deployment.index.IndexWrapper;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.index.PersistentClassIndex;
@@ -51,6 +52,7 @@ public class CombinedIndexBuildStep {
         }
 
         CompositeIndex compositeIndex = CompositeIndex.create(archivesIndex, indexer.complete());
+        RuntimeUpdatesProcessor.setLastStartIndex(compositeIndex);
         return new CombinedIndexBuildItem(compositeIndex,
                 new IndexWrapper(compositeIndex, Thread.currentThread().getContextClassLoader(), index));
     }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -22,6 +22,7 @@ import io.quarkus.bootstrap.app.AdditionalDependency;
 import io.quarkus.bootstrap.app.ArtifactResult;
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.ClassChangeInformation;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -91,7 +92,7 @@ public class AugmentActionImpl implements AugmentAction {
             throw new IllegalStateException("Can only create a production application when using NORMAL launch mode");
         }
         ClassLoader classLoader = curatedApplication.createDeploymentClassLoader();
-        BuildResult result = runAugment(true, Collections.emptySet(), classLoader, ArtifactResultBuildItem.class);
+        BuildResult result = runAugment(true, Collections.emptySet(), null, classLoader, ArtifactResultBuildItem.class);
 
         String debugSourcesDir = BootstrapDebug.DEBUG_SOURCES_DIR;
         if (debugSourcesDir != null) {
@@ -132,19 +133,21 @@ public class AugmentActionImpl implements AugmentAction {
         }
         ClassLoader classLoader = curatedApplication.createDeploymentClassLoader();
         @SuppressWarnings("unchecked")
-        BuildResult result = runAugment(true, Collections.emptySet(), classLoader, NON_NORMAL_MODE_OUTPUTS);
+        BuildResult result = runAugment(true, Collections.emptySet(), null, classLoader, NON_NORMAL_MODE_OUTPUTS);
         return new StartupActionImpl(curatedApplication, result);
     }
 
     @Override
-    public StartupActionImpl reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources) {
+    public StartupActionImpl reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources,
+            ClassChangeInformation classChangeInformation) {
         if (launchMode != LaunchMode.DEVELOPMENT) {
             throw new IllegalStateException("Only application with launch mode DEVELOPMENT can restart");
         }
         ClassLoader classLoader = curatedApplication.createDeploymentClassLoader();
 
         @SuppressWarnings("unchecked")
-        BuildResult result = runAugment(!hasStartedSuccessfully, changedResources, classLoader, NON_NORMAL_MODE_OUTPUTS);
+        BuildResult result = runAugment(!hasStartedSuccessfully, changedResources, classChangeInformation, classLoader,
+                NON_NORMAL_MODE_OUTPUTS);
 
         return new StartupActionImpl(curatedApplication, result);
     }
@@ -204,7 +207,8 @@ public class AugmentActionImpl implements AugmentAction {
         }
     }
 
-    private BuildResult runAugment(boolean firstRun, Set<String> changedResources, ClassLoader deploymentClassLoader,
+    private BuildResult runAugment(boolean firstRun, Set<String> changedResources,
+            ClassChangeInformation classChangeInformation, ClassLoader deploymentClassLoader,
             Class<? extends BuildItem>... finalOutputs) {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
@@ -228,9 +232,11 @@ public class AugmentActionImpl implements AugmentAction {
             builder.setLaunchMode(launchMode);
             builder.setRebuild(quarkusBootstrap.isRebuild());
             if (firstRun) {
-                builder.setLiveReloadState(new LiveReloadBuildItem(false, Collections.emptySet(), reloadContext));
+                builder.setLiveReloadState(
+                        new LiveReloadBuildItem(false, Collections.emptySet(), reloadContext, classChangeInformation));
             } else {
-                builder.setLiveReloadState(new LiveReloadBuildItem(true, changedResources, reloadContext));
+                builder.setLiveReloadState(
+                        new LiveReloadBuildItem(true, changedResources, reloadContext, classChangeInformation));
             }
             for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
                 //this gets added to the class path either way

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,6 +21,7 @@
         <module>test-extension</module>
         <module>devmode-spi</module>
         <module>launcher</module>
+        <module>class-change-agent</module>
     </modules>
 
     <build>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -148,6 +148,7 @@
                         <parentFirstArtifact>org.junit.jupiter:junit-jupiter-params</parentFirstArtifact>
                         <parentFirstArtifact>org.junit.platform:junit-platform-commons</parentFirstArtifact>
                         <parentFirstArtifact>org.junit.platform:junit-platform-engine</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus:quarkus-class-change-agent</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>io.quarkus:quarkus-bootstrap-runner</runnerParentFirstArtifact>

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -759,7 +759,12 @@ public class DevMojo extends AbstractMojo {
             //we only use the launcher for launching from the IDE, we need to exclude it
             if (!(appDep.getArtifact().getGroupId().equals("io.quarkus")
                     && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
-                builder.classpathEntry(appDep.getArtifact().getFile());
+                if (appDep.getArtifact().getGroupId().equals("io.quarkus")
+                        && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
+                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                } else {
+                    builder.classpathEntry(appDep.getArtifact().getFile());
+                }
             }
         }
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
@@ -7,5 +7,6 @@ public interface AugmentAction {
 
     StartupAction createInitialRuntimeApplication();
 
-    StartupAction reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources);
+    StartupAction reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources,
+            ClassChangeInformation classChangeInformation);
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ClassChangeInformation.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ClassChangeInformation.java
@@ -1,0 +1,29 @@
+package io.quarkus.bootstrap.app;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class ClassChangeInformation {
+
+    private final Set<String> changedClasses;
+    private final Set<String> deletedClasses;
+    private final Set<String> addedClasses;
+
+    public ClassChangeInformation(Set<String> changedClasses, Set<String> deletedClasses, Set<String> addedClasses) {
+        this.changedClasses = changedClasses;
+        this.deletedClasses = deletedClasses;
+        this.addedClasses = addedClasses;
+    }
+
+    public Set<String> getChangedClasses() {
+        return Collections.unmodifiableSet(changedClasses);
+    }
+
+    public Set<String> getDeletedClasses() {
+        return Collections.unmodifiableSet(deletedClasses);
+    }
+
+    public Set<String> getAddedClasses() {
+        return Collections.unmodifiableSet(addedClasses);
+    }
+}


### PR DESCRIPTION
This PR will speed up the hot reload time for larger applications. Improvements likely won't really be noticeable in small demos, but it should have a big impact for larger applications, and lays the groundwork for further improvements.

- If no changes are made to the class structure then an attempt is made to replace the classes with the instrumentation API and avoid an application restart, resulting in pretty much instant replacement
- If changes are made the details of these changes are propagated into the build process, allowing information to be cached. This PR uses this info to cache Hibernate generated proxies and class based transformations, which can save a lot of time for larger applications. 
