### PR TITLE
Allow disabling the Swagger/GraphQL/Health/OpenAPI UIs at Runtime

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLBuildItem.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class SmallRyeGraphQLBuildItem extends SimpleBuildItem {
+
+    private final String graphqlUiFinalDestination;
+    private final String graphqlUiPath;
+
+    public SmallRyeGraphQLBuildItem(String graphqlUiFinalDestination, String graphqlUiPath) {
+        this.graphqlUiFinalDestination = graphqlUiFinalDestination;
+        this.graphqlUiPath = graphqlUiPath;
+    }
+
+    public String getGraphqlUiFinalDestination() {
+        return graphqlUiFinalDestination;
+    }
+
+    public String getGraphqlUiPath() {
+        return graphqlUiPath;
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLUIConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLUIConfig.java
@@ -19,10 +19,4 @@ public class SmallRyeGraphQLUIConfig {
      */
     @ConfigItem(defaultValue = "false")
     boolean alwaysInclude;
-
-    /**
-     * If GraphQL UI should be enabled. By default, GraphQL UI is enabled.
-     */
-    @ConfigItem(defaultValue = "true")
-    boolean enable;
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLNotFoundHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLNotFoundHandler.java
@@ -1,0 +1,17 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handling static when disabled
+ */
+public class SmallRyeGraphQLNotFoundHandler implements Handler<RoutingContext> {
+
+    @Override
+    public void handle(RoutingContext event) {
+        event.response().setStatusCode(404);
+        event.response().end();
+    }
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "smallrye-graphql", phase = ConfigPhase.RUN_TIME)
+public class SmallRyeGraphQLRuntimeConfig {
+
+    /**
+     * If GraphQL UI should be enabled. By default, GraphQL UI is enabled if it is included (see {@code always-include}).
+     */
+    @ConfigItem(name = "ui.enable", defaultValue = "true")
+    boolean enable;
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLSchemaHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLSchemaHandler.java
@@ -21,13 +21,14 @@ public class SmallRyeGraphQLSchemaHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext event) {
+        HttpServerRequest request = event.request();
+        HttpServerResponse response = event.response();
+
         GraphQLSchema graphQLSchema = CDI.current().select(GraphQLSchema.class).get();
         SchemaPrinter schemaPrinter = CDI.current().select(SchemaPrinter.class).get();
 
         String schemaString = schemaPrinter.print(graphQLSchema);
 
-        HttpServerRequest request = event.request();
-        HttpServerResponse response = event.response();
         if (request.method().equals(HttpMethod.OPTIONS)) {
             response.headers().set(HttpHeaders.ALLOW, ALLOWED_METHODS);
         } else if (request.method().equals(HttpMethod.GET)) {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLStaticHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLStaticHandler.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.StaticHandler;
+
+/**
+ * Handling static Health UI content
+ */
+public class SmallRyeGraphQLStaticHandler implements Handler<RoutingContext> {
+
+    private String graphqlUiFinalDestination;
+    private String graphqlUiPath;
+
+    public SmallRyeGraphQLStaticHandler() {
+    }
+
+    public SmallRyeGraphQLStaticHandler(String graphqlUiFinalDestination, String graphqlUiPath) {
+        this.graphqlUiFinalDestination = graphqlUiFinalDestination;
+        this.graphqlUiPath = graphqlUiPath;
+    }
+
+    public String getGraphqlUiFinalDestination() {
+        return graphqlUiFinalDestination;
+    }
+
+    public void setGraphqlUiFinalDestination(String graphqlUiFinalDestination) {
+        this.graphqlUiFinalDestination = graphqlUiFinalDestination;
+    }
+
+    public String getGraphqlUiPath() {
+        return graphqlUiPath;
+    }
+
+    public void setGraphqlUiPath(String graphqlUiPath) {
+        this.graphqlUiPath = graphqlUiPath;
+    }
+
+    @Override
+    public void handle(RoutingContext event) {
+        StaticHandler staticHandler = StaticHandler.create().setAllowRootFileSystemAccess(true)
+                .setWebRoot(graphqlUiFinalDestination)
+                .setDefaultContentEncoding("UTF-8");
+
+        if (event.normalisedPath().length() == graphqlUiPath.length()) {
+
+            event.response().setStatusCode(302);
+            event.response().headers().set(HttpHeaders.LOCATION, graphqlUiPath + "/");
+            event.response().end();
+            return;
+        } else if (event.normalisedPath().length() == graphqlUiPath.length() + 1) {
+            event.reroute(graphqlUiPath + "/index.html");
+            return;
+        }
+
+        staticHandler.handle(event);
+    }
+
+}

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthBuildItem.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.smallrye.health.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class SmallRyeHealthBuildItem extends SimpleBuildItem {
+
+    private final String healthUiFinalDestination;
+    private final String healthUiPath;
+
+    public SmallRyeHealthBuildItem(String healthUiFinalDestination, String healthUiPath) {
+        this.healthUiFinalDestination = healthUiFinalDestination;
+        this.healthUiPath = healthUiPath;
+    }
+
+    public String getHealthUiFinalDestination() {
+        return healthUiFinalDestination;
+    }
+
+    public String getHealthUiPath() {
+        return healthUiPath;
+    }
+}

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthUIConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthUIConfig.java
@@ -19,9 +19,4 @@ public class SmallRyeHealthUIConfig {
     @ConfigItem(defaultValue = "false")
     boolean alwaysInclude;
 
-    /**
-     * If Health UI should be enabled. By default, Health UI is enabled.
-     */
-    @ConfigItem(defaultValue = "true")
-    boolean enable;
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthNotFoundHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthNotFoundHandler.java
@@ -1,0 +1,17 @@
+package io.quarkus.smallrye.health.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handling static when disabled
+ */
+public class SmallRyeHealthNotFoundHandler implements Handler<RoutingContext> {
+
+    @Override
+    public void handle(RoutingContext event) {
+        event.response().setStatusCode(404);
+        event.response().end();
+    }
+
+}

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthRuntimeConfig.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthRuntimeConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.smallrye.health.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "smallrye-health", phase = ConfigPhase.RUN_TIME)
+public class SmallRyeHealthRuntimeConfig {
+
+    /**
+     * If Health UI should be enabled. By default, Health UI is enabled if it is included (see {@code always-include}).
+     */
+    @ConfigItem(name = "ui.enable", defaultValue = "true")
+    boolean enable;
+}

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthStaticHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthStaticHandler.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.health.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.StaticHandler;
+
+/**
+ * Handling static Health UI content
+ */
+public class SmallRyeHealthStaticHandler implements Handler<RoutingContext> {
+
+    private String healthUiFinalDestination;
+    private String healthUiPath;
+
+    public SmallRyeHealthStaticHandler() {
+    }
+
+    public SmallRyeHealthStaticHandler(String healthUiFinalDestination, String healthUiPath) {
+        this.healthUiFinalDestination = healthUiFinalDestination;
+        this.healthUiPath = healthUiPath;
+    }
+
+    public String getHealthUiFinalDestination() {
+        return healthUiFinalDestination;
+    }
+
+    public void setHealthUiFinalDestination(String healthUiFinalDestination) {
+        this.healthUiFinalDestination = healthUiFinalDestination;
+    }
+
+    public String getHealthUiPath() {
+        return healthUiPath;
+    }
+
+    public void setHealthUiPath(String healthUiPath) {
+        this.healthUiPath = healthUiPath;
+    }
+
+    @Override
+    public void handle(RoutingContext event) {
+        StaticHandler staticHandler = StaticHandler.create().setAllowRootFileSystemAccess(true)
+                .setWebRoot(healthUiFinalDestination)
+                .setDefaultContentEncoding("UTF-8");
+
+        if (event.normalisedPath().length() == healthUiPath.length()) {
+
+            event.response().setStatusCode(302);
+            event.response().headers().set(HttpHeaders.LOCATION, healthUiPath + "/");
+            event.response().end();
+            return;
+        } else if (event.normalisedPath().length() == healthUiPath.length() + 1) {
+            event.reroute(healthUiPath + "/index.html");
+            return;
+        }
+
+        staticHandler.handle(event);
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -19,11 +19,8 @@ import io.vertx.ext.web.RoutingContext;
 public class OpenApiHandler implements Handler<RoutingContext> {
 
     private volatile OpenApiDocumentService openApiDocumentService;
-
     private static final String ALLOWED_METHODS = "GET, HEAD, OPTIONS";
-
     private static final String QUERY_PARAM_FORMAT = "format";
-
     private static final Map<String, String> RESPONSE_HEADERS = new HashMap<>();
 
     static {
@@ -36,13 +33,14 @@ public class OpenApiHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext event) {
-        if (event.request().method().equals(HttpMethod.OPTIONS)) {
-            event.response().headers().setAll(RESPONSE_HEADERS);
-            event.response().headers().set("Allow", ALLOWED_METHODS);
+        HttpServerRequest req = event.request();
+        HttpServerResponse resp = event.response();
+
+        if (req.method().equals(HttpMethod.OPTIONS)) {
+            resp.headers().setAll(RESPONSE_HEADERS);
+            resp.headers().set("Allow", ALLOWED_METHODS);
             event.next();
         } else {
-            HttpServerRequest req = event.request();
-            HttpServerResponse resp = event.response();
             String accept = req.headers().get("Accept");
 
             List<String> formatParams = event.queryParam(QUERY_PARAM_FORMAT);

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiNotFoundHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiNotFoundHandler.java
@@ -1,0 +1,17 @@
+package io.quarkus.smallrye.openapi.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handling not found when disabled
+ */
+public class OpenApiNotFoundHandler implements Handler<RoutingContext> {
+
+    @Override
+    public void handle(RoutingContext event) {
+        event.response().setStatusCode(404);
+        event.response().end();
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -2,9 +2,20 @@ package io.quarkus.smallrye.openapi.runtime;
 
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class OpenApiRecorder {
+
+    public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig) {
+
+        if (runtimeConfig.enable) {
+            return new OpenApiHandler();
+        } else {
+            return new OpenApiNotFoundHandler();
+        }
+    }
 
     public void setupClDevMode(ShutdownContext shutdownContext) {
         OpenApiConstants.classLoader = Thread.currentThread().getContextClassLoader();

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRuntimeConfig.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRuntimeConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.openapi.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "smallrye-openapi", phase = ConfigPhase.RUN_TIME)
+public class OpenApiRuntimeConfig {
+
+    /**
+     * Enable the openapi endpoint. By default it's enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enable;
+
+}

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiBuildItem.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.swaggerui.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class SwaggerUiBuildItem extends SimpleBuildItem {
+
+    private final String swaggerUiFinalDestination;
+    private final String swaggerUiPath;
+
+    public SwaggerUiBuildItem(String swaggerUiFinalDestination, String swaggerUiPath) {
+        this.swaggerUiFinalDestination = swaggerUiFinalDestination;
+        this.swaggerUiPath = swaggerUiPath;
+    }
+
+    public String getSwaggerUiFinalDestination() {
+        return swaggerUiFinalDestination;
+    }
+
+    public String getSwaggerUiPath() {
+        return swaggerUiPath;
+    }
+}

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
@@ -1,0 +1,261 @@
+package io.quarkus.swaggerui.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.openapi.ui.DocExpansion;
+import io.smallrye.openapi.ui.HttpMethod;
+import io.smallrye.openapi.ui.ThemeHref;
+
+@ConfigRoot
+public class SwaggerUiConfig {
+
+    /**
+     * The path where Swagger UI is available.
+     * <p>
+     * The value `/` is not allowed as it blocks the application from serving anything else.
+     */
+    @ConfigItem(defaultValue = "/swagger-ui")
+    String path;
+
+    /**
+     * If this should be included every time. By default this is only included when the application is running
+     * in dev mode.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean alwaysInclude;
+
+    /**
+     * The urls that will be included as options. By default the OpenAPI path will be used.
+     * Here you can override that and supply multiple urls that will appear in the TopBar plugin.
+     */
+    @ConfigItem
+    Map<String, String> urls;
+
+    /**
+     * If urls option is used, this will be the name of the default selection.
+     */
+    @ConfigItem
+    Optional<String> urlsPrimaryName;
+
+    /**
+     * The html title for the page.
+     */
+    @ConfigItem
+    Optional<String> title;
+
+    /**
+     * Swagger UI theme to be used.
+     */
+    @ConfigItem
+    Optional<ThemeHref> theme;
+
+    /**
+     * A footer for the html page. Nothing by default.
+     */
+    @ConfigItem
+    Optional<String> footer;
+
+    /**
+     * If set to true, enables deep linking for tags and operations.
+     */
+    @ConfigItem
+    Optional<Boolean> deepLinking;
+
+    /**
+     * Controls the display of operationId in operations list. The default is false.
+     */
+    @ConfigItem
+    Optional<Boolean> displayOperationId;
+
+    /**
+     * The default expansion depth for models (set to -1 completely hide the models).
+     */
+    @ConfigItem
+    OptionalInt defaultModelsExpandDepth;
+
+    /**
+     * The default expansion depth for the model on the model-example section.
+     */
+    @ConfigItem
+    OptionalInt defaultModelExpandDepth;
+
+    /**
+     * Controls how the model is shown when the API is first rendered.
+     */
+    @ConfigItem
+    Optional<String> defaultModelRendering;
+
+    /**
+     * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
+     */
+    @ConfigItem
+    Optional<Boolean> displayRequestDuration;
+
+    /**
+     * Controls the default expansion setting for the operations and tags.
+     */
+    @ConfigItem
+    Optional<DocExpansion> docExpansion;
+
+    /**
+     * If set, enables filtering. The top bar will show an edit box that you can use to filter the tagged operations that
+     * are shown.
+     * Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the
+     * filter expression.
+     * Filtering is case sensitive matching the filter expression anywhere inside the tag.
+     */
+    @ConfigItem
+    Optional<String> filter;
+
+    /**
+     * If set, limits the number of tagged operations displayed to at most this many. The default is to show all operations.
+     */
+    @ConfigItem
+    OptionalInt maxDisplayedTags;
+
+    /**
+     * Apply a sort to the operation list of each API.
+     * It can be 'alpha' (sort by paths alphanumerically), 'method' (sort by HTTP method) or a function (see
+     * Array.prototype.sort() to know how sort function works).
+     * Default is the order returned by the server unchanged.
+     */
+    @ConfigItem
+    Optional<String> operationsSorter;
+
+    /**
+     * Controls the display of vendor extension (x-) fields and values for Operations, Parameters, and Schema.
+     */
+    @ConfigItem
+    Optional<Boolean> showExtensions;
+
+    /**
+     * Controls the display of extensions (pattern, maxLength, minLength, maximum, minimum) fields and values for
+     * Parameters.
+     */
+    @ConfigItem
+    Optional<Boolean> showCommonExtensions;
+
+    /**
+     * Apply a sort to the tag list of each API.
+     * It can be 'alpha' (sort by paths alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
+     * sort function).
+     * Two tag name strings are passed to the sorter for each pass. Default is the order determined by Swagger UI.
+     */
+    @ConfigItem
+    Optional<String> tagsSorter;
+
+    /**
+     * Provides a mechanism to be notified when Swagger UI has finished rendering a newly provided definition.
+     */
+    @ConfigItem
+    Optional<String> onComplete;
+
+    /**
+     * Set to false to deactivate syntax highlighting of payloads and cURL command, can be otherwise an object with the
+     * activate and theme properties.
+     */
+    @ConfigItem
+    Optional<String> syntaxHighlight;
+
+    /**
+     * OAuth redirect URL.
+     */
+    @ConfigItem
+    Optional<String> oauth2RedirectUrl;
+
+    /**
+     * MUST be a function. Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
+     * Accepts one argument requestInterceptor(request) and must return the modified request, or a Promise that resolves to
+     * the modified request.
+     */
+    @ConfigItem
+    Optional<String> requestInterceptor;
+
+    /**
+     * If set, MUST be an array of command line options available to the curl command.
+     * This can be set on the mutated request in the requestInterceptor function.
+     */
+    @ConfigItem
+    Optional<List<String>> requestCurlOptions;
+
+    /**
+     * MUST be a function. Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
+     * Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves
+     * to the modified response.
+     */
+    @ConfigItem
+    Optional<String> responseInterceptor;
+
+    /**
+     * If set to true, uses the mutated request returned from a requestInterceptor to produce the curl command in the UI,
+     * otherwise the request before the requestInterceptor was applied is used.
+     */
+    @ConfigItem
+    Optional<Boolean> showMutatedRequest;
+
+    /**
+     * List of HTTP methods that have the "Try it out" feature enabled.
+     * An empty array disables "Try it out" for all operations. This does not filter the operations from the display.
+     */
+    @ConfigItem
+    Optional<List<HttpMethod>> supportedSubmitMethods;
+
+    /**
+     * By default, Swagger UI attempts to validate specs against swagger.io's online validator.
+     * You can use this parameter to set a different validator URL, for example for locally deployed validators (Validator
+     * Badge).
+     * Setting it to either none, 127.0.0.1 or localhost will disable validation.
+     */
+    @ConfigItem
+    Optional<String> validatorUrl;
+
+    /**
+     * If set to true, enables passing credentials, as defined in the Fetch standard, in CORS requests that are sent by the
+     * browser.
+     */
+    @ConfigItem
+    Optional<Boolean> withCredentials;
+
+    /**
+     * Function to set default values to each property in model. Accepts one argument modelPropertyMacro(property), property
+     * is immutable
+     */
+    @ConfigItem
+    Optional<String> modelPropertyMacro;
+
+    /**
+     * Function to set default value to parameters. Accepts two arguments parameterMacro(operation, parameter).
+     * Operation and parameter are objects passed for context, both remain immutable
+     */
+    @ConfigItem
+    Optional<String> parameterMacro;
+
+    /**
+     * If set to true, it persists authorization data and it would not be lost on browser close/refresh
+     */
+    @ConfigItem
+    Optional<Boolean> persistAuthorization;
+
+    /**
+     * The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
+     */
+    @ConfigItem
+    Optional<String> layout;
+
+    /**
+     * A list of plugin functions to use in Swagger UI.
+     */
+    @ConfigItem
+    Optional<List<String>> plugins;
+
+    /**
+     * A list of presets to use in Swagger UI.
+     */
+    @ConfigItem
+    Optional<List<String>> presets;
+}

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -3,14 +3,8 @@ package io.quarkus.swaggerui.deployment;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalInt;
 
-import javax.inject.Inject;
-
-import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
 import io.quarkus.deployment.Feature;
@@ -25,15 +19,12 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.WebJarUtil;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
+import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
-import io.smallrye.openapi.ui.DocExpansion;
-import io.smallrye.openapi.ui.HttpMethod;
 import io.smallrye.openapi.ui.IndexCreator;
 import io.smallrye.openapi.ui.Option;
 import io.smallrye.openapi.ui.ThemeHref;
@@ -47,84 +38,89 @@ public class SwaggerUiProcessor {
     private static final String SWAGGER_UI_WEBJAR_PREFIX = "META-INF/resources/openapi-ui/";
     private static final String SWAGGER_UI_FINAL_DESTINATION = "META-INF/swagger-ui-files";
 
-    /**
-     * The configuration for Swagger UI.
-     */
-    SwaggerUiConfig swaggerUiConfig;
-
-    SmallRyeOpenApiConfig openapi;
-
-    @Inject
-    private LaunchModeBuildItem launch;
-
     @BuildStep
-    void feature(BuildProducer<FeatureBuildItem> feature) {
-        if (swaggerUiConfig.enable && (launch.getLaunchMode().isDevOrTest() || swaggerUiConfig.alwaysInclude)) {
+    void feature(BuildProducer<FeatureBuildItem> feature,
+            LaunchModeBuildItem launchMode,
+            SwaggerUiConfig swaggerUiConfig) {
+        if (shouldInclude(launchMode, swaggerUiConfig)) {
             feature.produce(new FeatureBuildItem(Feature.SWAGGER_UI));
         }
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
-    public void registerSwaggerUiServletExtension(SwaggerUiRecorder recorder,
-            BuildProducer<RouteBuildItem> routes,
-            BeanContainerBuildItem container,
+    public void getSwaggerUiFinalDestination(
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
+            BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
             HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
-            CurateOutcomeBuildItem curateOutcomeBuildItem) throws Exception {
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            LaunchModeBuildItem launchMode,
+            SwaggerUiConfig swaggerUiConfig,
+            SmallRyeOpenApiConfig openapi) throws Exception {
 
-        if ("/".equals(swaggerUiConfig.path)) {
-            throw new ConfigurationError(
-                    "quarkus.swagger-ui.path was set to \"/\", this is not allowed as it blocks the application from serving anything else.");
-        }
-
-        if (!swaggerUiConfig.enable) {
-            return;
-        }
-
-        String openApiPath = httpRootPathBuildItem.adjustPath(openapi.path);
-        AppArtifact artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, SWAGGER_UI_WEBJAR_GROUP_ID,
-                SWAGGER_UI_WEBJAR_ARTIFACT_ID);
-
-        if (launch.getLaunchMode().isDevOrTest()) {
-            Path tempPath = WebJarUtil.devOrTest(curateOutcomeBuildItem, launch, artifact, SWAGGER_UI_WEBJAR_PREFIX);
-            // Update index.html
-            WebJarUtil.updateFile(tempPath.resolve("index.html"), generateIndexHtml(openApiPath));
-
-            Handler<RoutingContext> handler = recorder.handler(tempPath.toAbsolutePath().toString(),
-                    httpRootPathBuildItem.adjustPath(swaggerUiConfig.path));
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path, handler));
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*", handler));
-            displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(swaggerUiConfig.path + "/"));
-        } else if (swaggerUiConfig.alwaysInclude) {
-            Map<String, byte[]> files = WebJarUtil.production(curateOutcomeBuildItem, artifact, SWAGGER_UI_WEBJAR_PREFIX);
-            ThemeHref theme = swaggerUiConfig.theme.orElse(ThemeHref.feeling_blue);
-            for (Map.Entry<String, byte[]> file : files.entrySet()) {
-                String fileName = file.getKey();
-                // Make sure to only include the selected theme
-                if (fileName.equals(theme.toString()) || !fileName.startsWith("theme-")) {
-                    byte[] content;
-                    if (fileName.endsWith("index.html")) {
-                        content = generateIndexHtml(openApiPath);
-                    } else {
-                        content = file.getValue();
-                    }
-                    fileName = SWAGGER_UI_FINAL_DESTINATION + "/" + fileName;
-                    generatedResources.produce(new GeneratedResourceBuildItem(fileName, content));
-                    nativeImageResourceBuildItemBuildProducer.produce(new NativeImageResourceBuildItem(fileName));
-                }
+        if (shouldInclude(launchMode, swaggerUiConfig)) {
+            if ("/".equals(swaggerUiConfig.path)) {
+                throw new ConfigurationError(
+                        "quarkus.swagger-ui.path was set to \"/\", this is not allowed as it blocks the application from serving anything else.");
             }
 
-            Handler<RoutingContext> handler = recorder
-                    .handler(SWAGGER_UI_FINAL_DESTINATION, httpRootPathBuildItem.adjustPath(swaggerUiConfig.path));
+            String openApiPath = httpRootPathBuildItem.adjustPath(openapi.path);
+            AppArtifact artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, SWAGGER_UI_WEBJAR_GROUP_ID,
+                    SWAGGER_UI_WEBJAR_ARTIFACT_ID);
+
+            if (launchMode.getLaunchMode().isDevOrTest()) {
+                Path tempPath = WebJarUtil.devOrTest(curateOutcomeBuildItem, launchMode, artifact, SWAGGER_UI_WEBJAR_PREFIX);
+                // Update index.html
+                WebJarUtil.updateFile(tempPath.resolve("index.html"), generateIndexHtml(openApiPath, swaggerUiConfig));
+
+                swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(tempPath.toAbsolutePath().toString(),
+                        httpRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
+                displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(swaggerUiConfig.path + "/"));
+            } else {
+                Map<String, byte[]> files = WebJarUtil.production(curateOutcomeBuildItem, artifact, SWAGGER_UI_WEBJAR_PREFIX);
+                ThemeHref theme = swaggerUiConfig.theme.orElse(ThemeHref.feeling_blue);
+                for (Map.Entry<String, byte[]> file : files.entrySet()) {
+                    String fileName = file.getKey();
+                    // Make sure to only include the selected theme
+                    if (fileName.equals(theme.toString()) || !fileName.startsWith("theme-")) {
+                        byte[] content;
+                        if (fileName.endsWith("index.html")) {
+                            content = generateIndexHtml(openApiPath, swaggerUiConfig);
+                        } else {
+                            content = file.getValue();
+                        }
+                        fileName = SWAGGER_UI_FINAL_DESTINATION + "/" + fileName;
+                        generatedResources.produce(new GeneratedResourceBuildItem(fileName, content));
+                        nativeImageResourceBuildItemBuildProducer.produce(new NativeImageResourceBuildItem(fileName));
+                    }
+                }
+                swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(SWAGGER_UI_FINAL_DESTINATION,
+                        httpRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
+            }
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void registerSwaggerUiHandler(SwaggerUiRecorder recorder,
+            BuildProducer<RouteBuildItem> routes,
+            SwaggerUiBuildItem finalDestinationBuildItem,
+            SwaggerUiRuntimeConfig runtimeConfig,
+            LaunchModeBuildItem launchMode,
+            SwaggerUiConfig swaggerUiConfig) throws Exception {
+
+        if (shouldInclude(launchMode, swaggerUiConfig)) {
+            Handler<RoutingContext> handler = recorder.handler(finalDestinationBuildItem.getSwaggerUiFinalDestination(),
+                    finalDestinationBuildItem.getSwaggerUiPath(),
+                    runtimeConfig);
+
             routes.produce(new RouteBuildItem(swaggerUiConfig.path, handler));
             routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*", handler));
         }
     }
 
-    private byte[] generateIndexHtml(String openApiPath) throws IOException {
+    private byte[] generateIndexHtml(String openApiPath, SwaggerUiConfig swaggerUiConfig) throws IOException {
         Map<Option, String> options = new HashMap<>();
         Map<String, String> urlsMap = null;
 
@@ -274,257 +270,7 @@ public class SwaggerUiProcessor {
         return IndexCreator.createIndexHtml(urlsMap, swaggerUiConfig.urlsPrimaryName.orElse(null), options);
     }
 
-    @ConfigRoot
-    static final class SwaggerUiConfig {
-        /**
-         * The path where Swagger UI is available.
-         * <p>
-         * The value `/` is not allowed as it blocks the application from serving anything else.
-         */
-        @ConfigItem(defaultValue = "/swagger-ui")
-        String path;
-
-        /**
-         * If this should be included every time. By default this is only included when the application is running
-         * in dev mode.
-         */
-        @ConfigItem
-        boolean alwaysInclude;
-
-        /**
-         * If Swagger UI should be enabled. By default, Swagger UI is enabled.
-         */
-        @ConfigItem(defaultValue = "true")
-        boolean enable;
-
-        /**
-         * The urls that will be included as options. By default the OpenAPI path will be used.
-         * Here you can override that and supply multiple urls that will appear in the TopBar plugin.
-         */
-        @ConfigItem
-        Map<String, String> urls;
-
-        /**
-         * If urls option is used, this will be the name of the default selection.
-         */
-        @ConfigItem
-        Optional<String> urlsPrimaryName;
-
-        /**
-         * The html title for the page.
-         */
-        @ConfigItem
-        Optional<String> title;
-
-        /**
-         * Swagger UI theme to be used.
-         */
-        @ConfigItem
-        Optional<ThemeHref> theme;
-
-        /**
-         * A footer for the html page. Nothing by default.
-         */
-        @ConfigItem
-        Optional<String> footer;
-
-        /**
-         * If set to true, enables deep linking for tags and operations.
-         */
-        @ConfigItem
-        Optional<Boolean> deepLinking;
-
-        /**
-         * Controls the display of operationId in operations list. The default is false.
-         */
-        @ConfigItem
-        Optional<Boolean> displayOperationId;
-
-        /**
-         * The default expansion depth for models (set to -1 completely hide the models).
-         */
-        @ConfigItem
-        OptionalInt defaultModelsExpandDepth;
-
-        /**
-         * The default expansion depth for the model on the model-example section.
-         */
-        @ConfigItem
-        OptionalInt defaultModelExpandDepth;
-
-        /**
-         * Controls how the model is shown when the API is first rendered.
-         */
-        @ConfigItem
-        Optional<String> defaultModelRendering;
-
-        /**
-         * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
-         */
-        @ConfigItem
-        Optional<Boolean> displayRequestDuration;
-
-        /**
-         * Controls the default expansion setting for the operations and tags.
-         */
-        @ConfigItem
-        Optional<DocExpansion> docExpansion;
-
-        /**
-         * If set, enables filtering. The top bar will show an edit box that you can use to filter the tagged operations that
-         * are shown.
-         * Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the
-         * filter expression.
-         * Filtering is case sensitive matching the filter expression anywhere inside the tag.
-         */
-        @ConfigItem
-        Optional<String> filter;
-
-        /**
-         * If set, limits the number of tagged operations displayed to at most this many. The default is to show all operations.
-         */
-        @ConfigItem
-        OptionalInt maxDisplayedTags;
-
-        /**
-         * Apply a sort to the operation list of each API.
-         * It can be 'alpha' (sort by paths alphanumerically), 'method' (sort by HTTP method) or a function (see
-         * Array.prototype.sort() to know how sort function works).
-         * Default is the order returned by the server unchanged.
-         */
-        @ConfigItem
-        Optional<String> operationsSorter;
-
-        /**
-         * Controls the display of vendor extension (x-) fields and values for Operations, Parameters, and Schema.
-         */
-        @ConfigItem
-        Optional<Boolean> showExtensions;
-
-        /**
-         * Controls the display of extensions (pattern, maxLength, minLength, maximum, minimum) fields and values for
-         * Parameters.
-         */
-        @ConfigItem
-        Optional<Boolean> showCommonExtensions;
-
-        /**
-         * Apply a sort to the tag list of each API.
-         * It can be 'alpha' (sort by paths alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
-         * sort function).
-         * Two tag name strings are passed to the sorter for each pass. Default is the order determined by Swagger UI.
-         */
-        @ConfigItem
-        Optional<String> tagsSorter;
-
-        /**
-         * Provides a mechanism to be notified when Swagger UI has finished rendering a newly provided definition.
-         */
-        @ConfigItem
-        Optional<String> onComplete;
-
-        /**
-         * Set to false to deactivate syntax highlighting of payloads and cURL command, can be otherwise an object with the
-         * activate and theme properties.
-         */
-        @ConfigItem
-        Optional<String> syntaxHighlight;
-
-        /**
-         * OAuth redirect URL.
-         */
-        @ConfigItem
-        Optional<String> oauth2RedirectUrl;
-
-        /**
-         * MUST be a function. Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
-         * Accepts one argument requestInterceptor(request) and must return the modified request, or a Promise that resolves to
-         * the modified request.
-         */
-        @ConfigItem
-        Optional<String> requestInterceptor;
-
-        /**
-         * If set, MUST be an array of command line options available to the curl command.
-         * This can be set on the mutated request in the requestInterceptor function.
-         */
-        @ConfigItem
-        Optional<List<String>> requestCurlOptions;
-
-        /**
-         * MUST be a function. Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
-         * Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves
-         * to the modified response.
-         */
-        @ConfigItem
-        Optional<String> responseInterceptor;
-
-        /**
-         * If set to true, uses the mutated request returned from a requestInterceptor to produce the curl command in the UI,
-         * otherwise the request before the requestInterceptor was applied is used.
-         */
-        @ConfigItem
-        Optional<Boolean> showMutatedRequest;
-
-        /**
-         * List of HTTP methods that have the "Try it out" feature enabled.
-         * An empty array disables "Try it out" for all operations. This does not filter the operations from the display.
-         */
-        @ConfigItem
-        Optional<List<HttpMethod>> supportedSubmitMethods;
-
-        /**
-         * By default, Swagger UI attempts to validate specs against swagger.io's online validator.
-         * You can use this parameter to set a different validator URL, for example for locally deployed validators (Validator
-         * Badge).
-         * Setting it to either none, 127.0.0.1 or localhost will disable validation.
-         */
-        @ConfigItem
-        Optional<String> validatorUrl;
-
-        /**
-         * If set to true, enables passing credentials, as defined in the Fetch standard, in CORS requests that are sent by the
-         * browser.
-         */
-        @ConfigItem
-        Optional<Boolean> withCredentials;
-
-        /**
-         * Function to set default values to each property in model. Accepts one argument modelPropertyMacro(property), property
-         * is immutable
-         */
-        @ConfigItem
-        Optional<String> modelPropertyMacro;
-
-        /**
-         * Function to set default value to parameters. Accepts two arguments parameterMacro(operation, parameter).
-         * Operation and parameter are objects passed for context, both remain immutable
-         */
-        @ConfigItem
-        Optional<String> parameterMacro;
-
-        /**
-         * If set to true, it persists authorization data and it would not be lost on browser close/refresh
-         */
-        @ConfigItem
-        Optional<Boolean> persistAuthorization;
-
-        /**
-         * The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
-         */
-        @ConfigItem
-        Optional<String> layout;
-
-        /**
-         * A list of plugin functions to use in Swagger UI.
-         */
-        @ConfigItem
-        Optional<List<String>> plugins;
-
-        /**
-         * A list of presets to use in Swagger UI.
-         */
-        @ConfigItem
-        Optional<List<String>> presets;
+    private static boolean shouldInclude(LaunchModeBuildItem launchMode, SwaggerUiConfig swaggerUiConfig) {
+        return launchMode.getLaunchMode().isDevOrTest() || swaggerUiConfig.alwaysInclude;
     }
 }

--- a/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiNotFoundHandler.java
+++ b/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiNotFoundHandler.java
@@ -1,0 +1,17 @@
+package io.quarkus.swaggerui.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handling static when disabled
+ */
+public class SwaggerUiNotFoundHandler implements Handler<RoutingContext> {
+
+    @Override
+    public void handle(RoutingContext event) {
+        event.response().setStatusCode(404);
+        event.response().end();
+    }
+
+}

--- a/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRecorder.java
+++ b/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRecorder.java
@@ -2,34 +2,18 @@ package io.quarkus.swaggerui.runtime;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.StaticHandler;
 
 @Recorder
 public class SwaggerUiRecorder {
-    public Handler<RoutingContext> handler(String swaggerUiFinalDestination, String swaggerUiPath) {
 
-        StaticHandler staticHandler = StaticHandler.create().setAllowRootFileSystemAccess(true)
-                .setWebRoot(swaggerUiFinalDestination)
-                .setDefaultContentEncoding("UTF-8");
+    public Handler<RoutingContext> handler(String swaggerUiFinalDestination, String swaggerUiPath,
+            SwaggerUiRuntimeConfig runtimeConfig) {
 
-        return new Handler<RoutingContext>() {
-            @Override
-            public void handle(RoutingContext event) {
-                if (event.normalisedPath().length() == swaggerUiPath.length()) {
-
-                    event.response().setStatusCode(302);
-                    event.response().headers().set(HttpHeaders.LOCATION, swaggerUiPath + "/");
-                    event.response().end();
-                    return;
-                } else if (event.normalisedPath().length() == swaggerUiPath.length() + 1) {
-                    event.reroute(swaggerUiPath + "/index.html");
-                    return;
-                }
-
-                staticHandler.handle(event);
-            }
-        };
+        if (runtimeConfig.enable) {
+            return new SwaggerUiStaticHandler(swaggerUiFinalDestination, swaggerUiPath);
+        } else {
+            return new SwaggerUiNotFoundHandler();
+        }
     }
 }

--- a/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRuntimeConfig.java
+++ b/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRuntimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.swaggerui.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class SwaggerUiRuntimeConfig {
+
+    /**
+     * If Swagger UI is included, it should be enabled/disabled. By default, Swagger UI is enabled if it is included (see
+     * {@code always-include}).
+     */
+    @ConfigItem(defaultValue = "true")
+    boolean enable;
+
+}

--- a/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiStaticHandler.java
+++ b/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiStaticHandler.java
@@ -1,0 +1,59 @@
+package io.quarkus.swaggerui.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.StaticHandler;
+
+/**
+ * Handling static Swagger UI content
+ */
+public class SwaggerUiStaticHandler implements Handler<RoutingContext> {
+
+    private String swaggerUiFinalDestination;
+    private String swaggerUiPath;
+
+    public SwaggerUiStaticHandler() {
+    }
+
+    public SwaggerUiStaticHandler(String swaggerUiFinalDestination, String swaggerUiPath) {
+        this.swaggerUiFinalDestination = swaggerUiFinalDestination;
+        this.swaggerUiPath = swaggerUiPath;
+    }
+
+    public String getSwaggerUiFinalDestination() {
+        return swaggerUiFinalDestination;
+    }
+
+    public void setSwaggerUiFinalDestination(String swaggerUiFinalDestination) {
+        this.swaggerUiFinalDestination = swaggerUiFinalDestination;
+    }
+
+    public String getSwaggerUiPath() {
+        return swaggerUiPath;
+    }
+
+    public void setSwaggerUiPath(String swaggerUiPath) {
+        this.swaggerUiPath = swaggerUiPath;
+    }
+
+    @Override
+    public void handle(RoutingContext event) {
+        StaticHandler staticHandler = StaticHandler.create().setAllowRootFileSystemAccess(true)
+                .setWebRoot(swaggerUiFinalDestination)
+                .setDefaultContentEncoding("UTF-8");
+
+        if (event.normalisedPath().length() == swaggerUiPath.length()) {
+            event.response().setStatusCode(302);
+            event.response().headers().set(HttpHeaders.LOCATION, swaggerUiPath + "/");
+            event.response().end();
+            return;
+        } else if (event.normalisedPath().length() == swaggerUiPath.length() + 1) {
+            event.reroute(swaggerUiPath + "/index.html");
+            return;
+        }
+
+        staticHandler.handle(event);
+    }
+
+}


### PR DESCRIPTION
Fix #12942

This PR adds a Runtime config option to deactivate the
* Swagger UI (if the UI is included)
* GraphQL UI (if the UI is included) and GraphQL Schema
* Health UI (if the UI is included)
* OpenAPI Schema

As a example, if you build a REST Application with Swagger UI and you do a `quarkus.swagger-ui.always-include=true`, meaning that the UI will be included in the jar artefact, you can still disable the ui by starting the app:

`java -jar -Dquarkus.swagger-ui.enable=false target/yourapp-1.0.0-SNAPSHOT-runner.jar`

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>