### PR TITLE
Extract gRPC common stuff

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1344,6 +1344,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+            <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-grpc-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-grpc-codegen</artifactId>
                 <version>${project.version}</version>
@@ -1356,6 +1361,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-grpc-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-grpc-common-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/extensions/grpc-common/deployment/pom.xml
+++ b/extensions/grpc-common/deployment/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-grpc-common-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-grpc-common-deployment</artifactId>
+    <name>Quarkus - gRPC Common - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -1,0 +1,65 @@
+package io.quarkus.grpc.common.deployment;
+
+import java.util.Collection;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.grpc.internal.DnsNameResolverProvider;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
+import io.grpc.netty.NettyChannelProvider;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+
+public class GrpcCommonProcessor {
+
+    @BuildStep
+    public void configureNativeExecutable(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+
+        // we force the usage of the reflection invoker.
+        Collection<ClassInfo> messages = combinedIndex.getIndex()
+                .getAllKnownSubclasses(GrpcDotNames.GENERATED_MESSAGE_V3);
+        for (ClassInfo message : messages) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, message.name().toString()));
+        }
+        Collection<ClassInfo> builders = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.MESSAGE_BUILDER);
+        for (ClassInfo builder : builders) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, builder.name().toString()));
+        }
+
+        Collection<ClassInfo> lbs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.LOAD_BALANCER_PROVIDER);
+        for (ClassInfo lb : lbs) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, lb.name().toString()));
+        }
+
+        Collection<ClassInfo> nrs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.NAME_RESOLVER_PROVIDER);
+        for (ClassInfo nr : nrs) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, nr.name().toString()));
+        }
+
+        // Built-In providers:
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, DnsNameResolverProvider.class));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, PickFirstLoadBalancerProvider.class));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false,
+                "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, NettyChannelProvider.class));
+    }
+
+    @BuildStep
+    NativeImageConfigBuildItem nativeImageConfiguration() {
+        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder()
+                .addRuntimeInitializedClass("io.grpc.netty.Utils$ByteBufAllocatorPreferDirectHolder")
+                .addRuntimeInitializedClass("io.grpc.netty.Utils$ByteBufAllocatorPreferHeapHolder")
+                // substitutions are runtime-only, Utils have to be substituted until we cannot use EPoll
+                // in native. NettyServerBuilder and NettyChannelBuilder would "bring in" Utils in build time
+                // if they were not marked as runtime initialized:
+                .addRuntimeInitializedClass("io.grpc.netty.Utils")
+                .addRuntimeInitializedClass("io.grpc.netty.NettyServerBuilder")
+                .addRuntimeInitializedClass("io.grpc.netty.NettyChannelBuilder");
+        return builder.build();
+    }
+
+}

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
@@ -1,0 +1,15 @@
+package io.quarkus.grpc.common.deployment;
+
+import org.jboss.jandex.DotName;
+
+import com.google.protobuf.GeneratedMessageV3;
+
+import io.grpc.LoadBalancerProvider;
+import io.grpc.NameResolverProvider;
+
+public class GrpcDotNames {
+    static final DotName MESSAGE_BUILDER = DotName.createSimple(GeneratedMessageV3.Builder.class.getName());
+    static final DotName GENERATED_MESSAGE_V3 = DotName.createSimple(GeneratedMessageV3.class.getName());
+    static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
+    static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
+}

--- a/extensions/grpc-common/pom.xml
+++ b/extensions/grpc-common/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-grpc-common-parent</artifactId>
+    <name>Quarkus - gRPC Common</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/grpc-common/runtime/pom.xml
+++ b/extensions/grpc-common/runtime/pom.xml
@@ -1,86 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-grpc-parent</artifactId>
+        <artifactId>quarkus-grpc-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-grpc</artifactId>
-    <name>Quarkus - gRPC - Runtime</name>
-    <description>Serve and consume gRPC services</description>
+    <artifactId>quarkus-grpc-common</artifactId>
+    <name>Quarkus - gRPC Common - Runtime</name>
+
     <dependencies>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-grpc-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-grpc-stubs</artifactId>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-grpc</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mutiny</artifactId>
-        </dependency>
-        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-health</artifactId>
-            <optional>true</optional>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcNettySubstitutions.java
+++ b/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcNettySubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkus.grpc.runtime.graal;
+package io.quarkus.grpc.common.runtime.graal;
 
 import java.security.Provider;
 import java.util.logging.Level;

--- a/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcSubstitutions.java
+++ b/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcSubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkus.grpc.runtime.graal;
+package io.quarkus.grpc.common.runtime.graal;
 
 import static io.grpc.InternalServiceProviders.getCandidatesViaHardCoded;
 

--- a/extensions/grpc-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/grpc-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "gRPC Common"
+metadata:
+  keywords:
+    - "gRPC"
+  categories:
+    - "web"
+    - "serialization"
+    - "reactive"
+  status: "experimental"
+  unlisted: "true"

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -24,10 +24,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-utilities</artifactId>
         </dependency>
         <dependency>
