### PR TITLE
Wait for dev mode end after ctrl-C

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -903,6 +903,11 @@ public class DevMojo extends AbstractMojo {
                 @Override
                 public void run() {
                     process.destroy();
+                    try {
+                        process.waitFor();
+                    } catch (InterruptedException ignored) {
+                        getLog().warn("Unable to properly wait for dev-mode end", ignored);
+                    }
                 }
             }, "Development Mode Shutdown Hook"));
         }


### PR DESCRIPTION
This make sure we wait for the process to be destroy.

As mentioned @stuartwdouglas, I think we could catch a `InterruptedException` here : 

https://github.com/quarkusio/quarkus/blob/6f4e3b39f7adeafd6ec89e81973c3351ec1ccfad/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java#L387

I don't know what is the best solution. 

WDYT @stuartwdouglas, @mkouba ?

close #12723 