### PR TITLE
Fix jvm.info metric naming to match micrometer convention

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/JVMInfoBinder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/JVMInfoBinder.java
@@ -8,7 +8,7 @@ public class JVMInfoBinder implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        Counter.builder("jvm_info")
+        Counter.builder("jvm.info")
                 .description("JVM version info")
                 .tags("version", System.getProperty("java.runtime.version", "unknown"),
                         "vendor", System.getProperty("java.vm.vendor", "unknown"),


### PR DESCRIPTION
This patch brings the jvm.info metric in line with other jvm metric names and in line
with general micrometer naming conventions which define "." as the separator.
This will later automatically convert to "_" through a prometheus naming convention if prometheus
export is used. Even in a pure prometheus use-case the difference is relevantas metric mappers
and filters see the original name.