### PR TITLE
Update to Vert.x 3.9.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -44,7 +44,7 @@
         <smallrye-jwt.version>2.3.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.1.0</smallrye-converter-api.version>
+        <smallrye-converter-api.version>1.2.2</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>2.4.0</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.35.1</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
@@ -131,8 +131,8 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <mutiny.version>0.9.0</mutiny.version>
-        <axle-client.version>1.2.1</axle-client.version>
-        <mutiny-client.version>1.2.1</mutiny-client.version>
+        <axle-client.version>1.2.2</axle-client.version>
+        <mutiny-client.version>1.2.2</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -105,7 +105,7 @@
         <wildfly-elytron.version>1.13.1.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.1.1.Final</jboss-threads.version>
-        <vertx.version>3.9.3</vertx.version>
+        <vertx.version>3.9.4</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>


### PR DESCRIPTION
Update Vert.x to 3.9.4, and associated dependencies

This update contains a fix for https://github.com/vert-x3/vertx-web/issues/1714. 

- Update Vert.x version to 3.9.4
- Update Mutiny and Axle clients to 1.2.2
- Update Reactive converters to 1.2.2
