### PR TITLE
Avoid retaining empty instances of HashSet

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CollectionHelpers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CollectionHelpers.java
@@ -1,0 +1,29 @@
+package io.quarkus.arc.impl;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Inspired from Hibernate Validator: a couple tricks
+ * to minimize retained memory from long living, small collections.
+ */
+final class CollectionHelpers {
+
+    CollectionHelpers() {
+        //do not instantiate
+    }
+
+    static <T> Set<T> toImmutableSmallSet(Set<T> set) {
+        if (set == null)
+            return null;
+        switch (set.size()) {
+            case 0:
+                return Collections.emptySet();
+            case 1:
+                return Collections.singleton(set.iterator().next());
+            default:
+                return Collections.unmodifiableSet(set);
+        }
+    }
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
@@ -184,7 +184,7 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
 
         AnnotatedBase(Type baseType, Set<Annotation> annotations) {
             this.baseType = baseType;
-            this.annotations = annotations;
+            this.annotations = CollectionHelpers.toImmutableSmallSet(annotations);
         }
 
         @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
@@ -231,7 +231,7 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
             if (annotations == null) {
                 throw new UnsupportedOperationException();
             }
-            return Collections.unmodifiableSet(annotations);
+            return annotations;
         }
 
         @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
@@ -89,7 +89,7 @@ public final class Qualifiers {
         Set<Annotation> qualifiers = new HashSet<>();
         qualifiers.add(Default.Literal.INSTANCE);
         qualifiers.add(Any.Literal.INSTANCE);
-        return qualifiers;
+        return Collections.unmodifiableSet(qualifiers);
     }
 
     private static Object invoke(Method method, Object instance) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
@@ -4,7 +4,6 @@ import io.quarkus.arc.InjectableBean.Kind;
 import io.quarkus.arc.RemovedBean;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.Set;
 
 public final class RemovedBeanImpl implements RemovedBean {
@@ -17,8 +16,9 @@ public final class RemovedBeanImpl implements RemovedBean {
     public RemovedBeanImpl(Kind kind, String description, Set<Type> types, Set<Annotation> qualifiers) {
         this.kind = kind != null ? kind : Kind.CLASS;
         this.description = description;
-        this.types = Collections.unmodifiableSet(types);
-        this.qualifiers = qualifiers != null ? Collections.unmodifiableSet(qualifiers) : Qualifiers.DEFAULT_QUALIFIERS;
+        this.types = CollectionHelpers.toImmutableSmallSet(types);
+        this.qualifiers = qualifiers != null ? CollectionHelpers.toImmutableSmallSet(qualifiers)
+                : Qualifiers.DEFAULT_QUALIFIERS;
     }
 
     @Override


### PR DESCRIPTION
This is a very minor improvement; spotted it while browsing heap dumps:

apparently a Quarkus application is retaining a good amount of references to empty sets. We can trivially get rid of them.