### PR TITLE
Fix typos in asciidoc documentation

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -42,7 +42,7 @@ The operation of compiling Java bytecode into a native system-specific machine c
 
 * build time vs runtime in classic Java frameworks
   ** The build time corresponds to all the actions you apply to your Java source files to convert them into something runnable (class files, jar/war, native images).
-  Usually this stage is composed by the compilation, annotation processing, bytecode generation, etc. At this point, everything is under developer's scope and control.
+  Usually this stage is composed by the compilation, annotation processing, bytecode generation, etc. At this point, everything is under the developer's scope and control.
   ** The runtime is all the actions that happen when you execute your application.
   It's obviously focused on starting your business-oriented actions but it relies on a lot of technical actions like loading libraries and configuration files, scanning the application's classpath, configuring the dependency injection, setting up your Object-Relational Mapping, instantiating your REST controllers, etc.
 
@@ -674,7 +674,7 @@ Edsger W. Dijkstra
 ==== Debugging your application build
 
 Since your extension deployment is made during the application build, this process is triggered by your build tool.
-That means if your want to debug this phase you need to launch your build tool with the remote debug mode switched one.
+That means if you want to debug this phase you need to launch your build tool with the remote debug mode switched one.
 
 ===== Maven
 
@@ -718,7 +718,7 @@ By default, Maven will wait for a connection on `localhost:5005`.
 
 === Extension publication
 
-Now that you just finish to build your first extension you should be eager to use it in a Quarkus application! 
+Now that you just finished building your first extension you should be eager to use it in a Quarkus application! 
 
 *Classic Maven publication*
 

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -20,7 +20,7 @@ complete the conversion of these credentials to `SecurityIdentity`.
 
 For example, the credentials may be coming with the HTTP `Authorization` header, client HTTPS certificates or cookies.
 
-`IdentityProvider` verifies the authentication credentials and maps them to `SecurityIdentity` which contains the user name, roles, the original authentication credentials, and other attributes.
+`IdentityProvider` verifies the authentication credentials and maps them to `SecurityIdentity` which contains the username, roles, the original authentication credentials, and other attributes.
 
 For every authenticated resource, you can inject a `SecurityIdentity` instance to get the authenticated identity information.
 

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -180,7 +180,7 @@ concurrency control.
 <2> Then you create an instance that implements `FlightService`. You should not use it directly at this stage because
     access to it is not being managed by the STM subsystem.
 <3> To obtain a managed instance, pass the original object to the STM `container` which then returns a reference
-    through which you will be able perform transactional operations. This reference can be used safely from multiple threads.
+    through which you will be able to perform transactional operations. This reference can be used safely from multiple threads.
 
 == Defining transaction boundaries
 

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -284,7 +284,7 @@ NOTE: If you run `./mvnw clean test` the coverage information will be collected 
 
 == Measuring separately the coverage of each test type
 
-It is not strictly necessary, but let's distinguish the coverage brought by each test type. To do so, we`ll just output the coverage info in two different files, one in `jacoco-ut.exec` and one in `jacoco-it.exec`.
+It is not strictly necessary, but let's distinguish the coverage brought by each test type. To do so, we'll just output the coverage info in two different files, one in `jacoco-ut.exec` and one in `jacoco-it.exec`.
 We also need to generate a separate report for each test execution. Let's adjust the Jacoco configuration for that:
 
 [source,xml,subs=attributes+]

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -701,7 +701,7 @@ In environments with read only file systems you may receive errors of the form:
 java.lang.IllegalStateException: Failed to create cache dir
 ----
 
-Assuming `/tmp/` is writeable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
+Assuming `/tmp/` is writable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
 
 [[reverse-proxy]]
 == Running behind a reverse proxy
@@ -767,7 +767,7 @@ There are many other facets of Quarkus using Vert.x underneath:
 Quarkus integrates it so different beans can interact with asynchronous messages.
 This part is covered in the link:reactive-event-bus[event bus documentation].
 
-* Data streaming and Apache Kafka are a important parts of modern systems.
+* Data streaming and Apache Kafka are an important part of modern systems.
 Quarkus integrates data streaming using Reactive Messaging.
 More details on link:kafka[Interacting with Kafka].
 

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -167,7 +167,7 @@ You can also test your web socket applications using the approach detailed {quic
 
 Quarkus also contains a WebSocket client. You can call `ContainerProvider.getWebSocketContainer().connectToServer` to create a websocket connection.
 
-When you connect to the server you can either pass in the Class of the annotated client endpoint you want to use, or a an instance of `javax.websocket.Endpoint`. If you
+When you connect to the server you can either pass in the Class of the annotated client endpoint you want to use, or an instance of `javax.websocket.Endpoint`. If you
 are using the annotated endpoint then you can use the exact same annotations as you can on the server, except it must be annotated with `@ClientEndpoint` instead of
 `@ServerEndpoint`.
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -321,7 +321,7 @@ These operations should be done at build time and the metamodel be passed to the
 Get a CDI portable extension running::
 The CDI portable extension model is very flexible.
 Too flexible to benefit from the build time boot promoted by Quarkus.
-Most extension we have seen do not make use of these extreme flexibilities capabilities.
+Most extension we have seen do not make use of these extreme flexibility capabilities.
 The way to port a CDI extension to Quarkus is to rewrite it as a Quarkus extension which will define the various beans at build time (deployment time in extension parlance).
 
 == Technical aspect
@@ -380,7 +380,7 @@ TIP: You may want to use the `create-extension` mojo of `io.quarkus:quarkus-mave
 Your runtime artifact should depend on `io.quarkus:quarkus-core`, and possibly the runtime artifacts of other Quarkus
 modules if you want to use functionality provided by them.
 You will also need to include the `io.quarkus:quarkus-bootstrap-maven-plugin` to generate the Quarkus extension descriptor included into the runtime artifact, if you are using the Quarkus parent pom it will automatically inherit the correct configuration.
-Futhermore, you'll need to configure the `maven-compiler-plugin` to detect the `quarkus-extension-processor` annotation processor.
+Furthermore, you'll need to configure the `maven-compiler-plugin` to detect the `quarkus-extension-processor` annotation processor.
 
 NOTE: By convention the deployment time artifact has the `-deployment` suffix, and the runtime artifact
 has no suffix (and is what the end user adds to their project).


### PR DESCRIPTION
Fix for a couple typos I've encountered in the documentation.