### PR TITLE
Introduce PanacheQuery#select() method

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -579,9 +579,11 @@ Every query operation accepts passing parameters by index (`Object...`), or by n
 
 === Query projection
 
-Query projection can be done with the `project(Class)` method on the `PanacheQuery` object that is returned by the `find()` methods.
+Query projection can be done with the `project()` methods on the `PanacheQuery` object that is returned by the `find()` methods.
 
-You can use it to restrict which fields will be returned by the database.
+==== Projection class
+
+You can use `project(Class<T>)` to restrict which fields will be returned by the database.
 
 Hibernate will use **DTO projection** and generate a SELECT clause with the attributes from the projection class.
 This is also called **dynamic instantiation** or **constructor expression**, more info can be found on the Hibernate guide:
@@ -617,6 +619,24 @@ The implementation of the `project(Class)` method uses the constructor's paramet
 so the compiler must be configured to store parameter names inside the compiled class.
 This is enabled by default if you are using the Quarkus Maven archetype. If you are not using it, add the property `<maven.compiler.parameters>true</maven.compiler.parameters>` to your pom.xml.
 ====
+
+==== Row mapper
+
+You can also use `project(Function<Object[], T>, String...)` to create a DTO object from each result row by means of a mapper function. A result row is represented by an `Object[]`. 
+
+.Row Mapper Example
+[source,java]
+----
+PanacheQuery<Person> query = Person.find("order by height desc") 
+                .project(result -> {
+                    User user = new User();
+                    user.name = result[0].toString();
+                    user.surname = result[1].toString();
+                    return user;
+                }, "name", "surname");
+List<User> users = query.list(); <1>
+----
+<1> When a query is perfomed the mapper function is applied to every result row to build the final result list.
 
 == Multiple Persistence Units
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.panache.kotlin.runtime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -33,6 +34,12 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     public <NewEntity> PanacheQuery<NewEntity> project(Class<NewEntity> type) {
         return new PanacheQueryImpl<>(delegate.project(type));
+    }
+
+    @NotNull
+    @Override
+    public <NewEntity> PanacheQuery<NewEntity> project(List<String> properties, Function<Object[], NewEntity> rowMapper) {
+        return new PanacheQueryImpl<>(delegate.project(properties, rowMapper));
     }
 
     @NotNull

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheQuery.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheQuery.kt
@@ -5,6 +5,7 @@ import io.quarkus.panache.common.Parameters
 import org.hibernate.Session
 import org.hibernate.annotations.Filter
 import org.hibernate.annotations.FilterDef
+import java.util.function.Function
 import java.util.stream.Stream
 import javax.persistence.LockModeType
 import javax.persistence.NonUniqueResultException
@@ -26,6 +27,13 @@ interface PanacheQuery<Entity: Any> {
      * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
      */
     fun <NewEntity: Any> project(type: Class<NewEntity>): PanacheQuery<NewEntity>
+
+    /**
+     * Generates a SELECT clause with the specified properties. The row mapper function is used to build a DTO object for each row of the result.
+     *
+     * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
+     */
+    fun <NewEntity: Any> project(properties: List<String>, rowMapper: Function<Array<Any>, NewEntity>): PanacheQuery<NewEntity>
 
     /**
      * Sets the current page.

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/rowmapper/Person.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/rowmapper/Person.java
@@ -1,0 +1,12 @@
+package io.quarkus.hibernate.orm.panache.deployment.test.rowmapper;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Person extends PanacheEntity {
+    public String name;
+    public String surname;
+    public Integer height;
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/rowmapper/RowMapperFunctionTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/rowmapper/RowMapperFunctionTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.hibernate.orm.panache.deployment.test.rowmapper;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transactional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.exception.PanacheQueryException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RowMapperFunctionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application.properties")
+                    .addClasses(Person.class));
+
+    @Transactional
+    @Test
+    public void testRowMapper() {
+        Person person1 = new Person();
+        person1.name = "Jo";
+        person1.surname = "Ne";
+        person1.height = 10;
+        Person person2 = new Person();
+        person2.name = "Yep";
+        person2.surname = "Nope";
+        person2.height = 20;
+        Person.persist(person1, person2);
+
+        PanacheQuery<Person> query = Person.find("order by name asc").project(asList("name"), result -> {
+            Person p = new Person();
+            p.name = result[0].toString();
+            return p;
+        });
+        List<Person> names = query.list();
+        assertEquals(2, names.size());
+        assertEquals("Jo", names.get(0).name);
+        assertEquals("Jo", query.firstResult().name);
+
+        List<Integer> heights = Person.find("order by height desc").project(asList("height"), result -> (Integer) result[0])
+                .list();
+
+        assertEquals(2, heights.size());
+        assertEquals(20, heights.get(0));
+        assertEquals(10, heights.get(1));
+
+        List<Person> namesAndSurnames = Person.find("order by height desc")
+                .project(asList("name", "surname"), result -> {
+                    Person p = new Person();
+                    p.name = result[0].toString();
+                    p.surname = result[1].toString();
+                    return p;
+                }).stream().collect(Collectors.toList());
+
+        assertEquals(2, namesAndSurnames.size());
+        assertEquals("Yep", namesAndSurnames.get(0).name);
+        assertEquals("Nope", namesAndSurnames.get(0).surname);
+    }
+
+    @Test
+    public void testExistingSelectQuery() {
+        try {
+            Person.find("order by name asc").project(Person.class).project(asList("name"), result -> null);
+            fail();
+        } catch (PanacheQueryException expected) {
+        }
+    }
+
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.panache;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -37,8 +38,22 @@ public interface PanacheQuery<Entity> {
      * retrieved from the database.
      *
      * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
+     * @see #project(Function, String...)
      */
     public <T> PanacheQuery<T> project(Class<T> type);
+
+    /**
+     * Generates a SELECT clause with the specified properties.
+     * <p>
+     * The row mapper function is used to build a DTO object for each row of the result. A result row
+     * is represented by {@code Object[]}.
+     * 
+     * @param properties
+     * @param rowMapper Maps a result row to a DTO object.
+     * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
+     * @see #project(Class)
+     */
+    public <T> PanacheQuery<T> project(List<String> properties, Function<Object[], T> rowMapper);
 
     /**
      * Sets the current page.

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -31,6 +32,11 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     public <T> PanacheQuery<T> project(Class<T> type) {
         return new PanacheQueryImpl<>(delegate.project(type));
+    }
+
+    @Override
+    public <T> PanacheQuery<T> project(List<String> properties, Function<Object[], T> rowMapper) {
+        return new PanacheQueryImpl<>(delegate.project(properties, rowMapper));
     }
 
     @Override


### PR DESCRIPTION
The main motivation was to be able to reuse Panache queries when fetching data for a GraphQL query, i.e. something like:
https://github.com/mkouba/quarkus-quickstarts/blob/panache-graphql/hibernate-orm-panache-quickstart/src/main/java/org/acme/hibernate/orm/panache/FruitGraphqlResource.java#L24-L28