### PR TITLE
Run OIDC Challenge in the blocking mode if needed

### DIFF
--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -12,8 +12,9 @@ public class KeycloakPolicyEnforcerRecorder {
 
     public void setup(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, BeanContainer beanContainer,
             HttpConfiguration httpConfiguration) {
-        if (oidcConfig.defaultTenant.applicationType == OidcTenantConfig.ApplicationType.WEB_APP) {
-            throw new OIDCException("Application type [" + oidcConfig.defaultTenant.applicationType + "] is not supported");
+        if (oidcConfig.defaultTenant.getApplicationType() == OidcTenantConfig.ApplicationType.WEB_APP) {
+            throw new OIDCException(
+                    "Application type [" + oidcConfig.defaultTenant.getApplicationType() + "] is not supported");
         }
         beanContainer.instance(KeycloakPolicyEnforcerAuthorizer.class).init(oidcConfig, config, httpConfiguration);
     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -16,7 +16,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setTenantId("tenant-config-resolver");
             config.setAuthServerUrl(getIssuerUrl() + "/realms/devmode");
             config.setClientId("client-dev-mode");
-            config.applicationType = ApplicationType.WEB_APP;
+            config.setApplicationType(ApplicationType.WEB_APP);
             return config;
         }
         return null;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -187,8 +187,8 @@ public class OidcTenantConfig {
          * Certificate validation and hostname verification, which can be one of the following values from enum
          * {@link Verification}. Default is required.
          */
-        @ConfigItem(defaultValue = "REQUIRED")
-        public Verification verification;
+        @ConfigItem(defaultValue = "required")
+        public Verification verification = Verification.REQUIRED;
 
         public Verification getVerification() {
             return verification;
@@ -257,7 +257,7 @@ public class OidcTenantConfig {
          * Default TokenStateManager strategy.
          */
         @ConfigItem(defaultValue = "keep_all_tokens")
-        public Strategy strategy;
+        public Strategy strategy = Strategy.KEEP_ALL_TOKENS;
 
         /**
          * Default TokenStateManager keeps all tokens (ID, access and refresh)
@@ -435,6 +435,14 @@ public class OidcTenantConfig {
 
     public Logout getLogout() {
         return logout;
+    }
+
+    public ApplicationType getApplicationType() {
+        return applicationType;
+    }
+
+    public void setApplicationType(ApplicationType applicationType) {
+        this.applicationType = applicationType;
     }
 
     @ConfigGroup

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -99,8 +99,7 @@ public class DefaultTenantConfigResolver {
     boolean isBlocking(RoutingContext context) {
         TenantConfigContext resolver = resolve(context, false);
         return resolver != null
-                && (resolver.auth == null || resolver.oidcConfig.token.refreshExpired
-                        || resolver.oidcConfig.authentication.userInfoRequired);
+                && (resolver.oidcConfig.token.refreshExpired || resolver.oidcConfig.authentication.userInfoRequired);
     }
 
     boolean isSecurityEventObserved() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -64,10 +64,10 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     private boolean isWebApp(RoutingContext context, TenantConfigContext tenantContext) {
-        if (OidcTenantConfig.ApplicationType.HYBRID == tenantContext.oidcConfig.applicationType) {
+        if (OidcTenantConfig.ApplicationType.HYBRID == tenantContext.oidcConfig.getApplicationType()) {
             return context.request().getHeader("Authorization") == null;
         }
-        return OidcTenantConfig.ApplicationType.WEB_APP == tenantContext.oidcConfig.applicationType;
+        return OidcTenantConfig.ApplicationType.WEB_APP == tenantContext.oidcConfig.getApplicationType();
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -18,6 +18,7 @@ import io.quarkus.oidc.OidcTenantConfig.Credentials;
 import io.quarkus.oidc.OidcTenantConfig.Credentials.Secret;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTenantConfig.Tls.Verification;
+import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
@@ -62,9 +63,22 @@ public class OidcRecorder {
                         new Function<OidcTenantConfig, TenantConfigContext>() {
                             @Override
                             public TenantConfigContext apply(OidcTenantConfig config) {
-                                // OidcTenantConfig resolved by TenantConfigResolver must have its optional tenantId
-                                // initialized which is also enforced by DefaultTenantConfigResolver
-                                return createTenantContext(vertxValue, config, config.getTenantId().get());
+                                return Uni.createFrom().emitter(new Consumer<UniEmitter<? super TenantConfigContext>>() {
+                                    @Override
+                                    public void accept(UniEmitter<? super TenantConfigContext> uniEmitter) {
+                                        ExecutorRecorder.getCurrent().execute(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                try {
+                                                    uniEmitter.complete(createTenantContext(vertxValue, config,
+                                                            config.getTenantId().get()));
+                                                } catch (Throwable t) {
+                                                    uniEmitter.fail(t);
+                                                }
+                                            }
+                                        });
+                                    }
+                                }).await().indefinitely();
                             }
                         });
             }
@@ -120,7 +134,7 @@ public class OidcRecorder {
         options.setSite(authServerUrl);
 
         if (!oidcConfig.discoveryEnabled) {
-            if (oidcConfig.applicationType != ApplicationType.SERVICE) {
+            if (oidcConfig.getApplicationType() != ApplicationType.SERVICE) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
                     throw new OIDCException("'web-app' applications must have 'authorization-path' and 'token-path' properties "
                             + "set when the discovery is disabled.");
@@ -165,7 +179,7 @@ public class OidcRecorder {
                     "Use only 'credentials.secret' or 'credentials.client-secret' or 'credentials.jwt.secret' property");
         }
 
-        if (ApplicationType.SERVICE.equals(oidcConfig.applicationType)) {
+        if (ApplicationType.SERVICE.equals(oidcConfig.getApplicationType())) {
             if (oidcConfig.token.refreshExpired) {
                 throw new RuntimeException(
                         "The 'token.refresh-expired' property can only be enabled for " + ApplicationType.WEB_APP
@@ -299,7 +313,7 @@ public class OidcRecorder {
     @SuppressWarnings("deprecation")
     private static TenantConfigContext createdTenantContextFromPublicKey(OAuth2ClientOptions options,
             OidcTenantConfig oidcConfig) {
-        if (oidcConfig.applicationType != ApplicationType.SERVICE) {
+        if (oidcConfig.getApplicationType() != ApplicationType.SERVICE) {
             throw new ConfigurationException("'public-key' property can only be used with the 'service' applications");
         }
         LOG.debug("'public-key' property for the local token verification is set,"

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -3,6 +3,8 @@ package io.quarkus.it.keycloak;
 import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.vertx.ext.web.RoutingContext;
 
@@ -40,6 +42,16 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setDiscoveryEnabled(false);
             config.setJwksPath("jwks");
             config.setClientId("client");
+            return config;
+        } else if ("tenant-web-app-dynamic".equals(tenantId)) {
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("tenant-web-app-dynamic");
+            config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-webapp");
+            config.setClientId("quarkus-app-webapp");
+            config.getCredentials().setSecret("secret");
+            config.getAuthentication().setUserInfoRequired(true);
+            config.getRoles().setSource(Source.userinfo);
+            config.setApplicationType(ApplicationType.WEB_APP);
             return config;
         }
         return null;

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -56,7 +56,8 @@ public class TenantResource {
     @Path("webapp")
     @RolesAllowed("user")
     public String userNameWebApp(@PathParam("tenant") String tenant) {
-        if (!tenant.equals("tenant-web-app") && !tenant.equals("tenant-web-app-no-discovery")) {
+        if (!tenant.equals("tenant-web-app")
+                && !tenant.equals("tenant-web-app-dynamic") && !tenant.equals("tenant-web-app-no-discovery")) {
             throw new OIDCException("Wrong tenant");
         }
         UserInfo userInfo = getUserInfo();

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -54,11 +54,28 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testResolveTenantIdentifierWebAppDynamic() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app-dynamic/api/user/webapp");
+            // State cookie is available but there must be no saved path parameter
+            // as the tenant-web-app-dynamic configuration does not set a redirect-path property
+            assertNull(getStateCookieSavedPath(webClient, "tenant-web-app-dynamic"));
+            assertEquals("Log in to quarkus-webapp", page.getTitleText());
+            HtmlForm loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getInputByName("login").click();
+            assertEquals("tenant-web-app-dynamic:alice", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testResolveTenantIdentifierWebApp2() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user/webapp2");
             // State cookie is available but there must be no saved path parameter
-            // as the tenant-web-app configuration does not set a redirect-path property
+            // as the tenant-web-app2 configuration does not set a redirect-path property
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app2"));
             assertEquals("Log in to quarkus-webapp2", page.getTitleText());
             HtmlForm loginForm = page.getForms().get(0);

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -80,6 +80,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.getRoles().getRealm().add(new RoleRepresentation("admin", null, false));
         realm.getRoles().getRealm().add(new RoleRepresentation("confidential", null, false));
 
+        realm.setAccessTokenLifespan(10);
+
         return realm;
     }
 


### PR DESCRIPTION
Fixes #12754 

The problem is that if a `web-app` tenant is created in a custom `TenantConfigResolver` then it causes Vert.x to block.
I've just copied some code where Stuart did a blocking `SecurityIdentity` context implementation, keeping the same `interface + impl` approach for now.
Also did some updates to `OidcTenantConfig` to ensure it is initialized correctly without the injection.
@stuartwdouglas It is not really an OIDC specific issue so please check this PR as well :-)  