### PR TITLE
Changed the usage from slf4j-jboss-logging to slf4j-jboss-logmanager.

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -98,7 +98,7 @@
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
+        <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.13.1.Final</wildfly-elytron.version>
@@ -3534,8 +3534,8 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.slf4j</groupId>
-                <artifactId>slf4j-jboss-logging</artifactId>
-                <version>${slf4j-jboss-logging.version}</version>
+                <artifactId>slf4j-jboss-logmanager</artifactId>
+                <version>${slf4j-jboss-logmanager.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -400,7 +400,8 @@
                                             <exclude>commons-logging:commons-logging-api</exclude>
                                             <exclude>org.springframework:spring-jcl</exclude>
                                             <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logmanager instead) -->
+                                            <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                             <exclude>org.slf4j:slf4j-simple</exclude>
                                             <exclude>org.slf4j:slf4j-nop</exclude>
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
@@ -125,6 +125,8 @@
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-core</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-development-mode-spi</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-app-model</parentFirstArtifact>
+                        <parentFirstArtifact>org.slf4j:slf4j-api</parentFirstArtifact>
+                        <parentFirstArtifact>org.jboss.slf4j:slf4j-jboss-logmanager</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager-embedded</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logging:jboss-logging</parentFirstArtifact>
                         <parentFirstArtifact>org.ow2.asm:asm</parentFirstArtifact>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -147,7 +147,7 @@
 
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
 
         <!-- test -->

--- a/devtools/platform-descriptor-json-plugin/pom.xml
+++ b/devtools/platform-descriptor-json-plugin/pom.xml
@@ -65,7 +65,7 @@
      
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
 
     </dependencies>

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -409,7 +409,7 @@ And Slf4j:
 ----
 <dependency>
     <groupId>org.jboss.slf4j</groupId>
-    <artifactId>slf4j-jboss-logging</artifactId>
+    <artifactId>slf4j-jboss-logmanager</artifactId>
 </dependency>
 ----
 

--- a/extensions/amazon-alexa/runtime/pom.xml
+++ b/extensions/amazon-alexa/runtime/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/scheduler/runtime/pom.xml
+++ b/extensions/scheduler/runtime/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
         <groupId>org.jboss.slf4j</groupId>
-        <artifactId>slf4j-jboss-logging</artifactId>
+        <artifactId>slf4j-jboss-logmanager</artifactId>
     </dependency>
   </dependencies>
 

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -237,7 +237,8 @@
                                             <exclude>commons-logging:commons-logging-api</exclude>
                                             <exclude>org.springframework:spring-jcl</exclude>
                                             <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logmanager instead) -->
+                                            <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                             <exclude>org.slf4j:slf4j-simple</exclude>
                                             <exclude>org.slf4j:slf4j-nop</exclude>
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -23,8 +23,12 @@
             <artifactId>gradle-tooling-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -19,8 +19,20 @@
             <artifactId>quarkus-bootstrap-app-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager-embedded</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -42,8 +42,9 @@
         <commons-lang.version>3.9</commons-lang.version>
         <guava.version>30.0-jre</guava.version>
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager-embedded.version>1.0.4</jboss-logmanager-embedded.version>
-        <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
+        <jboss-logmanager-embedded.version>1.0.5</jboss-logmanager-embedded.version>
+        <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
+        <slf4j-api.version>1.7.30</slf4j-api.version>
         <graal-sdk.version>20.2.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
@@ -324,8 +325,13 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.slf4j</groupId>
-                <artifactId>slf4j-jboss-logging</artifactId>
-                <version>${slf4j-jboss-logging.version}</version>
+                <artifactId>slf4j-jboss-logmanager</artifactId>
+                <version>${slf4j-jboss-logmanager.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
@@ -450,7 +456,8 @@
                                             <exclude>commons-logging:commons-logging-api</exclude>
                                             <exclude>org.springframework:spring-jcl</exclude>
                                             <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logmanager instead) -->
+                                            <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                             <exclude>org.slf4j:slf4j-simple</exclude>
                                             <exclude>org.slf4j:slf4j-nop</exclude>
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -165,7 +165,8 @@
                                             <exclude>commons-logging:commons-logging-api</exclude>
                                             <exclude>org.springframework:spring-jcl</exclude>
                                             <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logmanager instead) -->
+                                            <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                             <exclude>org.slf4j:slf4j-simple</exclude>
                                             <exclude>org.slf4j:slf4j-nop</exclude>
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -297,7 +297,8 @@
                                         <exclude>commons-logging:commons-logging-api</exclude>
                                         <exclude>org.springframework:spring-jcl</exclude>
                                         <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                        <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                        <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logmanager instead) -->
+                                        <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                         <exclude>org.slf4j:slf4j-simple</exclude>
                                         <exclude>org.slf4j:slf4j-nop</exclude>
                                         <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/integration-tests/amazon-services/pom.xml
+++ b/integration-tests/amazon-services/pom.xml
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logging</artifactId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Is related with #12615
To be able to support forwarding slf4j logging parameters to LogManager without formatting more than once.
The change from `slf4j-jboss-logging` to  `slf4j-jboss-logmanager`.

A new release is still required of `slf4j-jboss-logmanager`, to include the parameter forwarding.