### PR TITLE
Remove unnecessary kotlin path declaration in gradle build file

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
@@ -8,14 +8,6 @@ plugins {
 {/plugins}
 {/include}
 
-quarkus {
-    setOutputDirectory("$projectDir/build/classes/kotlin/main")
-}
-
-tasks.withType<io.quarkus.gradle.tasks.QuarkusDev> {
-    setSourceDir("$projectDir/src/main/kotlin")
-}
-
 allOpen {
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/kotlin/build.tpl.qute.gradle
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/kotlin/build.tpl.qute.gradle
@@ -8,14 +8,6 @@ plugins {
 {/plugins}
 {/include}
 
-quarkus {
-    setOutputDirectory("$projectDir/build/classes/kotlin/main")
-}
-
-quarkusDev {
-    setSourceDir("$projectDir/src/main/kotlin")
-}
-
 allOpen {
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/build.gradle
@@ -23,33 +23,16 @@ dependencies {
 group 'org.acme'
 version '1.0.0-SNAPSHOT'
 
-quarkus {
-    setOutputDirectory("$projectDir/build/classes/kotlin/main")
-}
-
-quarkusDev {
-    setSourceDir("$projectDir/src/main/kotlin")
-}
-
 allOpen {
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
 compileKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
     kotlinOptions.javaParameters = true
 }
 
-compileTestKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
-}
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
 }


### PR DESCRIPTION
As mentionned by @aloubyansky, it's not necessary to declare source path and output path for kotlin. 

I removed it from tests and from codestart template. 
