### PR TITLE
Drop log entry when closing the Kubernetes client

### DIFF
--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
@@ -4,8 +4,6 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
-import org.jboss.logging.Logger;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -13,8 +11,6 @@ import io.quarkus.arc.DefaultBean;
 
 @Singleton
 public class KubernetesClientProducer {
-
-    private static final Logger LOGGER = Logger.getLogger(KubernetesClientProducer.class);
 
     private KubernetesClient client;
 
@@ -36,7 +32,6 @@ public class KubernetesClientProducer {
     @PreDestroy
     public void destroy() {
         if (client != null) {
-            LOGGER.info("Closing Kubernetes client");
             client.close();
         }
     }


### PR DESCRIPTION
This is very minor but...

If we start logging something for every client we close, shutdown will
be far too verbose.