### PR TITLE
Change the version when the creation of test structure was introduced in create-extension mojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
@@ -516,7 +516,7 @@ public class CreateExtensionMojo extends AbstractMojo {
     /**
      * Indicates whether to generate a unit test class for the extension
      *
-     * @since 1.3.0
+     * @since 1.10.0
      */
     @Parameter(property = "quarkus.generateUnitTest", defaultValue = "true")
     boolean generateUnitTest;
@@ -524,7 +524,7 @@ public class CreateExtensionMojo extends AbstractMojo {
     /**
      * Indicates whether to generate a dev mode unit test class for the extension
      *
-     * @since 1.3.0
+     * @since 1.10.0
      */
     @Parameter(property = "quarkus.generateDevModeTest", defaultValue = "true")
     boolean generateDevModeTest;


### PR DESCRIPTION
It should at least be 1.10.0 and not 1.3.0.

Follows up #12690

/cc @jaikiran @gastaldi 