### PR TITLE
Add jsonp for cases where jsonb is not in scope

### DIFF
--- a/extensions/elytron-security-oauth2/deployment/pom.xml
+++ b/extensions/elytron-security-oauth2/deployment/pom.xml
@@ -26,6 +26,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-deployment</artifactId>
         </dependency>
+        <!-- JSON-P is needed for cases where JSON-B is not in scope-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/elytron-security-oauth2/runtime/pom.xml
+++ b/extensions/elytron-security-oauth2/runtime/pom.xml
@@ -18,6 +18,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security</artifactId>
         </dependency>
+        <!-- JSON-P is needed for cases where JSON-B is not in scope-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-realm-token</artifactId>


### PR DESCRIPTION
Add `quarkus-jsonp` dependency for cases where `quarkus-jsonb` is not in scope.

I hesitate to add only `org.glassfish:jakarta.json` as it's the needed dependency to fix the issue, but as I understand it `quarkus-jsonb` is the integration of this library inside Quarkus so I prefere to add it.

Without it native image generation is not possible when an application didn't include `quarkus-jsonb` (I doubt the application even works) due to `com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved type during parsing: javax.json.JsonObject`.

Part of #12625 but not full fix as the issue references two problems.