### PR TITLE
Add oidc-wiremock to CI Security2 category

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -494,11 +494,11 @@ jobs:
             timeout: 70
             keycloak: "true"
             test-modules: >
-              elytron-resteasy
               oidc
               oidc-code-flow
               oidc-tenancy
               keycloak-authorization
+              oidc-wiremock
           - category: Security3
             timeout: 50
             test-modules: >
@@ -514,6 +514,7 @@ jobs:
           - category: HTTP
             timeout: 60
             test-modules: >
+              elytron-resteasy
               resteasy-jackson
               resteasy-mutiny
               vertx

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
@@ -3,12 +3,13 @@ package io.quarkus.it.keycloak;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 import java.util.Collections;
 import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -17,40 +18,23 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager {
 
+    private static final Logger LOG = Logger.getLogger(KeycloakTestResource.class);
+
     private WireMockServer server;
 
     @Override
     public Map<String, String> start() {
 
-        server = new WireMockServer(options().port(8180));
+        server = new WireMockServer();
         server.start();
 
-        WireMock.configureFor(8180);
         WireMock.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus/.well-known/openid-configuration"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                                 .withBody("{\n" +
-                                        "    \"authorization_endpoint\": \"http://localhost:8180/authenticate\",\n" +
-                                        "    \"end_session_endpoint\": \"http://localhost:8180/logout\",\n" +
-                                        "    \"id_token_signing_alg_values_supported\": [\n" +
-                                        "        \"RS256\",\n" +
-                                        "        \"ES256\",\n" +
-                                        "        \"HS256\"\n" +
-                                        "    ],\n" +
-                                        "    \"issuer\": \"http://localhost:8180/auth/realms/quarkus\",\n" +
-                                        "    \"jwks_uri\": \"http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/certs\",\n"
-                                        +
-                                        "    \"response_types_supported\": [\n" +
-                                        "        \"code\",\n" +
-                                        "        \"code id_token\",\n" +
-                                        "        \"id_token\",\n" +
-                                        "        \"token id_token\"\n" +
-                                        "    ],\n" +
-                                        "    \"subject_types_supported\": [\n" +
-                                        "        \"public\"\n" +
-                                        "    ],\n" +
-                                        "    \"token_endpoint\": \"http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/token\"\n"
+                                        "    \"jwks_uri\": \"" + server.baseUrl()
+                                        + "/auth/realms/quarkus/protocol/openid-connect/certs\"\n"
                                         +
                                         "}")));
 
@@ -70,7 +54,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
                                         "  ]\n" +
                                         "}")));
 
-        System.out.println("[INFO] Keycloak started in mock mode: " + server.baseUrl());
+        LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
         return Collections.singletonMap("quarkus.oidc.auth-server-url", server.baseUrl() + "/auth/realms/quarkus");
     }
 
@@ -78,7 +62,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
     public synchronized void stop() {
         if (server != null) {
             server.stop();
-            System.out.println("[INFO] Keycloak was shut down");
+            LOG.info("Keycloak was shut down");
             server = null;
         }
     }


### PR DESCRIPTION
I've also move `elytron-resteasy` to the `HTTP` category where all other resteasy tests are run