### PR TITLE
Add RuntimeInitializedPackageBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedClassBuildItem.java
@@ -2,6 +2,9 @@ package io.quarkus.deployment.builditem.nativeimage;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A class that will be initialized at runtime in native mode.
+ */
 public final class RuntimeInitializedClassBuildItem extends MultiBuildItem {
 
     private final String className;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedPackageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedPackageBuildItem.java
@@ -1,0 +1,19 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A package that will be initialized at runtime in native mode.
+ */
+public final class RuntimeInitializedPackageBuildItem extends MultiBuildItem {
+
+    private final String packageName;
+
+    public RuntimeInitializedPackageBuildItem(String packageName) {
+        this.packageName = packageName;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedPackageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeInitializedPackageBuildItem.java
@@ -4,6 +4,11 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * A package that will be initialized at runtime in native mode.
+ * <p>
+ * WARNING: this build item should not be used in Quarkus itself and is only provided
+ * to simplify the early stages of external extensions development.
+ * <p>
+ * For Quarkus development, please take the time to surgically mark individual classes as runtime initialized.
  */
 public final class RuntimeInitializedPackageBuildItem extends MultiBuildItem {
 

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.extest.runtime.FinalFieldReflectionObject;
 import io.quarkus.extest.runtime.IConfigConsumer;
 import io.quarkus.extest.runtime.RuntimeXmlConfigService;
@@ -67,6 +68,7 @@ import io.quarkus.extest.runtime.config.TestConfigRoot;
 import io.quarkus.extest.runtime.config.TestRunTimeConfig;
 import io.quarkus.extest.runtime.config.XmlConfig;
 import io.quarkus.extest.runtime.logging.AdditionalLogHandlerValueFactory;
+import io.quarkus.extest.runtime.runtimeinitializedpackage.RuntimeInitializedClass;
 import io.quarkus.extest.runtime.subst.DSAPublicKeyObjectSubstitution;
 import io.quarkus.extest.runtime.subst.KeyProxy;
 import io.quarkus.runtime.RuntimeValue;
@@ -466,6 +468,11 @@ public final class TestProcessor {
         if (!Objects.equals("1234", bt.mapMap.get("outer-key").get("inner-key"))) {
             throw new AssertionError("BT map map failed");
         }
+    }
+
+    @BuildStep
+    RuntimeInitializedPackageBuildItem runtimeInitializedPackage() {
+        return new RuntimeInitializedPackageBuildItem(RuntimeInitializedClass.class.getPackage().getName());
     }
 
     @BuildStep(onlyIf = Never.class)

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/runtimeinitializedpackage/RuntimeInitializedClass.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/runtimeinitializedpackage/RuntimeInitializedClass.java
@@ -1,0 +1,5 @@
+package io.quarkus.extest.runtime.runtimeinitializedpackage;
+
+public class RuntimeInitializedClass {
+
+}


### PR DESCRIPTION
Some packages have too many classes to runtime initialize to be practical to list. This exposes the package runtime initialization to extension developers through a `BuildItem` in addition to the configuration.