### PR TITLE
Support micrometer StatsD meter registry

### DIFF
--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -317,6 +317,32 @@ In this example, a singleton CDI bean will produce two different `MeterFilter` b
 Prometheus `MeterRegistry` instances (using the `@MeterFilterConstraint` qualifier), and another will be applied
 to all `MeterRegistry` instances. An application configuration property is also injected and used as a tag value.
 
+== Creating a customized MeterRegistry
+
+In some instances, you may want to customize how your registry is intialized. Use a custom `@Produces` 
+method to create and produce your initialized `MeterRegistry`.
+
+The following example customizes the line format used for StatsD. 
+
+[source,java]
+----
+@Produces
+@Singleton
+public StatsdMeterRegistry createStatsdMeterRegistry(StatsdConfig statsdConfig, Clock clock) {
+    // define what to do with lines
+    Consumer<String> lineLogger = line -> logger.info(line);
+
+    // inject a configuration object, and then customize the line builder
+    return StatsdMeterRegistry.builder(statsdConfig)
+          .clock(clock)
+          .lineSink(lineLogger)
+          .build();
+}
+----
+
+This example corresponds to the following instructions in the Micrometer documentation: 
+https://micrometer.io/docs/registry/statsD#_customizing_the_metrics_sink
+
 == Support for the MicroProfile Metrics API
 
 If you use the MicroProfile Metrics API in your application, the Micrometer extension will create an adaptive

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>micrometer-registry-stackdriver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-statsd</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/AzureMonitorRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/AzureMonitorRegistryProcessor.java
@@ -7,6 +7,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
@@ -32,7 +33,13 @@ public class AzureMonitorRegistryProcessor {
         }
     }
 
