### PR TITLE
Set a higher timeout in BasicRestProjectGeneratorTest

### DIFF
--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/project/codegen/rest/BasicRestProjectGeneratorTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/project/codegen/rest/BasicRestProjectGeneratorTest.java
@@ -58,7 +58,7 @@ class BasicRestProjectGeneratorTest extends PlatformAwareTestBase {
     }
 
     @Test
-    @Timeout(2)
+    @Timeout(5)
     @DisplayName("Should generate correctly multiple times in parallel with multiple threads")
     void generateMultipleTimes() throws InterruptedException {
         final ExecutorService executorService = Executors.newFixedThreadPool(4);


### PR DESCRIPTION
We sometimes have a timeout on CI so let's try to set it higher.