### PR TITLE
Improve pom.xml changes in remote dev mode

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -9,6 +9,7 @@ import static io.vertx.core.file.impl.FileResolver.CACHE_DIR_BASE_PROP_NAME;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -372,6 +373,11 @@ public class VertxCoreRecorder {
                 return threads;
             }
         };
+    }
+
+    public static Supplier<Vertx> recoverFailedStart(VertxConfiguration config) {
+        return vertx = new VertxSupplier(config, Collections.emptyList());
+
     }
 
     static class VertxSupplier implements Supplier<Vertx> {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
@@ -65,6 +65,7 @@ public class HttpRemoteDevClient implements RemoteDevClient {
         private final Thread httpThread;
         private final String url;
         private final URL devUrl;
+        private final URL probeUrl;
         int errorCount;
 
         private Session(RemoteDevState initialState,
@@ -74,6 +75,7 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             this.initialConnectFunction = initialConnectFunction;
             this.changeRequestFunction = changeRequestFunction;
             devUrl = new URL(HttpRemoteDevClient.this.url + RemoteSyncHandler.DEV);
+            probeUrl = new URL(HttpRemoteDevClient.this.url + RemoteSyncHandler.PROBE);
             url = HttpRemoteDevClient.this.url;
             httpThread = new Thread(this, "Remote dev client thread");
             httpThread.start();
@@ -248,7 +250,9 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             }
             while (System.currentTimeMillis() < timeout) {
                 try {
-                    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+                    HttpURLConnection connection = (HttpURLConnection) probeUrl.openConnection();
+                    connection.setRequestMethod("POST");
+                    connection.addRequestProperty(HttpHeaders.CONTENT_TYPE.toString(), RemoteSyncHandler.APPLICATION_QUARKUS);
                     IoUtil.readBytes(connection.getInputStream());
                     return doConnect(initialState, initialConnectFunction);
                 } catch (IOException e) {


### PR DESCRIPTION
Fixes a few issues:

- If startup fails the remote sync handler is not installed
- If startup fails the default executor may not exist
- The JDK client sends malformed q values (.2 instead of 0.2), resteasy rejects this with a bad request exception. This means that the 'restart probe' I was was using of GET '/' could fail, and the client would not reconnect.

Fixes #12497

