### PR TITLE
Optimize OIDC code flow to do one less redirect when the original path has to be restored

### DIFF
--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -23,6 +23,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-logout";
         }
 
+        if (path.contains("tenant-query")) {
+            return "tenant-query";
+        }
+
         if (path.contains("tenant-listener")) {
             return "tenant-listener";
         }
@@ -51,11 +55,27 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-javascript";
         }
 
-        return path.contains("callback-after-redirect") || path.contains("callback-before-redirect") ? "tenant-1"
-                : path.contains("callback-jwt-after-redirect") || path.contains("callback-jwt-before-redirect") ? "tenant-jwt"
-                        : path.contains("callback-jwt-not-used-after-redirect")
-                                || path.contains("callback-jwt-not-used-before-redirect")
-                                        ? "tenant-jwt-not-used"
-                                        : path.contains("/web-app2") ? "tenant-2" : null;
+        if (path.contains("callback-before-wrong-redirect")) {
+            return context.getCookie("q_auth_tenant-before-wrong-redirect") == null ? "tenant-before-wrong-redirect"
+                    : "tenant-1";
+        }
+
+        if (path.contains("callback-after-redirect") || path.contains("callback-before-redirect")) {
+            return "tenant-1";
+        }
+
+        if (path.contains("callback-jwt-after-redirect") || path.contains("callback-jwt-before-redirect")) {
+            return "tenant-jwt";
+        }
+
+        if (path.contains("callback-jwt-not-used-after-redirect") || path.contains("callback-jwt-not-used-before-redirect")) {
+            return "tenant-jwt-not-used";
+        }
+
+        if (path.contains("/web-app2")) {
+            return "tenant-2";
+        }
+
+        return null;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -75,6 +75,12 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("callback-before-wrong-redirect")
+    public String getNameCallbackBeforeWrongRedirect() {
+        throw new InternalServerErrorException("This method must not be invoked");
+    }
+
+    @GET
     @Path("callback-before-redirect")
     public String getNameCallbackBeforeRedirect() {
         throw new InternalServerErrorException("This method must not be invoked");

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -23,6 +23,12 @@ quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
 quarkus.oidc.tenant-listener.application-type=web-app
 
 
+quarkus.oidc.tenant-before-wrong-redirect.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-before-wrong-redirect.client-id=quarkus-app
+quarkus.oidc.tenant-before-wrong-redirect.credentials.client-secret.value=secret
+quarkus.oidc.tenant-before-wrong-redirect.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-before-wrong-redirect.application-type=web-app
+
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
 quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-1.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -440,9 +440,9 @@ public class CodeFlowTest {
 
     @Test
     public void testAuthenticationCompletionFailedNoStateCookie() throws IOException, InterruptedException {
-        // tenant-3 configuration uses a '/some/other/path' redirect parameter which does not have the same root
+        // tenant-3 configuration uses a '/web-app3' redirect parameter which does not have the same root
         // as the original request which is 'web-app', as a result, when the user is returned back to Quarkus
-        // to '/some/other/path' no state cookie is detected.
+        // to '/web-app3' no state cookie is detected.
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-redirect?tenantId=tenant-3");
             assertEquals("Log in to quarkus", page.getTitleText());
@@ -468,7 +468,7 @@ public class CodeFlowTest {
         // When the user is redirected back, CustomTenantResolver will resolve a 'tenant-1' configuration with
         // a redirect_uri '/web-app/callback-after-redirect' which will cause a code to token exchange failure
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-redirect?tenantId");
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-wrong-redirect");
             assertEquals("Log in to quarkus", page.getTitleText());
 
             HtmlForm loginForm = page.getForms().get(0);
@@ -644,7 +644,7 @@ public class CodeFlowTest {
     }
 
     @Test
-    public void testAccessAndRefreshTokenInjectionWithoutIndexHtmlWithQuery() throws Exception {
+    public void testAccessAndRefreshTokenInjectionWithQuery() throws Exception {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh-query?a=aValue");
             assertEquals("/web-app/refresh-query?a=aValue", getStateCookieSavedPath(webClient, null));


### PR DESCRIPTION
OIDC `CodeAuthenticationMechanism` can restore the original request path, for example:
1. User does `GET /web-app/service`
2. Redirect path is configured as `/web-app`
3. The user, after authenticating, is redirected back to Quarkus to `/web-app`
4. Now, before proceeding with the code to token exchange, the user is redirected to `/web-app/service` thus restoring the original request URI; to implement it, a custom `pathChecked` query is added, so it is not ideal
5. Finally, after the code has been exchanged, another redirect follows, dropping `code` and `state` and other non-custom query parameters

So, step 4 is redundant, it adds to the cost of processing and also returns `code` and `state` back to the browser because the code flow has not completed yet.

As such this PR drops step 4 and the original path, if needed, will be restored as part of the last step

I had to fix a few tests because they were written around the flow involving step4.