### PR TITLE
Revert "fix(redis): re-introduce "ssl", "database" and "password" configuration for backward compatibility"

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
@@ -33,7 +33,7 @@ class RedisAPIProducer {
                 if (redisConfig.timeout.isPresent()) {
                     timeout = redisConfig.timeout.get().getSeconds();
                 }
-                RedisOptions options = RedisClientUtil.buildOptions(redisConfig, name);
+                RedisOptions options = RedisClientUtil.buildOptions(redisConfig);
                 Redis redis = Redis.createClient(vertx, options);
                 RedisAPI redisAPI = RedisAPI.api(redis);
                 MutinyRedis mutinyRedis = new MutinyRedis(redis);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisConfig.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 
 import io.quarkus.redis.client.RedisClient;
@@ -55,39 +54,6 @@ public class RedisConfig {
 
     @ConfigGroup
     public static class RedisConfiguration {
-        /**
-         * The redis password
-         * <p>
-         * 
-         * @deprecated It should be removed in the 1.10 release.
-         *             Follows up https://github.com/quarkusio/quarkus/pull/11908#issuecomment-694794724
-         */
-        @ConfigItem
-        @Deprecated
-        public Optional<String> password;
-
-        /**
-         * Enables or disables ssl connection.
-         * <p>
-         * 
-         * @deprecated It should be removed in the 1.10 release.
-         *             Follows up https://github.com/quarkusio/quarkus/pull/11908#issuecomment-694794724
-         */
-        @ConfigItem
-        @Deprecated
-        public Optional<Boolean> ssl;
-
-        /**
-         * The redis database
-         * <p>
-         * 
-         * @deprecated It should be removed in the 1.10 release.
-         *             Follows up https://github.com/quarkusio/quarkus/pull/11908#issuecomment-694794724
-         */
-        @ConfigItem
-        @Deprecated
-        public OptionalInt database;
-
         /**
          * The redis hosts to use while connecting to the redis server. Only the cluster mode will consider more than
          * 1 element.


### PR DESCRIPTION

This reverts commit fc3f648a99ba53354e1c166117daacc0d36cc66a since 1.9 has been branched.

/cc @gsmet 