### PR TITLE
Clean up the config of service integration

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.smallrye.graphql.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -15,10 +17,28 @@ public class SmallRyeGraphQLConfig {
     String rootPath;
 
     /**
-     * Enable metrics
+     * Enable metrics. By default this will be enabled if the metrics extension is added.
      */
-    @ConfigItem(name = "metrics.enabled", defaultValue = "false")
-    boolean metricsEnabled;
+    @ConfigItem(name = "metrics.enabled")
+    Optional<Boolean> metricsEnabled;
+
+    /**
+     * Enable tracing. By default this will be enabled if the tracing extension is added.
+     */
+    @ConfigItem(name = "tracing.enabled")
+    Optional<Boolean> tracingEnabled;
+
+    /**
+     * Enable validation. By default this will be enabled if the Hibernate Validator extension is added.
+     */
+    @ConfigItem(name = "validation.enabled")
+    Optional<Boolean> validationEnabled;
+
+    /**
+     * Enable eventing. Allow you to receive events on bootstrap and execution.
+     */
+    @ConfigItem(name = "events.enabled", defaultValue = "false")
+    boolean eventsEnabled;
 
     /**
      * Change the type naming strategy.

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLNamingTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLNamingTest.java
@@ -53,6 +53,7 @@ public class GraphQLNamingTest extends AbstractGraphQLTest {
     private static Map<String, String> configuration() {
         Map<String, String> m = new HashMap<>();
         m.put("quarkus.smallrye-graphql.auto-name-strategy", "MergeInnerClass");
+        m.put("quarkus.smallrye-graphql.events.enabled", "true");
         return m;
 
     }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
@@ -2,6 +2,9 @@ package io.quarkus.smallrye.graphql.deployment;
 
 import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hamcrest.CoreMatchers;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -28,7 +31,7 @@ public class GraphQLTest extends AbstractGraphQLTest {
     static QuarkusUnitTest test = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestResource.class, TestPojo.class, TestRandom.class, TestGenericsPojo.class)
-                    .addAsResource(new StringAsset(getPropertyAsString()), "application.properties")
+                    .addAsResource(new StringAsset(getPropertyAsString(configuration())), "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
     @Test
@@ -162,5 +165,11 @@ public class GraphQLTest extends AbstractGraphQLTest {
                 .statusCode(200)
                 .and()
                 .body(CoreMatchers.containsString("{\"data\":{\"context\":\"/context\"}}"));
+    }
+
+    private static Map<String, String> configuration() {
+        Map<String, String> m = new HashMap<>();
+        m.put("quarkus.smallrye-graphql.events.enabled", "true");
+        return m;
     }
 }

--- a/extensions/smallrye-graphql/runtime/pom.xml
+++ b/extensions/smallrye-graphql/runtime/pom.xml
@@ -32,11 +32,6 @@
             <artifactId>quarkus-jsonb</artifactId>    
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-metrics</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-cdi</artifactId>
         </dependency>


### PR DESCRIPTION
This PR clean up the service integration from the SmallRye GraphQL extension.
This include metrics, tracing, bean validation and general events.

The logic is as follows: Without any configuration set, the service will be auto-enabled if the relative extension is added.
Else, the user can explicitly switch it off via config.
If the user explicitly switched it on but the relevant extension is not available, a warning will be printed.

Close #12673

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>