-    @BuildStep(onlyIf = AzureMonitorEnabled.class)
+    @BuildStep(onlyIf = { NativeBuild.class, AzureMonitorEnabled.class })
+    MicrometerRegistryProviderBuildItem nativeModeNotSupported() {
+        log.info("The Azure Monitor meter registry does not support running in native mode.");
+        return null;
+    }
+
+    @BuildStep(onlyIf = AzureMonitorEnabled.class, onlyIfNot = NativeBuild.class)
     MicrometerRegistryProviderBuildItem createAzureMonitorRegistry(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 
         // Add the AzureMonitor Registry Producer

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/StackdriverRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/StackdriverRegistryProcessor.java
@@ -34,8 +34,8 @@ public class StackdriverRegistryProcessor {
     }
 
     @BuildStep(onlyIf = { NativeBuild.class, StackdriverEnabled.class })
-    MicrometerRegistryProviderBuildItem createStackdriverRegistry(CombinedIndexBuildItem index) {
-        log.info("Stackdriver does not support running in native mode.");
+    MicrometerRegistryProviderBuildItem nativeModeNotSupported() {
+        log.info("The Stackdriver meter registry does not support running in native mode.");
         return null;
     }
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
@@ -28,6 +28,7 @@ public class AllRegistriesDisabledTest {
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.signalfx.enabled", "false")
             .overrideConfigKey("quarkus.micrometer.export.stackdriver.enabled", "false")
+            .overrideConfigKey("quarkus.micrometer.export.statsd.enabled", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SignalFxEnabledInvalidTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SignalFxEnabledInvalidTest.java
@@ -19,7 +19,7 @@ public class SignalFxEnabledInvalidTest {
             .overrideConfigKey("quarkus.micrometer.export.signalfx.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(StackdriverRegistryProcessor.REGISTRY_CLASS))
+                    .addClass(SignalFxRegistryProcessor.REGISTRY_CLASS))
             .setLogRecordPredicate(r -> "io.quarkus.micrometer.runtime.export.ConfigAdapter".equals(r.getLoggerName()))
             .assertLogRecords(r -> Util.assertMessage(testedAttribute, r))
             .assertException(t -> {

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SignalFxEnabledInvalidUriTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/SignalFxEnabledInvalidUriTest.java
@@ -21,7 +21,7 @@ public class SignalFxEnabledInvalidUriTest {
             .overrideConfigKey("quarkus.micrometer.export.signalfx.uri", "intentionally-bad-uri")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(StackdriverRegistryProcessor.REGISTRY_CLASS))
+                    .addClass(SignalFxRegistryProcessor.REGISTRY_CLASS))
             .setLogRecordPredicate(r -> "io.quarkus.micrometer.runtime.export.ConfigAdapter".equals(r.getLoggerName()))
             .assertLogRecords(r -> Util.assertMessage(testedAttribute, r))
             .assertException(t -> Assertions.assertEquals(ValidationException.class.getName(), t.getClass().getName(),

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/StatsdEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/StatsdEnabledTest.java
@@ -15,29 +15,29 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class SignalFxEnabledTest {
-    static final String REGISTRY_CLASS_NAME = "io.micrometer.signalfx.SignalFxMeterRegistry";
+public class StatsdEnabledTest {
+    static final String REGISTRY_CLASS_NAME = "io.micrometer.statsd.StatsdMeterRegistry";
     static final Class<?> REGISTRY_CLASS = MicrometerRecorder.getClassForName(REGISTRY_CLASS_NAME);
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withConfigurationResource("test-logging.properties")
             .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
-            .overrideConfigKey("quarkus.micrometer.export.signalfx.enabled", "true")
-            .overrideConfigKey("quarkus.micrometer.export.signalfx.access-token", "required")
+            .overrideConfigKey("quarkus.micrometer.export.statsd.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.export.statsd.publish", "false")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(SignalFxRegistryProcessor.REGISTRY_CLASS));
+                    .addClass(StatsdRegistryProcessor.REGISTRY_CLASS));
 
     @Inject
     MeterRegistry registry;
 
     @Test
     public void testMeterRegistryPresent() {
-        // SignalFx is enabled (alone, all others disabled)
+        // Stackdriver is enabled (alone, all others disabled)
         Assertions.assertNotNull(registry, "A registry should be configured");
         Set<MeterRegistry> subRegistries = ((CompositeMeterRegistry) registry).getRegistries();
         Assertions.assertEquals(REGISTRY_CLASS, subRegistries.iterator().next().getClass(),
-                "Should be SignalFxMeterRegistry");
+                "Should be StatsdMeterRegistry");
     }
 }

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>micrometer-registry-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-statsd</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Dependencies for Binding (optional) -->
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
@@ -123,6 +123,7 @@ public final class MicrometerConfig {
         public PrometheusConfig prometheus;
         public SignalFxConfig signalfx;
         public StackdriverConfig stackdriver;
+        public StatsdConfig statsd;
     }
 
     public static interface CapabilityEnabled {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/StatsdConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/StatsdConfig.java
@@ -1,0 +1,32 @@
+package io.quarkus.micrometer.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class StatsdConfig implements MicrometerConfig.CapabilityEnabled {
+    /**
+     * Support for export to StatsD.
+     * <p>
+     * Support for StatsD will be enabled if micrometer
+     * support is enabled, the StatsFxMeterRegistry is on the classpath
+     * and either this value is true, or this value is unset and
+     * {@code quarkus.micrometer.registry-enabled-default} is true.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled;
+
+    @Override
+    public Optional<Boolean> getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName()
+                + "{enabled=" + enabled
+                + '}';
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/ExportConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/ExportConfig.java
@@ -9,13 +9,14 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 /**
  * Runtime configuration for Micrometer meter registries.
  */
+@SuppressWarnings("unused")
 @ConfigRoot(name = "micrometer.export", phase = ConfigPhase.RUN_TIME)
 public class ExportConfig {
     // @formatter:off
     /**
      * Azure Monitor registry configuration properties.
      * <p>
-     * A property source for configuration of the AzureMonitor MeterRegistry,
+     * A property source for configuration of the AzureMonitor MeterRegistry.
      *
      * Available values:
      *
@@ -39,7 +40,7 @@ public class ExportConfig {
 
     // @formatter:off
     /**
-     * Datadog MeterRegistry configuration
+     * Datadog MeterRegistry configuration properties.
      * <p>
      * A property source for configuration of the Datadog MeterRegistry to push
      * metrics using the Datadog API, see https://micrometer.io/docs/registry/datadog.
@@ -165,4 +166,54 @@ public class ExportConfig {
     // @formatter:on
     @ConfigItem
     Map<String, String> stackdriver;
+
+    // @formatter:off
+    /**
+     * StatsD registry configuration properties.
+     * <p>
+     * A property source for configuration of the StatsD MeterRegistry,
+     * see https://micrometer.io/docs/registry/statsD.
+     *
+     * Available values:
+     *
+     * [cols=2]
+     * !===
+     * h!Property=Default
+     * h!Description
+     *
+     * !`flavor=datadog`
+     * !Specify the flavor of the StatsD line protocol. The original StatsD line protocol
+     * specification is `etsy`. The default value is `datadog`.
+     *
+     * !`host=localhost`
+     * !The host name of the StatsD agent.
+     *
+     * !`maxPacketLength=1400`
+     * !Adjust the packet length to keep the payload within your network's MTU.
+     *
+     * !`port=8125`
+     * !The port of the StatsD agent`.
+     *
+     * !`protocol=UDP`
+     * !The protocol of the connection to the agent (UDP or TCP).
+     *
+     * !`publish=true`
+     * !By default, gathered metrics will be published to StatsD when the MeterRegistry is enabled.
+     * Use this attribute to selectively disable publication of metrics in some environments.
+     *
+     * !`step=1m`
+     * !The interval at which metrics are sent to StatsD Monitoring. The default is 1 minute.
+     * !===
+     *
+     * Other micrometer configuration attributes can also be specified.
+     *
+     * As mentioned in the Micrometer StatsD documentation, if you want to customize the metrics
+     * sink, do so by providing your own `StatsDMeterRegistry` instance using a CDI `@Produces`
+     * method.
+     *
+     * @asciidoclet
+     */
+    // @formatter:on
+    @ConfigItem
+    Map<String, String> statsd;
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/StackdriverMeterRegistryProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/StackdriverMeterRegistryProvider.java
@@ -29,7 +29,7 @@ public class StackdriverMeterRegistryProvider {
         final Map<String, String> properties = ConfigAdapter.captureProperties(config, PREFIX);
 
         // Special check: if publish is set, override the value of enabled
-        // Specifically, the stackdriver registry must be enabled for this
+        // Specifically, the StackDriver registry must be enabled for this
         // Provider to even be present. If this instance (at runtime) wants
         // to prevent metrics from being published, then it would set
         // quarkus.micrometer.export.stackdriver.publish=false

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/StatsdMeterRegistryProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/StatsdMeterRegistryProvider.java
@@ -1,0 +1,52 @@
+package io.quarkus.micrometer.runtime.export;
+
+import java.util.Map;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.logging.Logger;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdMeterRegistry;
+import io.quarkus.arc.DefaultBean;
+
+@Singleton
+public class StatsdMeterRegistryProvider {
+    private static final Logger log = Logger.getLogger(StatsdMeterRegistryProvider.class);
+
+    static final String PREFIX = "quarkus.micrometer.export.statsd.";
+    static final String PUBLISH = "statsd.publish";
+    static final String ENABLED = "statsd.enabled";
+
+    @Produces
+    @Singleton
+    @DefaultBean
+    public StatsdConfig configure(Config config) {
+        final Map<String, String> properties = ConfigAdapter.captureProperties(config, PREFIX);
+
+        // Special check: if publish is set, override the value of enabled
+        // Specifically, the StatsD registry must be enabled for this
+        // Provider to even be present. If this instance (at runtime) wants
+        // to prevent metrics from being published, then it would set
+        // quarkus.micrometer.export.statsd.publish=false
+        if (properties.containsKey(PUBLISH)) {
+            properties.put(ENABLED, properties.get(PUBLISH));
+        }
+
+        return ConfigAdapter.validate(new StatsdConfig() {
+            @Override
+            public String get(String key) {
+                return properties.get(key);
+            }
+        });
+    }
+
+    @Produces
+    @Singleton
+    public StatsdMeterRegistry registry(StatsdConfig config, Clock clock) {
+        return new StatsdMeterRegistry(config, clock);
+    }
+}

--- a/integration-tests/micrometer-native/pom.xml
+++ b/integration-tests/micrometer-native/pom.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-micrometer-native</artifactId>
+    <name>Quarkus - Integration Tests - Micrometer Native</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+
+        <!-- Do not use Resteasy! Deliberately focused on vertx-web alone -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-azure-monitor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-datadog</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-signalfx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-stackdriver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-statsd</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/micrometer-native/src/main/java/io/quarkus/it/micrometer/native_mode/MessageResource.java
+++ b/integration-tests/micrometer-native/src/main/java/io/quarkus/it/micrometer/native_mode/MessageResource.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.micrometer.native_mode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.core.http.HttpMethod;
+
+@RouteBase(path = "/message")
+public class MessageResource {
+
+    private final MeterRegistry registry;
+
+    public MessageResource(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Route(path = "ping", methods = HttpMethod.GET)
+    public List<String> message() {
+        CompositeMeterRegistry compositeMeterRegistry = (CompositeMeterRegistry) registry;
+        Set<MeterRegistry> subRegistries = compositeMeterRegistry.getRegistries();
+
+        List<String> names = new ArrayList(subRegistries.size());
+        subRegistries.forEach(x -> names.add(x.getClass().getName()));
+        return names;
+    }
+
+    @Route(path = "fail", methods = HttpMethod.GET)
+    public String fail() {
+        throw new RuntimeException("Failed on purpose");
+    }
+}

--- a/integration-tests/micrometer-native/src/main/resources/application.properties
+++ b/integration-tests/micrometer-native/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+quarkus.log.category."io.quarkus.bootstrap".level=INFO
+quarkus.log.category."io.quarkus.netty".level=INFO
+quarkus.log.category."io.quarkus.resteasy.runtime".level=INFO
+
+quarkus.log.category."io.netty".level=INFO
+quarkus.log.category."org.apache".level=INFO
+
+deployment.env=test
+
+quarkus.micrometer.export.azuremonitor.instrumentation-key=dummy
+quarkus.micrometer.export.datadog.apiKey=dummy
+quarkus.micrometer.export.signalfx.access-token=dummy
+quarkus.micrometer.export.stackdriver.project-id=dummy
+quarkus.micrometer.export.statsd.publish=false

--- a/integration-tests/micrometer-native/src/test/java/io/quarkus/it/micrometer/native_mode/NativeMeterRegistriesIT.java
+++ b/integration-tests/micrometer-native/src/test/java/io/quarkus/it/micrometer/native_mode/NativeMeterRegistriesIT.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.micrometer.native_mode;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.NativeImageTest;
+import io.restassured.response.Response;
+
+@NativeImageTest
+class NativeMeterRegistriesIT extends NativeMeterRegistriesTest {
+
+    @Test
+    @Override
+    void testRegistryInjection() {
+        // We expect all 6 registries on the classpath to be initialized
+        Response response = given()
+                .when().get("/message/ping");
+
+        Assertions.assertEquals(200, response.statusCode());
+
+        List<Object> registries = response.jsonPath().getList("$");
+        MatcherAssert.assertThat(registries, Matchers.containsInAnyOrder(
+                "io.micrometer.datadog.DatadogMeterRegistry"));
+
+        MatcherAssert.assertThat(registries, Matchers.not(Matchers.containsInAnyOrder(
+                "io.micrometer.azuremonitor.AzureMonitorMeterRegistry",
+                "io.micrometer.jmx.JmxMeterRegistry",
+                "io.micrometer.signalfx.SignalFxMeterRegistry",
+                "io.micrometer.stackdriver.StackdriverMeterRegistry",
+                "io.micrometer.statsd.StatsdMeterRegistry")));
+    }
+}

--- a/integration-tests/micrometer-native/src/test/java/io/quarkus/it/micrometer/native_mode/NativeMeterRegistriesTest.java
+++ b/integration-tests/micrometer-native/src/test/java/io/quarkus/it/micrometer/native_mode/NativeMeterRegistriesTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.micrometer.native_mode;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+
+/**
+ * Test functioning MeterRegistries
+ * Use test execution order to ensure one http server request measurement
+ * is present when the endpoint is scraped.
+ */
+@QuarkusTest
+class NativeMeterRegistriesTest {
+
+    @Test
+    void testRegistryInjection() {
+        // We expect all 6 registries on the classpath to be initialized
+        Response response = given()
+                .when().get("/message/ping");
+
+        Assertions.assertEquals(200, response.statusCode());
+
+        List<Object> registries = response.jsonPath().getList("$");
+        MatcherAssert.assertThat(registries, Matchers.containsInAnyOrder(
+                "io.micrometer.azuremonitor.AzureMonitorMeterRegistry",
+                "io.micrometer.datadog.DatadogMeterRegistry",
+                "io.micrometer.jmx.JmxMeterRegistry",
+                "io.micrometer.signalfx.SignalFxMeterRegistry",
+                "io.micrometer.stackdriver.StackdriverMeterRegistry",
+                "io.micrometer.statsd.StatsdMeterRegistry"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -294,6 +294,7 @@
                 <module>picocli-native</module>
                 <module>gradle</module>
                 <module>micrometer-mp-metrics</module>
+                <module>micrometer-native</module>
                 <module>micrometer-prometheus</module>
                 <module>smallrye-metrics</module>
                 <module>logging-json</module>


### PR DESCRIPTION
Resolves #12900 

To be clear: this enables the registry in JVM mode. Native mode is (for the moment) disabled, as I work with the micrometer team on how best to disentangle the reactor/shaded netty dependencies 