### PR TITLE
Fixed the default platform version range for the create command

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -85,7 +85,7 @@ public final class CreateUtils {
                 DefaultArtifactVersion pluginVersion = new DefaultArtifactVersion(baseVersion);
                 int majorVer = pluginVersion.getMajorVersion();
                 int minorVer = pluginVersion.getMinorVersion();
-                version = "[" + majorVer + "." + minorVer + "-alpha, " + majorVer + "." + (minorVer + 1) + ")";
+                version = "[" + majorVer + "." + minorVer + "-alpha, " + majorVer + "." + (minorVer + 1) + "-alpha)";
             }
         }
 


### PR DESCRIPTION
Exclude pre-Final versions of the next minor releases of the platform when picking the preferred latest version

Fixes #12703 