### PR TITLE
Externalize gradle/maven wrapper command from codestart template

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/codestart.yml
@@ -14,15 +14,16 @@ language:
           id: io.quarkus
       buildtool:
         build-dir: build
+        cli: gradle
         guide: https://quarkus.io/guides/gradle-tooling
         guide-native: https://quarkus.io/guides/gradle-tooling#building-a-native-executable
         cmd:
-          dev: gradle quarkusDev
-          package: gradle build
-          package-uberjar: gradle build -Dquarkus.package.type=uber-jar
-          package-native: gradle build -Dquarkus.package.type=native
-          package-native-container: gradle build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
-          build-ci: gradle build
+          dev: quarkusDev
+          package: build
+          package-uberjar: build -Dquarkus.package.type=uber-jar
+          package-native: build -Dquarkus.package.type=native
+          package-native-container: build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+          build-ci: build
   kotlin:
     dependencies:
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/codestart.yml
@@ -14,15 +14,16 @@ language:
           id: io.quarkus
       buildtool:
         build-dir: build
+        cli: gradle
         guide: https://quarkus.io/guides/gradle-tooling
         guide-native: https://quarkus.io/guides/gradle-tooling#building-a-native-executable
         cmd:
-          dev: gradle quarkusDev
-          package: gradle build
-          package-uberjar: gradle build --Dquarkus.package.type=uber-jar
-          package-native: gradle build -Dquarkus.package.type=native
-          package-native-container: gradle build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
-          build-ci: gradle build
+          dev: quarkusDev
+          package: build
+          package-uberjar: build --Dquarkus.package.type=uber-jar
+          package-native: build -Dquarkus.package.type=native
+          package-native-container: build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
+          build-ci: build
   kotlin:
     dependencies:
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/codestart.yml
@@ -20,12 +20,13 @@ language:
     shared-data:
       buildtool:
         build-dir: target
+        cli: mvn
         guide: https://quarkus.io/guides/maven-tooling.html
         guide-native: https://quarkus.io/guides/building-native-image
         cmd:
-          dev: mvn compile quarkus:dev
-          package: mvn package
-          package-uberjar: mvn package -Dquarkus.package.type=uber-jar
-          package-native: mvn package -Pnative
-          package-native-container: mvn package -Pnative -Dquarkus.native.container-build=true
-          build-ci: mvn verify -B
+          dev: compile quarkus:dev
+          package: package
+          package-uberjar: package -Dquarkus.package.type=uber-jar
+          package-native: package -Pnative
+          package-native-container: package -Pnative -Dquarkus.native.container-build=true
+          build-ci: verify -B

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/resteasy-example/base/src/main/resources/META-INF/resources/index.tpl.qute.html
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/resteasy-example/base/src/main/resources/META-INF/resources/index.tpl.qute.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>{buildtool.cmd.dev}</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>{buildtool.cli} {buildtool.cmd.dev}</code>.
         </p>
         <ul>
             <li>Open the example <a href="{resource.path}" target="_blank">"/hello"</a> endpoint</li>

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/spring-web-example/base/src/main/resources/META-INF/resources/spring.tpl.qute.html
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/spring-web-example/base/src/main/resources/META-INF/resources/spring.tpl.qute.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>{buildtool.cmd.dev}</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>{buildtool.cli} {buildtool.cmd.dev}</code>.
         </p>
         <ul>
             <li>Open the example <a href="{resource.path}" target="_blank">"/hello"</a> endpoint</li>

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/project/quarkus/base/README.tpl.qute.md
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/project/quarkus/base/README.tpl.qute.md
@@ -8,21 +8,21 @@ If you want to learn more about Quarkus, please visit its website: https://quark
 
 You can run your application in dev mode that enables live coding using:
 ```shell script
-{buildtool.cmd.dev}
+{buildtool.cli} {buildtool.cmd.dev}
 ```
 
 ## Packaging and running the application
 
 The application can be packaged using:
 ```shell script
-{buildtool.cmd.package}
+{buildtool.cli} {buildtool.cmd.package}
 ```
 It produces the `{project.artifact-id}-{project.version}-runner.jar` file in the `/{buildtool.build-dir}` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `{buildtool.build-dir}/lib` directory.
 
 If you want to build an _über-jar_, execute the following command:
 ```shell script
-{buildtool.cmd.package-uberjar}
+{buildtool.cli} {buildtool.cmd.package-uberjar}
 ```
 
 The application is now runnable using `java -jar {buildtool.build-dir}/{project.artifact-id}-{project.version}-runner.jar`.
