### PR TITLE
Add property expansion and dotted secret config kv path name in Vaut Config Source

### DIFF
--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/config/VaultConfigSourceExpansionTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/config/VaultConfigSourceExpansionTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.vault.runtime.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class VaultConfigSourceExpansionTest {
+
+    private Map<String, String> values = new HashMap<>();
+
+    private VaultConfigSource source = new VaultConfigSource(0) {
+        @Override
+        protected String getBaseProperty(String propertyName, String defaultValue) {
+            return values.getOrDefault(propertyName, defaultValue);
+        }
+    };
+
+    @BeforeEach
+    public void init() {
+        values.put("my-vault-host", "localhost");
+        values.put("port", "${offset}00");
+        values.put("offset", "82");
+        values.put("quarkus.vault.url", "http://${my-vault-host}:${port}");
+        values.put("one", "${two}");
+        values.put("two", "${three}");
+        values.put("three", "${four}");
+        values.put("four", "${five}");
+        values.put("five", "5");
+    }
+
+    @Test
+    void expansionPattern() {
+
+        assertEquals("http://localhost:8200", source.getProperty("quarkus.vault.url", null, 0));
+
+        Exception exception = assertThrows(RuntimeException.class, () -> source.getProperty("one", null, 0));
+        assertEquals("max expansion depth reached when looking for key four", exception.getMessage());
+
+        assertEquals("5", source.getProperty("one", null, 4));
+    }
+}

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/config/VaultConfigSourceTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/config/VaultConfigSourceTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.vault.runtime.config;
+
+import static io.quarkus.vault.runtime.config.VaultConfigSource.SECRET_CONFIG_KV_PATH_PATTERN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.api.Test;
+
+public class VaultConfigSourceTest {
+
+    @Test
+    void secretConfigKvPathPattern() {
+
+        Matcher matcher;
+
+        matcher = SECRET_CONFIG_KV_PATH_PATTERN.matcher("quarkus.vault.secret-config-kv-path.hello");
+        assertTrue(matcher.matches());
+        assertEquals("hello", matcher.group(1));
+
+        matcher = SECRET_CONFIG_KV_PATH_PATTERN.matcher("quarkus.vault.secret-config-kv-path.\"mp.jwt.verify\"");
+        assertTrue(matcher.matches());
+        assertEquals("mp.jwt.verify", matcher.group(2));
+    }
+}


### PR DESCRIPTION
This PR brings two minor improvements:
 - property expansion, which fixes https://github.com/quarkusio/quarkus/issues/10390
 - support for secret config kv path, such as `quarkus.vault.secret-config-kv-path."mp.jwt.verify"=myapps/app1`, which fixes https://github.com/quarkusio/quarkus/issues/11921

a better solution should come up with https://github.com/quarkusio/quarkus/issues/12515, or https://github.com/quarkusio/quarkus/issues/4848, but those issues have been waiting for some time now, and I feel like we may want to provide this improvement as a tactical (hopefully short term) workaround. 

/cc @radcortez 