### PR TITLE
BuildMojo - Delete .jar.original for both file and directory case

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -20,6 +20,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.util.IoUtils;
 
 /**
  * Build the application.
@@ -97,7 +98,7 @@ public class BuildMojo extends QuarkusBootstrapMojo {
                         final Path standardJar = curatedApplication.getAppModel().getAppArtifact().getPaths().getSinglePath();
                         if (Files.exists(standardJar)) {
                             try {
-                                Files.deleteIfExists(result.getJar().getOriginalArtifact());
+                                IoUtils.recursiveDelete(result.getJar().getOriginalArtifact());
                                 Files.move(standardJar, result.getJar().getOriginalArtifact());
                             } catch (IOException e) {
                                 throw new UncheckedIOException(e);


### PR DESCRIPTION
BuildMojo - Delete .jar.original for both file and directory case

Fixes https://github.com/quarkusio/quarkus/issues/12786

@aloubyansky fyi