### PR TITLE
Disable REST Client encoding test on Windows

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -45,6 +47,7 @@ public class RestClientTestCase {
                 .body(is("TEST"));
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testEmojis() {
         RestAssured.when().get("/client/encoding")


### PR DESCRIPTION
No idea why it fails but we need to fix CI.