### PR TITLE
Allow custom path and class for spring-web codestart

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/QuarkusCodestartData.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/QuarkusCodestartData.java
@@ -73,7 +73,11 @@ public final class QuarkusCodestartData {
 
         RESTEASY_EXAMPLE_RESOURCE_PATH("path"),
         RESTEASY_EXAMPLE_PACKAGE_NAME(QuarkusCodestartData::convertPackageName),
-        RESTEASY_EXAMPLE_RESOURCE_CLASS_NAME(QuarkusCodestartData::convertClassName);
+        RESTEASY_EXAMPLE_RESOURCE_CLASS_NAME(QuarkusCodestartData::convertClassName),
+
+        SPRING_WEB_EXAMPLE_RESOURCE_PATH("path"),
+        SPRING_WEB_EXAMPLE_PACKAGE_NAME(QuarkusCodestartData::convertPackageName),
+        SPRING_WEB_EXAMPLE_RESOURCE_CLASS_NAME(QuarkusCodestartData::convertClassName);
 
         private final String key;
         private final Function<Map<String, Object>, Object> converter;

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/ProjectTestUtil.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/ProjectTestUtil.java
@@ -1,10 +1,14 @@
 package io.quarkus.devtools;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -26,5 +30,17 @@ public final class ProjectTestUtil {
 
         Assertions.assertFalse(
                 Files.exists(file.toPath()), "Directory still exists");
+    }
+
+    public static Consumer<Path> checkContains(String s) {
+        return (p) -> assertThat(getContent(p)).contains(s);
+    }
+
+    public static String getContent(Path p) {
+        return org.assertj.core.util.Files.contentOf(p.toFile(), StandardCharsets.UTF_8);
+    }
+
+    public static Consumer<Path> checkMatches(String regex) {
+        return (p) -> assertThat(getContent(p)).matches(regex);
     }
 }

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/QuarkusCodestartGenerationTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/QuarkusCodestartGenerationTest.java
@@ -1,17 +1,15 @@
 package io.quarkus.devtools.codestarts;
 
+import static io.quarkus.devtools.ProjectTestUtil.checkContains;
 import static io.quarkus.devtools.codestarts.QuarkusCodestartData.DataKey.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -538,10 +536,6 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         assertThat(projectDir.resolve("settings.gradle.kts"))
                 .exists()
                 .satisfies(checkContains("rootProject.name=\"test-codestart\""));
