### PR TITLE
Support additional JDBC properties for a DataSource

### DIFF
--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -1,9 +1,11 @@
 package io.quarkus.agroal.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 
@@ -38,7 +40,7 @@ public class DefaultDataSourceConfigTest {
 
     private static void testDataSource(AgroalDataSource dataSource, String username, int minSize, int maxSize,
             int initialSize, Duration backgroundValidationInterval, Duration acquisitionTimeout, Duration leakDetectionInterval,
-            Duration idleRemovalInterval, Duration maxLifetime, String newConnectionSql) throws SQLException {
+            Duration idleRemovalInterval, Duration maxLifetime, String newConnectionSql) {
         AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration().connectionPoolConfiguration();
         AgroalConnectionFactoryConfiguration agroalConnectionFactoryConfiguration = configuration
                 .connectionFactoryConfiguration();
@@ -59,7 +61,10 @@ public class DefaultDataSourceConfigTest {
         assertTrue(agroalConnectionFactoryConfiguration.trackJdbcResources());
         assertTrue(dataSource.getConfiguration().metricsEnabled());
         assertEquals(newConnectionSql, agroalConnectionFactoryConfiguration.initialSql());
-        try (Connection connection = dataSource.getConnection()) {
-        }
+        assertThat(agroalConnectionFactoryConfiguration.jdbcProperties())
+                .contains(
+                        entry("extraProperty1", "extraProperty1Value"),
+                        entry("extraProperty2", "extraProperty2Value"));
+        assertThatCode(() -> dataSource.getConnection().close()).doesNotThrowAnyException();
     }
 }

--- a/extensions/agroal/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-default-datasource.properties
@@ -13,3 +13,5 @@ quarkus.datasource.jdbc.idle-removal-interval=56
 quarkus.datasource.jdbc.max-lifetime=57
 quarkus.datasource.jdbc.transaction-isolation-level=serializable
 quarkus.datasource.jdbc.new-connection-sql=create schema if not exists schema_default
+quarkus.datasource.jdbc.additional-jdbc-properties.extraProperty1=extraProperty1Value
+quarkus.datasource.jdbc.additional-jdbc-properties.extraProperty2=extraProperty2Value

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.agroal.runtime;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -103,4 +104,11 @@ public class DataSourceJdbcRuntimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean poolingEnabled = true;
+
+    /**
+     * Other unspecified properties to be passed to the JDBC driver when creating new connections.
+     */
+    @ConfigItem
+    public Map<String, String> additionalJdbcProperties;
+
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -5,6 +5,7 @@ import java.sql.Driver;
 import java.sql.Statement;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -248,6 +249,11 @@ public class DataSources {
             String name = dataSourceRuntimeConfig.credentialsProvider.get();
             connectionFactoryConfiguration
                     .credential(new AgroalVaultCredentialsProviderPassword(name, credentialsProvider));
+        }
+
+        // Extra JDBC properties
+        for (Map.Entry<String, String> entry : dataSourceJdbcRuntimeConfig.additionalJdbcProperties.entrySet()) {
+            connectionFactoryConfiguration.jdbcProperty(entry.getKey(), entry.getValue());
         }
 
         // Pool size configuration:


### PR DESCRIPTION
Some environments use these properties for additional metadata (eg. in Google CloudSQL)

Closes #6634