### PR TITLE
Correcting the  micrometer quick start example

### DIFF
--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -126,7 +126,7 @@ public class PrimeNumberResource {
     @GET
     @Path("/{number}")
     @Produces(MediaType.TEXT_PLAIN)
-    public String checkIfPrime(@PathParam("number") int number) {
+    public String checkIfPrime(@PathParam("number") long number) {
         if (number < 1) {
             return "Only natural numbers can be prime numbers.";
         }

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/PrimeNumberResource.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/PrimeNumberResource.java
@@ -28,7 +28,7 @@ public class PrimeNumberResource {
     @GET
     @Path("/{number}")
     @Produces("text/plain")
-    public String checkIfPrime(@PathParam("number") int number) {
+    public String checkIfPrime(@PathParam("number") long number) {
         if (number < 1) {
             return "Only natural numbers can be prime numbers.";
         }


### PR DESCRIPTION
Using int, causes the API to break for the example 629521085409773