-    }
-
-    private Consumer<Path> checkContains(String s) {
-        return (p) -> assertThat(Files.contentOf(p.toFile(), StandardCharsets.UTF_8)).contains(s);
     }
 
     private QuarkusCodestartCatalog getCatalog() throws IOException {

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
@@ -1,14 +1,18 @@
 package io.quarkus.devtools.commands;
 
+import static io.quarkus.devtools.ProjectTestUtil.checkContains;
+import static io.quarkus.devtools.ProjectTestUtil.checkMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.contentOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -32,37 +36,134 @@ import io.quarkus.maven.utilities.MojoUtils;
 
 public class CreateProjectTest extends PlatformAwareTestBase {
     @Test
-    public void create() throws Exception {
-        final File file = new File("target/basic-rest");
+    public void createRESTEasy() throws Exception {
+        final File file = new File("target/basic-resteasy");
+        final Path projectDir = file.toPath();
         ProjectTestUtil.delete(file);
-        createProject(file, "io.quarkus", "basic-rest", "1.0.0-SNAPSHOT");
+        assertCreateProject(newCreateProject(projectDir)
+                .groupId("io.foo")
+                .artifactId("resteasy-app")
+                .version("1.0.0-FOO")
+                .className("my.project.resteasy.FooResource")
+                .resourcePath("/foo")
+                .extensions(Collections.singleton("resteasy")));
 
-        final File gitignore = new File(file, ".gitignore");
-        assertTrue(gitignore.exists());
-        final String gitignoreContent = new String(Files.readAllBytes(gitignore.toPath()), StandardCharsets.UTF_8);
-        assertThat(gitignoreContent).matches("(?s).*target/\\R.*");
+        assertThat(projectDir.resolve(".gitignore"))
+                .exists()
+                .satisfies(checkMatches("(?s).*target/\\R.*"));
+        assertThat(projectDir.resolve("src/main/java/my/project/resteasy/FooResource.java"))
+                .exists()
+                .satisfies(checkContains("class FooResource"))
+                .satisfies(checkContains("@Path(\"/foo\")"));
+        assertThat(projectDir.resolve("pom.xml"))
+                .exists()
+                .satisfies(checkContains("<groupId>io.foo</groupId>"))
+                .satisfies(checkContains("<artifactId>resteasy-app</artifactId>"))
+                .satisfies(checkContains("<version>1.0.0-FOO</version>"))
+                .satisfies(checkContains("<artifactId>quarkus-resteasy</artifactId>"));
+
+        assertThat(projectDir.resolve("README.md"))
+                .exists()
+                .satisfies(checkContains("./mvnw"));
+    }
+
+    @Test
+    public void createSpringWeb() throws Exception {
+        final File file = new File("target/create-spring");
+        final Path projectDir = file.toPath();
+        ProjectTestUtil.delete(file);
+        assertCreateProject(newCreateProject(projectDir)
+                .groupId("io.bar")
+                .artifactId("spring-web-app")
+                .version("1.0.0-BAR")
+                .className("my.project.spring.BarController")
+                .resourcePath("/bar")
+                .extensions(Collections.singleton("spring-web")));
+        assertThat(projectDir.resolve("pom.xml"))
+                .exists()
+                .satisfies(checkContains("<groupId>io.bar</groupId>"))
+                .satisfies(checkContains("<artifactId>spring-web-app</artifactId>"))
+                .satisfies(checkContains("<version>1.0.0-BAR</version>"))
+                .satisfies(checkContains("<artifactId>quarkus-spring-web</artifactId>"));
+
+        assertThat(projectDir.resolve("src/main/java/my/project/spring/BarController.java"))
+                .exists()
+                .satisfies(checkContains("@RestController"))
+                .satisfies(checkContains("class BarController"))
+                .satisfies(checkContains("@RequestMapping(\"/bar\")"));
+    }
+
+    @Test
+    public void createRESTEasyAndSpringWeb() throws Exception {
+        final File file = new File("target/create-spring-resteasy");
+        final Path projectDir = file.toPath();
+        ProjectTestUtil.delete(file);
+        assertCreateProject(newCreateProject(projectDir)
+                .artifactId("spring-web-resteasy-app")
+                .className("my.project.spring.BarController")
+                .resourcePath("/bar")
+                .extensions(new HashSet<>(Arrays.asList("resteasy", "spring-web"))));
+        assertThat(projectDir.resolve("pom.xml"))
+                .exists()
+                .satisfies(checkContains("<artifactId>spring-web-resteasy-app</artifactId>"))
+                .satisfies(checkContains("<artifactId>quarkus-spring-web</artifactId>"))
+                .satisfies(checkContains("<artifactId>quarkus-resteasy</artifactId>"));
+
+        assertThat(projectDir.resolve("src/main/java/org/acme/spring/web/ExampleController.java"))
+                .exists()
+                .satisfies(checkContains("@RestController"))
+                .satisfies(checkContains("class ExampleController"))
+                .satisfies(checkContains("@RequestMapping(\"/springweb/hello\")"));
+
+        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java"))
+                .exists()
+                .satisfies(checkContains("class ExampleResource"))
+                .satisfies(checkContains("@Path(\"/resteasy/hello\")"));
     }
 
     @Test
     public void createGradle() throws Exception {
-        final File file = new File("target/basic-rest-gradle");
+        final File file = new File("target/create-resteasy-gradle");
+        final Path projectDir = file.toPath();
         ProjectTestUtil.delete(file);
-        createProject(BuildTool.GRADLE, file, "io.quarkus", "basic-rest", "1.0.0-SNAPSHOT");
+        assertCreateProject(newCreateProject(projectDir)
+                .buildTool(BuildTool.GRADLE)
+                .groupId("io.foo")
+                .artifactId("resteasy-app")
+                .version("1.0.0-FOO")
+                .className("my.project.FooResource")
+                .resourcePath("/foo")
+                .extensions(Collections.singleton("resteasy")));
 
-        final File gitignore = new File(file, ".gitignore");
-        assertTrue(gitignore.exists());
-        final String gitignoreContent = new String(Files.readAllBytes(gitignore.toPath()), StandardCharsets.UTF_8);
-        assertThat(gitignoreContent).doesNotMatch("(?s).*target/\\R.*");
-        assertThat(gitignoreContent).matches("(?s).*build/\\R.*");
-        assertThat(gitignoreContent).matches("(?s).*\\.gradle/\\R.*");
+        assertThat(projectDir.resolve(".gitignore"))
+                .exists()
+                .satisfies(checkMatches("(?s).*build/\\R.*"))
+                .satisfies(checkMatches("(?s).*\\.gradle/\\R.*"));
+        assertThat(projectDir.resolve("src/main/java/my/project/FooResource.java"))
+                .exists()
+                .satisfies(checkContains("@Path(\"/foo\")"));
+        assertThat(projectDir.resolve("build.gradle"))
+                .exists()
+                .satisfies(checkContains("group 'io.foo'"))
+                .satisfies(checkContains("version '1.0.0-FOO'"))
+                .satisfies(checkContains("implementation 'io.quarkus:quarkus-resteasy'"));
 
-        assertThat(new File(file, "README.md")).exists();
-        assertThat(contentOf(new File(file, "README.md"), "UTF-8")).contains("./gradlew");
+        assertThat(projectDir.resolve("settings.gradle"))
+                .exists()
+                .satisfies(checkContains("rootProject.name='resteasy-app'"));
+
+        assertThat(projectDir.resolve("README.md"))
+                .exists()
+                .satisfies(checkContains("./gradlew"));
+    }
+
+    private CreateProject newCreateProject(Path dir) {
+        return new CreateProject(dir, getPlatformDescriptor());
     }
 
     @Test
     public void createOnTopOfExisting() throws Exception {
-        final File testDir = new File("target/existing");
+        final File testDir = new File("target/create-existing");
         ProjectTestUtil.delete(testDir);
         testDir.mkdirs();
 
@@ -109,21 +210,13 @@ public class CreateProjectTest extends PlatformAwareTestBase {
         latch.await();
     }
 
-    private void createProject(final File file, String groupId, String artifactId, String version)
+    private void assertCreateProject(CreateProject createProject)
             throws QuarkusCommandException {
-        createProject(BuildTool.MAVEN, file, groupId, artifactId, version);
-    }
-
-    private void createProject(BuildTool buildTool, File file, String groupId, String artifactId, String version)
-            throws QuarkusCommandException {
-        final QuarkusCommandOutcome result = new CreateProject(file.toPath(), getPlatformDescriptor())
-                .buildTool(buildTool)
-                .groupId(groupId)
-                .artifactId(artifactId)
-                .version(version)
+        final QuarkusCommandOutcome result = createProject
                 .quarkusMavenPluginVersion("2.3.5")
                 .quarkusGradlePluginVersion("2.3.5-gradle")
                 .execute();
         assertTrue(result.isSuccess());
     }
+
 }


### PR DESCRIPTION
- Make sure that custom `path` and `className` are ignored when resteasy is selected (to avoid conflicts)
- Add tests

Fixes https://github.com/quarkusio/quarkus/issues/12604