### PR TITLE
Change default media type to JSON

### DIFF
--- a/docs/src/main/asciidoc/amazon-dynamodb.adoc
+++ b/docs/src/main/asciidoc/amazon-dynamodb.adoc
@@ -281,17 +281,13 @@ package org.acme.dynamodb;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     @Inject

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -331,7 +331,6 @@ public class S3SyncClientResource extends CommonResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public List<FileObject> listFiles() {
         ListObjectsRequest listRequest = ListObjectsRequest.builder().bucket(bucketName).build();
 
@@ -511,7 +510,6 @@ public class S3AsyncClientResource extends CommonResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<List<FileObject>> listFiles() {
         ListObjectsRequest listRequest = ListObjectsRequest.builder()
                 .bucket(bucketName)

--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -242,8 +242,6 @@ public class QuarksShieldSyncResource {
     static ObjectReader QUARK_READER = new ObjectMapper().readerFor(Quark.class);
 
     @GET
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Quark> receive() {
         List<Message> messages = sqs.receiveMessage(m -> m.maxNumberOfMessages(10).queueUrl(queueUrl)).messages();
 
@@ -423,8 +421,6 @@ public class QuarksShieldAsyncResource {
     static ObjectReader QUARK_READER = new ObjectMapper().readerFor(Quark.class);
 
     @GET
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<List<Quark>> receive() {
         return Uni.createFrom()
             .completionStage(sqs.receiveMessage(m -> m.maxNumberOfMessages(10).queueUrl(queueUrl)))

--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -177,8 +177,6 @@ public class GiftResource {
     SantaClausService santaClausService;
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     @Transactional
     public Response createGift(GiftUpdateView view) {
         entityViewManager.save(entityManager, view);
@@ -193,8 +191,6 @@ public class GiftResource {
 
     @PUT
     @Path("{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     @Transactional
     public GiftView updateGift(@EntityViewId("id") GiftUpdateView view) {
         evm.save(em, view);

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -158,7 +158,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.jaxrs.QueryParam;
@@ -170,7 +169,6 @@ public class WeatherForecastResource {
     WeatherForecastService service;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WeatherForecast getForecast(@QueryParam String city, @QueryParam long daysInFuture) { <1>
         long executionStart = System.currentTimeMillis();
         List<String> dailyForecasts = Arrays.asList(

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -212,8 +212,6 @@ The last missing piece is the REST API that will expose GET and POST methods:
 [source,java]
 ----
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
   private static final String STORE_NAME = "acme";

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -112,7 +112,6 @@ them to the client as JSON using link:rest-json[JSON-B or Jackson]:
     @Transactional
     @GET
     @Path("/people")
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<List<Person>> people() throws SystemException {
         // Create a REST client to the Star Wars API
         WebClient client = WebClient.create(vertx,

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -203,8 +203,6 @@ Now, edit the `org.acme.elasticsearch.FruitResource` class as follows:
 [source,java]
 ----
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
     @Inject
     FruitService fruitService;

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -540,8 +540,6 @@ import javax.ws.rs.core.Response.Status;
 import java.net.URI;
 
 @Path("fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     @Inject

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -765,14 +765,10 @@ Let's start by implementing the `/{tenant}` endpoint. As you can see from the so
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 
 @ApplicationScoped
-@Produces("application/json")
-@Consumes("application/json")
 @Path("/{tenant}")
 public class FruitResource {
 

--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -220,8 +220,6 @@ import org.jboss.resteasy.annotations.jaxrs.FormParam;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/library")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class LibraryResource {
 
     @Inject

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -727,11 +727,9 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -748,8 +746,6 @@ public class WeatherStationEndpoint {
 
     @GET
     @Path("/data/{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getWeatherStationData(@PathParam("id") int id) {
         GetWeatherStationDataResult result = interactiveQueries.getWeatherStationData(id);
 

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -81,14 +81,12 @@ We also update the `GreetingResource.kt` like so:
 ----
 import javax.ws.rs.GET
 import javax.ws.rs.Path
-import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
 @Path("/greeting")
 class GreetingResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     fun hello() = Greeting("hello")
 }
 ----

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -89,7 +89,6 @@ public class Pods {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{namespace}")
     public List<Pod> pods(@PathParam("namespace") String namespace) {
         return kubernetesClient.pods().inNamespace(namespace).list().getItems();

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -104,6 +104,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Supplier;
 
@@ -124,7 +125,7 @@ public class PrimeNumberResource {
 
     @GET
     @Path("/{number}")
-    @Produces("text/plain")
+    @Produces(MediaType.TEXT_PLAIN)
     public String checkIfPrime(@PathParam("number") int number) {
         if (number < 1) {
             return "Only natural numbers can be prime numbers.";

--- a/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
@@ -163,13 +163,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.jboss.logging.Logger;
 
 @Path("/coffee")
-@Produces(MediaType.APPLICATION_JSON)
 public class CoffeeResource {
 
     private static final Logger LOGGER = Logger.getLogger(CoffeeResource.class);

--- a/docs/src/main/asciidoc/microprofile-metrics.adoc
+++ b/docs/src/main/asciidoc/microprofile-metrics.adoc
@@ -107,6 +107,7 @@ import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 @Path("/")
 public class PrimeNumberChecker {
@@ -115,7 +116,7 @@ public class PrimeNumberChecker {
 
     @GET
     @Path("/{number}")
-    @Produces("text/plain")
+    @Produces(MediaType.TEXT_PLAIN)
     @Counted(name = "performedChecks", description = "How many primality checks have been performed.")
     @Timed(name = "checksTimer", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
     public String checkIfPrime(@PathParam long number) {

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -200,8 +200,6 @@ Now, edit the `org.acme.mongodb.FruitResource` class as follows:
 [source,java]
 ----
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     @Inject FruitService fruitService;

--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -201,16 +201,11 @@ Add a `FruitResource` skeleton like this and `@Inject` a `org.neo4j.driver.Drive
 package org.acme.neo4j;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.neo4j.driver.Driver;
 
 @Path("fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     @Inject

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -82,16 +82,11 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     private Set<Fruit> fruits = Collections.newSetFromMap(Collections.synchronizedMap(new LinkedHashMap<>()));

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -612,19 +612,14 @@ package org.acme.optaplanner.rest;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.acme.optaplanner.domain.TimeTable;
 import org.optaplanner.core.api.solver.SolverJob;
 import org.optaplanner.core.api.solver.SolverManager;
 
 @Path("/timeTable")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class TimeTableResource {
 
     @Inject

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -129,7 +129,7 @@ public class GreetingEndpoint {
 
     @GET
     @Path("/greeting")
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     public Greeting greeting(@QueryParam("name") String name) {
         System.out.println(new SimpleDateFormat("HH:mm:ss.SSS").format(new java.util.Date(System.currentTimeMillis())));
         String suffix = name != null ? name : "World";

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -250,7 +250,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/tasks")
-@Produces(MediaType.APPLICATION_JSON)
 public class TaskResource {
 
     @GET

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -144,8 +144,6 @@ With that you may create your `FruitResource` skeleton and `@Inject` a `io.vertx
 .src/main/java/org/acme/vertx/FruitResource.java
 ----
 @Path("fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     @Inject

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -201,19 +201,14 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.PUT;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
 import javax.ws.rs.Path;
 import javax.ws.rs.POST;
 import javax.ws.rs.DELETE;
-import javax.ws.rs.core.MediaType;
 import java.util.List;
 
 import io.smallrye.mutiny.Uni;
 
 @Path("/increments")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class IncrementResource {
 
     @Inject

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -126,17 +126,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
     private Set<Fruit> fruits = Collections.newSetFromMap(Collections.synchronizedMap(new LinkedHashMap<>()));
@@ -172,9 +167,13 @@ depending on the extension you chose when initializing the project.
 
 [NOTE]
 ====
-While RESTEasy supports auto-negotiation, when using Quarkus, it is very important to define the `@Produces` and `@Consumes` annotations.
-They are analyzed at build time and Quarkus restricts the number of JAX-RS providers included in the native executable to the minimum required by the application.
-It allows to reduce the size of the native executable.
+When JSON extension is installed such as `quarkus-resteasy-jsonb` Quarkus will use this by default for most return values, unless the media type is explicitly set via
+and `@Produces` or `@Consumes` annotation (there are some exceptions for well known types, such as `String` and `File`, which default to `text/plain` and `application/octet-stream`
+respectively).
+
+If you don't want JSON by default you can set `quarkus.resteasy-json.default-json=false` and the default will change back to `application/octet-stream`. If you set this
+you will need to add `@Produces(MediaType.APPLICATION_JSON)` and `@Consumes(MediaType.APPLICATION_JSON)` to your endpoints in order to use JSON.
+
 ====
 
 === Configuring JSON support
@@ -266,7 +265,6 @@ When you have the following REST method, Quarkus determines that `Fruit` will be
 [source,JAVA]
 ----
 @GET
-@Produces("application/json")
 public List<Fruit> list() {
     // ...
 }
@@ -286,7 +284,6 @@ Your REST method then looks like this:
 [source,JAVA]
 ----
 @GET
-@Produces("application/json")
 public Response list() {
     // ...
 }

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -142,9 +142,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
 @Path("/api/users")
@@ -153,7 +151,6 @@ public class UserResource {
     @GET
     @RolesAllowed("user")
     @Path("/me")
-    @Produces(MediaType.APPLICATION_JSON)
     public String me(@Context SecurityContext securityContext) {
         return securityContext.getUserPrincipal().getName();
     }

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -143,9 +143,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
 @Path("/api/users")
@@ -154,7 +152,6 @@ public class UserResource {
     @GET
     @RolesAllowed("user")
     @Path("/me")
-    @Produces(MediaType.APPLICATION_JSON)
     public String me(@Context SecurityContext securityContext) {
         return securityContext.getUserPrincipal().getName();
     }

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -112,8 +112,6 @@ package org.acme.security.keycloak.authorization;;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 
@@ -127,7 +125,6 @@ public class UsersResource {
 
     @GET
     @Path("/me")
-    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public User me() {
         return new User(identity);
@@ -319,7 +316,6 @@ public class ProtectedResource {
     
     
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<List<Permission>> get() {
         return identity.checkPermission(new AuthPermission("{resource_name}"))
                 .thenCompose(granted -> {

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -137,9 +137,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
 @Path("/api/users")
@@ -148,7 +146,6 @@ public class UserResource {
     @GET
     @RolesAllowed("standardRole")
     @Path("/me")
-    @Produces(MediaType.APPLICATION_JSON)
     public String me(@Context SecurityContext securityContext) {
         return securityContext.getUserPrincipal().getName();
     }

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -100,8 +100,6 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -115,7 +113,6 @@ public class UsersResource {
     @GET
     @Path("/me")
     @RolesAllowed("user")
-    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public User me() {
         return new User(securityIdentity);

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -146,8 +146,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
@@ -158,7 +156,6 @@ public class WeatherForecastResource {
     WeatherForecastService service;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WeatherForecast getForecast(@QueryParam String city, @QueryParam long daysInFuture) { // <1>
         long executionStart = System.currentTimeMillis();
         List<String> dailyForecasts = Arrays.asList(

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -201,7 +201,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
@@ -218,7 +217,6 @@ public class FruitResource {
     }
 
     @GET
-    @Produces("application/json")
     public Iterable<Fruit> findAll() {
         return fruitRepository.findAll();
     }
@@ -232,14 +230,12 @@ public class FruitResource {
 
     @POST
     @Path("/name/{name}/color/{color}")
-    @Produces("application/json")
     public Fruit create(@PathParam String name, @PathParam String color) {
         return fruitRepository.save(new Fruit(name, color));
     }
 
     @PUT
     @Path("/id/{id}/color/{color}")
-    @Produces("application/json")
     public Fruit changeColor(@PathParam Long id, @PathParam String color) {
         Optional<Fruit> optional = fruitRepository.findById(id);
         if (optional.isPresent()) {
@@ -253,7 +249,6 @@ public class FruitResource {
 
     @GET
     @Path("/color/{color}")
-    @Produces("application/json")
     public List<Fruit> findByColor(@PathParam String color) {
         return fruitRepository.findByColor(color);
     }

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -122,8 +122,6 @@ Add the following method:
 ----
 @Path("/manual-validation")
 @POST
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public Result tryMeManualValidation(Book book) {
     Set<ConstraintViolation<Book>> violations = validator.validate(book);
     if (violations.isEmpty()) {
@@ -233,8 +231,6 @@ Calling the service in your rest end point triggers the `Book` validation automa
 
 @Path("/service-method-validation")
 @POST
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public Result tryMeServiceMethodValidation(Book book) {
     try {
         bookService.validateBook(book);

--- a/extensions/resteasy-jackson/deployment/src/main/java/io/quarkus/resteasy/jackson/deployment/ResteasyJacksonProcessor.java
+++ b/extensions/resteasy-jackson/deployment/src/main/java/io/quarkus/resteasy/jackson/deployment/ResteasyJacksonProcessor.java
@@ -6,6 +6,9 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
+import io.quarkus.resteasy.deployment.ResteasyJsonConfig;
+import io.quarkus.resteasy.jackson.runtime.QuarkusJacksonSerializer;
 
 public class ResteasyJacksonProcessor {
 
@@ -18,5 +21,13 @@ public class ResteasyJacksonProcessor {
     void capabilities(BuildProducer<CapabilityBuildItem> capability) {
         capability.produce(new CapabilityBuildItem(Capability.RESTEASY_JSON));
         capability.produce(new CapabilityBuildItem(Capability.REST_JACKSON));
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem provider(ResteasyJsonConfig config) {
+        if (config.jsonDefault) {
+            return new ResteasyJaxrsProviderBuildItem(QuarkusJacksonSerializer.class.getName());
+        }
+        return null;
     }
 }

--- a/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/HelloNoMediaTypeResource.java
+++ b/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/HelloNoMediaTypeResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.jackson;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello-default")
+public class HelloNoMediaTypeResource {
+
+    @GET
+    public Message hello() {
+        Message m = new Message();
+        m.setMessage("Hello");
+        return m;
+    }
+}

--- a/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/Message.java
+++ b/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/Message.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.jackson;
+
+public class Message {
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Message setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+}

--- a/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/NoMediaTypeTest.java
+++ b/extensions/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/NoMediaTypeTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.jackson;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class NoMediaTypeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloNoMediaTypeResource.class, Message.class));
+
+    @Test
+    public void testJsonDefaultNoProduces() {
+        RestAssured.get("/hello-default").then()
+                .statusCode(200)
+                .body("message", equalTo("Hello"));
+    }
+
+}

--- a/extensions/resteasy-jackson/runtime/src/main/java/io/quarkus/resteasy/jackson/runtime/QuarkusJacksonSerializer.java
+++ b/extensions/resteasy-jackson/runtime/src/main/java/io/quarkus/resteasy/jackson/runtime/QuarkusJacksonSerializer.java
@@ -1,0 +1,78 @@
+package io.quarkus.resteasy.jackson.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import javax.activation.DataSource;
+import javax.annotation.Priority;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.plugins.providers.FileRange;
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+import org.jboss.resteasy.spi.AsyncOutputStream;
+import org.jboss.resteasy.spi.AsyncStreamingOutput;
+
+/**
+ * provider that can produce JSON by default, removing the need for @Produces and @Consumes everywhere
+ */
+@Provider
+@Produces(MediaType.WILDCARD)
+@Consumes(MediaType.WILDCARD)
+@Priority(Priorities.USER - 200)
+public class QuarkusJacksonSerializer extends ResteasyJackson2Provider {
+
+    /**
+     * RESTEasy can already handle these
+     */
+    private static final Set<Class<?>> BUILTIN_DEFAULTS = new HashSet<>(
+            Arrays.asList(String.class, InputStream.class, FileRange.class, AsyncStreamingOutput.class, DataSource.class,
+                    Reader.class, StreamingOutput.class, byte[].class, File.class));
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        if (BUILTIN_DEFAULTS.contains(type)) {
+            return false;
+        }
+        return super.isReadable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        if (BUILTIN_DEFAULTS.contains(type)) {
+            return false;
+        }
+        return mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                || super.isWriteable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public void writeTo(Object t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        super.writeTo(t, type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+
+    @Override
+    public CompletionStage<Void> asyncWriteTo(Object t, Class<?> type, Type genericType, Annotation[] annotations,
+            MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, AsyncOutputStream entityStream) {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        return super.asyncWriteTo(t, type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+}

--- a/extensions/resteasy-jsonb/deployment/src/main/java/io/quarkus/resteasy/jsonb/deployment/ResteasyJsonbProcessor.java
+++ b/extensions/resteasy-jsonb/deployment/src/main/java/io/quarkus/resteasy/jsonb/deployment/ResteasyJsonbProcessor.java
@@ -11,6 +11,9 @@ import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.jsonb.spi.JsonbDeserializerBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
+import io.quarkus.resteasy.deployment.ResteasyJsonConfig;
+import io.quarkus.resteasy.jsonb.runtime.QuarkusJsonbSerializer;
 import io.quarkus.resteasy.jsonb.vertx.VertxJson;
 
 public class ResteasyJsonbProcessor {
@@ -40,5 +43,13 @@ public class ResteasyJsonbProcessor {
             BuildProducer<JsonbDeserializerBuildItem> deserializers) {
         serializers.produce(new JsonbSerializerBuildItem(VERTX_SERIALIZERS));
         deserializers.produce(new JsonbDeserializerBuildItem(VERTX_DESERIALIZERS));
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem provider(ResteasyJsonConfig config) {
+        if (config.jsonDefault) {
+            return new ResteasyJaxrsProviderBuildItem(QuarkusJsonbSerializer.class.getName());
+        }
+        return null;
     }
 }

--- a/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/HelloNoMediaTypeResource.java
+++ b/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/HelloNoMediaTypeResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.jsonb;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello-default")
+public class HelloNoMediaTypeResource {
+
+    @GET
+    public Message hello() {
+        Message m = new Message();
+        m.setMessage("Hello");
+        return m;
+    }
+}

--- a/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/Message.java
+++ b/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/Message.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.jsonb;
+
+public class Message {
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Message setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+}

--- a/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/NoMediaTypeTest.java
+++ b/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/NoMediaTypeTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.jsonb;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class NoMediaTypeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloNoMediaTypeResource.class, Message.class));
+
+    @Test
+    public void testJsonDefaultNoProduces() {
+        RestAssured.get("/hello-default").then()
+                .statusCode(200)
+                .body("message", equalTo("Hello"));
+    }
+
+}

--- a/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/ResourceSendingJsonObjects.java
+++ b/extensions/resteasy-jsonb/deployment/src/test/java/io/quarkus/resteasy/jsonb/ResourceSendingJsonObjects.java
@@ -4,12 +4,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Assertions;
@@ -18,7 +15,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @Path("/test")
-@Produces(MediaType.APPLICATION_JSON)
 public class ResourceSendingJsonObjects {
 
     @GET
@@ -38,7 +34,6 @@ public class ResourceSendingJsonObjects {
     }
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/objects")
     public Response receiveJsonObjects(List<JsonObject> objects) {
         Assertions.assertEquals(2, objects.size());
@@ -50,7 +45,6 @@ public class ResourceSendingJsonObjects {
     }
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/arrays")
     public Response receiveJsonArrays(List<JsonArray> array) {
         Assertions.assertEquals(1, array.size());

--- a/extensions/resteasy-jsonb/runtime/src/main/java/io/quarkus/resteasy/jsonb/runtime/QuarkusJsonbSerializer.java
+++ b/extensions/resteasy-jsonb/runtime/src/main/java/io/quarkus/resteasy/jsonb/runtime/QuarkusJsonbSerializer.java
@@ -1,0 +1,77 @@
+package io.quarkus.resteasy.jsonb.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import javax.activation.DataSource;
+import javax.annotation.Priority;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.plugins.providers.FileRange;
+import org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider;
+import org.jboss.resteasy.spi.AsyncOutputStream;
+import org.jboss.resteasy.spi.AsyncStreamingOutput;
+
+/**
+ * provider that can produce JSON by default, removing the need for @Produces and @Consumes everywhere
+ */
+@Provider
+@Produces(MediaType.WILDCARD)
+@Consumes(MediaType.WILDCARD)
+@Priority(Priorities.USER - 200)
+public class QuarkusJsonbSerializer extends JsonBindingProvider {
+
+    /**
+     * RESTEasy can already handle these
+     */
+    private static final Set<Class<?>> BUILTIN_DEFAULTS = new HashSet<>(
+            Arrays.asList(String.class, InputStream.class, FileRange.class, AsyncStreamingOutput.class, DataSource.class,
+                    Reader.class, StreamingOutput.class, byte[].class, File.class));
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        if (BUILTIN_DEFAULTS.contains(type)) {
+            return false;
+        }
+        return isSupportedMediaType(mediaType);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        if (BUILTIN_DEFAULTS.contains(type)) {
+            return false;
+        }
+        return isSupportedMediaType(mediaType) || mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+    }
+
+    @Override
+    public void writeTo(Object t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        super.writeTo(t, type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+
+    @Override
+    public CompletionStage<Void> asyncWriteTo(Object t, Class<?> type, Type genericType, Annotation[] annotations,
+            MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, AsyncOutputStream entityStream) {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        return super.asyncWriteTo(t, type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+}

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyJsonConfig.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyJsonConfig.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public class ResteasyJsonConfig {
+
+    /**
+     * If this is true (the default) then JSON is set to the default media type. If a method has no
+     * produces/consumes and there is no builtin provider than can handle the type
+     * then we will assume the response should be JSON.
+     *
+     * Note that this will only take effect if a JSON provider has been installed, such as quarkus-resteasy-jsonb
+     * or quarkus-resteasy-jackson.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean jsonDefault;
+}

--- a/integration-tests/cache/src/main/java/io/quarkus/it/cache/CaffeineResource.java
+++ b/integration-tests/cache/src/main/java/io/quarkus/it/cache/CaffeineResource.java
@@ -9,8 +9,6 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 
@@ -35,7 +33,6 @@ public class CaffeineResource {
 
     @GET
     @Path("/hasLoadAll")
-    @Produces(MediaType.APPLICATION_JSON)
     public JsonObject hasLoadAll() {
         return Json.createObjectBuilder()
                 .add("loader", hasLoadAll(new MyCacheLoader()))

--- a/integration-tests/cache/src/main/java/io/quarkus/it/cache/ExpensiveResource.java
+++ b/integration-tests/cache/src/main/java/io/quarkus/it/cache/ExpensiveResource.java
@@ -4,9 +4,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 
 import io.quarkus.cache.CacheKey;
 import io.quarkus.cache.CacheResult;
@@ -19,7 +17,6 @@ public class ExpensiveResource {
 
     @GET
     @Path("/{keyElement1}/{keyElement2}/{keyElement3}")
-    @Produces(MediaType.APPLICATION_JSON)
     @CacheResult(cacheName = "expensiveResourceCache", lockTimeout = 5000)
     public ExpensiveResponse getExpensiveResponse(@PathParam("keyElement1") @CacheKey String keyElement1,
             @PathParam("keyElement2") @CacheKey String keyElement2, @PathParam("keyElement3") @CacheKey String keyElement3,

--- a/integration-tests/elasticsearch-rest-client/src/main/java/io/quarkus/it/elasticsearch/FruitResource.java
+++ b/integration-tests/elasticsearch-rest-client/src/main/java/io/quarkus/it/elasticsearch/FruitResource.java
@@ -7,19 +7,14 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
     @Inject
     FruitService fruitService;

--- a/integration-tests/elasticsearch-rest-high-level-client/src/main/java/io/quarkus/it/elasticsearch/highlevel/FruitResource.java
+++ b/integration-tests/elasticsearch-rest-high-level-client/src/main/java/io/quarkus/it/elasticsearch/highlevel/FruitResource.java
@@ -7,19 +7,14 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/fruits")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
     @Inject
     FruitService fruitService;

--- a/integration-tests/elytron-security-oauth2/src/main/java/io/quarkus/it/elytron/oauth2/ElytronOauth2ExtensionResource.java
+++ b/integration-tests/elytron-security-oauth2/src/main/java/io/quarkus/it/elytron/oauth2/ElytronOauth2ExtensionResource.java
@@ -3,11 +3,8 @@ package io.quarkus.it.elytron.oauth2;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/api")
-@Produces(MediaType.APPLICATION_JSON)
 public class ElytronOauth2ExtensionResource {
 
     @GET

--- a/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/FlywayFunctionalityResource.java
+++ b/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/FlywayFunctionalityResource.java
@@ -5,11 +5,8 @@ import java.util.Objects;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
@@ -17,8 +14,6 @@ import org.flywaydb.core.api.MigrationVersion;
 import io.quarkus.flyway.FlywayDataSource;
 
 @Path("/")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public class FlywayFunctionalityResource {
     @Inject
     Flyway flyway;

--- a/integration-tests/grpc-streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingEndpoint.java
+++ b/integration-tests/grpc-streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingEndpoint.java
@@ -4,8 +4,6 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
@@ -15,7 +13,6 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @Path("/streaming")
-@Produces(MediaType.APPLICATION_JSON)
 public class StreamingEndpoint {
 
     @Inject

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/BookResource.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/BookResource.java
@@ -7,8 +7,6 @@ import javax.transaction.Transactional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/book")
 public class BookResource {
@@ -19,7 +17,6 @@ public class BookResource {
     @Transactional
     @GET
     @Path("/{name}/{author}")
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Book> addAndListAll(@PathParam("name") String name, @PathParam("author") String author) {
         bookDao.persist(new Book(name, author));
         return bookDao.listAll();

--- a/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2AlternativeTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2AlternativeTestEndpoint.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -18,7 +16,6 @@ import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
 
 @Path("/alternative-tests")
-@Produces(MediaType.APPLICATION_JSON)
 public class HibernateReactiveDB2AlternativeTestEndpoint {
 
     @Inject

--- a/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -33,7 +31,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactiveFind")
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB().convert().toCompletionStage()
@@ -42,7 +39,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactiveFindMutiny")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB()
@@ -51,7 +47,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactivePersist")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
         return mutinySession.persist(new GuineaPig(10, "Tulip"))
                 .chain(() -> mutinySession.flush())
@@ -60,7 +55,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactiveRemoveTransientEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
         return populateDB()
                 .chain(() -> selectNameFromId(5))
@@ -80,7 +74,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactiveRemoveManagedEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
         return populateDB()
                 .chain(() -> mutinySession.find(GuineaPig.class, 5))
@@ -93,7 +86,6 @@ public class HibernateReactiveDB2TestEndpoint {
 
     @GET
     @Path("/reactiveUpdate")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
         return populateDB()

--- a/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLAlternativeTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLAlternativeTestEndpoint.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -18,7 +16,6 @@ import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
 
 @Path("/alternative-tests")
-@Produces(MediaType.APPLICATION_JSON)
 public class HibernateReactiveMySQLAlternativeTestEndpoint {
 
     @Inject
@@ -50,7 +47,6 @@ public class HibernateReactiveMySQLAlternativeTestEndpoint {
 
     @GET
     @Path("/reactivePersist")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
         return mutinySession.persist(new GuineaPig(10, "Tulip"))
                 .chain(() -> mutinySession.flush())

--- a/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -33,7 +31,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactiveFind")
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB().convert().toCompletionStage()
@@ -42,7 +39,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactiveFindMutiny")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB()
@@ -51,7 +47,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactivePersist")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
         return mutinySession.persist(new GuineaPig(10, "Tulip"))
                 .chain(() -> mutinySession.flush())
@@ -60,7 +55,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactiveRemoveTransientEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
         return populateDB()
                 .chain(() -> selectNameFromId(5))
@@ -80,7 +74,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactiveRemoveManagedEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
         return populateDB()
                 .chain(() -> mutinySession.find(GuineaPig.class, 5))
@@ -93,7 +86,6 @@ public class HibernateReactiveMySQLTestEndpoint {
 
     @GET
     @Path("/reactiveUpdate")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
         return populateDB()

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -33,7 +31,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveFind")
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<GuineaPig> reactiveFind() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB().convert().toCompletionStage()
@@ -42,7 +39,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveFindMutiny")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<GuineaPig> reactiveFindMutiny() {
         final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
         return populateDB().chain(() -> mutinySession.find(GuineaPig.class, expectedPig.getId()));
@@ -50,7 +46,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactivePersist")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactivePersist() {
         final GuineaPig pig = new GuineaPig(10, "Tulip");
         return mutinySession
@@ -61,7 +56,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveCowPersist")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<FriesianCow> reactiveCowPersist() {
         final FriesianCow cow = new FriesianCow();
         cow.name = "Carolina";
@@ -74,7 +68,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveRemoveTransientEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveTransientEntity() {
         return populateDB()
                 .chain(() -> selectNameFromId(5))
@@ -96,7 +89,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveRemoveManagedEntity")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveRemoveManagedEntity() {
         return populateDB()
                 .chain(() -> mutinySession.find(GuineaPig.class, 5))
@@ -113,7 +105,6 @@ public class HibernateReactiveTestEndpoint {
 
     @GET
     @Path("/reactiveUpdate")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<String> reactiveUpdate() {
         final String NEW_NAME = "Tina";
         return populateDB()

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpointAlternative.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpointAlternative.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -18,7 +16,6 @@ import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
 
 @Path("/alternative-tests")
-@Produces(MediaType.APPLICATION_JSON)
 public class HibernateReactiveTestEndpointAlternative {
 
     @Inject

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -24,7 +24,6 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -220,7 +219,6 @@ public class HibernateValidatorTestResource
     @POST
     @Path("/test-manual-validation-message-locale")
     @Produces(MediaType.TEXT_PLAIN)
-    @Consumes(MediaType.APPLICATION_JSON)
     public String testManualValidationMessageLocale(MyLocaleTestBean test) {
         Set<ConstraintViolation<MyLocaleTestBean>> violations = validator.validate(test);
 

--- a/integration-tests/kafka-avro/src/main/java/io/quarkus/it/kafka/avro/AvroEndpoint.java
+++ b/integration-tests/kafka-avro/src/main/java/io/quarkus/it/kafka/avro/AvroEndpoint.java
@@ -5,8 +5,6 @@ import java.time.Duration;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -24,7 +22,6 @@ public class AvroEndpoint {
 
     @GET
     @Path("/confluent")
-    @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getConfluent() {
         return get(AvroKafkaCreator.createConfluentConsumer("test-avro-confluent-consumer", "test-avro-confluent-consumer"));
     }
@@ -38,7 +35,6 @@ public class AvroEndpoint {
 
     @GET
     @Path("/apicurio")
-    @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getApicurio() {
         return get(AvroKafkaCreator.createApicurioConsumer("test-avro-apicurio-consumer", "test-avro-apicurio-consumer"));
     }

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
@@ -2,13 +2,10 @@ package io.quarkus.it.kafka.streams;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -45,8 +42,6 @@ public class KafkaStreamsEndpoint {
 
     @GET
     @Path("/category/{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public Long getCategory(@PathParam("id") int id) {
         return getCountstore().get(id);
     }

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/CodecEndpoint.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/CodecEndpoint.java
@@ -5,12 +5,9 @@ import java.util.Collections;
 import java.util.Properties;
 
 import javax.annotation.PostConstruct;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -33,8 +30,6 @@ import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
  * deserializer (ObjectMapperDeserializer), topic: movies
  */
 @Path("/codecs")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class CodecEndpoint {
 
     public static Producer<String, Pet> createPetProducer() {

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -8,15 +8,12 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 import javax.security.auth.AuthPermission;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 
 import org.keycloak.representations.idm.authorization.Permission;
 
@@ -31,7 +28,6 @@ public class ProtectedResource {
     SecurityIdentity identity;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<List<Permission>> permissions() {
         return identity.checkPermission(new AuthPermission("Permission Resource")).onItem()
                 .apply(new Function<Boolean, List<Permission>>() {
@@ -47,7 +43,6 @@ public class ProtectedResource {
 
     @GET
     @Path("/scope")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<List<Permission>> hasScopePermission(@QueryParam("scope") String scope) {
         return identity.checkPermission(new BasicPermission("Scope Permission Resource") {
             @Override
@@ -68,22 +63,18 @@ public class ProtectedResource {
 
     @Path("/claim-protected")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Permission> claimProtected() {
         return identity.getAttribute("permissions");
     }
 
     @Path("/http-response-claim-protected")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Permission> httpResponseClaimProtected() {
         return identity.getAttribute("permissions");
     }
 
     @Path("/body-claim")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Permission> bodyClaim(Map<String, Object> body, @Context HttpServerRequest request) {
         if (body == null || !body.containsKey("from-body")) {
             return Collections.emptyList();

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -3,8 +3,6 @@ package io.quarkus.it.keycloak;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -16,7 +14,6 @@ public class UsersResource {
 
     @GET
     @Path("/me")
-    @Produces(MediaType.APPLICATION_JSON)
     public User me() {
         return new User(keycloakSecurityContext);
     }

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
@@ -8,8 +8,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -26,7 +24,6 @@ public class Pods {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{namespace}")
     public Response pods(@PathParam("namespace") String namespace) {
         return Response.ok(kubernetesClient.pods().inNamespace(namespace).list().getItems()).build();
@@ -45,7 +42,6 @@ public class Pods {
     }
 
     @PUT
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{namespace}")
     public Response updateFirst(@PathParam("namespace") String namespace) {
         final List<Pod> pods = kubernetesClient.pods().inNamespace(namespace).list().getItems();
@@ -64,7 +60,6 @@ public class Pods {
     }
 
     @POST
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{namespace}")
     public Response createNew(@PathParam("namespace") String namespace) {
         return Response

--- a/integration-tests/liquibase/src/main/java/io/quarkus/it/liquibase/LiquibaseFunctionalityResource.java
+++ b/integration-tests/liquibase/src/main/java/io/quarkus/it/liquibase/LiquibaseFunctionalityResource.java
@@ -5,12 +5,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
 
 import io.quarkus.liquibase.LiquibaseFactory;
 import liquibase.Liquibase;
@@ -20,8 +17,6 @@ import liquibase.command.CommandFactory;
 import liquibase.command.core.DropAllCommand;
 
 @Path("/")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public class LiquibaseFunctionalityResource {
 
     @Inject

--- a/integration-tests/main/src/main/java/io/quarkus/it/jaxb/rest/NewsResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/jaxb/rest/NewsResource.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.it.jaxb.mapper.process.UnmarshalRSSProcess;
@@ -21,7 +19,6 @@ public class NewsResource {
     UnmarshalRSSProcess newsProcessor;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Response getNews() {
         try {
             final Collection<INews> results = new ArrayList<>();

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
@@ -163,7 +163,6 @@ public class ClientResource {
 
     @GET
     @Path("/jaxrs-client")
-    @Produces(MediaType.APPLICATION_JSON)
     public Greeting testJaxrsClient() throws ClassNotFoundException {
         Greeting greeting = client.target(loopbackEndpoint.get())
                 .request()

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClientImpl.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClientImpl.java
@@ -6,11 +6,8 @@ import java.util.Set;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 
-@Produces(MediaType.APPLICATION_JSON)
 @Path("gouv-geo-api")
 public class GouvFrGeoApiClientImpl {
 

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/LoopbackResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/LoopbackResource.java
@@ -4,14 +4,11 @@ import java.time.LocalDate;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/loopback")
 public class LoopbackResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Greeting hello() {
         return new Greeting("hello self", LocalDate.of(2020, 02, 13));
     }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/BookResource.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/BookResource.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.mongodb.client.FindIterable;
@@ -17,8 +16,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 @Path("/books")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class BookResource {
 
     @Inject

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/ReactiveBookResource.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/ReactiveBookResource.java
@@ -8,15 +8,12 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
 
 @Path("/reactive-books")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class ReactiveBookResource {
 
     @Inject

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/VehicleResource.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/VehicleResource.java
@@ -9,12 +9,9 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.mongodb.client.FindIterable;
@@ -23,8 +20,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 @Path("/vehicles")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class VehicleResource {
     @Inject
     MongoClient client;

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/book/BookEntityResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/book/BookEntityResource.kt
@@ -22,8 +22,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/books/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class BookEntityResource {
     @PostConstruct
     fun init() {

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.kt
@@ -23,8 +23,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/books/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class BookRepositoryResource {
     @Inject
     lateinit var bookRepository: BookRepository

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/person/PersonEntityResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/person/PersonEntityResource.kt
@@ -16,8 +16,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/persons/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class PersonEntityResource {
     @GET
     fun getPersons(@QueryParam("sort") sort: String?): List<PersonEntity> =

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.kt
@@ -17,8 +17,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/persons/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class PersonRepositoryResource {
     // fake unused injection point to force ArC to not remove this otherwise I can't mock it in the tests
     @Inject

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookEntityResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookEntityResource.kt
@@ -25,8 +25,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/reactive/books/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class ReactiveBookEntityResource {
     @PostConstruct
     fun init() {

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookRepositoryResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookRepositoryResource.kt
@@ -27,8 +27,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/reactive/books/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class ReactiveBookRepositoryResource {
     @Inject
     lateinit var reactiveBookRepository: ReactiveBookRepository

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.kt
@@ -19,8 +19,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/reactive/persons/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class ReactivePersonEntityResource {
     @GET
     fun getPersons(@QueryParam("sort") sort: String?): Uni<List<ReactivePersonEntity>> {

--- a/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/main/kotlin/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.kt
@@ -21,8 +21,6 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 @Path("/reactive/persons/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 class ReactivePersonRepositoryResource {
     @Inject
     lateinit var reactivePersonRepository: ReactivePersonRepository

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.bson.types.ObjectId;
@@ -16,8 +15,6 @@ import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 
 @Path("/books/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class BookEntityResource {
     private static final Logger LOGGER = Logger.getLogger(BookEntityResource.class);
 

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.bson.types.ObjectId;
@@ -17,8 +16,6 @@ import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 
 @Path("/books/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class BookRepositoryResource {
     private static final Logger LOGGER = Logger.getLogger(BookRepositoryResource.class);
     @Inject

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
@@ -6,14 +6,11 @@ import java.util.List;
 import java.util.Set;
 
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.panache.common.Sort;
 
 @Path("/persons/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class PersonEntityResource {
     @GET
     public List<PersonEntity> getPersons(@QueryParam("sort") String sort) {

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
@@ -7,14 +7,11 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.panache.common.Sort;
 
 @Path("/persons/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class PersonRepositoryResource {
 
     // fake unused injection point to force ArC to not remove this otherwise I can't mock it in the tests

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookEntityResource.java
@@ -19,8 +19,6 @@ import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 @Path("/reactive/books/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class ReactiveBookEntityResource {
     private static final Logger LOGGER = Logger.getLogger(ReactiveBookEntityResource.class);
 

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/book/ReactiveBookRepositoryResource.java
@@ -21,8 +21,6 @@ import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 @Path("/reactive/books/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class ReactiveBookRepositoryResource {
     private static final Logger LOGGER = Logger.getLogger(ReactiveBookRepositoryResource.class);
     @Inject

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.it.mongodb.panache.person.PersonName;
@@ -14,8 +13,6 @@ import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 @Path("/reactive/persons/entity")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class ReactivePersonEntityResource {
     @GET
     public Uni<List<ReactivePersonEntity>> getPersons(@QueryParam("sort") String sort) {

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.it.mongodb.panache.person.Person;
@@ -16,8 +15,6 @@ import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 @Path("/reactive/persons/repository")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class ReactivePersonRepositoryResource {
 
     @Inject

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -3,8 +3,6 @@ package io.quarkus.it.keycloak;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.ClaimValue;
@@ -20,7 +18,6 @@ public class AdminResource {
 
     @GET
     @RolesAllowed("admin")
-    @Produces(MediaType.APPLICATION_JSON)
     public String admin() {
         return "granted:" + claim.getValue();
     }

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/PermissionResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/PermissionResource.java
@@ -8,8 +8,6 @@ import javax.inject.Inject;
 import javax.json.JsonString;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -22,7 +20,6 @@ public class PermissionResource {
     @GET
     @Path("/{name}")
     @RolesAllowed("user")
-    @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Object> permissions() {
         Map<String, Object> claims = new HashMap<>();
         for (String i : jwt.getClaimNames()) {

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -4,8 +4,6 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -23,7 +21,6 @@ public class UsersResource {
     @GET
     @Path("/me")
     @RolesAllowed("user")
-    @Produces(MediaType.APPLICATION_JSON)
     public User principalName() {
         return new User(identity.getPrincipal().getName());
     }
@@ -31,7 +28,6 @@ public class UsersResource {
     @GET
     @Path("/preferredUserName")
     @RolesAllowed("user")
-    @Produces(MediaType.APPLICATION_JSON)
     public User preferredUserName() {
         return new User(((JsonWebToken) identity.getPrincipal()).getClaim("preferred_username"));
     }

--- a/integration-tests/openshift-client/src/main/java/io/quarkus/it/openshift/client/Routes.java
+++ b/integration-tests/openshift-client/src/main/java/io/quarkus/it/openshift/client/Routes.java
@@ -3,8 +3,6 @@ package io.quarkus.it.openshift.client;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -19,7 +17,6 @@ public class Routes {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{namespace}")
     public Response routes(@PathParam("namespace") String namespace) {
         return Response.ok(openshiftClient.routes().inNamespace(namespace).list().getItems()).build();

--- a/integration-tests/reactive-db2-client/src/main/java/io/quarkus/it/reactive/db2/client/FruitResource.java
+++ b/integration-tests/reactive-db2-client/src/main/java/io/quarkus/it/reactive/db2/client/FruitResource.java
@@ -6,8 +6,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -33,7 +31,6 @@ public class FruitResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<JsonArray> listFruits() {
         return client.query("SELECT * FROM fruits").execute()
                 .map(mysqlRowSet -> {

--- a/integration-tests/reactive-messaging-amqp/src/main/java/io/quarkus/it/amqp/AmqpEndpoint.java
+++ b/integration-tests/reactive-messaging-amqp/src/main/java/io/quarkus/it/amqp/AmqpEndpoint.java
@@ -5,8 +5,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/amqp")
 public class AmqpEndpoint {
@@ -16,7 +14,6 @@ public class AmqpEndpoint {
 
     @GET
     @Path("/people")
-    @Produces(MediaType.APPLICATION_JSON)
     public List<Person> getPeople() {
         return people.getPeople();
     }

--- a/integration-tests/reactive-mysql-client/src/main/java/io/quarkus/it/reactive/mysql/client/FruitResource.java
+++ b/integration-tests/reactive-mysql-client/src/main/java/io/quarkus/it/reactive/mysql/client/FruitResource.java
@@ -6,8 +6,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -31,7 +29,6 @@ public class FruitResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<JsonArray> listFruits() {
         return client.query("SELECT * FROM fruits").execute()
                 .map(mysqlRowSet -> {

--- a/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
+++ b/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
@@ -6,8 +6,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -31,7 +29,6 @@ public class FruitResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<JsonArray> listFruits() {
         return client.query("SELECT * FROM fruits").execute()
                 .map(pgRowSet -> {

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HotReloadFruitResource.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HotReloadFruitResource.java
@@ -6,8 +6,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -31,7 +29,6 @@ public class HotReloadFruitResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public CompletionStage<JsonArray> listFruits() {
         return client.query("SELECT * FROM fruits").execute()
                 .map(pgRowSet -> {

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/BigKeysResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/BigKeysResource.java
@@ -4,18 +4,13 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/bigkeys")
 public class BigKeysResource {
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public Payload post(Payload payload) {
         return payload;
     }

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
@@ -5,14 +5,11 @@ import java.time.LocalDate;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Greeting hello() {
         LocalDate localDate = LocalDate.of(2019, 01, 01);
         return new Greeting("hello", localDate, new Date(localDate.toEpochDay()));

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MutinyResource.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MutinyResource.java
@@ -42,21 +42,18 @@ public class MutinyResource {
 
     @GET
     @Path("/hello/stream")
-    @Produces(MediaType.APPLICATION_JSON)
     public Multi<String> helloAsMulti() {
         return service.greetingAsMulti();
     }
 
     @GET
     @Path("/pet")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<Pet> pet() {
         return service.getPet();
     }
 
     @GET
     @Path("/pet/stream")
-    @Produces(MediaType.APPLICATION_JSON)
     public Multi<Pet> pets() {
         return service.getPets();
     }
@@ -81,7 +78,6 @@ public class MutinyResource {
 
     @GET
     @Path("/client/pet")
-    @Produces(MediaType.APPLICATION_JSON)
     public Uni<Pet> callPet() {
         return client.pet();
     }

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MyRestService.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MyRestService.java
@@ -1,9 +1,7 @@
 package io.quarkus.it.resteasy.mutiny;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -19,7 +17,6 @@ public interface MyRestService {
 
     @GET
     @Path("/pet")
-    @Consumes(MediaType.APPLICATION_JSON)
     Uni<Pet> pet();
 
 }

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerResource.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerResource.java
@@ -3,12 +3,9 @@ package io.quarkus.it.smallrye.config;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/server")
-@Produces(MediaType.APPLICATION_JSON)
 public class ServerResource {
     @Inject
     Server server;

--- a/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/GreetingResource.java
+++ b/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/GreetingResource.java
@@ -4,14 +4,11 @@ import java.time.LocalDate;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Greeting hello() {
         return new Greeting("hello", LocalDate.of(2019, 01, 01));
     }


### PR DESCRIPTION
This adds a new RESTEasy provider that will produce
JSON by default. This removes the need to add
@Produces(MediaType.APPLICATION_JSON) and
@Consumes(MediaType.APPLICATION_JSON) everywhere.

The old behaviour can be retained by setting:

quarkus.resteasy-json.default-json=false

in application.properties.