### PR TITLE
Inject any number of gRPC stubs per configured client

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServiceBuildItem.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServiceBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkus.grpc.deployment;
 
-import javax.enterprise.inject.spi.DeploymentException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.jboss.jandex.ClassType;
 
@@ -8,48 +9,22 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class GrpcServiceBuildItem extends MultiBuildItem {
 
-    ClassType blockingStubClass;
-    ClassType mutinyStubClass;
     final String name;
+    Set<ClassType> stubClasses = new HashSet<ClassType>();
 
     public GrpcServiceBuildItem(String name) {
         this.name = name;
     }
 
-    public void setBlockingStubClass(ClassType blockingStubClass) {
-        if (this.blockingStubClass != null
-                && !this.blockingStubClass.name().equals(blockingStubClass.name())) {
-            throw new DeploymentException("Invalid gRPC Service - multiple stubs founds for " + name);
-        }
-        this.blockingStubClass = blockingStubClass;
+    public Set<ClassType> getStubClasses() {
+        return stubClasses;
     }
 
-    public void setMutinyStubClass(ClassType mutinyStubClass) {
-        if (this.mutinyStubClass != null
-                && !this.mutinyStubClass.name().equals(mutinyStubClass.name())) {
-            throw new DeploymentException("Invalid gRPC Service - multiple stubs founds for " + name);
-        }
-
-        this.mutinyStubClass = mutinyStubClass;
+    public void addStubClass(ClassType stubClass) {
+        stubClasses.add(stubClass);
     }
 
     public String getServiceName() {
         return name;
-    }
-
-    public String getBlockingGrpcServiceName() {
-        if (blockingStubClass.name().isInner()) {
-            return blockingStubClass.name().prefix().toString();
-        } else {
-            return blockingStubClass.name().toString();
-        }
-    }
-
-    public String getMutinyGrpcServiceName() {
-        if (mutinyStubClass.name().isInner()) {
-            return mutinyStubClass.name().prefix().toString();
-        } else {
-            return mutinyStubClass.name().toString();
-        }
     }
 }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/GoodbyeService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/GoodbyeService.java
@@ -1,0 +1,18 @@
+package io.quarkus.grpc.server.services;
+
+import javax.inject.Singleton;
+
+import io.grpc.examples.goodbyeworld.FarewellGrpc;
+import io.grpc.examples.goodbyeworld.GoodbyeReply;
+import io.grpc.examples.goodbyeworld.GoodbyeRequest;
+import io.grpc.stub.StreamObserver;
+
+@Singleton
+public class GoodbyeService extends FarewellGrpc.FarewellImplBase {
+
+    @Override
+    public void sayGoodbye(GoodbyeRequest request, StreamObserver<GoodbyeReply> responseObserver) {
+        responseObserver.onNext(GoodbyeReply.newBuilder().setMessage("Goodbye " + request.getName()).build());
+        responseObserver.onCompleted();
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyGoodbyeService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyGoodbyeService.java
@@ -1,0 +1,19 @@
+package io.quarkus.grpc.server.services;
+
+import javax.inject.Singleton;
+
+import io.grpc.examples.goodbyeworld.GoodbyeReply;
+import io.grpc.examples.goodbyeworld.GoodbyeRequest;
+import io.grpc.examples.goodbyeworld.MutinyFarewellGrpc;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+public class MutinyGoodbyeService extends MutinyFarewellGrpc.FarewellImplBase {
+
+    @Override
+    public Uni<GoodbyeReply> sayGoodbye(GoodbyeRequest request) {
+        return Uni.createFrom().item(request.getName())
+                .map(s -> "Goodbye " + s)
+                .map(s -> GoodbyeReply.newBuilder().setMessage(s).build());
+    }
+}

--- a/extensions/grpc/deployment/src/test/proto/goodbyeworld.proto
+++ b/extensions/grpc/deployment/src/test/proto/goodbyeworld.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.goodbyeworld";
+option java_outer_classname = "GoodbyeWorldProto";
+option objc_class_prefix = "GBW";
+
+package goodbyeworld;
+
+// The farewell service definition.
+service Farewell {
+    // Sends a farewell
+    rpc SayGoodbye (GoodbyeRequest) returns (GoodbyeReply) {}
+}
+
+// The request message containing the user's name.
+message GoodbyeRequest {
+    string name = 1;
+}
+
+// The response message containing the farewells
+message GoodbyeReply {
+    string message = 1;
+}


### PR DESCRIPTION
There is currently a limit of injecting one blocking stub class and one of Mutiny stub class per configured gRPC channel/client. If you inject a BlockingStubA for a channel, you cannot inject a BlockingStubB for the same channel. The same relationship would apply for a MutinyStubA and MutinyStubB. This PR removes the limitation and allows the injection of any number of stub classes per channel.