### PR TITLE
Rename bind-param config property to bind-parameters

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -63,10 +63,19 @@ public class HibernateOrmConfig {
          * Setting it to true is obviously not recommended in production.
          */
         @ConfigItem
+        @Deprecated
         public boolean bindParam;
 
+        /**
+         * Logs SQL bind parameters.
+         * <p>
+         * Setting it to true is obviously not recommended in production.
+         */
+        @ConfigItem
+        public boolean bindParameters;
+
         public boolean isAnyPropertySet() {
-            return bindParam;
+            return bindParam || bindParameters;
         }
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -566,7 +566,7 @@ public final class HibernateOrmProcessor {
     @BuildStep
     public void produceLoggingCategories(HibernateOrmConfig hibernateOrmConfig,
             BuildProducer<LogCategoryBuildItem> categories) {
-        if (hibernateOrmConfig.log.bindParam) {
+        if (hibernateOrmConfig.log.bindParam || hibernateOrmConfig.log.bindParameters) {
             categories.produce(new LogCategoryBuildItem("org.hibernate.type.descriptor.sql.BasicBinder", Level.TRACE));
         }
     }


### PR DESCRIPTION
bind-param really doesn't look good enough.

Noted while working on the runtime config. Note that this one is still build time anyway as it defines a log level. We should probably adjust Hibernate ORM to make it a per persistence-unit config property as all the other logging properties.