### PR TITLE
Remove dead link

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -30,15 +30,6 @@ To complete this guide, you need:
 * JDK 1.8+ installed with `JAVA_HOME` configured appropriately
 * Apache Maven {maven-version}
 
-== Solution
-
-We recommend that you follow the instructions in the next sections and create the extension step by step.
-However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `getting-started-extension` {quickstarts-tree-url}/getting-started-extension[directory].
-
 == Basic Concepts
 
 First things first, we will need to start with some basic concepts.


### PR DESCRIPTION
The example `getting-started-extension` seems to be already gone. Moreover, I cannot find any alternatives.
Then, the only solution is to remove it.