### PR TITLE
Gradle Kotlin codegen: do not execute the test code generating task unless the tests need to run

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -181,10 +181,16 @@ public class QuarkusPlugin implements Plugin<Project> {
 
                     tasks.withType(Test.class).forEach(configureTestTask);
                     tasks.withType(Test.class).whenTaskAdded(configureTestTask::accept);
+
+                    sourceSets.create(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES).getOutput()
+                            .dir(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
+                    sourceSets.create(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES).getOutput()
+                            .dir(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
                 });
+
         project.getPlugins().withId("org.jetbrains.kotlin.jvm", plugin -> {
-            Task compileKotlinTask = tasks.getByName("compileKotlin");
-            compileKotlinTask.dependsOn(quarkusGenerateCode, quarkusGenerateCodeTests);
+            tasks.getByName("compileKotlin").dependsOn(quarkusGenerateCode);
+            tasks.getByName("compileTestKotlin").dependsOn(quarkusGenerateCodeTests);
         });
     }
 

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -27,6 +27,9 @@ import io.quarkus.deployment.CodeGenerator;
 
 public class QuarkusGenerateCode extends QuarkusTask {
 
+    public static final String QUARKUS_GENERATED_SOURCES = "quarkus-generated-sources";
+    public static final String QUARKUS_TEST_GENERATED_SOURCES = "quarkus-test-generated-sources";
+
     public static final String INIT_AND_RUN = "initAndRun";
     private Set<Path> sourcesDirectories;
     private Consumer<Path> sourceRegistrar;
@@ -61,9 +64,8 @@ public class QuarkusGenerateCode extends QuarkusTask {
             final Convention convention = getProject().getConvention();
             JavaPluginConvention javaConvention = convention.findPlugin(JavaPluginConvention.class);
             if (javaConvention != null) {
-                String generateSourcesDir = test ? "quarkus-test-generated-sources" : "quarkus-generated-sources";
-                final SourceSet generatedSources = javaConvention.getSourceSets().create(generateSourcesDir);
-                generatedSources.getOutput().dir(generateSourcesDir);
+                final String generateSourcesDir = test ? QUARKUS_TEST_GENERATED_SOURCES : QUARKUS_GENERATED_SOURCES;
+                final SourceSet generatedSources = javaConvention.getSourceSets().findByName(generateSourcesDir);
                 List<Path> paths = new ArrayList<>();
                 generatedSources.getOutput()
                         .filter(f -> f.getName().equals(generateSourcesDir))


### PR DESCRIPTION
Currently `compileKotlin` depends on both `quarkusGenerateCode` and `quarkusGenerateCodeTests` which is not necessary, afaics. This change is meant to not execute the test code generating task unless the tests actually need to be executed.

cc @glefloch 