### PR TITLE
Add support for blocking annotation

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
-        <smallrye-common.version>1.4.0</smallrye-common.version>
+        <smallrye-common.version>1.4.1</smallrye-common.version>
         <smallrye-config.version>1.9.2</smallrye-config.version>
         <smallrye-health.version>2.2.5</smallrye-health.version>
         <smallrye-metrics.version>2.4.4</smallrye-metrics.version>

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -208,6 +208,11 @@ The main differences are the following:
 * it extends the `ImplBase` from `MutinyGreeterGrpc` instead of `GreeterGrpc`
 * the signature of the method is using Mutiny types
 
+NOTE: If your service implementation logic is blocking (use blocking I/O for example), annotate your method with
+`@Blocking`.
+The `io.smallrye.common.annotation.Blocking` annotation instructs the framework to invoke the
+annotated method on a worker thread instead of the I/O thread (event-loop).
+
 === The gRPC server
 
 The services are _served_ by a _server_.

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -613,6 +613,19 @@ public class PriceStorage {
 
 The complete example is available in the `kafka-panache-quickstart` {quickstarts-tree-url}/kafka-panache-quickstart[directory].
 
+[NOTE]
+====
+There are 2 `@Blocking` annotations:
+
+ 1. `io.smallrye.reactive.messaging.annotations.Blocking`
+ 2. `io.smallrye.common.annotation.Blocking`
+
+They have the same effect.
+Thus, you can use both.
+The first one provides more fine-grain tuning such as the worker pool to use and whether it preserves the order.
+The second one, used in also with other reactive features of Quarkus, uses the default worker pool and preserves the order.
+====
+
 == Going further
 
 This guide has shown how you can interact with Kafka using Quarkus.

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -89,6 +89,18 @@ void consumeBlocking(String message) {
     // Something blocking
 }
 ----
+
+Alternatively, you can annotate your method with `@io.smallrye.common.annotation.Blocking`:
+[source, java]
+----
+@ConsumeEvent(value = "blocking-consumer")
+@Blocking
+void consumeBlocking(String message) {
+    // Something blocking
+}
+----
+
+When using `@Blocking`, it ignores the value of the `blocking` attribute of `@ConsumeEvent`.
 ====
 
 Asynchronous processing is also possible by returning either an `io.smallrye.mutiny.Uni` or a `java.util.concurrent.CompletionStage`:

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -101,6 +101,20 @@ public void blocking(RoutingContext rc) {
 }
 ----
 
+[NOTE]
+====
+Alternatively, you can use `@io.smallrye.common.annotation.Blocking` and omit the `type = Route.HandlerType.BLOCKING`:
+[source, java]
+----
+@Route(methods = HttpMethod.POST, path = "/post")
+@Blocking
+public void blocking(RoutingContext rc) {
+    // ...
+}
+----
+When `@Blocking` is used, it ignores the `type` attribute of `@Route`.
+====
+
 The `@Route` annotation is repeatable and so you can declare several routes for a single method:
 
 [source,java]
@@ -322,7 +336,7 @@ String helloSync(RoutingContext context) {
 ----
 
 Be aware, the processing must be **non-blocking** as reactive routes are invoked on the IO Thread.
-Otherwise, use the `blocking` attribute of the `@Route` annotation.
+Otherwise, use the `blocking` attribute of the `@Route` annotation or the `@Blocking` annotation.
 
 The method can return:
 

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/BindableServiceBuildItem.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/BindableServiceBuildItem.java
@@ -1,5 +1,8 @@
 package io.quarkus.grpc.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jboss.jandex.DotName;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -7,9 +10,25 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class BindableServiceBuildItem extends MultiBuildItem {
 
     final DotName serviceClass;
+    final List<String> blockingMethods = new ArrayList<>();
 
     public BindableServiceBuildItem(DotName serviceClass) {
         this.serviceClass = serviceClass;
+    }
+
+    /**
+     * A method from {@code serviceClass} is annotated with {@link io.smallrye.common.annotation.Blocking}.
+     * Stores the method name so the runtime interceptor can recognize it.
+     * Note: gRPC method have unique names - overloading is not permitted.
+     *
+     * @param method the method name
+     */
+    public void registerBlockingMethod(String method) {
+        blockingMethods.add(method);
+    }
+
+    public boolean hasBlockingMethods() {
+        return !blockingMethods.isEmpty();
     }
 
 }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
@@ -11,6 +11,7 @@ import io.grpc.NameResolverProvider;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
 import io.quarkus.grpc.runtime.supports.Channels;
+import io.smallrye.common.annotation.Blocking;
 
 public class GrpcDotNames {
 
@@ -21,6 +22,8 @@ public class GrpcDotNames {
     static final DotName GENERATED_MESSAGE_V3 = DotName.createSimple(GeneratedMessageV3.class.getName());
     static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
     static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
+
+    static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
 
     static final MethodDescriptor CREATE_CHANNEL_METHOD = MethodDescriptor.ofMethod(Channels.class, "createChannel",
             Channel.class, String.class);

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -4,10 +4,13 @@ import static io.quarkus.deployment.Feature.GRPC_SERVER;
 
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
 import io.grpc.internal.DnsNameResolverProvider;
@@ -52,7 +55,13 @@ public class GrpcServerProcessor {
                 .getAllKnownImplementors(GrpcDotNames.BINDABLE_SERVICE);
         for (ClassInfo service : bindableServices) {
             if (!Modifier.isAbstract(service.flags()) && service.classAnnotation(DotNames.SINGLETON) != null) {
-                bindables.produce(new BindableServiceBuildItem(service.name()));
+                BindableServiceBuildItem item = new BindableServiceBuildItem(service.name());
+                for (MethodInfo method : service.methods()) {
+                    if (method.hasAnnotation(GrpcDotNames.BLOCKING)) {
+                        item.registerBlockingMethod(method.name());
+                    }
+                }
+                bindables.produce(item);
             }
         }
     }
@@ -83,8 +92,17 @@ public class GrpcServerProcessor {
     ServiceStartBuildItem build(GrpcServerRecorder recorder, GrpcConfiguration config,
             ShutdownContextBuildItem shutdown, List<BindableServiceBuildItem> bindables,
             VertxBuildItem vertx) {
+
+        // Build the list of blocking methods per service implementation
+        Map<String, List<String>> blocking = new HashMap<>();
+        for (BindableServiceBuildItem bindable : bindables) {
+            if (bindable.hasBlockingMethods()) {
+                blocking.put(bindable.serviceClass.toString(), bindable.blockingMethods);
+            }
+        }
+
         if (!bindables.isEmpty()) {
-            recorder.initializeGrpcServer(vertx.getVertx(), config, shutdown);
+            recorder.initializeGrpcServer(vertx.getVertx(), config, shutdown, blocking);
             return new ServiceStartBuildItem(GRPC_SERVER);
         }
         return null;

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
@@ -1,0 +1,102 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.EmptyProtos;
+
+import grpc.health.v1.HealthGrpc;
+import grpc.health.v1.HealthOuterClass;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.reflection.v1alpha.MutinyServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.reflection.v1alpha.ServiceResponse;
+import io.grpc.testing.integration.Messages;
+import io.grpc.testing.integration.TestServiceGrpc;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
+import io.quarkus.grpc.server.services.BlockingMutinyHelloService;
+import io.quarkus.grpc.server.services.TestService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class BlockingAndNonBlockingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HealthGrpc.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addPackage(TestServiceGrpc.class.getPackage())
+                    .addPackage(EmptyProtos.class.getPackage())
+                    .addClasses(BlockingMutinyHelloService.class, TestService.class))
+            .withConfigurationResource("blocking-config.properties");
+
+    @Inject
+    GrpcHealthStorage healthService;
+
+    @Inject
+    @GrpcService("reflection-service")
+    MutinyServerReflectionGrpc.MutinyServerReflectionStub reflection;
+
+    @Inject
+    @GrpcService("test-service")
+    TestServiceGrpc.TestServiceBlockingStub test;
+
+    @Inject
+    @GrpcService("greeter-service")
+    GreeterGrpc.GreeterBlockingStub greeter;
+
+    @Test
+    public void testInvokingABlockingService() {
+        HelloReply reply = greeter.sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+    }
+
+    @Test
+    public void testInvokingANonBlockingService() {
+        Messages.SimpleResponse reply = test.unaryCall(Messages.SimpleRequest.newBuilder().build());
+        assertThat(reply).isNotNull();
+    }
+
+    @Test
+    public void testHealth() {
+        assertThat(healthService.getStatuses()).contains(
+                entry(GreeterGrpc.SERVICE_NAME, HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING),
+                entry(TestServiceGrpc.SERVICE_NAME, HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING)
+
+        );
+    }
+
+    @Test
+    public void testReflection() {
+        ServerReflectionRequest request = ServerReflectionRequest.newBuilder().setHost("localhost")
+                .setListServices("").build();
+
+        ServerReflectionResponse response = invoke(request);
+        List<ServiceResponse> list = response.getListServicesResponse().getServiceList();
+        assertThat(list).hasSize(3)
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo(GreeterGrpc.SERVICE_NAME))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo(TestServiceGrpc.SERVICE_NAME))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("grpc.health.v1.Health"));
+    }
+
+    private ServerReflectionResponse invoke(ServerReflectionRequest request) {
+        return reflection.serverReflectionInfo(Multi.createFrom().item(request))
+                .collectItems().first()
+                .await().indefinitely();
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsTest.java
@@ -1,0 +1,217 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.EmptyProtos;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.integration.Messages;
+import io.quarkus.grpc.blocking.BlockingTestServiceGrpc;
+import io.quarkus.grpc.blocking.MutinyBlockingTestServiceGrpc;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.server.services.BlockingTestService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+public class BlockingMethodsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(EmptyProtos.class.getPackage())
+                    .addPackage(Messages.class.getPackage())
+                    .addPackage(BlockingTestServiceGrpc.class.getPackage())
+                    .addClasses(BlockingTestService.class))
+            .withConfigurationResource("blocking-test-config.properties");
+
+    protected static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @Inject
+    @GrpcService("blocking-test")
+    BlockingTestServiceGrpc.BlockingTestServiceBlockingStub service;
+
+    @Inject
+    @GrpcService("blocking-test")
+    MutinyBlockingTestServiceGrpc.MutinyBlockingTestServiceStub mutiny;
+
+    @Test
+    @Timeout(5)
+    public void testEmpty() {
+        EmptyProtos.Empty empty = service
+                .emptyCall(EmptyProtos.Empty.newBuilder().build());
+        assertThat(empty).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testBlockingEmpty() {
+        EmptyProtos.Empty empty = service
+                .emptyCallBlocking(EmptyProtos.Empty.newBuilder().build());
+        assertThat(empty).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testUnaryMethod() {
+        Messages.SimpleResponse response = service
+                .unaryCall(Messages.SimpleRequest.newBuilder().build());
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testUnaryMethodBlocking() {
+        Messages.SimpleResponse response = service
+                .unaryCallBlocking(Messages.SimpleRequest.newBuilder().build());
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingOutMethod() {
+        Iterator<Messages.StreamingOutputCallResponse> iterator = service
+                .streamingOutputCall(Messages.StreamingOutputCallRequest.newBuilder().build());
+        assertThat(iterator).isNotNull();
+        List<String> list = new CopyOnWriteArrayList<>();
+        iterator.forEachRemaining(so -> {
+            String content = so.getPayload().getBody().toStringUtf8();
+            list.add(content);
+        });
+        assertThat(list).hasSize(10)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("eventloop");
+                });
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingOutMethodBlocking() {
+        Iterator<Messages.StreamingOutputCallResponse> iterator = service
+                .streamingOutputCallBlocking(Messages.StreamingOutputCallRequest.newBuilder().build());
+        assertThat(iterator).isNotNull();
+        List<String> list = new CopyOnWriteArrayList<>();
+        iterator.forEachRemaining(so -> {
+            String content = so.getPayload().getBody().toStringUtf8();
+            list.add(content);
+        });
+        assertThat(list).hasSize(10)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("worker");
+                });
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingInMethodWithMutinyClient() {
+        Multi<Messages.StreamingInputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingInputCallRequest.newBuilder().setPayload(p).build());
+        Uni<Messages.StreamingInputCallResponse> done = mutiny.streamingInputCall(input);
+        assertThat(done).isNotNull();
+        done.await().atMost(TIMEOUT);
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingInMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingInputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingInputCallRequest.newBuilder().setPayload(p).build());
+        Uni<Messages.StreamingInputCallResponse> done = mutiny.streamingInputCallBlocking(input);
+        assertThat(done).isNotNull();
+        done.await().atMost(TIMEOUT);
+    }
+
+    @Test
+    @Timeout(5)
+    public void testFullDuplexMethodWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.fullDuplexCall(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("eventloop");
+                });
+    }
+
+    @Test
+    @Timeout(5)
+    public void testFullDuplexMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.fullDuplexCallBlocking(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("worker");
+                });
+    }
+
+    @Test
+    public void testHalfDuplexMethodWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.halfDuplexCall(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("eventloop");
+                });
+    }
+
+    @Test
+    public void testHalfDuplexMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.halfDuplexCallBlocking(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .allSatisfy(s -> {
+                    assertThat(s).contains("worker");
+                });
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testUnimplementedMethod() {
+        Assertions.assertThatThrownBy(
+                () -> service
+                        .unimplementedCall(EmptyProtos.Empty.newBuilder().build()))
+                .isInstanceOf(StatusRuntimeException.class).hasMessageContaining("UNIMPLEMENTED");
+
+        Assertions.assertThatThrownBy(
+                () -> service
+                        .unimplementedCallBlocking(EmptyProtos.Empty.newBuilder().build()))
+                .isInstanceOf(StatusRuntimeException.class).hasMessageContaining("UNIMPLEMENTED");
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsWithMutinyImplTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsWithMutinyImplTest.java
@@ -1,0 +1,206 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.EmptyProtos;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.integration.Messages;
+import io.quarkus.grpc.blocking.BlockingTestServiceGrpc;
+import io.quarkus.grpc.blocking.MutinyBlockingTestServiceGrpc;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.server.services.BlockingMutinyTestService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+public class BlockingMethodsWithMutinyImplTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(EmptyProtos.class.getPackage())
+                    .addPackage(Messages.class.getPackage())
+                    .addPackage(BlockingTestServiceGrpc.class.getPackage())
+                    .addClasses(BlockingMutinyTestService.class))
+            .withConfigurationResource("blocking-test-config.properties");
+
+    protected static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @Inject
+    @GrpcService("blocking-test")
+    BlockingTestServiceGrpc.BlockingTestServiceBlockingStub service;
+
+    @Inject
+    @GrpcService("blocking-test")
+    MutinyBlockingTestServiceGrpc.MutinyBlockingTestServiceStub mutiny;
+
+    @Test
+    @Timeout(5)
+    public void testEmpty() {
+        EmptyProtos.Empty empty = service
+                .emptyCall(EmptyProtos.Empty.newBuilder().build());
+        assertThat(empty).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testBlockingEmpty() {
+        EmptyProtos.Empty empty = service
+                .emptyCallBlocking(EmptyProtos.Empty.newBuilder().build());
+        assertThat(empty).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testUnaryMethod() {
+        Messages.SimpleResponse response = service
+                .unaryCall(Messages.SimpleRequest.newBuilder().build());
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testUnaryMethodBlocking() {
+        Messages.SimpleResponse response = service
+                .unaryCallBlocking(Messages.SimpleRequest.newBuilder().build());
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingOutMethod() {
+        Iterator<Messages.StreamingOutputCallResponse> iterator = service
+                .streamingOutputCall(Messages.StreamingOutputCallRequest.newBuilder().build());
+        assertThat(iterator).isNotNull();
+        List<String> list = new CopyOnWriteArrayList<>();
+        iterator.forEachRemaining(so -> {
+            String content = so.getPayload().getBody().toStringUtf8();
+            list.add(content);
+        });
+        assertThat(list).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingOutMethodBlocking() {
+        Iterator<Messages.StreamingOutputCallResponse> iterator = service
+                .streamingOutputCallBlocking(Messages.StreamingOutputCallRequest.newBuilder().build());
+        assertThat(iterator).isNotNull();
+        List<String> list = new CopyOnWriteArrayList<>();
+        iterator.forEachRemaining(so -> {
+            String content = so.getPayload().getBody().toStringUtf8();
+            list.add(content);
+        });
+        assertThat(list).hasSize(10)
+                .containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingInMethodWithMutinyClient() {
+        Multi<Messages.StreamingInputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingInputCallRequest.newBuilder().setPayload(p).build());
+        Uni<Messages.StreamingInputCallResponse> done = mutiny.streamingInputCall(input);
+        assertThat(done).isNotNull();
+        done.await().atMost(TIMEOUT);
+    }
+
+    @Test
+    @Timeout(5)
+    public void testStreamingInMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingInputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingInputCallRequest.newBuilder().setPayload(p).build());
+        Uni<Messages.StreamingInputCallResponse> done = mutiny.streamingInputCallBlocking(input);
+        assertThat(done).isNotNull();
+        done.await().atMost(TIMEOUT);
+    }
+
+    @Test
+    @Timeout(5)
+    public void testFullDuplexMethodWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.fullDuplexCall(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .containsExactly("a1", "b2", "c3", "d4");
+    }
+
+    @Test
+    @Timeout(5)
+    public void testFullDuplexMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.fullDuplexCallBlocking(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .containsExactly("a1", "b2", "c3", "d4");
+    }
+
+    @Test
+    @Timeout(5)
+    public void testHalfDuplexMethodWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.halfDuplexCall(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4).containsExactly("A", "B", "C", "D");
+
+    }
+
+    @Test
+    @Timeout(5)
+    public void testHalfDuplexMethodBlockingWithMutinyClient() {
+        Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
+                .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
+                .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
+        List<String> response = mutiny.halfDuplexCallBlocking(input)
+                .map(o -> o.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .await().atMost(TIMEOUT);
+        assertThat(response).isNotNull().hasSize(4)
+                .containsExactly("A", "B", "C", "D");
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testUnimplementedMethod() {
+        Assertions.assertThatThrownBy(
+                () -> service
+                        .unimplementedCall(EmptyProtos.Empty.newBuilder().build()))
+                .isInstanceOf(StatusRuntimeException.class).hasMessageContaining("UNIMPLEMENTED");
+
+        Assertions.assertThatThrownBy(
+                () -> service
+                        .unimplementedCallBlocking(EmptyProtos.Empty.newBuilder().build()))
+                .isInstanceOf(StatusRuntimeException.class).hasMessageContaining("UNIMPLEMENTED");
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.grpc.server.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import grpc.health.v1.HealthGrpc;
+import grpc.health.v1.HealthOuterClass;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.reflection.v1alpha.MutinyServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.reflection.v1alpha.ServiceResponse;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
+import io.quarkus.grpc.server.services.BlockingMutinyHelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class BlockingServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HealthGrpc.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClasses(BlockingMutinyHelloService.class))
+            .withConfigurationResource("reflection-config.properties");
+
+    protected ManagedChannel channel;
+
+    @Inject
+    GrpcHealthStorage healthService;
+
+    @Inject
+    @GrpcService("reflection-service")
+    MutinyServerReflectionGrpc.MutinyServerReflectionStub reflection;
+
+    @BeforeEach
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+                .usePlaintext()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingABlockingService() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+    }
+
+    @Test
+    public void testHealth() {
+        assertThat(healthService.getStatuses())
+                .contains(entry("helloworld.Greeter", HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING));
+    }
+
+    @Test
+    public void testReflection() {
+        ServerReflectionRequest request = ServerReflectionRequest.newBuilder().setHost("localhost")
+                .setListServices("").build();
+
+        ServerReflectionResponse response = invoke(request);
+        List<ServiceResponse> list = response.getListServicesResponse().getServiceList();
+        assertThat(list).hasSize(2)
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("helloworld.Greeter"))
+                .anySatisfy(r -> assertThat(r.getName()).isEqualTo("grpc.health.v1.Health"));
+    }
+
+    private ServerReflectionResponse invoke(ServerReflectionRequest request) {
+        return reflection.serverReflectionInfo(Multi.createFrom().item(request))
+                .collectItems().first()
+                .await().indefinitely();
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingMutinyHelloService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingMutinyHelloService.java
@@ -1,0 +1,22 @@
+
+package io.quarkus.grpc.server.services;
+
+import javax.inject.Singleton;
+
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+public class BlockingMutinyHelloService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    @Blocking
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        return Uni.createFrom().item(request.getName())
+                .map(s -> Thread.currentThread().getName() + " " + s)
+                .map(s -> HelloReply.newBuilder().setMessage(s).build());
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingMutinyTestService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingMutinyTestService.java
@@ -1,0 +1,179 @@
+package io.quarkus.grpc.server.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Singleton;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.EmptyProtos;
+
+import io.grpc.testing.integration.Messages;
+import io.quarkus.grpc.blocking.MutinyBlockingTestServiceGrpc;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+@Singleton
+public class BlockingMutinyTestService
+        extends MutinyBlockingTestServiceGrpc.BlockingTestServiceImplBase {
+
+    private void assertRunOnEventLoop() {
+        assertThat(Vertx.currentContext()).isNotNull();
+        assertThat(Vertx.currentContext().isEventLoopContext());
+        assertThat(Thread.currentThread().getName()).contains("eventloop-thread");
+    }
+
+    private void assertRunOnWorker() {
+        assertThat(Vertx.currentContext()).isNotNull();
+        assertThat(Thread.currentThread().getName()).contains("worker");
+    }
+
+    @Override
+    public Uni<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        return Uni.createFrom().item(EmptyProtos.Empty.newBuilder().build());
+    }
+
+    @Override
+    @Blocking
+    public Uni<EmptyProtos.Empty> emptyCallBlocking(EmptyProtos.Empty request) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        return Uni.createFrom().item(EmptyProtos.Empty.newBuilder().build());
+    }
+
+    @Override
+    public Uni<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        return Uni.createFrom().item(Messages.SimpleResponse.newBuilder().build());
+    }
+
+    @Override
+    @Blocking
+    public Uni<Messages.SimpleResponse> unaryCallBlocking(Messages.SimpleRequest request) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        return Uni.createFrom().item(Messages.SimpleResponse.newBuilder().build());
+    }
+
+    @Override
+    public Multi<Messages.StreamingOutputCallResponse> streamingOutputCall(
+            Messages.StreamingOutputCallRequest request) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        return Multi.createFrom().range(0, 10)
+                .map(i -> ByteString.copyFromUtf8(Integer.toString(i)))
+                .map(s -> Messages.Payload.newBuilder().setBody(s).build())
+                .map(p -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(p).build());
+    }
+
+    @Override
+    @Blocking
+    public Multi<Messages.StreamingOutputCallResponse> streamingOutputCallBlocking(
+            Messages.StreamingOutputCallRequest request) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        return Multi.createFrom().range(0, 10)
+                .map(i -> ByteString.copyFromUtf8(Integer.toString(i)))
+                .map(s -> Messages.Payload.newBuilder().setBody(s).build())
+                .map(p -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(p).build());
+    }
+
+    @Override
+    public Uni<Messages.StreamingInputCallResponse> streamingInputCall(
+            Multi<Messages.StreamingInputCallRequest> request) {
+        assertRunOnEventLoop();
+        return request.map(i -> i.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .map(list -> {
+                    assertRunOnEventLoop();
+                    assertThat(list).containsExactly("a", "b", "c", "d");
+                    return Messages.StreamingInputCallResponse.newBuilder().build();
+                });
+    }
+
+    @Override
+    @Blocking
+    public Uni<Messages.StreamingInputCallResponse> streamingInputCallBlocking(
+            Multi<Messages.StreamingInputCallRequest> request) {
+        assertRunOnWorker();
+        return request.map(i -> i.getPayload().getBody().toStringUtf8())
+                .collectItems().asList()
+                .map(list -> {
+                    assertRunOnWorker();
+                    assertThat(list).containsExactly("a", "b", "c", "d");
+                    return Messages.StreamingInputCallResponse.newBuilder().build();
+                });
+    }
+
+    @Override
+    public Multi<Messages.StreamingOutputCallResponse> fullDuplexCall(
+            Multi<Messages.StreamingOutputCallRequest> request) {
+        AtomicInteger counter = new AtomicInteger();
+        assertRunOnEventLoop();
+        return request
+                .map(r -> r.getPayload().getBody().toStringUtf8())
+                .map(r -> {
+                    assertRunOnEventLoop();
+                    return r + counter.incrementAndGet();
+                })
+                .map(r -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(r)).build())
+                .map(r -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(r).build());
+    }
+
+    @Override
+    @Blocking
+    public Multi<Messages.StreamingOutputCallResponse> fullDuplexCallBlocking(
+            Multi<Messages.StreamingOutputCallRequest> request) {
+        AtomicInteger counter = new AtomicInteger();
+        assertRunOnWorker();
+        return request
+                .map(r -> r.getPayload().getBody().toStringUtf8())
+                .map(r -> {
+                    assertRunOnWorker();
+                    return r + counter.incrementAndGet();
+                })
+                .map(r -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(r)).build())
+                .map(r -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(r).build());
+    }
+
+    @Override
+    public Multi<Messages.StreamingOutputCallResponse> halfDuplexCall(
+            Multi<Messages.StreamingOutputCallRequest> request) {
+        assertRunOnEventLoop();
+        return request
+                .map(r -> {
+                    assertRunOnEventLoop();
+                    return r.getPayload().getBody().toStringUtf8();
+                })
+                .map(String::toUpperCase)
+                .collectItems().asList()
+                .onItem().transformToMulti(s -> Multi.createFrom().iterable(s))
+                .map(r -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(r)).build())
+                .map(r -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(r).build());
+
+    }
+
+    @Override
+    @Blocking
+    public Multi<Messages.StreamingOutputCallResponse> halfDuplexCallBlocking(
+            Multi<Messages.StreamingOutputCallRequest> request) {
+        assertRunOnWorker();
+        return request
+                .map(r -> {
+                    assertRunOnWorker();
+                    return r.getPayload().getBody().toStringUtf8();
+                })
+                .map(String::toUpperCase)
+                .collectItems().asList()
+                .onItem().transformToMulti(s -> Multi.createFrom().iterable(s))
+                .map(r -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(r)).build())
+                .map(r -> Messages.StreamingOutputCallResponse.newBuilder().setPayload(r).build());
+
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingTestService.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/BlockingTestService.java
@@ -1,0 +1,279 @@
+package io.quarkus.grpc.server.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Singleton;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.EmptyProtos;
+
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.Messages;
+import io.quarkus.grpc.blocking.BlockingTestServiceGrpc;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.Vertx;
+
+@Singleton
+public class BlockingTestService extends BlockingTestServiceGrpc.BlockingTestServiceImplBase {
+
+    private void assertRunOnEventLoop() {
+        assertThat(Vertx.currentContext()).isNotNull();
+        assertThat(Vertx.currentContext().isEventLoopContext());
+        assertThat(Thread.currentThread().getName()).contains("eventloop");
+    }
+
+    private void assertRunOnWorker() {
+        assertThat(Vertx.currentContext()).isNotNull();
+        assertThat(Thread.currentThread().getName()).contains("worker");
+    }
+
+    @Override
+    public void emptyCall(EmptyProtos.Empty request, StreamObserver<EmptyProtos.Empty> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        responseObserver.onNext(EmptyProtos.Empty.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    @Blocking
+    public void emptyCallBlocking(EmptyProtos.Empty request, StreamObserver<EmptyProtos.Empty> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        responseObserver.onNext(EmptyProtos.Empty.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void unaryCall(Messages.SimpleRequest request,
+            StreamObserver<Messages.SimpleResponse> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        responseObserver.onNext(Messages.SimpleResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    @Blocking
+    public void unaryCallBlocking(Messages.SimpleRequest request,
+            StreamObserver<Messages.SimpleResponse> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        responseObserver.onNext(Messages.SimpleResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void streamingOutputCall(Messages.StreamingOutputCallRequest request,
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnEventLoop();
+        for (int i = 0; i < 10; i++) {
+            ByteString value = ByteString.copyFromUtf8(i + "-" + Thread.currentThread().getName());
+            Messages.Payload payload = Messages.Payload.newBuilder().setBody(value).build();
+            responseObserver.onNext(Messages.StreamingOutputCallResponse.newBuilder().setPayload(payload).build());
+        }
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    @Blocking
+    public void streamingOutputCallBlocking(Messages.StreamingOutputCallRequest request,
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        assertThat(request).isNotNull();
+        assertRunOnWorker();
+        for (int i = 0; i < 10; i++) {
+            ByteString value = ByteString.copyFromUtf8(i + "-" + Thread.currentThread().getName());
+            Messages.Payload payload = Messages.Payload.newBuilder().setBody(value).build();
+            responseObserver.onNext(Messages.StreamingOutputCallResponse.newBuilder().setPayload(payload).build());
+        }
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public StreamObserver<Messages.StreamingInputCallRequest> streamingInputCall(
+            StreamObserver<Messages.StreamingInputCallResponse> responseObserver) {
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertRunOnEventLoop();
+        return new StreamObserver<Messages.StreamingInputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingInputCallRequest streamingInputCallRequest) {
+                assertRunOnEventLoop();
+                list.add(streamingInputCallRequest.getPayload().getBody().toStringUtf8());
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertThat(list).containsExactly("a", "b", "c", "d");
+                assertRunOnEventLoop();
+                responseObserver.onNext(Messages.StreamingInputCallResponse.newBuilder().build());
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    @Blocking
+    public StreamObserver<Messages.StreamingInputCallRequest> streamingInputCallBlocking(
+            StreamObserver<Messages.StreamingInputCallResponse> responseObserver) {
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertRunOnWorker();
+        return new StreamObserver<Messages.StreamingInputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingInputCallRequest streamingInputCallRequest) {
+                assertRunOnWorker();
+                list.add(streamingInputCallRequest.getPayload().getBody().toStringUtf8());
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertThat(list).containsExactly("a", "b", "c", "d");
+                assertRunOnWorker();
+                responseObserver.onNext(Messages.StreamingInputCallResponse.newBuilder().build());
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    public StreamObserver<Messages.StreamingOutputCallRequest> fullDuplexCall(
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        AtomicInteger counter = new AtomicInteger();
+        assertRunOnEventLoop();
+        return new StreamObserver<Messages.StreamingOutputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingOutputCallRequest streamingOutputCallRequest) {
+                assertRunOnEventLoop();
+                Messages.Payload payload = streamingOutputCallRequest.getPayload();
+                ByteString value = ByteString
+                        .copyFromUtf8(payload.getBody().toStringUtf8() + counter.incrementAndGet() + "-"
+                                + Thread.currentThread().getName());
+                Messages.Payload resp = Messages.Payload.newBuilder().setBody(value).build();
+                Messages.StreamingOutputCallResponse response = Messages.StreamingOutputCallResponse.newBuilder()
+                        .setPayload(resp).build();
+                responseObserver.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertRunOnEventLoop();
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    @Blocking
+    public StreamObserver<Messages.StreamingOutputCallRequest> fullDuplexCallBlocking(
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        AtomicInteger counter = new AtomicInteger();
+        assertRunOnWorker();
+        return new StreamObserver<Messages.StreamingOutputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingOutputCallRequest streamingOutputCallRequest) {
+                assertRunOnWorker();
+                Messages.Payload payload = streamingOutputCallRequest.getPayload();
+                ByteString value = ByteString
+                        .copyFromUtf8(payload.getBody().toStringUtf8() + counter.incrementAndGet() + "-"
+                                + Thread.currentThread().getName());
+                Messages.Payload resp = Messages.Payload.newBuilder().setBody(value).build();
+                Messages.StreamingOutputCallResponse response = Messages.StreamingOutputCallResponse.newBuilder()
+                        .setPayload(resp).build();
+                responseObserver.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertRunOnWorker();
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    public StreamObserver<Messages.StreamingOutputCallRequest> halfDuplexCall(
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        assertRunOnEventLoop();
+        List<Messages.StreamingOutputCallResponse> list = new CopyOnWriteArrayList<>();
+        return new StreamObserver<Messages.StreamingOutputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingOutputCallRequest streamingOutputCallRequest) {
+                assertRunOnEventLoop();
+                String payload = streamingOutputCallRequest.getPayload().getBody().toStringUtf8();
+                ByteString value = ByteString.copyFromUtf8(payload.toUpperCase() + "-" + Thread.currentThread().getName());
+                Messages.Payload response = Messages.Payload.newBuilder().setBody(value).build();
+                Messages.StreamingOutputCallResponse resp = Messages.StreamingOutputCallResponse.newBuilder()
+                        .setPayload(response).build();
+                list.add(resp);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertRunOnEventLoop();
+                list.forEach(responseObserver::onNext);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    @Blocking
+    public StreamObserver<Messages.StreamingOutputCallRequest> halfDuplexCallBlocking(
+            StreamObserver<Messages.StreamingOutputCallResponse> responseObserver) {
+        assertRunOnWorker();
+        List<Messages.StreamingOutputCallResponse> list = new CopyOnWriteArrayList<>();
+        return new StreamObserver<Messages.StreamingOutputCallRequest>() {
+            @Override
+            public void onNext(Messages.StreamingOutputCallRequest streamingOutputCallRequest) {
+                assertRunOnWorker();
+                String payload = streamingOutputCallRequest.getPayload().getBody().toStringUtf8();
+                ByteString value = ByteString.copyFromUtf8(payload.toUpperCase() + "-" + Thread.currentThread().getName());
+                Messages.Payload response = Messages.Payload.newBuilder().setBody(value).build();
+                Messages.StreamingOutputCallResponse resp = Messages.StreamingOutputCallResponse.newBuilder()
+                        .setPayload(response).build();
+                list.add(resp);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                assertRunOnWorker();
+                list.forEach(responseObserver::onNext);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/extensions/grpc/deployment/src/test/proto/blocking-test.proto
+++ b/extensions/grpc/deployment/src/test/proto/blocking-test.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+import "empty.proto";
+import "messages.proto";
+
+package grpc.testing;
+
+option java_package = "io.quarkus.grpc.blocking";
+
+// Expect implementation to use @Blocking on method with names suffixed with Blocking
+service BlockingTestService {
+    // Called on event loop
+    rpc EmptyCall (grpc.testing.Empty) returns (grpc.testing.Empty);
+
+    // Called on blocking
+    rpc EmptyCallBlocking (grpc.testing.Empty) returns (grpc.testing.Empty);
+
+    // The response contains the thread name
+    rpc UnaryCall (SimpleRequest) returns (SimpleResponse);
+    rpc UnaryCallBlocking (SimpleRequest) returns (SimpleResponse);
+    // The response contains the thread name in each item
+    rpc StreamingOutputCall (StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+    rpc StreamingOutputCallBlocking (StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+
+    // The response contains the thread name
+    rpc StreamingInputCall (stream StreamingInputCallRequest) returns (StreamingInputCallResponse);
+    rpc StreamingInputCallBlocking (stream StreamingInputCallRequest) returns (StreamingInputCallResponse);
+
+    rpc FullDuplexCall (stream StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+    rpc FullDuplexCallBlocking (stream StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+
+    rpc HalfDuplexCall (stream StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+    rpc HalfDuplexCallBlocking (stream StreamingOutputCallRequest) returns (stream StreamingOutputCallResponse);
+
+    // The test server will not implement this method. It will be used
+    // to test the behavior when clients call unimplemented methods.
+    rpc UnimplementedCall (grpc.testing.Empty) returns (grpc.testing.Empty);
+    rpc UnimplementedCallBlocking (grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+

--- a/extensions/grpc/deployment/src/test/resources/blocking-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/blocking-config.properties
@@ -1,0 +1,4 @@
+quarkus.grpc.clients.reflection-service.host=localhost
+quarkus.grpc.clients.test-service.host=localhost
+quarkus.grpc.clients.greeter-service.host=localhost
+quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/deployment/src/test/resources/blocking-test-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/blocking-test-config.properties
@@ -1,0 +1,2 @@
+quarkus.grpc.clients.blocking-test.host=localhost
+quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -98,6 +98,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/BlockingServerInterceptor.java
@@ -1,0 +1,142 @@
+package io.quarkus.grpc.runtime.supports;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * gRPC Server interceptor offloading the execution of the gRPC method on a wroker thread if the method is annotated
+ * with {@link io.smallrye.common.annotation.Blocking}.
+ *
+ * For non-annotated methods, the interceptor acts as a pass-through.
+ */
+public class BlockingServerInterceptor implements ServerInterceptor {
+
+    private final Vertx vertx;
+    private final List<String> blockingMethods;
+    private final Map<String, Boolean> cache = new HashMap<>();
+
+    public BlockingServerInterceptor(Vertx vertx, List<String> blockingMethods) {
+        this.vertx = vertx;
+        this.blockingMethods = new ArrayList<>();
+        for (String method : blockingMethods) {
+            this.blockingMethods.add(method.toLowerCase());
+        }
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        // We need to check if the method is annotated with @Blocking.
+        // Unfortunately, we can't have the Java method object, we can only have the gRPC full method name.
+        // We extract the method name, and check if the name if is the list.
+        // This makes the following assumptions:
+        // 1. the code generator does not change the method name (which makes sense)
+        // 2. the method name is unique, which is a constraint of gRPC
+
+        // For performance purpose, we execute the lookup only once
+        String fullMethodName = call.getMethodDescriptor().getFullMethodName();
+        boolean isBlocking = cache.computeIfAbsent(fullMethodName, new Function<String, Boolean>() {
+            @Override
+            public Boolean apply(String name) {
+                String methodName = name.substring(name.lastIndexOf("/") + 1);
+                return blockingMethods.contains(methodName.toLowerCase());
+            }
+        });
+
+        if (isBlocking) {
+            ReplayListener<ReqT> replay = new ReplayListener<>();
+
+            vertx.executeBlocking(new Handler<Promise<Object>>() {
+                @Override
+                public void handle(Promise<Object> f) {
+                    ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
+                    replay.setDelegate(listener);
+                    f.complete(null);
+                }
+            }, null);
+
+            return replay;
+        } else {
+            return next.startCall(call, headers);
+        }
+    }
+
+    /**
+     * Stores the incoming events until the listener is injected.
+     * When injected, replay the events.
+     *
+     * Note that event must be executed in order, explaining the `ordered:true`.
+     */
+    private class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
+        private ServerCall.Listener<ReqT> delegate;
+        private final List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
+
+        synchronized void setDelegate(ServerCall.Listener<ReqT> delegate) {
+            this.delegate = delegate;
+            for (Consumer<ServerCall.Listener<ReqT>> event : incomingEvents) {
+                event.accept(delegate);
+            }
+            incomingEvents.clear();
+        }
+
+        private synchronized void executeOnContextOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
+            if (this.delegate != null) {
+                vertx.executeBlocking(new Handler<Promise<Object>>() {
+                    @Override
+                    public void handle(Promise<Object> f) {
+                        consumer.accept(delegate);
+                        f.complete();
+                    }
+                }, true, null);
+            } else {
+                incomingEvents.add(consumer);
+            }
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            executeOnContextOrEnqueue(new Consumer<ServerCall.Listener<ReqT>>() {
+                @Override
+                public void accept(ServerCall.Listener<ReqT> t) {
+                    t.onMessage(message);
+                }
+            });
+        }
+
+        @Override
+        public void onHalfClose() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onHalfClose);
+        }
+
+        @Override
+        public void onCancel() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onCancel);
+        }
+
+        @Override
+        public void onComplete() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onComplete);
+        }
+
+        @Override
+        public void onReady() {
+            executeOnContextOrEnqueue(ServerCall.Listener::onReady);
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -1,6 +1,12 @@
 package io.quarkus.smallrye.reactivemessaging.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.*;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.ACKNOWLEDGMENT;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BLOCKING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.BROADCAST;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.INCOMING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.MERGE;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.OUTGOING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.SMALLRYE_BLOCKING;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -122,15 +128,20 @@ public final class QuarkusMediatorConfigurationUtil {
                 }));
 
         AnnotationInstance blockingAnnotation = methodInfo.annotation(BLOCKING);
-        if (blockingAnnotation != null) {
+        AnnotationInstance smallryeBlockingAnnotation = methodInfo.annotation(SMALLRYE_BLOCKING);
+        if (blockingAnnotation != null || smallryeBlockingAnnotation != null) {
             mediatorConfigurationSupport.validateBlocking(validationOutput);
             configuration.setBlocking(true);
-            AnnotationValue ordered = blockingAnnotation.value("ordered");
-            configuration.setBlockingExecutionOrdered(ordered == null || ordered.asBoolean());
-            String poolName;
-            if (blockingAnnotation.value() != null &&
-                    !(poolName = blockingAnnotation.value().asString()).equals(Blocking.DEFAULT_WORKER_POOL)) {
-                configuration.setWorkerPoolName(poolName);
+            if (blockingAnnotation != null) {
+                AnnotationValue ordered = blockingAnnotation.value("ordered");
+                configuration.setBlockingExecutionOrdered(ordered == null || ordered.asBoolean());
+                String poolName;
+                if (blockingAnnotation.value() != null &&
+                        !(poolName = blockingAnnotation.value().asString()).equals(Blocking.DEFAULT_WORKER_POOL)) {
+                    configuration.setWorkerPoolName(poolName);
+                }
+            } else {
+                configuration.setBlockingExecutionOrdered(true);
             }
         }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
@@ -31,6 +31,8 @@ public final class ReactiveMessagingDotNames {
     static final DotName MERGE = DotName.createSimple(Merge.class.getName());
     static final DotName BROADCAST = DotName.createSimple(Broadcast.class.getName());
 
+    static final DotName SMALLRYE_BLOCKING = DotName.createSimple(io.smallrye.common.annotation.Blocking.class.getName());
+
     // Do not directly reference the MetricDecorator (due to its direct references to MP Metrics, which may not be present)
     static final DotName METRIC_DECORATOR = DotName.createSimple("io.smallrye.reactive.messaging.metrics.MetricDecorator");
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SmallRyeBlockingSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SmallRyeBlockingSubscriberTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.smallrye.reactivemessaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.IncomingUsingSmallRyeBlocking;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class SmallRyeBlockingSubscriberTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProduceIn.class, IncomingUsingSmallRyeBlocking.class)
+                    .addAsResource(
+                            new File("src/test/resources/config/worker-config.properties"),
+                            "application.properties"));
+
+    @Inject
+    IncomingUsingSmallRyeBlocking incoming;
+
+    @Test
+    public void testIncomingUsingRunOnWorkerThread() {
+        await().until(() -> incoming.list().size() == 6);
+        assertThat(incoming.list()).contains("a", "b", "c", "d", "e", "f");
+
+        List<String> threadNames = incoming.threads().stream().distinct()
+                .collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProduceIn {
+        @Outgoing("in")
+        public Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingPublisherTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingPublisherTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.smallrye.reactivemessaging.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.BeanReturningMessagesUsingSmallRyeBlocking;
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.BeanReturningPayloadsUsingSmallRyeBlocking;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+
+public class SmallRyeBlockingPublisherTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanReturningPayloadsUsingSmallRyeBlocking.class,
+                            BeanReturningMessagesUsingSmallRyeBlocking.class));
+
+    @Inject
+    BeanReturningPayloadsUsingSmallRyeBlocking beanReturningPayloads;
+    @Inject
+    BeanReturningMessagesUsingSmallRyeBlocking beanReturningMessages;
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @Test
+    public void testBlockingWhenProducingPayload() {
+        List<PublisherBuilder<? extends Message<?>>> producer = channelRegistry.getPublishers("infinite-producer-payload");
+        assertThat(producer).isNotEmpty();
+        List<Integer> list = producer.get(0).map(Message::getPayload)
+                .limit(5)
+                .map(i -> (Integer) i)
+                .toList().run().toCompletableFuture().join();
+        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+
+        List<String> threadNames = beanReturningPayloads.threads().stream().distinct().collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+
+    @Test
+    public void testBlockingWhenProducingMessages() {
+        List<PublisherBuilder<? extends Message<?>>> producer = channelRegistry.getPublishers("infinite-producer-msg");
+        assertThat(producer).isNotEmpty();
+        List<Integer> list = producer.get(0).map(Message::getPayload)
+                .limit(5)
+                .map(i -> (Integer) i)
+                .toList().run().toCompletableFuture().join();
+        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+
+        List<String> threadNames = beanReturningMessages.threads().stream().distinct().collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingSubscriberTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.smallrye.reactivemessaging.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.smallrye.reactivemessaging.blocking.beans.IncomingUsingSmallRyeBlocking;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class SmallRyeBlockingSubscriberTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProduceIn.class, IncomingUsingSmallRyeBlocking.class)
+                    .addAsResource(
+                            new File("src/test/resources/config/worker-config.properties"),
+                            "application.properties"));
+
+    @Inject
+    IncomingUsingSmallRyeBlocking incoming;
+
+    @Test
+    public void testIncomingUsingRunOnWorkerThread() {
+        await().until(() -> incoming.list().size() == 6);
+        assertThat(incoming.list()).contains("a", "b", "c", "d", "e", "f");
+
+        List<String> threadNames = incoming.threads().stream().distinct()
+                .collect(Collectors.toList());
+        assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
+        for (String name : threadNames) {
+            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProduceIn {
+        @Outgoing("in")
+        public Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningMessagesUsingSmallRyeBlocking.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningMessagesUsingSmallRyeBlocking.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.common.annotation.Blocking;
+
+@ApplicationScoped
+public class BeanReturningMessagesUsingSmallRyeBlocking {
+    private final AtomicInteger count = new AtomicInteger();
+    private final List<String> threads = new CopyOnWriteArrayList<>();
+
+    @Blocking
+    @Outgoing("infinite-producer-msg")
+    public Message<Integer> create() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        threads.add(Thread.currentThread().getName());
+        return Message.of(count.incrementAndGet());
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningPayloadsUsingSmallRyeBlocking.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/BeanReturningPayloadsUsingSmallRyeBlocking.java
@@ -1,0 +1,33 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.common.annotation.Blocking;
+
+@ApplicationScoped
+public class BeanReturningPayloadsUsingSmallRyeBlocking {
+    private AtomicInteger count = new AtomicInteger();
+    private List<String> threads = new CopyOnWriteArrayList<>();
+
+    @Blocking
+    @Outgoing("infinite-producer-payload")
+    public int create() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        threads.add(Thread.currentThread().getName());
+        return count.incrementAndGet();
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/IncomingUsingSmallRyeBlocking.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/beans/IncomingUsingSmallRyeBlocking.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.reactivemessaging.blocking.beans;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.common.annotation.Blocking;
+
+@ApplicationScoped
+public class IncomingUsingSmallRyeBlocking {
+    private final List<String> list = new CopyOnWriteArrayList<>();
+    private final List<String> threads = new CopyOnWriteArrayList<>();
+
+    @Incoming("in")
+    @Blocking
+    public void consume(String s) {
+        if (s.equals("b") || s.equals("d") || s.equals("f")) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        threads.add(Thread.currentThread().getName());
+        list.add(s);
+    }
+
+    public List<String> list() {
+        return list;
+    }
+
+    public List<String> threads() {
+        return threads;
+    }
+}

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
@@ -11,6 +11,7 @@ import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.RouteBase;
 import io.quarkus.vertx.web.RouteFilter;
 import io.quarkus.vertx.web.RoutingExchange;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.buffer.Buffer;
@@ -49,5 +50,6 @@ final class DotNames {
     static final DotName LIST = DotName.createSimple(List.class.getName());
     static final DotName EXCEPTION = DotName.createSimple(Exception.class.getName());
     static final DotName THROWABLE = DotName.createSimple(Throwable.class.getName());
+    static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
 
 }

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -327,6 +327,16 @@ class VertxWebProcessor {
                     }
                 }
 
+                if (businessMethod.getMethod().annotation(DotNames.BLOCKING) != null) {
+                    if (handlerType == HandlerType.NORMAL) {
+                        handlerType = HandlerType.BLOCKING;
+                    } else if (handlerType == HandlerType.FAILURE) {
+                        throw new IllegalStateException(
+                                "Invalid combination - a reactive route cannot use @Blocking and use the type `failure` at the same time: "
+                                        + businessMethod.getMethod().toString());
+                    }
+                }
+
                 if (routeHandler == null) {
                     String handlerClass = generateHandler(
                             new HandlerDescriptor(businessMethod.getMethod(), beanValidationAnnotations.orElse(null),

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.vertx.web.blocking;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.containsString;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.http.HttpMethod;
+
+public class BlockingRouteTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyRoutes.class));
+
+    @Test
+    public void testBlockingRoutes() {
+        get("/non-blocking")
+                .then().statusCode(200)
+                .body(containsString("nonBlocking-"), containsString("eventloop"));
+
+        get("/blocking")
+                .then().statusCode(200)
+                .body(containsString("blocking-"), containsString("worker"));
+
+        get("/worker")
+                .then().statusCode(200)
+                .body(containsString("worker-"), containsString("worker"));
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        @Route(methods = HttpMethod.GET, path = "/non-blocking")
+        public String nonBlocking() {
+            return "nonBlocking-" + Thread.currentThread().getName();
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/blocking", type = Route.HandlerType.BLOCKING)
+        public String blocking() {
+            return "blocking-" + Thread.currentThread().getName();
+        }
+
+        @Route(methods = HttpMethod.GET, path = "/worker")
+        @Blocking
+        public String worker() {
+            return "worker-" + Thread.currentThread().getName();
+        }
+
+    }
+
+}

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>quarkus-vertx-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-axle-generator</artifactId>
             <exclusions>


### PR DESCRIPTION
Fix #12077.

Add support for the new @Blocking/ @NonBlocking annotations from SmallRye Common Annotations:

* add support into the gRPC extension (for services implementation)
* add support into the reactive messaging extension - equivalent to @Blocking
* add support into the vertx extension (@ConsumeEvent) - equivalent to blocking=true
* add support into the vertx-web extension (@route) - equivalent to type=BLOCKING


The documentation of these extensions has been updated.