### PR TITLE
Common Maven Quarkus app bootstraping Mojo

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -46,7 +46,7 @@ public class CodeGenerator {
             } catch (ClassNotFoundException e) {
                 throw new CodeGenException("Failde to load CodeGenProvider class from deployment classloader", e);
             }
-            for (CodeGenProvider provider : ServiceLoader.load(codeGenProviderClass)) {
+            for (CodeGenProvider provider : ServiceLoader.load(codeGenProviderClass, deploymentClassLoader)) {
                 Path outputDir = codeGenOutDir(generatedSourcesDir, provider, sourceRegistrar);
                 for (Path sourceParentDir : sourceParentDirs) {
                     result.add(

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -6,31 +6,20 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Properties;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Resource;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
-import io.quarkus.bootstrap.app.QuarkusBootstrap;
-import io.quarkus.bootstrap.model.AppArtifact;
-import io.quarkus.bootstrap.model.AppArtifactKey;
-import io.quarkus.bootstrap.model.PathsCollection;
-import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 
 /**
  * Build the application.
@@ -40,37 +29,12 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
  * @author Alexey Loubyansky
  */
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
-public class BuildMojo extends AbstractMojo {
+public class BuildMojo extends QuarkusBootstrapMojo {
 
-    protected static final String QUARKUS_PACKAGE_UBER_JAR = "quarkus.package.uber-jar";
-    /**
-     * The entry point to Aether, i.e. the component doing all the work.
-     *
-     * @component
-     */
-    @Component
-    private RepositorySystem repoSystem;
+    public static final String QUARKUS_PACKAGE_UBER_JAR = "quarkus.package.uber-jar";
 
     @Component
     private MavenProjectHelper projectHelper;
-
-    /**
-     * The current repository/network configuration of Maven.
-     *
-     * @parameter default-value="${repositorySystemSession}"
-     * @readonly
-     */
-    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
-    private RepositorySystemSession repoSession;
-
-    /**
-     * The project's remote repositories to use for the resolution of artifacts and their dependencies.
-     *
-     * @parameter default-value="${project.remoteProjectRepositories}"
-     * @readonly
-     */
-    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
-    private List<RemoteRepository> repos;
 
     /**
      * The project's remote repositories to use for the resolution of plugins and their dependencies.
@@ -88,138 +52,45 @@ public class BuildMojo extends AbstractMojo {
     @Deprecated
     private File outputDirectory;
 
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    protected MavenProject project;
-
     /**
      * The directory for generated source files.
      */
     @Parameter(defaultValue = "${project.build.directory}/generated-sources")
     private File generatedSourcesDirectory;
 
-    @Parameter(defaultValue = "${project.build.directory}")
-    private File buildDir;
-
-    @Parameter(defaultValue = "${project.build.finalName}")
-    private String finalName;
-
-    @Parameter(property = "uberJar", defaultValue = "false")
-    private boolean uberJar;
-
-    /**
-     * When using the uberJar option, this array specifies entries that should
-     * be excluded from the final jar. The entries are relative to the root of
-     * the file. An example of this configuration could be:
-     * <code><pre>
-     * &#x3C;configuration&#x3E;
-     *   &#x3C;uberJar&#x3E;true&#x3C;/uberJar&#x3E;
-     *   &#x3C;ignoredEntries&#x3E;
-     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.SF&#x3C;/ignoredEntry&#x3E;
-     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.DSA&#x3C;/ignoredEntry&#x3E;
-     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.SF&#x3C;/ignoredEntry&#x3E;
-     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.DSA&#x3C;/ignoredEntry&#x3E;
-     *   &#x3C;/ignoredEntries&#x3E;
-     * &#x3C;/configuration&#x3E;
-     * </pre></code>
-     */
-    @Parameter(property = "ignoredEntries")
-    private String[] ignoredEntries;
-
     /** Skip the execution of this mojo */
     @Parameter(defaultValue = "false", property = "quarkus.build.skip")
     private boolean skip = false;
 
-    public BuildMojo() {
-        MojoLogger.logSupplier = this::getLog;
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Skipping Quarkus build");
+            return false;
+        }
+        if (mavenProject().getPackaging().equals("pom")) {
+            getLog().info("Type of the artifact is POM, skipping build goal");
+            return false;
+        }
+        if (!mavenProject().getArtifact().getArtifactHandler().getExtension().equals("jar")) {
+            throw new MojoExecutionException(
+                    "The project artifact's extension is '" + mavenProject().getArtifact().getArtifactHandler().getExtension()
+                            + "' while this goal expects it be 'jar'");
+        }
+        return true;
     }
 
     @Override
-    public void execute() throws MojoExecutionException {
-        if (skip) {
-            getLog().info("Skipping Quarkus build");
-            return;
-        }
-        if (project.getPackaging().equals("pom")) {
-            getLog().info("Type of the artifact is POM, skipping build goal");
-            return;
-        }
-        if (!project.getArtifact().getArtifactHandler().getExtension().equals("jar")) {
-            throw new MojoExecutionException(
-                    "The project artifact's extension is '" + project.getArtifact().getArtifactHandler().getExtension()
-                            + "' while this goal expects it be 'jar'");
-        }
+    protected void doExecute() throws MojoExecutionException {
 
         boolean clear = false;
         try {
-
-            final Properties projectProperties = project.getProperties();
-            final Properties effectiveProperties = new Properties();
-            // quarkus. properties > ignoredEntries in pom.xml
-            if (ignoredEntries != null && ignoredEntries.length > 0) {
-                String joinedEntries = String.join(",", ignoredEntries);
-                effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);
-            }
-            for (String name : projectProperties.stringPropertyNames()) {
-                if (name.startsWith("quarkus.")) {
-                    effectiveProperties.setProperty(name, projectProperties.getProperty(name));
-                }
-            }
-            if (uberJar && System.getProperty(QUARKUS_PACKAGE_UBER_JAR) == null) {
-                System.setProperty(QUARKUS_PACKAGE_UBER_JAR, "true");
-                clear = true;
-            }
-            effectiveProperties.putIfAbsent("quarkus.application.name", project.getArtifactId());
-            effectiveProperties.putIfAbsent("quarkus.application.version", project.getVersion());
-
-            MavenArtifactResolver resolver = MavenArtifactResolver.builder()
-                    .setWorkspaceDiscovery(false)
-                    .setRepositorySystem(repoSystem)
-                    .setRepositorySystemSession(repoSession)
-                    .setRemoteRepositories(repos)
-                    .build();
-
-            final Artifact projectArtifact = project.getArtifact();
-            final AppArtifact appArtifact = new AppArtifact(projectArtifact.getGroupId(), projectArtifact.getArtifactId(),
-                    projectArtifact.getClassifier(), projectArtifact.getArtifactHandler().getExtension(),
-                    projectArtifact.getVersion());
-
-            File projectFile = projectArtifact.getFile();
-            if (projectFile == null) {
-                projectFile = new File(project.getBuild().getOutputDirectory());
-                if (!projectFile.exists()) {
-                    if (hasSources(project)) {
-                        throw new MojoExecutionException("Project " + project.getArtifact() + " has not been compiled yet");
-                    }
-                    if (!projectFile.mkdirs()) {
-                        throw new MojoExecutionException("Failed to create the output dir " + projectFile);
-                    }
-                }
-            }
-            appArtifact.setPaths(PathsCollection.of(projectFile.toPath()));
-
-            QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
-                    .setAppArtifact(appArtifact)
-                    .setMavenArtifactResolver(resolver)
-                    .setIsolateDeployment(true)
-                    .setBaseClassLoader(BuildMojo.class.getClassLoader())
-                    .setBuildSystemProperties(effectiveProperties)
-                    .setLocalProjectDiscovery(false)
-                    .setProjectRoot(project.getBasedir().toPath())
-                    .setBaseName(finalName)
-                    .setTargetDirectory(buildDir.toPath());
-
-            for (MavenProject project : project.getCollectedProjects()) {
-                builder.addLocalArtifact(new AppArtifactKey(project.getGroupId(), project.getArtifactId(), null,
-                        project.getArtifact().getArtifactHandler().getExtension()));
-            }
-
-            try (CuratedApplication curatedApplication = builder
-                    .build().bootstrap()) {
+            try (CuratedApplication curatedApplication = bootstrapApplication()) {
 
                 AugmentAction action = curatedApplication.createAugmentor();
                 AugmentResult result = action.createProductionApplication();
 
-                Artifact original = project.getArtifact();
+                Artifact original = mavenProject().getArtifact();
                 if (result.getJar() != null) {
 
                     if (result.getJar().isUberJar() && result.getJar().getOriginalArtifact() != null) {
@@ -235,7 +106,7 @@ public class BuildMojo extends AbstractMojo {
                         }
                     }
                     if (result.getJar().isUberJar()) {
-                        projectHelper.attachArtifact(project, result.getJar().getPath().toFile(),
+                        projectHelper.attachArtifact(mavenProject(), result.getJar().getPath().toFile(),
                                 result.getJar().getClassifier());
                     }
                 }
@@ -247,17 +118,5 @@ public class BuildMojo extends AbstractMojo {
                 System.clearProperty(QUARKUS_PACKAGE_UBER_JAR);
             }
         }
-    }
-
-    private static boolean hasSources(MavenProject project) {
-        if (new File(project.getBuild().getSourceDirectory()).exists()) {
-            return true;
-        }
-        for (Resource r : project.getBuild().getResources()) {
-            if (new File(r.getDirectory()).exists()) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
@@ -12,9 +12,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = "generate-code-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class GenerateCodeTestsMojo extends GenerateCodeMojo {
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        String projectDir = project.getBasedir().getAbsolutePath();
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        String projectDir = mavenProject().getBasedir().getAbsolutePath();
         Path testSources = Paths.get(projectDir, "src", "test");
-        doExecute(testSources, path -> project.addTestCompileSourceRoot(path.toString()), true);
+        generateCode(testSources, path -> mavenProject().addTestCompileSourceRoot(path.toString()), true);
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -1,0 +1,179 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+
+public abstract class QuarkusBootstrapMojo extends AbstractMojo {
+
+    @Component
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    /**
+     * The current repository/network configuration of Maven.
+     *
+     * @parameter default-value="${repositorySystemSession}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /**
+     * The project's remote repositories to use for the resolution of artifacts and their dependencies.
+     *
+     * @parameter default-value="${project.remoteProjectRepositories}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${project.build.directory}")
+    private File buildDir;
+
+    @Parameter(defaultValue = "${project.build.finalName}")
+    private String finalName;
+
+    @Parameter(property = "uberJar", defaultValue = "false")
+    private boolean uberJar;
+
+    /**
+     * When using the uberJar option, this array specifies entries that should
+     * be excluded from the final jar. The entries are relative to the root of
+     * the file. An example of this configuration could be:
+     * <code><pre>
+     * &#x3C;configuration&#x3E;
+     *   &#x3C;uberJar&#x3E;true&#x3C;/uberJar&#x3E;
+     *   &#x3C;ignoredEntries&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *   &#x3C;/ignoredEntries&#x3E;
+     * &#x3C;/configuration&#x3E;
+     * </pre></code>
+     */
+    @Parameter(property = "ignoredEntries")
+    private String[] ignoredEntries;
+
+    private AppArtifactKey projectId;
+    private boolean clearUberJarProp;
+
+    protected QuarkusBootstrapMojo() {
+        MojoLogger.logSupplier = this::getLog;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!beforeExecute()) {
+            return;
+        }
+        try {
+            doExecute();
+        } finally {
+            if (clearUberJarProp) {
+                System.clearProperty(BuildMojo.QUARKUS_PACKAGE_UBER_JAR);
+                clearUberJarProp = false;
+            }
+        }
+    }
+
+    protected void clearUberJarProp() {
+        this.clearUberJarProp = true;
+    }
+
+    /**
+     * This callback allows to evaluate whether this mojo should be executed, skipped or fail.
+     *
+     * @return false if the execution of the mojo should be skipped, true if the mojo should be executed
+     * @throws MojoExecutionException in case of a failure
+     * @throws MojoFailureException in case of a failure
+     */
+    protected abstract boolean beforeExecute() throws MojoExecutionException, MojoFailureException;
+
+    /**
+     * Main mojo execution code
+     *
+     * @throws MojoExecutionException in case of a failure
+     * @throws MojoFailureException in case of a failure
+     */
+    protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
+
+    protected RepositorySystem repositorySystem() {
+        return bootstrapProvider.repositorySystem();
+    }
+
+    protected RemoteRepositoryManager remoteRepositoryManager() {
+        return bootstrapProvider.remoteRepositoryManager();
+    }
+
+    protected RepositorySystemSession repositorySystemSession() {
+        return repoSession;
+    }
+
+    protected List<RemoteRepository> remoteRepositories() {
+        return repos;
+    }
+
+    protected MavenProject mavenProject() {
+        return project;
+    }
+
+    protected File buildDir() {
+        return buildDir;
+    }
+
+    protected File baseDir() {
+        return project.getBasedir();
+    }
+
+    protected String finalName() {
+        return finalName;
+    }
+
+    protected String[] ignoredEntries() {
+        return ignoredEntries;
+    }
+
+    protected boolean uberJar() {
+        return uberJar;
+    }
+
+    protected AppArtifactKey projectId() {
+        return projectId == null ? projectId = new AppArtifactKey(project.getGroupId(), project.getArtifactId()) : projectId;
+    }
+
+    protected AppArtifact projectArtifact() throws MojoExecutionException {
+        return bootstrapProvider.projectArtifact(this);
+    }
+
+    protected MavenArtifactResolver artifactResolver() throws MojoExecutionException {
+        return bootstrapProvider.artifactResolver(this);
+    }
+
+    protected QuarkusBootstrap bootstrapQuarkus() throws MojoExecutionException {
+        return bootstrapProvider.bootstrapQuarkus(this);
+    }
+
+    protected CuratedApplication bootstrapApplication() throws MojoExecutionException {
+        return bootstrapProvider.bootstrapApplication(this);
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -1,0 +1,225 @@
+package io.quarkus.maven;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.bootstrap.model.PathsCollection;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+
+@Component(role = QuarkusBootstrapProvider.class, instantiationStrategy = "singleton")
+public class QuarkusBootstrapProvider implements Closeable {
+
+    @Requirement(role = RepositorySystem.class, optional = false)
+    protected RepositorySystem repoSystem;
+
+    @Requirement(role = RemoteRepositoryManager.class, optional = false)
+    protected RemoteRepositoryManager remoteRepoManager;
+
+    private final Cache<AppArtifactKey, QuarkusAppBootstrapProvider> appBootstrapProviders = CacheBuilder.newBuilder()
+            .concurrencyLevel(4).softValues().initialCapacity(10).build();
+
+    public RepositorySystem repositorySystem() {
+        return repoSystem;
+    }
+
+    public RemoteRepositoryManager remoteRepositoryManager() {
+        return remoteRepoManager;
+    }
+
+    private QuarkusAppBootstrapProvider provider(AppArtifactKey projectId) {
+        try {
+            return appBootstrapProviders.get(projectId, () -> new QuarkusAppBootstrapProvider());
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to cache a new instance of " + QuarkusAppBootstrapProvider.class.getName(),
+                    e);
+        }
+    }
+
+    public MavenArtifactResolver artifactResolver(QuarkusBootstrapMojo mojo)
+            throws MojoExecutionException {
+        return provider(mojo.projectId()).artifactResolver(mojo);
+    }
+
+    public AppArtifact projectArtifact(QuarkusBootstrapMojo mojo)
+            throws MojoExecutionException {
+        return provider(mojo.projectId()).projectArtifact(mojo);
+    }
+
+    public QuarkusBootstrap bootstrapQuarkus(QuarkusBootstrapMojo mojo)
+            throws MojoExecutionException {
+        return provider(mojo.projectId()).bootstrapQuarkus(mojo);
+    }
+
+    public CuratedApplication bootstrapApplication(QuarkusBootstrapMojo mojo)
+            throws MojoExecutionException {
+        return provider(mojo.projectId()).curateApplication(mojo);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (appBootstrapProviders.size() == 0) {
+            return;
+        }
+        for (QuarkusAppBootstrapProvider p : appBootstrapProviders.asMap().values()) {
+            try {
+                p.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private class QuarkusAppBootstrapProvider implements Closeable {
+
+        private AppArtifact projectArtifact;
+        private MavenArtifactResolver artifactResolver;
+        private QuarkusBootstrap quarkusBootstrap;
+        private CuratedApplication curatedApp;
+
+        private MavenArtifactResolver artifactResolver(QuarkusBootstrapMojo mojo)
+                throws MojoExecutionException {
+            if (artifactResolver != null) {
+                return artifactResolver;
+            }
+            try {
+                return artifactResolver = MavenArtifactResolver.builder()
+                        .setWorkspaceDiscovery(false)
+                        .setRepositorySystem(repoSystem)
+                        .setRepositorySystemSession(mojo.repositorySystemSession())
+                        .setRemoteRepositories(mojo.remoteRepositories())
+                        .setRemoteRepositoryManager(remoteRepoManager)
+                        .build();
+            } catch (BootstrapMavenException e) {
+                throw new MojoExecutionException("Failed to initialize Quarkus bootstrap Maven artifact resolver", e);
+            }
+        }
+
+        private AppArtifact projectArtifact(QuarkusBootstrapMojo mojo) throws MojoExecutionException {
+            if (projectArtifact != null) {
+                return projectArtifact;
+            }
+            final Artifact projectArtifact = mojo.mavenProject().getArtifact();
+            final AppArtifact appArtifact = new AppArtifact(projectArtifact.getGroupId(), projectArtifact.getArtifactId(),
+                    projectArtifact.getClassifier(), projectArtifact.getArtifactHandler().getExtension(),
+                    projectArtifact.getVersion());
+
+            File projectFile = projectArtifact.getFile();
+            if (projectFile == null) {
+                projectFile = new File(mojo.mavenProject().getBuild().getOutputDirectory());
+                if (!projectFile.exists()) {
+                    /*
+                     * TODO GenerateCodeMojo would fail
+                     * if (hasSources(project)) {
+                     * throw new MojoExecutionException("Project " + project.getArtifact() + " has not been compiled yet");
+                     * }
+                     */
+                    if (!projectFile.mkdirs()) {
+                        throw new MojoExecutionException("Failed to create the output dir " + projectFile);
+                    }
+                }
+            }
+            appArtifact.setPaths(PathsCollection.of(projectFile.toPath()));
+            return appArtifact;
+        }
+
+        protected QuarkusBootstrap bootstrapQuarkus(QuarkusBootstrapMojo mojo) throws MojoExecutionException {
+            if (quarkusBootstrap != null) {
+                return quarkusBootstrap;
+            }
+
+            final Properties projectProperties = mojo.mavenProject().getProperties();
+            final Properties effectiveProperties = new Properties();
+            // quarkus. properties > ignoredEntries in pom.xml
+            if (mojo.ignoredEntries() != null && mojo.ignoredEntries().length > 0) {
+                String joinedEntries = String.join(",", mojo.ignoredEntries());
+                effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);
+            }
+            for (String name : projectProperties.stringPropertyNames()) {
+                if (name.startsWith("quarkus.")) {
+                    effectiveProperties.setProperty(name, projectProperties.getProperty(name));
+                }
+            }
+            if (mojo.uberJar() && System.getProperty(BuildMojo.QUARKUS_PACKAGE_UBER_JAR) == null) {
+                System.setProperty(BuildMojo.QUARKUS_PACKAGE_UBER_JAR, "true");
+                mojo.clearUberJarProp();
+            }
+            effectiveProperties.putIfAbsent("quarkus.application.name", mojo.mavenProject().getArtifactId());
+            effectiveProperties.putIfAbsent("quarkus.application.version", mojo.mavenProject().getVersion());
+
+            QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
+                    .setAppArtifact(projectArtifact(mojo))
+                    .setMavenArtifactResolver(artifactResolver(mojo))
+                    .setIsolateDeployment(true)
+                    .setBaseClassLoader(getClass().getClassLoader())
+                    .setBuildSystemProperties(effectiveProperties)
+                    .setLocalProjectDiscovery(false)
+                    .setProjectRoot(mojo.baseDir().toPath())
+                    .setBaseName(mojo.finalName())
+                    .setTargetDirectory(mojo.buildDir().toPath());
+
+            for (MavenProject project : mojo.mavenProject().getCollectedProjects()) {
+                builder.addLocalArtifact(new AppArtifactKey(project.getGroupId(), project.getArtifactId(), null,
+                        project.getArtifact().getArtifactHandler().getExtension()));
+            }
+
+            return quarkusBootstrap = builder.build();
+        }
+
+        protected CuratedApplication curateApplication(QuarkusBootstrapMojo mojo) throws MojoExecutionException {
+            if (curatedApp != null) {
+                return curatedApp;
+            }
+            try {
+                return curatedApp = bootstrapQuarkus(mojo).bootstrap();
+            } catch (MojoExecutionException e) {
+                throw e;
+            } catch (BootstrapException e) {
+                throw new MojoExecutionException("Failed to bootstrap the application", e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (curatedApp != null) {
+                curatedApp.close();
+                curatedApp = null;
+            }
+            this.artifactResolver = null;
+            this.quarkusBootstrap = null;
+        }
+    }
+
+    /*
+     * private static boolean hasSources(MavenProject project) {
+     * if (new File(project.getBuild().getSourceDirectory()).exists()) {
+     * return true;
+     * }
+     * for (Resource r : project.getBuild().getResources()) {
+     * if (new File(r.getDirectory()).exists()) {
+     * return true;
+     * }
+     * }
+     * return false;
+     * }
+     */
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -1,0 +1,27 @@
+package io.quarkus.maven.components;
+
+import java.io.IOException;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+
+import io.quarkus.maven.QuarkusBootstrapProvider;
+
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "quarkus-bootstrap")
+public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant {
+
+    @Requirement(optional = false)
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    @Override
+    public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
+        try {
+            bootstrapProvider.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Common Maven Quarkus app bootstraping Mojo that allows bootstraping the app once and re-using the CuratedApplication in other mojos extending the common bootstrap Mojo configured for the same project (i.e. code generation, test code generation and packaging).

Typical project generated by our tools includes the following config:
```
      <plugin>
        <groupId>io.quarkus</groupId>
        <artifactId>quarkus-maven-plugin</artifactId>
        <version>${quarkus-plugin.version}</version>
        <executions>
          <execution>
            <goals>
              <goal>build</goal>
              <goal>generate-code</goal>
              <goal>generate-code-tests</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
```
This means for even e.g. `mvn package -DskipTests` the `CuratedApplication` will be bootstrapped three times, i.e. once per goal. This change introduces a kind build flow cache per project, so the `CuratedApplication` is created only once and then shared between these goals.