### PR TITLE
Exclude Xerces dependency in Tika extension

### DIFF
--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -45,6 +45,10 @@
 	                <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Tika brings in a dependency that is incompatible with the APIs available during reload.  I think, long term, we should look at trying to recreate that initial classpath for use inside the dev plugin, but this fix will at least remove the errant dep and reloads once again work with tika enabled.

(the gradle dev plugin depends on the `classes` task which takes care of the initial compilation before handing this off to the plugin.  the classpath that the plugin assembles is different and so includes only the errant, old XML api causing the breakage.  If we could pass in/discover the `implementation` scope's classpath, we could solve this problem generically, I think.  But I lack the gradle mojo to make that happen just now.)

fixes #8708