### PR TITLE
Request scope performance improvements

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CurrentVertxRequest.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CurrentVertxRequest.java
@@ -8,7 +8,7 @@ import io.vertx.ext.web.RoutingContext;
 @RequestScoped
 public class CurrentVertxRequest {
 
-    public RoutingContext current;
+    private RoutingContext current;
 
     @Produces
     @RequestScoped

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -5,7 +5,6 @@ import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_VOLATILE;
 
-import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
@@ -31,7 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import javax.enterprise.context.spi.Contextual;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -276,22 +274,17 @@ public class ClientProxyGenerator extends AbstractGenerator {
         }
 
         ResultHandle beanHandle = creator.readInstanceField(beanField, creator.getThis());
-        ResultHandle contextHandle;
 
         if (BuiltinScope.APPLICATION.is(bean.getScope())) {
-            // Application context stored in a field and is always active
-            contextHandle = creator.readInstanceField(
-                    FieldDescriptor.of(clientProxy.getClassName(), CONTEXT_FIELD, InjectableContext.class), creator.getThis());
-
-            creator.returnValue(creator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(InjectableContext.class, "getOrCreate", Object.class, Contextual.class),
-                    contextHandle, beanHandle));
+            // Application context is stored in a field and is always active
+            creator.returnValue(creator.invokeStaticMethod(MethodDescriptors.CLIENT_PROXIES_GET_APP_SCOPED_DELEGATE,
+                    creator.readInstanceField(
+                            FieldDescriptor.of(clientProxy.getClassName(), CONTEXT_FIELD, InjectableContext.class),
+                            creator.getThis()),
+                    beanHandle));
         } else {
-            // Arc.container()
-            ResultHandle container = creator.invokeStaticMethod(MethodDescriptors.ARC_CONTAINER);
-            creator.returnValue(creator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(ArcContainer.class, "normalScopedInstance", Object.class, InjectableBean.class),
-                    container, beanHandle));
+            creator.returnValue(creator.invokeStaticMethod(MethodDescriptors.CLIENT_PROXIES_GET_DELEGATE,
+                    beanHandle));
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -5,14 +5,13 @@ import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_VOLATILE;
 
+import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
-import io.quarkus.arc.impl.CreationalContextImpl;
 import io.quarkus.arc.impl.Mockable;
 import io.quarkus.arc.processor.BeanGenerator.ProviderType;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
-import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.DescriptorUtils;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.spi.Contextual;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -284,33 +282,17 @@ public class ClientProxyGenerator extends AbstractGenerator {
             // Application context stored in a field and is always active
             contextHandle = creator.readInstanceField(
                     FieldDescriptor.of(clientProxy.getClassName(), CONTEXT_FIELD, InjectableContext.class), creator.getThis());
+
+            creator.returnValue(creator.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(InjectableContext.class, "getOrCreate", Object.class, Contextual.class),
+                    contextHandle, beanHandle));
         } else {
             // Arc.container()
             ResultHandle container = creator.invokeStaticMethod(MethodDescriptors.ARC_CONTAINER);
-            // bean.getScope()
-            ResultHandle scope = creator
-                    .invokeInterfaceMethod(MethodDescriptor.ofMethod(InjectableBean.class, "getScope", Class.class),
-                            beanHandle);
-            // getContext()
-            contextHandle = creator.invokeInterfaceMethod(MethodDescriptors.ARC_CONTAINER_GET_ACTIVE_CONTEXT,
-                    container, scope);
-
-            BytecodeCreator inactiveBranch = creator.ifNull(contextHandle).trueBranch();
-            ResultHandle exception = inactiveBranch.newInstance(
-                    MethodDescriptor.ofConstructor(ContextNotActiveException.class, String.class),
-                    inactiveBranch.invokeVirtualMethod(MethodDescriptors.OBJECT_TO_STRING, scope));
-            inactiveBranch.throwException(exception);
+            creator.returnValue(creator.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(ArcContainer.class, "normalScopedInstance", Object.class, InjectableBean.class),
+                    container, beanHandle));
         }
-
-        AssignableResultHandle ret = creator.createVariable(Object.class);
-        creator.assign(ret, creator.invokeInterfaceMethod(MethodDescriptors.CONTEXT_GET_IF_PRESENT, contextHandle, beanHandle));
-        BytecodeCreator isNullBranch = creator.ifNull(ret).trueBranch();
-        // Create a new contextual instance - new CreationalContextImpl<>()
-        ResultHandle creationContext = isNullBranch
-                .newInstance(MethodDescriptor.ofConstructor(CreationalContextImpl.class, Contextual.class), beanHandle);
-        isNullBranch.assign(ret,
-                isNullBranch.invokeInterfaceMethod(MethodDescriptors.CONTEXT_GET, contextHandle, beanHandle, creationContext));
-        creator.returnValue(ret);
     }
 
     void implementGetContextualInstance(ClassCreator clientProxy, ProviderType providerType) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -8,6 +8,7 @@ import io.quarkus.arc.InjectableBean.Kind;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
