### PR TITLE
Fix typo in column name

### DIFF
--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -374,7 +374,7 @@ using Docker, run the following commands:
 [source,bash]
 ----
 docker exec -it local-cassandra-instance cqlsh -e "CREATE KEYSPACE IF NOT EXISTS k1 WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}"
-docker exec -it local-cassandra-instance cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(id text, name text, description text, PRIMARY KEY((id), name))"
+docker exec -it local-cassandra-instance cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(store_id text, name text, description text, PRIMARY KEY((store_id), name))"
 ----
 
 If you're running Cassandra locally you can execute the cqlsh commands directly:
@@ -382,7 +382,7 @@ If you're running Cassandra locally you can execute the cqlsh commands directly:
 [source,bash]
 ----
 cqlsh -e "CREATE KEYSPACE IF NOT EXISTS k1 WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}
-cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(id text, name text, description text, PRIMARY KEY((id), name))
+cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(store_id text, name text, description text, PRIMARY KEY((store_id), name))
 ----
 
 == Creating a frontend


### PR DESCRIPTION
The correct name of the column in the Cassandra example is not `id` but `store_id`. The docs in the [original repo](https://github.com/datastax/cassandra-quarkus/tree/master/quickstart) are updated but this guide still has the typo.

Created this new PR as per the message on https://github.com/quarkusio/quarkusio.github.io/pull/774