### PR TITLE
Feat/doc and test traced

### DIFF
--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -165,6 +165,33 @@ Then visit the http://localhost:16686[Jaeger UI] to see the tracing information.
 
 Hit `CTRL+C` to stop the application.
 
+== Tracing additional methods
+
+REST endpoints are automatically traced.
+If you need to trace additional methods, you can use the `org.eclipse.microprofile.opentracing.Traced` annotation at class or method level.
+
+This can be useful to trace incoming requests from non-REST calls (like request coming from a message) or to create spans inside a trace.
+
+Here is an example of a `FrancophoneService` which methods are traced.
+
+[code, java]
+----
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.opentracing.Traced;
+
+@Traced
+@ApplicationScoped
+public class FrancophoneService {
+
+    public String bonjour() {
+        return "bonjour";
+    }
+}
+----
+
+NOTE: the best way to add OpenTracing capability to reactive messaging based applications is by adding the `Traced` annotation to all incoming methods.
+
 == Additional instrumentation
 
 The https://github.com/opentracing-contrib[OpenTracing API Contributions project] offers additional instrumentation that can be used to add tracing to a large variety of technologies/components.
@@ -200,4 +227,3 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
 == Jaeger Configuration Reference
 
 include::{generated-dir}/config/quarkus-jaeger.adoc[leveloffset=+1, opts=optional]
-

--- a/integration-tests/main/src/main/java/io/quarkus/it/opentracing/OpenTracingResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/opentracing/OpenTracingResource.java
@@ -1,21 +1,22 @@
 package io.quarkus.it.opentracing;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.opentracing.Traced;
-
 import io.jaegertracing.internal.JaegerTracer;
 
 @Path("/opentracing")
 public class OpenTracingResource {
+    @Inject
+    TracedService tracedService;
 
+    // calling this endpoint should generate a trace with two spans
     @GET
-    @Traced
     public String getTest() {
-        return "TEST";
+        return tracedService.testTraced();
     }
 
     @GET

--- a/integration-tests/main/src/main/java/io/quarkus/it/opentracing/TracedService.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/opentracing/TracedService.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.opentracing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.opentracing.Traced;
+
+@ApplicationScoped
+public class TracedService {
+    @Traced
+    public String testTraced() {
+        return "TEST";
+    }
+}


### PR DESCRIPTION
Add `@Traced` to the documentation. It exists in the quickstart so it's worth mentioning it inside the guide.

Update the `main` integration test to use `@Traced` in another bean as the REST endpoint is traced by default and it reflect the typical usage of `@Traced`.