### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <hibernate-orm.version>5.4.22.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha10</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Beta10</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta11</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.8</agroal.version>


### PR DESCRIPTION
No need to update the quickstart. This upgrade mostly adds new features and fixes bugs, with very few changes to existing features.

The only potentially important [breaking change](https://in.relation.to/2020/10/09/hibernate-search-6-0-0-Beta11/#breaking_changes) relates to the AWS IAM integration, which we don't even test in Quarkus, so I would say there is nothing to add to the migration guide.