@@ -31,12 +31,12 @@ The application is now runnable using `java -jar {buildtool.build-dir}/{project.
 
 You can create a native executable using: 
 ```shell script
-{buildtool.cmd.package-native}
+{buildtool.cli} {buildtool.cmd.package-native}
 ```
 
 Or, if you don't have GraalVM installed, you can run the native executable build in a container using: 
 ```shell script
-{buildtool.cmd.package-native-container}
+{buildtool.cli} {buildtool.cmd.package-native-container}
 ```
 
 You can then execute your native executable with: `./{buildtool.build-dir}/{project.artifact-id}-{project.version}-runner`

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
@@ -18,4 +18,10 @@ jobs:
         with:
           java-version: {java.version}
       - name: Build
-        run: {buildtool.cmd.build-ci}
+        {#if buildtool.cli == 'gradle'}
+          uses: eskatos/gradle-command-action@v1
+          with:
+            arguments: {buildtool.cmd.build-ci}
+        {#else}
+          run: {buildtool.cli} {buildtool.cmd.build-ci}
+        {/if}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/gradle-wrapper/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/gradle-wrapper/codestart.yml
@@ -7,10 +7,4 @@ language:
         version: 6.5.1
     shared-data:
       buildtool:
-        cmd:
-          dev: ./gradlew quarkusDev
-          package: ./gradlew build
-          package-uberjar: ./gradlew build -Dquarkus.package.type=uber-jar
-          package-native: ./gradlew build -Dquarkus.package.type=native
-          package-native-container: ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
-          build-ci: ./gradlew build
+        cli: ./gradlew

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/maven-wrapper/codestart.yml
@@ -8,10 +8,4 @@ language:
         wrapper-version: 0.5.6
     shared-data:
       buildtool:
-        cmd:
-          dev: ./mvnw compile quarkus:dev
-          package: ./mvnw package
-          package-uberjar: ./mvnw package -Dquarkus.package.type=uber-jar
-          package-native: ./mvnw package -Pnative
-          package-native-container: ./mvnw package -Pnative -Dquarkus.native.container-build=true
-          build-ci: ./mvnw verify -B
+        cli: ./mvnw

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/QuarkusCodestartData.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/QuarkusCodestartData.java
@@ -43,8 +43,6 @@ public final class QuarkusCodestartData {
         NO_BUILD_TOOL_WRAPPER("quarkus-project.no-build-tool-wrapper"),
         NO_DOCKERFILES("quarkus-project.no-dockerfiles");
 
-        ;
-
         private final String key;
 
         DataKey(String key) {

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/QuarkusCodestartRunIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/QuarkusCodestartRunIT.java
@@ -154,6 +154,7 @@ class QuarkusCodestartRunIT extends PlatformAwareTestBase {
         final CodestartProjectDefinition projectDefinition = getCatalog().createProject(input);
         Path projectDir = testDirPath.resolve(name);
         projectDefinition.generate(projectDir);
+
         final int result = WrapperRunner.run(projectDir,
                 WrapperRunner.Wrapper.fromBuildtool(buildToolName));
         assertThat(result).isZero();


### PR DESCRIPTION
This branch aims to externalize the build tool command used in the generated github action workflow. 

@ia3andy I added a field `build-cmd` which could be used by all command such as: 

    cmd:
          dev: ${buildtool.cmd.build-cmd} compile quarkus:dev
          package: ${buildtool.cmd.build-cmd} package

But I don't know if this is the goal. 

also, I don't how to test if my code is correct, could you give me pointers to validate it ? thanks :) 

close #12438 