### PR TITLE
Use counter for JVM Info

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/JVMInfoBinder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/JVMInfoBinder.java
@@ -1,6 +1,6 @@
 package io.quarkus.micrometer.runtime.binder;
 
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
@@ -8,12 +8,12 @@ public class JVMInfoBinder implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        Gauge.builder("jvm_info", () -> 1L)
+        Counter.builder("jvm_info")
                 .description("JVM version info")
                 .tags("version", System.getProperty("java.runtime.version", "unknown"),
                         "vendor", System.getProperty("java.vm.vendor", "unknown"),
                         "runtime", System.getProperty("java.runtime.name", "unknown"))
-                .strongReference(true)
-                .register(registry);
+                .register(registry)
+                .increment();
     }
 }


### PR DESCRIPTION
Use a counter instead of a gauge to avoid NaN from GC.

Resolves #12694