### PR TITLE
Create github action workflow to validate release build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,30 @@
+name: Quarkus Release Test Build
+
+on:
+  schedule:
+    - cron: '0 3 * * 2'
+env:
+  LANG: en_US.UTF-8
+jobs:
+  build:
+    name: "Prepare release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Set up JDK 8
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        with:
+          java-version: 8
+      - name: Create maven repo
+        run: mkdir -p $HOME/release/repository
+      - name: Build and Test
+        run: |
+          mvn --settings .github/mvn-settings.xml \
+            -DskipITs -Dinvoker.skip=true \
+            -Dmaven.repo.local=$HOME/release/repository \
+            clean install

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -85,7 +85,7 @@
                                 <argument>--no-daemon</argument>
                             </arguments>
                             <environmentVariables>
-                                <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>
+                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
                                 <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
                             </environmentVariables>
                             <skip>${skip.gradle.build}</skip>

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -61,7 +61,7 @@
                                         <argument>--stacktrace</argument>
                                     </arguments>
                                     <environmentVariables>
-                                        <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>
+                                        <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
                                         <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
                                     </environmentVariables>
                                     <skip>${skip.gradle.tests}</skip>


### PR DESCRIPTION
Init a github action workflow to test release build process. 

This aims to avoid having failing tests when releasing. 

@gsmet should I add some other actions ? like replacing the `999-SNAPSHOT` version ?

close #12620 

