### PR TITLE
Bump dekorate to 0.13.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -147,7 +147,7 @@
         <aws-alexa-sdk.version>2.35.1</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.72</kotlin.version>
-        <dekorate.version>0.13.2</dekorate.version>
+        <dekorate.version>0.13.5</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>


### PR DESCRIPTION
This pull request bumps dekorate to version 0.13.5 that includes changes of interest like:

- Consistent way of handling labels (only on named resources which is aligned with kubernetes extension).
- Improved way of matching ports (fixes NPE when user brings own manifest with nameless ports).
- Improve way of matching containers