@@ -37,6 +33,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-common-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
@@ -2,12 +2,8 @@ package io.quarkus.grpc.deployment;
 
 import org.jboss.jandex.DotName;
 
-import com.google.protobuf.GeneratedMessageV3;
-
 import io.grpc.BindableService;
 import io.grpc.Channel;
-import io.grpc.LoadBalancerProvider;
-import io.grpc.NameResolverProvider;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
 import io.quarkus.grpc.runtime.supports.Channels;
@@ -17,10 +13,6 @@ public class GrpcDotNames {
     static final DotName BINDABLE_SERVICE = DotName.createSimple(BindableService.class.getName());
     static final DotName CHANNEL = DotName.createSimple(Channel.class.getName());
     static final DotName GRPC_SERVICE = DotName.createSimple(GrpcService.class.getName());
-    static final DotName MESSAGE_BUILDER = DotName.createSimple(GeneratedMessageV3.Builder.class.getName());
-    static final DotName GENERATED_MESSAGE_V3 = DotName.createSimple(GeneratedMessageV3.class.getName());
-    static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
-    static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
 
     static final MethodDescriptor CREATE_CHANNEL_METHOD = MethodDescriptor.ofMethod(Channels.class, "createChannel",
             Channel.class, String.class);

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -10,10 +10,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.logging.Logger;
 
-import io.grpc.internal.DnsNameResolverProvider;
-import io.grpc.internal.PickFirstLoadBalancerProvider;
 import io.grpc.internal.ServerImpl;
-import io.grpc.netty.NettyChannelProvider;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsDevelopment;
@@ -28,8 +25,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.grpc.deployment.devmode.FieldDefinalizingVisitor;
 import io.quarkus.grpc.runtime.GrpcContainer;
 import io.quarkus.grpc.runtime.GrpcServerRecorder;
@@ -99,42 +94,6 @@ public class GrpcServerProcessor {
     }
 
     @BuildStep
-    public void configureNativeExecutable(CombinedIndexBuildItem combinedIndex,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport) {
-
-        // we force the usage of the reflection invoker.
-        Collection<ClassInfo> messages = combinedIndex.getIndex()
-                .getAllKnownSubclasses(GrpcDotNames.GENERATED_MESSAGE_V3);
-        for (ClassInfo message : messages) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, message.name().toString()));
-        }
-        Collection<ClassInfo> builders = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.MESSAGE_BUILDER);
-        for (ClassInfo builder : builders) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, builder.name().toString()));
-        }
-
-        Collection<ClassInfo> lbs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.LOAD_BALANCER_PROVIDER);
-        for (ClassInfo lb : lbs) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, lb.name().toString()));
-        }
-
-        Collection<ClassInfo> nrs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.NAME_RESOLVER_PROVIDER);
-        for (ClassInfo nr : nrs) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, nr.name().toString()));
-        }
-
-        // Built-In providers:
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, DnsNameResolverProvider.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, PickFirstLoadBalancerProvider.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false,
-                "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, NettyChannelProvider.class));
-
-        extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(GRPC_SERVER));
-    }
-
-    @BuildStep
     HealthBuildItem addHealthChecks(GrpcServerBuildTimeConfig config,
             List<BindableServiceBuildItem> bindables,
             BuildProducer<AdditionalBeanBuildItem> beans) {
@@ -157,17 +116,7 @@ public class GrpcServerProcessor {
     }
 
     @BuildStep
-    NativeImageConfigBuildItem nativeImageConfiguration() {
-        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder()
-                .addRuntimeInitializedClass("io.grpc.netty.Utils$ByteBufAllocatorPreferDirectHolder")
-                .addRuntimeInitializedClass("io.grpc.netty.Utils$ByteBufAllocatorPreferHeapHolder")
-                // substitutions are runtime-only, Utils have to be substituted until we cannot use EPoll
-                // in native. NettyServerBuilder and NettyChannelBuilder would "bring in" Utils in build time
-                // if they were not marked as runtime initialized:
-                .addRuntimeInitializedClass("io.grpc.netty.Utils")
-                .addRuntimeInitializedClass("io.grpc.netty.NettyServerBuilder")
-                .addRuntimeInitializedClass("io.grpc.netty.NettyChannelBuilder");
-        return builder.build();
+    ExtensionSslNativeSupportBuildItem extensionSslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(GRPC_SERVER);
     }
-
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -189,6 +189,7 @@
         <module>picocli</module>
         <module>google-cloud-functions-http</module>
         <module>google-cloud-functions</module>
+        <module>grpc-common</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Fixes #12602

This externalize the gRPC dependency management and native image stuff so it can be share with the Quarkiverse Google Cloud Services extension.