### PR TITLE
Fix REST client extension SSL native include

### DIFF
--- a/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -173,7 +173,6 @@ class RestClientProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
             BuildProducer<BeanRegistrarBuildItem> beanRegistrars,
-            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             BuildProducer<ServiceProviderBuildItem> serviceProvider,
             BuildProducer<RestClientBuildItem> restClient) {
 
@@ -254,9 +253,11 @@ class RestClientProcessor {
                 }
             }
         }));
+    }
 
-        // Indicates that this extension would like the SSL support to be enabled
-        extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.REST_CLIENT));
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(Feature.REST_CLIENT);
     }
 
     // currently default methods on a rest-client interface


### PR DESCRIPTION
Resolves #12525 

I figured out that the build step that is including the ExtensionSslNativeSupportBuildItem is not executed if there is no MP REST client interface included in the application. Moving the ExtensionSslNativeSupportBuildItem into a separate build step fixes the issue.