### PR TITLE
Don't register methods that are added by transformation

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -99,6 +99,7 @@ import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
@@ -325,6 +326,7 @@ public final class HibernateOrmProcessor {
             List<IgnorableNonIndexedClasses> ignorableNonIndexedClassesBuildItems,
             List<NonJpaModelBuildItem> nonJpaModelBuildItems,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
             List<PersistenceXmlDescriptorBuildItem> persistenceXmlDescriptors) throws Exception {
 
         Set<String> nonJpaModelClasses = nonJpaModelBuildItems.stream()
@@ -340,7 +342,7 @@ public final class HibernateOrmProcessor {
         }
 
         JpaJandexScavenger scavenger = new JpaJandexScavenger(reflectiveClass, persistenceXmlDescriptors,
-                indexBuildItem.getIndex(),
+                reflectiveMethod, indexBuildItem.getIndex(),
                 nonJpaModelClasses, ignorableNonIndexedClasses);
         final JpaEntitiesBuildItem domainObjects = scavenger.discoverModelAndRegisterForReflection();
         domainObjectsProducer.produce(domainObjects);

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -25,6 +25,7 @@ import org.jboss.jandex.Type;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
 
 /**
@@ -51,17 +52,19 @@ final class JpaJandexScavenger {
 
     private final List<PersistenceXmlDescriptorBuildItem> explicitDescriptors;
     private final BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
+    private final BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod;
     private final IndexView indexView;
     private final Set<String> nonJpaModelClasses;
     private final Set<String> ignorableNonIndexedClasses;
 
     JpaJandexScavenger(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             List<PersistenceXmlDescriptorBuildItem> explicitDescriptors,
-            IndexView indexView,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod, IndexView indexView,
             Set<String> nonJpaModelClasses,
             Set<String> ignorableNonIndexedClasses) {
         this.reflectiveClass = reflectiveClass;
         this.explicitDescriptors = explicitDescriptors;
+        this.reflectiveMethod = reflectiveMethod;
         this.indexView = indexView;
         this.nonJpaModelClasses = nonJpaModelClasses;
         this.ignorableNonIndexedClasses = ignorableNonIndexedClasses;
@@ -90,7 +93,7 @@ final class JpaJandexScavenger {
                     managedClassNames, unindexedClasses);
         }
 
-        domainObjectCollector.registerAllForReflection(reflectiveClass);
+        domainObjectCollector.registerAllForReflection(reflectiveMethod, reflectiveClass, indexView);
 
         if (!enumTypeCollector.isEmpty()) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, Enum.class.getName()));


### PR DESCRIPTION
The JPA transformer adds a lot of new methods, these
are not needed for reflection