### PR TITLE
Add missing dependencies in SmallRye GraphQL for Mandrel native

### DIFF
--- a/extensions/smallrye-graphql/runtime/pom.xml
+++ b/extensions/smallrye-graphql/runtime/pom.xml
@@ -40,6 +40,14 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-cdi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Related to #12795. Definitely affects 1.7, which is priority.

* Added microprofile metrics API and opentracing API.