### PR TITLE
Improved MongoHealthCheck to include reactiveClients

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
@@ -2,10 +2,10 @@ package io.quarkus.mongodb.health;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.Bean;
 
 import org.bson.Document;
@@ -17,40 +17,69 @@ import org.eclipse.microprofile.health.Readiness;
 import com.mongodb.client.MongoClient;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.mongodb.MongoClientName;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 
 @Readiness
 @ApplicationScoped
 public class MongoHealthCheck implements HealthCheck {
-    private static final String DEFAULT_CLIENT = "__default__";
+
+    public static final String CLIENT_DEFAULT = "<default>";
+    public static final String CLIENT_DEFAULT_REACTIVE = "<default-reactive>";
+
     private Map<String, MongoClient> clients = new HashMap<>();
+    private Map<String, ReactiveMongoClient> reactiveClients = new HashMap<>();
 
     @PostConstruct
     protected void init() {
-        Set<Bean<?>> beans = Arc.container().beanManager().getBeans(MongoClient.class);
-        for (Bean<?> bean : beans) {
-            if (bean.getName() == null) {
-                // this is the default mongo client: retrieve it by type
-                MongoClient defaultClient = Arc.container().instance(MongoClient.class).get();
-                clients.put(DEFAULT_CLIENT, defaultClient);
-            } else {
-                MongoClient client = (MongoClient) Arc.container().instance(bean.getName()).get();
-                clients.put(bean.getName(), client);
+        for (InstanceHandle<MongoClient> handle : Arc.container().select(MongoClient.class, Any.Literal.INSTANCE).handles()) {
+            String clientName = getMongoClientName(handle.getBean());
+            clients.put(clientName == null ? CLIENT_DEFAULT : clientName, handle.get());
+        }
+        // reactive clients
+        for (InstanceHandle<ReactiveMongoClient> handle : Arc.container()
+                .select(ReactiveMongoClient.class, Any.Literal.INSTANCE).handles()) {
+            String clientName = getMongoClientName(handle.getBean());
+            reactiveClients.put(clientName == null ? CLIENT_DEFAULT_REACTIVE : clientName, handle.get());
+        }
+    }
+
+    /**
+     * Get mongoClient name if defined.
+     *
+     * @param bean
+     * @return mongoClient name or null if not defined
+     * @see MongoClientName
+     */
+    private String getMongoClientName(Bean bean) {
+        for (Object qualifier : bean.getQualifiers()) {
+            if (qualifier instanceof MongoClientName) {
+                return ((MongoClientName) qualifier).value();
             }
         }
+        return null;
     }
 
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("MongoDB connection health check").up();
+        Document command = new Document("ping", 1);
         for (Map.Entry<String, MongoClient> client : clients.entrySet()) {
-            boolean isDefault = DEFAULT_CLIENT.equals(client.getKey());
-            MongoClient mongoClient = client.getValue();
             try {
-                Document document = mongoClient.getDatabase("admin").runCommand(new Document("ping", 1));
-                String mongoClientName = isDefault ? "default" : client.getKey();
-                builder.up().withData(mongoClientName, document.toJson());
+                Document document = client.getValue().getDatabase("admin").runCommand(command);
+                builder.up().withData(client.getKey(), document.toJson());
             } catch (Exception e) {
-                return builder.down().withData("reason", e.getMessage()).build();
+                return builder.down().withData("reason", "client [" + client.getKey() + "]: " + e.getMessage()).build();
+            }
+        }
+        for (Map.Entry<String, ReactiveMongoClient> client : reactiveClients.entrySet()) {
+            try {
+                Document document = client.getValue().getDatabase("admin").runCommand(command).await().indefinitely();
+                builder.up().withData(client.getKey(), document.toJson());
+            } catch (Exception e) {
+                return builder.down().withData("reason", "reactive client [" + client.getKey() + "]: " + e.getMessage())
+                        .build();
             }
         }
         return builder.build();

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.mongodb;
 
 import static io.restassured.RestAssured.get;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Arrays;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.it.mongodb.discriminator.Car;
 import io.quarkus.it.mongodb.discriminator.Moto;
 import io.quarkus.it.mongodb.pojo.Pojo;
+import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -123,6 +125,8 @@ public class BookResourceTest {
     public void health() throws Exception {
         RestAssured.when().get("/health/ready").then()
                 .body("status", is("UP"),
+                        "checks.data", containsInAnyOrder(hasKey(MongoHealthCheck.CLIENT_DEFAULT)),
+                        "checks.data", containsInAnyOrder(hasKey(MongoHealthCheck.CLIENT_DEFAULT_REACTIVE)),
                         "checks.status", containsInAnyOrder("UP"),
                         "checks.name", containsInAnyOrder("MongoDB connection health check"));
     }


### PR DESCRIPTION
MongoHealthCheck now goes through ReactiveMongoClient as well.
Also properly get `mongoClientName` from the annotation because `bean.getName()` returns always null.

default blocking client stays same as `default`. Reactive is `defaultReactive` .

fixes #12716