### PR TITLE
Re-enable creation of the test structure (unit and devmode test) when using create-extension Maven Mojo.

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
@@ -513,6 +513,22 @@ public class CreateExtensionMojo extends AbstractMojo {
     @Parameter(defaultValue = COMPILER_PLUGIN_DEFAULT_VERSION, required = true, property = "quarkus.mavenCompilerPluginVersion")
     String compilerPluginVersion;
 
+    /**
+     * Indicates whether to generate a unit test class for the extension
+     *
+     * @since 1.3.0
+     */
+    @Parameter(property = "quarkus.generateUnitTest", defaultValue = "true")
+    boolean generateUnitTest;
+
+    /**
+     * Indicates whether to generate a dev mode unit test class for the extension
+     *
+     * @since 1.3.0
+     */
+    @Parameter(property = "quarkus.generateDevModeTest", defaultValue = "true")
+    boolean generateDevModeTest;
+
     boolean currentProjectIsBaseDir;
 
     Charset charset;
@@ -825,6 +841,14 @@ public class CreateExtensionMojo extends AbstractMojo {
                 .resolve("deployment")
                 .resolve(templateParams.artifactIdBaseCamelCase + "Processor.java");
         evalTemplate(cfg, "Processor.java", processorPath, templateParams);
+
+        if (generateUnitTest) {
+            generateUnitTestClass(cfg, templateParams);
+        }
+
+        if (generateDevModeTest) {
+            generateDevModeTestClass(cfg, templateParams);
+        }
     }
 
     private PomTransformer pomTransformer(Path basePomXml) {
@@ -903,6 +927,24 @@ public class CreateExtensionMojo extends AbstractMojo {
         templateCfg.setInterpolationSyntax(Configuration.SQUARE_BRACKET_INTERPOLATION_SYNTAX);
         templateCfg.setTagSyntax(Configuration.SQUARE_BRACKET_TAG_SYNTAX);
         return templateCfg;
+    }
+
+    private void generateUnitTestClass(Configuration cfg, TemplateParams model) throws IOException, TemplateException {
+        final Path unitTest = basedir.toPath()
+                .resolve(model.artifactIdBase + "/deployment/src/test/java/" + model.javaPackageBase.replace('.', '/')
+                        + "/test/" + model.artifactIdBaseCamelCase + "Test.java");
+
+        evalTemplate(cfg, "UnitTest.java", unitTest, model);
+    }
+
+    private void generateDevModeTestClass(Configuration cfg, TemplateParams model) throws IOException, TemplateException {
+        final Path devModeTest = basedir
+                .toPath()
+                .resolve(model.artifactIdBase + "/deployment/src/test/java/" + model.javaPackageBase.replace('.', '/')
+                        + "/test/" + model.artifactIdBaseCamelCase + "DevModeTest.java");
+
+        evalTemplate(cfg, "DevModeTest.java", devModeTest, model);
+
     }
 
     void generateItest(Configuration cfg, TemplateParams model)

--- a/devtools/maven/src/main/resources/create-extension-templates/DevModeTest.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/DevModeTest.java
@@ -1,0 +1,22 @@
+package [=javaPackageBase].test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class [=artifactIdBaseCamelCase]DevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/devtools/maven/src/main/resources/create-extension-templates/UnitTest.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/UnitTest.java
@@ -1,0 +1,23 @@
+package [=javaPackageBase].test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class [=artifactIdBaseCamelCase]Test {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/devtools/maven/src/main/resources/create-extension-templates/deployment-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/deployment-pom.xml
@@ -25,6 +25,11 @@
 [#if !assumeManaged ]            <version>[=r"$"]{project.version}</version>
 [/#if]
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -34,6 +34,8 @@ public class CreateExtensionMojoTest {
         final CreateExtensionMojo mojo = new CreateExtensionMojo();
         mojo.project = new MavenProject();
         mojo.basedir = projectDir.toFile();
+        mojo.generateDevModeTest = true;
+        mojo.generateUnitTest = true;
 
         final File pom = new File(projectDir.toFile(), "pom.xml");
         if (pom.exists()) {
@@ -125,7 +127,7 @@ public class CreateExtensionMojoTest {
 
     @Test
     void createExtensionUnderExistingPomMinimal() throws MojoExecutionException, MojoFailureException,
-            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+            IllegalArgumentException, SecurityException, IOException {
         final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(minimal-extension)";
         mojo.assumeManaged = false;
@@ -137,7 +139,7 @@ public class CreateExtensionMojoTest {
 
     @Test
     void createExtensionUnderExistingPomWithAdditionalRuntimeDependencies() throws MojoExecutionException, MojoFailureException,
-            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+            IllegalArgumentException, SecurityException, IOException {
         final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(add-to-bom)";
         mojo.assumeManaged = false;
@@ -152,7 +154,7 @@ public class CreateExtensionMojoTest {
 
     @Test
     void createExtensionUnderExistingPomWithItest() throws MojoExecutionException, MojoFailureException,
-            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+            IllegalArgumentException, SecurityException, IOException {
         final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(itest)";
         mojo.assumeManaged = false;
@@ -165,7 +167,7 @@ public class CreateExtensionMojoTest {
 
     @Test
     void createExtensionUnderExistingPomCustomGrandParent() throws MojoExecutionException, MojoFailureException,
-            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+            IllegalArgumentException, SecurityException, IOException {
         final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "myproject-(with-grand-parent)";
         mojo.parentArtifactId = "grand-parent";
@@ -241,7 +243,7 @@ public class CreateExtensionMojoTest {
     }
 
     @Test
-    void getPackage() throws IOException {
+    void getPackage() {
         assertEquals("org.apache.camel.quarkus.aws.sns.deployment", CreateExtensionMojo
                 .getJavaPackage("org.apache.camel.quarkus", null, "camel-quarkus-aws-sns-deployment"));
         assertEquals("org.apache.camel.quarkus.component.aws.sns.deployment", CreateExtensionMojo
@@ -249,7 +251,7 @@ public class CreateExtensionMojoTest {
     }
 
     @Test
-    void toCapCamelCase() throws IOException {
+    void toCapCamelCase() {
         assertEquals("FooBarBaz", CreateExtensionMojo.toCapCamelCase("foo-bar-baz"));
     }
 

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>my-project-add-to-bom</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.my.project.add.to.bom.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class AddToBomDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomTest.java
@@ -1,0 +1,23 @@
+package org.acme.my.project.add.to.bom.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class AddToBomTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>my-project-itest</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.my.project.itest.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class ItestDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestTest.java
@@ -1,0 +1,23 @@
+package org.acme.my.project.itest.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class ItestTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>my-project-minimal-extension</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.my.project.minimal.extension.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class MinimalExtensionDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionTest.java
@@ -1,0 +1,23 @@
+package org.acme.my.project.minimal.extension.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class MinimalExtensionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/pom.xml
@@ -22,6 +22,11 @@
             <groupId>org.acme</groupId>
             <artifactId>myproject-with-grand-parent</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.myproject.with.grand.parent.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class WithGrandParentDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentTest.java
@@ -1,0 +1,23 @@
+package org.acme.myproject.with.grand.parent.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class WithGrandParentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>my-ext</artifactId>
             <version>\${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.my.ext.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class MyExtDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtTest.java
@@ -1,0 +1,23 @@
+package org.acme.my.ext.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class MyExtTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>my-ext</artifactId>
             <version>\${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
@@ -1,0 +1,22 @@
+package org.acme.my.ext.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class MyExtDevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtTest.java
@@ -1,0 +1,23 @@
+package org.acme.my.ext.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class MyExtTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}


### PR DESCRIPTION
Fixes #3585 

This reverts commit 3495f91a8e45451def283f29aa865fa42542b493.

Follows up https://github.com/quarkusio/quarkus/pull/12687 and https://github.com/quarkusio/quarkus/pull/5438

/cc @gastaldi this should fix the failing tests.