### PR TITLE
CI caches adjustments

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: n1hility/cache@v2
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -69,19 +69,18 @@ jobs:
         uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: 11
-      - name: Compute cache restore key
-        # Always recompute on a push so that the maven repo doesnt grow indefinitely with old versions
+      - name: Get Date
+        id: get-date
         run: |
-          if ${{ github.event_name == 'pull_request' }}; then echo "::set-env name=COMPUTED_RESTORE_KEY::q2maven-"; fi
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
       - name: Cache Maven Repository
         id: cache-maven
         uses: n1hility/cache@v2
         with:
           path: ~/.m2/repository
-          # Improves the reusability of the cache to limit key changes
-          key: q2maven-${{ hashFiles('bom/application/pom.xml') }}
-          restore-keys: ${{ env.COMPUTED_RESTORE_KEY }}
-          restore-only: ${{ github.event_name == 'pull_request' }}
+          # refresh cache every month to avoid unlimited growth
+          key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build
         run: |
           mvn -e -B -DskipTests -DskipITs -Dno-format clean install

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: n1hility/cache@v2
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -21,6 +21,18 @@ jobs:
         uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
         with:
           java-version: 8
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: n1hility/cache@v2
+        with:
+          path: ~/.m2/repository
+          # refresh cache every month to avoid unlimited growth
+          key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build and Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
@@ -31,6 +43,9 @@ jobs:
             -DskipITs -Dno-format -Dinvoker.skip=true \
             -DretryFailedDeploymentCount=10 \
             clean deploy
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/io/quarkus
 
       - name: Report
         if: always()


### PR DESCRIPTION
We use to use a hash of the BOM as the cache key and I think it's too aggressive.

With this PR, we only refresh the cache monthly, which should be good enough.

I also enabled the cache for the snapshots deployment action.