### PR TITLE
Put parentId from trace context into MDC

### DIFF
--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -113,7 +113,7 @@ The first approach is by providing the properties within the `src/main/resources
 quarkus.jaeger.service-name=myservice // <1>
 quarkus.jaeger.sampler-type=const // <2>
 quarkus.jaeger.sampler-param=1 // <3>
-quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n // <4>
+quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n // <4>
 ----
 
 <1> If the `quarkus.jaeger.service-name` property (or `JAEGER_SERVICE_NAME` environment variable) is not provided then a "no-op" tracer will be configured, resulting in no tracing data being reported to the backend.
@@ -155,7 +155,7 @@ hello
 When the first request has been submitted, the Jaeger tracer within the app will be initialized:
 ```
 2019-10-16 09:35:23,464 INFO  [io.jae.Configuration] (executor-thread-1) Initialized tracer=JaegerTracer(version=Java-0.34.0, serviceName=myservice, reporter=RemoteReporter(sender=UdpSender(), closeEnqueueTimeout=1000), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), tags={hostname=localhost.localdomain, jaeger.version=Java-0.34.0, ip=127.0.0.1}, zipkinSharedRpcSpan=false, expandExceptionLogs=false, useTraceId128Bit=false)
-13:20:11 INFO  traceId=1336b2b0a76a96a3, spanId=1336b2b0a76a96a3, sampled=true [or.ac.qu.TracedResource] (executor-thread-63) hello
+13:20:11 INFO  traceId=1336b2b0a76a96a3, parentId=0, spanId=1336b2b0a76a96a3, sampled=true [or.ac.qu.TracedResource] (executor-thread-63) hello
 ```
 
 Then visit the http://localhost:16686[Jaeger UI] to see the tracing information.

--- a/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/NestedMdcScopesTest.java
+++ b/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/NestedMdcScopesTest.java
@@ -25,27 +25,32 @@ public class NestedMdcScopesTest {
         assertNull(mdcScopeManager.active());
         assertNull(threadLocalScopeManager.active());
         assertNull(MDC.get("traceId"));
+        assertNull(MDC.get("parentId"));
 
-        JaegerSpanContext span = new JaegerSpanContext(1, 1, 1, 1, Byte.valueOf("0"));
+        JaegerSpanContext span = new JaegerSpanContext(1, 1, 1, 0, Byte.valueOf("0"));
         Scope scope = mdcScopeManager.activate(new TestSpan(span), true);
         assertSame(span, threadLocalScopeManager.active().span().context());
         assertEquals("10000000000000001", MDC.get("traceId"));
+        assertEquals("0", MDC.get("parentId"));
 
         JaegerSpanContext subSpan = new JaegerSpanContext(2, 2, 2, 1, Byte.valueOf("0"));
         Scope subScope = mdcScopeManager.activate(new TestSpan(subSpan), true);
         assertSame(subSpan, threadLocalScopeManager.active().span().context());
         assertEquals("20000000000000002", MDC.get("traceId"));
+        assertEquals("1", MDC.get("parentId"));
 
         subScope.close();
 
         assertSame(span, threadLocalScopeManager.active().span().context());
         assertEquals("10000000000000001", MDC.get("traceId"));
+        assertEquals("0", MDC.get("parentId"));
 
         scope.close();
 
         assertNull(mdcScopeManager.active());
         assertNull(threadLocalScopeManager.active());
         assertNull(MDC.get("traceId"));
+        assertNull(MDC.get("parentId"));
     }
 
     static class TestSpan implements Span {

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScope.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScope.java
@@ -16,17 +16,20 @@ public class MDCScope implements Scope {
      */
     private static final String TRACE_ID = "traceId";
     private static final String SPAN_ID = "spanId";
+    private static final String PARENT_ID = "parentId";
     private static final String SAMPLED = "sampled";
 
     private final Scope wrapped;
     private final Object originalTraceId;
     private final Object originalSpanId;
+    private final Object originalParentId;
     private final Object originalSampled;
 
     public MDCScope(Scope scope) {
         this.wrapped = scope;
         this.originalTraceId = MDC.get(TRACE_ID);
         this.originalSpanId = MDC.get(SPAN_ID);
+        this.originalParentId = MDC.get(PARENT_ID);
         this.originalSampled = MDC.get(SAMPLED);
         if (scope.span().context() instanceof JaegerSpanContext) {
             putContext((JaegerSpanContext) scope.span().context());
@@ -38,6 +41,7 @@ public class MDCScope implements Scope {
         wrapped.close();
         MDC.remove(TRACE_ID);
         MDC.remove(SPAN_ID);
+        MDC.remove(PARENT_ID);
         MDC.remove(SAMPLED);
 
         if (originalTraceId != null) {
@@ -45,6 +49,9 @@ public class MDCScope implements Scope {
         }
         if (originalSpanId != null) {
             MDC.put(SPAN_ID, originalSpanId);
+        }
+        if (originalParentId != null) {
+            MDC.put(PARENT_ID, originalParentId);
         }
         if (originalSampled != null) {
             MDC.put(SAMPLED, originalSampled);
@@ -59,6 +66,7 @@ public class MDCScope implements Scope {
     protected void putContext(JaegerSpanContext spanContext) {
         MDC.put(TRACE_ID, spanContext.getTraceId());
         MDC.put(SPAN_ID, Long.toHexString(spanContext.getSpanId()));
+        MDC.put(PARENT_ID, Long.toHexString(spanContext.getParentId()));
         MDC.put(SAMPLED, Boolean.toString(spanContext.isSampled()));
     }
 }


### PR DESCRIPTION
Modern microservices depens on asynchronous calls. Every call usually creates new span. Because of asynchronity the log messages are mixed. To be able to track the calls correctly the information about parent span is needed. This parent span is represented by parentId. 

This commit adds parentId to the MDC to enable insert it in the log messages. 