### PR TITLE
Fix REST client test on windows

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -487,6 +487,7 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
+                        <encoding>UTF-8</encoding>
                         <parameters>true</parameters>
                     </configuration>
                 </plugin>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -47,7 +45,6 @@ public class RestClientTestCase {
                 .body(is("TEST"));
     }
 
-    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testEmojis() {
         RestAssured.when().get("/client/encoding")


### PR DESCRIPTION
I think the test sources must be compiled with
a different encoding, I can't see any other way
to explain this failure.