### PR TITLE
Add OpenTracing support for Kafka

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -22,6 +22,7 @@
         <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
+        <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <jaeger.version>0.34.3</jaeger.version>
         <quarkus-http.version>3.0.15.Final</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
@@ -2389,6 +2390,11 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-jdbc</artifactId>
                 <version>${opentracing-jdbc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-kafka-client</artifactId>
+                <version>${opentracing-kafka.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -196,8 +196,41 @@ quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
 ----
 
+
+=== Kafka
+
+The https://github.com/opentracing-contrib/java-kafka-client[Kafka instrumentation] will add a span for each message sent to or received from a Kafka topic. To enable it, add the following dependency to your pom.xml:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-kafka-client</artifactId>
+    <version>${opentracing-kafka.version}</version>
+</dependency>
+----
+
+It contains OpenTracing interceptors that must be registered on Kafka producers and consumers.
+
+If you followed the link:kafka[Kafka guide], the interceptors can be added on the `generated-price` and the `prices` channels as follows:
+
+[source, properties]
+----
+# Configure the Kafka sink (we write to it)
+mp.messaging.outgoing.generated-price.connector=smallrye-kafka
+mp.messaging.outgoing.generated-price.topic=prices
+mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.outgoing.generated-price.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor
+
+# Configure the Kafka source (we read from it)
+mp.messaging.incoming.prices.connector=smallrye-kafka
+mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+mp.messaging.incoming.prices.interceptor.classes=io.opentracing.contrib.kafka.TracingConsumerInterceptor
+----
+
+NOTE: `interceptor.classes` accept a list of classes separated by a comma.
+
 [[configuration-reference]]
 == Jaeger Configuration Reference
 
 include::{generated-dir}/config/quarkus-jaeger.adoc[leveloffset=+1, opts=optional]
-

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -47,6 +47,7 @@ import org.jboss.jandex.Type.Kind;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
@@ -211,6 +212,19 @@ public class KafkaProcessor {
 
         } catch (ClassNotFoundException e) {
             //ignore, Apicurio Avro is not in the classpath
+        }
+
+        //opentracing contrib kafka interceptors: https://github.com/opentracing-contrib/java-kafka-client
+        if (capabilities.isPresent(Capability.OPENTRACING)) {
+            try {
+                Class.forName("io.opentracing.contrib.kafka.TracingProducerInterceptor", false,
+                        Thread.currentThread().getContextClassLoader());
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false,
+                        "io.opentracing.contrib.kafka.TracingProducerInterceptor",
+                        "io.opentracing.contrib.kafka.TracingConsumerInterceptor"));
+            } catch (ClassNotFoundException e) {
+                //ignore, opentracing contrib kafka is not in the classpath
+            }
         }
 
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -7,12 +7,14 @@ import java.util.function.Consumer;
 
 import javax.security.auth.spi.LoginModule;
 
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.consumer.RoundRobinAssignor;
 import org.apache.kafka.clients.consumer.StickyAssignor;
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor;
 import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.security.authenticator.AbstractLogin;
 import org.apache.kafka.common.security.authenticator.DefaultLogin;
@@ -112,6 +114,8 @@ public class KafkaProcessor {
         // PartitionAssignor is now deprecated, replaced by ConsumerPartitionAssignor
         collectImplementors(toRegister, indexBuildItem, PartitionAssignor.class);
         collectImplementors(toRegister, indexBuildItem, ConsumerPartitionAssignor.class);
+        collectImplementors(toRegister, indexBuildItem, ConsumerInterceptor.class);
+        collectImplementors(toRegister, indexBuildItem, ProducerInterceptor.class);
 
         for (Class<?> i : BUILT_INS) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, i.getName()));


### PR DESCRIPTION
This PR adds two distinct features:
- Register for reflection all Kafka consumer/producer interceptor so they can be used in native
- Integrate Kafka OpenTracing contributor interceptors inside Quarkus (doc, bom, register for reflection)

See the Zulip thread for reference: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/OpenTracing.20Kafka.20intereptors