### PR TITLE
Ignore amazon deps when validating extensions json

### DIFF
--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,7 +107,7 @@ public class GenerateExtensionsJsonMojo extends AbstractMojo {
      * by preventing the download of artifacts that are not required.
      */
     @Parameter
-    private Set<String> ignoredGroupIds;
+    private Set<String> ignoredGroupIds = new HashSet<>(0);
 
     public GenerateExtensionsJsonMojo() {
         MojoLogger.logSupplier = this::getLog;
@@ -143,10 +144,8 @@ public class GenerateExtensionsJsonMojo extends AbstractMojo {
         String quarkusCoreVersion = null;
         for (Dependency dep : deps) {
             final Artifact artifact = dep.getArtifact();
-            if (ignoredGroupIds != null && ignoredGroupIds.contains(artifact.getGroupId())) {
-                continue;
-            }
-            if (!artifact.getExtension().equals("jar")
+            if (ignoredGroupIds.contains(artifact.getGroupId())
+                    || !artifact.getExtension().equals("jar")
                     || "javadoc".equals(artifact.getClassifier())
                     || "tests".equals(artifact.getClassifier())
                     || "sources".equals(artifact.getClassifier())) {

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -178,6 +178,9 @@
                                     <jsonGroupId>io.quarkus</jsonGroupId>
                                     <jsonArtifactId>quarkus-bom-descriptor-json</jsonArtifactId>
                                     <jsonVersion>${project.version}</jsonVersion>
+                                    <ignoredGroupIds>
+                                        <ignoredGroupId>software.amazon.awssdk</ignoredGroupId>
+                                    </ignoredGroupIds>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This is an equivalent config used for the JSON generating goal.