### PR TITLE
Fix spring-data-jpa field lookup with layered @MappedSuperclasses

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
@@ -194,8 +194,8 @@ public class MethodNameParser {
             }
             FieldInfo fieldInfo = getField(fieldName);
             if (fieldInfo == null) {
-                String parsingExceptionMethod = "Entity " + entityClass + " does not contain a field named: " + part + ". " +
-                        "Offending method is " + methodName;
+                String parsingExceptionMethod = "Entity " + entityClass + " does not contain a field named: " + fieldName +
+                        ". " + "Offending method is " + methodName;
 
                 // determine if we are trying to use a field of one of the associated entities
 
@@ -587,13 +587,13 @@ public class MethodNameParser {
         List<ClassInfo> mappedSuperClassInfoElements = new ArrayList<>(3);
         Type superClassType = entityClass.superClassType();
         while (superClassType != null && !superClassType.name().equals(DotNames.OBJECT)) {
-            ClassInfo superClass = indexView.getClassByName(entityClass.superName());
+            ClassInfo superClass = indexView.getClassByName(superClassType.name());
             if (superClass.classAnnotation(DotNames.JPA_MAPPED_SUPERCLASS) != null) {
                 mappedSuperClassInfoElements.add(superClass);
             }
 
             if (superClassType.kind() == Kind.CLASS) {
-                superClassType = indexView.getClassByName(superClassType.name()).superClassType();
+                superClassType = superClass.superClassType();
             } else if (superClassType.kind() == Kind.PARAMETERIZED_TYPE) {
                 ParameterizedType parameterizedType = superClassType.asParameterizedType();
                 superClassType = parameterizedType.owner();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Animal.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Animal.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class Animal {
+
+    @Id
+    @GeneratedValue
+    public long id;
+
+    public long getId() {
+        return id;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Cat.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Cat.java
@@ -1,15 +1,9 @@
 package io.quarkus.it.spring.data.jpa;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 
 @Entity
-public class Cat {
-
-    @Id
-    @GeneratedValue
-    public long id;
+public class Cat extends Mammal {
 
     private String breed;
 
@@ -23,10 +17,6 @@ public class Cat {
     public Cat(String breed, String color) {
         this.breed = breed;
         this.color = color;
-    }
-
-    public long getId() {
-        return id;
     }
 
     public String getBreed() {

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Mammal.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Mammal.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class Mammal extends Animal {
+
+}


### PR DESCRIPTION
Fixes #12753

Note: Before the fix, but with the new `Animal` and `Mammal` mapped superclasses, the integration tests were failing with:
```
UnableToParseMethodException: Field id which was configured as the order field does not exist in the entity. Offending method is findByColorIsNotNullOrderByIdDesc
```
This is not _exactly_ the same type of query/method name as #12753, but I think it is good enough.

/cc @geoand 