### PR TITLE
Enable Maven extensions for the Quarkus Maven plugin

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/base/pom.tpl.qute.xml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/base/pom.tpl.qute.xml
@@ -101,6 +101,7 @@
                 <groupId>{quarkus.maven-plugin.group-id}</groupId>
                 <artifactId>{quarkus.maven-plugin.artifact-id}</artifactId>
                 <version>$\{quarkus-plugin.version}</version>
+                <extensions>true</extensions>
                 {#if uberjar}
                 <configuration>
                     <uberJar>true</uberJar>

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -58,6 +58,7 @@
                 <groupId>${maven_plugin_groupId}</groupId>
                 <artifactId>${maven_plugin_artifactId}</artifactId>
                 <version>${quarkus-plugin.version}</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This change allows registering Maven extensions bundled with the Quarkus Maven plugin. One example would be
https://github.com/quarkusio/quarkus/blob/master/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
And I think there will be more in the future.