### PR TITLE
SyntheticBeanBuildItem: facade method to configure generified implClass

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
@@ -5,6 +5,8 @@ import java.util.function.Supplier;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 
 import io.quarkus.arc.processor.BeanConfigurator;
 import io.quarkus.arc.processor.BeanConfiguratorBase;
@@ -22,6 +24,15 @@ public final class SyntheticBeanBuildItem extends MultiBuildItem {
 
     public static ExtendedBeanConfigurator configure(Class<?> implClazz) {
         return configure(DotName.createSimple(implClazz.getName()));
+    }
+
+    public static ExtendedBeanConfigurator configure(Class<?> implClazz, Class<?>... genericTypeParameters) {
+        DotName implDotName = DotName.createSimple(implClazz.getName());
+        Type[] genericTypes = new Type[genericTypeParameters.length];
+        for (int i = 0; i < genericTypeParameters.length; i++) {
+            genericTypes[i] = Type.create(DotName.createSimple(genericTypeParameters[i].getName()), Type.Kind.CLASS);
+        }
+        return configure(implDotName).addType(ParameterizedType.create(implDotName, genericTypes, null));
     }
 
     public static ExtendedBeanConfigurator configure(DotName implClazz) {


### PR DESCRIPTION
Why?
It turns this injection of `SolverFactory<TimeTable>`:

```
syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(SolverFactory.class)
                .addType(ParameterizedType.create(DotName.createSimple(SolverFactory.class.getName()),
                        new Type[] { Type.create(DotName.createSimple(TimeTable.class.getName()), Type.Kind.CLASS)},
                        null))
                ...;
```
into this
```
syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(SolverFactory.class, TimeTable.class)
                ...);
```