### PR TITLE
Added config for disabling HTTP policies

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledPermissionTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledPermissionTestCase.java
@@ -1,0 +1,152 @@
+package io.quarkus.vertx.http.security;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DisabledPermissionTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.permission.test1.paths=/default\n" +
+            "quarkus.http.auth.permission.test1.policy=authenticated\n" +
+
+            "quarkus.http.auth.permission.test2.enabled=false\n" +
+            "quarkus.http.auth.permission.test2.paths=/disabled\n" +
+            "quarkus.http.auth.permission.test2.policy=deny\n" +
+
+            "quarkus.http.auth.permission.test3.enabled=true\n" +
+            "quarkus.http.auth.permission.test3.paths=/enabled\n" +
+            "quarkus.http.auth.permission.test3.policy=permit\n" +
+
+            "quarkus.http.auth.permission.test4.enabled=true\n" +
+            "quarkus.http.auth.permission.test4.paths=/restricted\n" +
+            "quarkus.http.auth.permission.test4.methods=GET\n" +
+            "quarkus.http.auth.permission.test4.policy=authenticated\n" +
+
+            "quarkus.http.auth.permission.test5.enabled=false\n" +
+            "quarkus.http.auth.permission.test5.paths=/unrestricted\n" +
+            "quarkus.http.auth.permission.test5.methods=GET\n" +
+            "quarkus.http.auth.permission.test5.policy=authenticated\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+            .addClasses(
+                    TestIdentityController.class,
+                    TestIdentityProvider.class,
+                    PathHandler.class)
+            .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("test", "test", "test");
+    }
+
+    @Test
+    public void testAnonymousDenied() {
+        RestAssured
+                .given()
+                .when()
+                .get("/default")
+                .then()
+                .assertThat()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testAnonymousAllowed() {
+        RestAssured
+                .given()
+                .when()
+                .get("/enabled")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo(":/enabled"));
+    }
+
+    @Test
+    public void testDefaultEnabled() {
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/default")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("test:/default"));
+    }
+
+    @Test
+    public void testDisabled() {
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/disabled")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("test:/disabled"));
+    }
+
+    @Test
+    public void testEnabled() {
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/enabled")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("test:/enabled"));
+    }
+
+    @Test
+    public void testRestricted() {
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .post("/restricted")
+                .then()
+                .assertThat()
+                .statusCode(403);
+    }
+
+    @Test
+    public void testUnrestricted() {
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/unrestricted")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("test:/unrestricted"));
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
@@ -10,6 +10,14 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class PolicyMappingConfig {
 
     /**
+     * Determines whether the entire permission set is enabled, or not.
+     * 
+     * By default, if the permission set is defined, it is enabled.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled;
+
+    /**
      * The HTTP policy that this permission set is linked to.
      *
      * There are 3 built in policies: permit, deny and authenticated. Role based

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -83,25 +83,27 @@ public class PathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
                 throw new RuntimeException("Unable to find HTTP security policy " + entry.getValue().policy);
             }
 
-            for (String path : entry.getValue().paths.orElse(Collections.emptyList())) {
-                path = path.trim();
-                if (tempMap.containsKey(path)) {
-                    HttpMatcher m = new HttpMatcher(new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),
-                            checker);
-                    tempMap.get(path).add(m);
-                } else {
-                    HttpMatcher m = new HttpMatcher(new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),
-                            checker);
-                    List<HttpMatcher> perms = new ArrayList<>();
-                    tempMap.put(path, perms);
-                    perms.add(m);
-                    if (path.endsWith("/*")) {
-                        String stripped = path.substring(0, path.length() - 2);
-                        pathMatcher.addPrefixPath(stripped.isEmpty() ? "/" : stripped, perms);
-                    } else if (path.endsWith("*")) {
-                        pathMatcher.addPrefixPath(path.substring(0, path.length() - 1), perms);
+            if (entry.getValue().enabled.orElse(Boolean.TRUE)) {
+                for (String path : entry.getValue().paths.orElse(Collections.emptyList())) {
+                    path = path.trim();
+                    if (tempMap.containsKey(path)) {
+                        HttpMatcher m = new HttpMatcher(new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),
+                                checker);
+                        tempMap.get(path).add(m);
                     } else {
-                        pathMatcher.addExactPath(path, perms);
+                        HttpMatcher m = new HttpMatcher(new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),
+                                checker);
+                        List<HttpMatcher> perms = new ArrayList<>();
+                        tempMap.put(path, perms);
+                        perms.add(m);
+                        if (path.endsWith("/*")) {
+                            String stripped = path.substring(0, path.length() - 2);
+                            pathMatcher.addPrefixPath(stripped.isEmpty() ? "/" : stripped, perms);
+                        } else if (path.endsWith("*")) {
+                            pathMatcher.addPrefixPath(path.substring(0, path.length() - 1), perms);
+                        } else {
+                            pathMatcher.addExactPath(path, perms);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #12738

* added config property to allow disabling the whole permission set (default is enabled)
* added check for the config property when building the collection of path matchers
* added unit test to attempt to cover the use cases

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>