### PR TITLE
Partly fix release 1.9 disabled gradle test 

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/core/ExecuteUtil.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/core/ExecuteUtil.java
@@ -173,6 +173,9 @@ public class ExecuteUtil {
             return SOFTWARE;
         }
         String[] newArgs = args;
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            newArgs = prependArray("-Dmaven.repo.local=" + System.getProperty("maven.repo.local"), newArgs);
+        }
         if (cli.isShowErrors()) {
             newArgs = prependArray("--full-stacktrace", newArgs);
         }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartProjectGeneration.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartProjectGeneration.java
@@ -34,7 +34,7 @@ final class CodestartProjectGeneration {
 
         log.debug("processed shared-data: %s" + data);
 
-        final Codestart projectCodestart = projectDefinition.getRequiredCodestart(CodestartType.PROJECT);
+        projectDefinition.getRequiredCodestart(CodestartType.PROJECT);
 
         final List<CodestartFileStrategy> strategies = buildStrategies(mergeStrategies(projectDefinition));
 

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/WrapperRunner.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/WrapperRunner.java
@@ -52,6 +52,11 @@ public final class WrapperRunner {
         List<String> command = new LinkedList<>();
         command.add(projectDir.resolve(wrapper.getExec()).toAbsolutePath().toString());
         command.addAll(Arrays.asList(wrapper.getCmdArgs()));
+
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            command.add("-Dmaven.repo.local=" + System.getProperty("maven.repo.local"));
+        }
+
         try {
             System.out.println("Running command: " + command);
             final Process p = new ProcessBuilder()


### PR DESCRIPTION
This branch fix tests that have been disabled for the release process. 

The main problem is coming from gradle losing the reference to `maven.repo.local`. 

This branch fix tests disabled by these two commits:

* some tests in the CLI module: b4551ff
* some tests in the Codestarts module: 630a9d3