+import io.quarkus.arc.impl.ClientProxies;
 import io.quarkus.arc.impl.CreationalContextImpl;
 import io.quarkus.arc.impl.FixedValueSupplier;
 import io.quarkus.arc.impl.InjectableReferenceProviders;
@@ -241,6 +242,12 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor REMOVED_BEAN_IMPL = MethodDescriptor.ofConstructor(RemovedBeanImpl.class, Kind.class,
             String.class, Set.class, Set.class);
+
+    public static final MethodDescriptor CLIENT_PROXIES_GET_APP_SCOPED_DELEGATE = MethodDescriptor.ofMethod(ClientProxies.class,
+            "getApplicationScopedDelegate", Object.class, InjectableContext.class, InjectableBean.class);
+
+    public static final MethodDescriptor CLIENT_PROXIES_GET_DELEGATE = MethodDescriptor.ofMethod(ClientProxies.class,
+            "getDelegate", Object.class, InjectableBean.class);
 
     private MethodDescriptors() {
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -99,6 +99,14 @@ public interface ArcContainer {
     <T> InstanceHandle<T> instance(InjectableBean<T> bean);
 
     /**
+     * Returns an instance of a normal scoped bean
+     *
+     * @param bean
+     * @return a new bean instance
+     */
+    <T> T normalScopedInstance(InjectableBean<T> bean);
+
+    /**
      * Instances of dependent scoped beans obtained with the returned injectable instance must be explicitly destroyed, either
      * via the {@link Instance#destroy(Object)} method invoked upon the same injectable instance or with
      * {@link InstanceHandle#destroy()}.

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -2,6 +2,7 @@ package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -27,6 +28,13 @@ public interface ArcContainer {
      * @throws IllegalArgumentException if there is more than one active context for the given scope
      */
     InjectableContext getActiveContext(Class<? extends Annotation> scopeType);
+
+    /**
+     * 
+     * @param scopeType
+     * @return the matching context objects, never null
+     */
+    Collection<InjectableContext> getContexts(Class<? extends Annotation> scopeType);
 
     /**
      * 
@@ -97,14 +105,6 @@ public interface ArcContainer {
      * @return a new bean instance handle
      */
     <T> InstanceHandle<T> instance(InjectableBean<T> bean);
-
-    /**
-     * Returns an instance of a normal scoped bean
-     *
-     * @param bean
-     * @return a new bean instance
-     */
-    <T> T normalScopedInstance(InjectableBean<T> bean);
 
     /**
      * Instances of dependent scoped beans obtained with the returned injectable instance must be explicitly destroyed, either

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
@@ -1,0 +1,49 @@
+package io.quarkus.arc.impl;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.context.spi.Contextual;
+
+public final class ClientProxies {
+
+    private ClientProxies() {
+    }
+
+    public static <T> T getApplicationScopedDelegate(InjectableContext applicationContext, InjectableBean<T> bean) {
+        T result = applicationContext.get(bean);
+        if (result == null) {
+            result = applicationContext.get(bean, newCreationalContext(bean));
+        }
+        return result;
+    }
+
+    public static <T> T getDelegate(InjectableBean<T> bean) {
+        Iterable<InjectableContext> contexts = Arc.container().getContexts(bean.getScope());
+        T result = null;
+        InjectableContext selectedContext = null;
+        for (InjectableContext context : contexts) {
+            if (result != null) {
+                if (context.isActive()) {
+                    throw new IllegalArgumentException(
+                            "More than one context object for the given scope: " + selectedContext + " " + context);
+                }
+            } else {
+                result = context.getIfActive(bean, ClientProxies::newCreationalContext);
+                if (result != null) {
+                    selectedContext = context;
+                }
+            }
+        }
+        if (result == null) {
+            throw new ContextNotActiveException();
+        }
+        return result;
+    }
+
+    private static <T> CreationalContextImpl<T> newCreationalContext(Contextual<T> contextual) {
+        return new CreationalContextImpl<>(contextual);
+    }
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 
@@ -16,7 +17,7 @@ import javax.enterprise.context.spi.CreationalContext;
  *
  * @param <T>
  */
-public class CreationalContextImpl<T> implements CreationalContext<T> {
+public class CreationalContextImpl<T> implements CreationalContext<T>, Function<Contextual<T>, CreationalContext<T>> {
 
     private final Contextual<T> contextual;
     private final CreationalContextImpl<?> parent;
@@ -84,6 +85,11 @@ public class CreationalContextImpl<T> implements CreationalContext<T> {
 
     public <C> CreationalContextImpl<C> child(Contextual<C> contextual) {
         return new CreationalContextImpl<>(contextual, this);
+    }
+
+    @Override
+    public CreationalContext<T> apply(Contextual<T> contextual) {
+        return this;
     }
 
     public static <T> CreationalContextImpl<T> unwrap(CreationalContext<T> ctx) {


### PR DESCRIPTION
Previously this required 3 ThreadLocal operations:

- isActive()
- create(Contextual)
- create(Contextual, CreationalContext)

This PR provides a single operation so that these can
be accomplished with only a single ThreadLocal op