### PR TITLE
Fix codestarts encoding problem

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/AppendCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/AppendCodestartFileStrategyHandler.java
@@ -2,7 +2,6 @@ package io.quarkus.devtools.codestarts.core.strategy;
 
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,6 @@ final class AppendCodestartFileStrategyHandler implements CodestartFileStrategyH
         checkTargetDoesNotExist(targetPath);
         createDirectories(targetPath);
         final String content = codestartFiles.stream().map(TargetFile::getContent).collect(Collectors.joining("\n"));
-        Files.write(targetPath, content.getBytes());
+        writeFile(targetPath, content);
     }
 }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/CodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/CodestartFileStrategyHandler.java
@@ -3,6 +3,7 @@ package io.quarkus.devtools.codestarts.core.strategy;
 import io.quarkus.devtools.codestarts.CodestartStructureException;
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -46,6 +47,10 @@ public interface CodestartFileStrategyHandler {
 
     default void createDirectories(Path targetPath) throws IOException {
         Files.createDirectories(targetPath.getParent());
+    }
+
+    default void writeFile(final Path targetPath, final String content) throws IOException {
+        Files.write(targetPath, content.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/ExecutableFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/ExecutableFileStrategyHandler.java
@@ -4,7 +4,6 @@ import io.quarkus.devtools.codestarts.CodestartStructureException;
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +26,7 @@ final class ExecutableFileStrategyHandler implements CodestartFileStrategyHandle
                     "Multiple files found for path with executable FileStrategy: " + relativePath);
         }
         createDirectories(targetPath);
-        Files.write(targetPath, codestartFiles.get(0).getContent().getBytes());
+        writeFile(targetPath, codestartFiles.get(0).getContent());
         final File file = targetPath.toFile();
         file.setExecutable(true, false);
         file.setReadable(true, false);

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/FailOnDuplicateCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/FailOnDuplicateCodestartFileStrategyHandler.java
@@ -28,7 +28,7 @@ final class FailOnDuplicateCodestartFileStrategyHandler implements DefaultCodest
                     "Multiple files found for path with 'fail-on-duplicate' FileStrategy: " + relativePath);
         }
         createDirectories(targetPath);
-        Files.write(targetPath, codestartFiles.get(0).getContent().getBytes());
+        writeFile(targetPath, codestartFiles.get(0).getContent());
     }
 
     @Override

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/ReplaceCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/ReplaceCodestartFileStrategyHandler.java
@@ -29,7 +29,7 @@ final class ReplaceCodestartFileStrategyHandler implements DefaultCodestartFileS
         final Path targetPath = targetDirectory.resolve(relativePath);
         checkTargetDoesNotExist(targetPath);
         createDirectories(targetPath);
-        Files.write(targetPath,
-                codestartFiles.get(codestartFiles.size() - 1).getContent().getBytes());
+        writeFile(targetPath,
+                codestartFiles.get(codestartFiles.size() - 1).getContent());
     }
 }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -7,7 +7,6 @@ import io.quarkus.devtools.codestarts.CodestartException;
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 import io.quarkus.devtools.codestarts.utils.NestedMaps;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +66,7 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
         final Path propertiesTargetPath = targetPath.getParent()
                 .resolve(targetPath.getFileName().toString().replace(".yml", ".properties"));
         checkTargetDoesNotExist(propertiesTargetPath);
-        Files.write(propertiesTargetPath, builder.toString().getBytes());
+        writeFile(propertiesTargetPath, builder.toString());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Try to fix encoding problem as reported by @gastaldi:
Also there are some encoding errors in the produced file:
```
Be aware that it?s not an _?ber-jar_ as the dependencies are copied into the `target/lib` directory.
If you want to build an _?ber-jar_, just add the `--uber-jar` option to the command line:
```