### PR TITLE
feat: Introduce 3.x and 4.x style of openshift manifests.

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -157,12 +157,6 @@ public class KubernetesCommonHelper {
                             : AddRoleBindingResourceDecorator.RoleKind.Role))));
         }
 
-        // The presence of optional is causing issues in OCP 3.11, so we better remove them.
-        // The following 4 decorator will set the optional property to null, so that it won't make it into the file.
-        result.add(new DecoratorBuildItem(target, new RemoveOptionalFromSecretEnvSourceDecorator()));
-        result.add(new DecoratorBuildItem(target, new RemoveOptionalFromConfigMapEnvSourceDecorator()));
-        result.add(new DecoratorBuildItem(target, new RemoveOptionalFromSecretKeySelectorDecorator()));
-        result.add(new DecoratorBuildItem(target, new RemoveOptionalFromConfigMapKeySelectorDecorator()));
         return result;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -14,6 +14,19 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot
 public class OpenshiftConfig implements PlatformConfiguration {
 
+    public static enum OpenshiftFlavor {
+        v3,
+        v4;
+    }
+
+    /**
+     * The OpenShift flavor / version to use.
+     * Older versions of OpenShift have minor differrences in the labels and fields they support.
+     * This option allows users to have their manifests automatically aligned to the OpenShift 'flavor' they use.
+     */
+    @ConfigItem(defaultValue = "v4")
+    OpenshiftFlavor flavor;
+
     /**
      * The name of the group this component belongs too
      */

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV3Test.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV3Test.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftV3Test {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-v3")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("openshift-v3.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"))
+                .satisfies(p -> assertThat(p.toFile().listFiles()).hasSize(2));
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-v3");
+                assertThat(m.getLabels().get("app.openshift.io/runtime")).isEqualTo("quarkus");
+                assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v3");
+                assertThat(m.getLabels().get("app")).isEqualTo("openshift-v3");
+                assertThat(m.getNamespace()).isNull();
+            });
+            AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
+            specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {
+                assertThat(selectorsMap).containsOnly(entry("app.kubernetes.io/name", "openshift-v3"),
+                        entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+            });
+        });
+
+        assertThat(openshiftList).filteredOn(h -> "Service".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h).isInstanceOfSatisfying(Service.class, s -> {
+                assertThat(s.getMetadata()).satisfies(m -> {
+                    assertThat(m.getNamespace()).isNull();
+                    assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v3");
+                    assertThat(m.getLabels().get("app")).isEqualTo("openshift-v3");
+                });
+
+                assertThat(s.getSpec()).satisfies(spec -> {
+                    assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "openshift-v3"),
+                            entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4Test.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4Test.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftV4Test {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-v4")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("openshift-v4.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"))
+                .satisfies(p -> assertThat(p.toFile().listFiles()).hasSize(2));
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-v4");
+                assertThat(m.getLabels().get("app.openshift.io/runtime")).isEqualTo("quarkus");
+                assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v4");
+                assertThat(m.getLabels().get("app")).isNull();
+                assertThat(m.getNamespace()).isNull();
+            });
+            AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
+            specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {
+                assertThat(selectorsMap).containsOnly(entry("app.kubernetes.io/name", "openshift-v4"),
+                        entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+            });
+        });
+
+        assertThat(openshiftList).filteredOn(h -> "Service".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h).isInstanceOfSatisfying(Service.class, s -> {
+                assertThat(s.getMetadata()).satisfies(m -> {
+                    assertThat(m.getNamespace()).isNull();
+                    assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v4");
+                    assertThat(m.getLabels().get("app")).isNull();
+                });
+
+                assertThat(s.getSpec()).satisfies(spec -> {
+                    assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "openshift-v4"),
+                            entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-v3.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-v3.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.flavor=v3

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-v4.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-v4.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.flavor=v4


### PR DESCRIPTION
This pull request introduces `quarkus.openshift.flavor` which supports values: `v3` and `v4` (default).
Based on the specified value:

# 3.x 
- We add the label `app` which is needed by the openshift console.
- We remove optional from secrets and configmaps.