### PR TITLE
Bootstrap Maven: don't check MAVEN_PROJECTBASEDIR for the root project dir

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -794,28 +794,10 @@ public class BootstrapMavenContext {
     }
 
     public Path getRootProjectBaseDir() {
-        return rootProjectDir == null ? rootProjectDir = resolveRootProjectDir() : rootProjectDir;
-    }
-
-    private Path resolveRootProjectDir() {
-        final String rootBaseDir = System.getenv(MAVEN_PROJECTBASEDIR);
-        if (rootBaseDir == null) {
-            return null;
-        }
-        // if the alternate POM was set (not on the CLI) and its base dir does not match the base dir
-        // set by the Maven process then the root project set by the Maven process is probably not relevant too
-        if (alternatePomName != null) {
-            final Path currentPom = getCurrentProjectPomOrNull();
-            if (currentPom == null || !getCurrentProjectBaseDir().equals(currentPom.getParent())) {
-                return null;
-            }
-        }
-        final Path rootProjectBaseDirPath = Paths.get(rootBaseDir);
-        // if the root project dir set by the Maven process (through the env variable) doesn't have a pom.xml
-        // then it probably isn't relevant
-        if (!Files.exists(rootProjectBaseDirPath.resolve("pom.xml"))) {
-            return null;
-        }
-        return rootProjectBaseDirPath;
+        // originally we checked for MAVEN_PROJECTBASEDIR which is set by the mvn script
+        // and points to the first parent containing '.mvn' dir but it's not consistent
+        // with how Maven discovers the workspace and also created issues testing the Quarkus platform
+        // due to its specific FS layout
+        return rootProjectDir;
     }
 }


### PR DESCRIPTION
This env var which is set by the mvn script was used as an optimization to quickly locate the project root dir (or the most probably root project dir). However, this principle of workspace discovery appears to be inconsistent with Maven itself in certain project layouts, such as the Quarkus platform one.