### PR TITLE
Reconcile "old" and "new" S2I config properties

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
@@ -94,13 +94,14 @@ public class OpenshiftUtils {
 
         Config config = ConfigProvider.getConfig();
         Set<String> properties = StreamSupport.stream(config.getPropertyNames().spliterator(), false)
-                .filter(s -> s.startsWith("quarkus.s2i."))
+                .filter(s -> s.startsWith("quarkus.s2i.") || s.startsWith("quarkus.openshift."))
                 .collect(Collectors.toSet());
 
         boolean hasS2iBaseJvmImage = properties.contains("quarkus.s2i.base-jvm-image");
         boolean hasS2iBaseNativeImage = properties.contains("quarkus.s2i.base-native-image");
         boolean hasS2iJvmArguments = properties.contains("quarkus.s2i.jvm-arguments");
         boolean hasS2iNativeArguments = properties.contains("quarkus.s2i.native-arguments");
+        boolean hasS2iJarDirectory = properties.contains("quarkus.s2i.jar-directory");
         boolean hasS2iJarFileName = properties.contains("quarkus.s2i.jar-file-name");
         boolean hasS2iNativeBinaryDirectory = properties.contains("quarkus.s2i.native-binary-directory");
         boolean hasS2iNativeBinaryFileName = properties.contains("quarkus.s2i.native-binary-file-name");
@@ -110,6 +111,7 @@ public class OpenshiftUtils {
         boolean hasOpenshiftBaseNativeImage = properties.contains("quarkus.openshift.base-native-image");
         boolean hasOpenshiftJvmArguments = properties.contains("quarkus.openshift.jvm-arguments");
         boolean hasOpenshiftNativeArguments = properties.contains("quarkus.openshift.native-arguments");
+        boolean hasOpenshiftJarDirectory = properties.contains("quarkus.openshift.jar-directory");
         boolean hasOpenshiftJarFileName = properties.contains("quarkus.openshift.jar-file-name");
         boolean hasOpenshiftNativeBinaryDirectory = properties.contains("quarkus.openshift.native-binary-directory");
         boolean hasOpenshiftNativeBinaryFileName = properties.contains("quarkus.openshift.native-binary-file-name");
@@ -123,6 +125,8 @@ public class OpenshiftUtils {
                 : openshiftConfig.jvmArguments;
         result.nativeArguments = hasS2iNativeArguments && !hasOpenshiftNativeArguments ? s2iConfig.nativeArguments
                 : openshiftConfig.nativeArguments;
+        result.jarDirectory = hasS2iJarDirectory && !hasOpenshiftJarDirectory ? s2iConfig.jarDirectory
+                : openshiftConfig.jarDirectory;
         result.jarFileName = hasS2iJarFileName && !hasOpenshiftJarFileName ? s2iConfig.jarFileName
                 : openshiftConfig.jarFileName;
         result.nativeBinaryDirectory = hasS2iNativeBinaryDirectory && !hasOpenshiftNativeBinaryDirectory

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -15,15 +15,6 @@ public class S2iConfig {
     public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0";
     public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 
-    public static final String DEFAULT_JVM_DOCKERFILE = "src/main/docker/Dockerfile.jvm";
-    public static final String DEFAULT_NATIVE_DOCKERFILE = "src/main/docker/Dockerfile.native";
-
-    /**
-     * The build config strategy to use.
-     */
-    @ConfigItem(defaultValue = "binary")
-    public BuildStrategy buildStrategy;
-
     /**
      * The base image to be used when a container image is being produced for the jar build
      */
@@ -35,18 +26,6 @@ public class S2iConfig {
      */
     @ConfigItem(defaultValue = DEFAULT_BASE_NATIVE_IMAGE)
     public String baseNativeImage;
-
-    /**
-     * The default Dockerfile to use for jvm builds
-     */
-    @ConfigItem(defaultValue = DEFAULT_JVM_DOCKERFILE)
-    public String jvmDockerfile;
-
-    /**
-     * The default Dockerfile to use for native builds
-     */
-    @ConfigItem(defaultValue = DEFAULT_NATIVE_DOCKERFILE)
-    public String nativeDockerfile;
 
     /**
      * Additional JVM arguments to pass to the JVM when starting the application
@@ -64,7 +43,7 @@ public class S2iConfig {
      * The directory where the jar is added during the assemble phase.
      * This is dependent on the S2I image and should be supplied if a non default image is used.
      */
-    @ConfigItem(defaultValue = "/deployments/target/")
+    @ConfigItem(defaultValue = "/deployments/")
     public String jarDirectory;
 
     /**
@@ -110,24 +89,6 @@ public class S2iConfig {
      */
     public boolean hasDefaultBaseNativeImage() {
         return baseNativeImage.equals(DEFAULT_BASE_NATIVE_IMAGE);
-    }
-
-    /**
-     * Check if jvmDockerfile is the default
-     *
-     * @returns true if jvmDockerfile is the default
-     */
-    public boolean hasDefaultJvmDockerfile() {
-        return jvmDockerfile.equals(DEFAULT_JVM_DOCKERFILE);
-    }
-
-    /**
-     * Check if nativeDockerfile is the default
-     *
-     * @returns true if nativeDockerfile is the default
-     */
-    public boolean hasDefaultativeDockerfile() {
-        return nativeDockerfile.equals(DEFAULT_NATIVE_DOCKERFILE);
     }
 
 }


### PR DESCRIPTION
This commit removes some pieces from the "old" S2I config that
were added recently (by mistake). It also reverts the default
value of `s2i.jar-directory` in the "old" S2I config, because
the `container-image-s2i` extension still builds the image
so that application files are in `/deployments`.

In addition, this commit also fixes the way how `S2IConfig`
(the "new" S2I config) and `OpenshiftConfig` are merged.