### PR TITLE
Hibernate ORM 5.4.23 and Hibernate Reactive 1.0.0.Alpha11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -86,7 +86,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.22.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.23.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha10</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta11</hibernate-search.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -87,7 +87,7 @@
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.23.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.Alpha10</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.Alpha11</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta11</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
@@ -11,7 +11,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import io.quarkus.deployment.QuarkusClassWriter;
-import net.bytebuddy.utility.OpenedClassReader;
+import io.quarkus.gizmo.Gizmo;
 
 /**
  * Used to transform bytecode by registering to
@@ -41,7 +41,9 @@ public final class HibernateEntityEnhancer implements BiFunction<String, ClassVi
         private final Enhancer enhancer;
 
         public HibernateEnhancingClassVisitor(String className, ClassVisitor outputClassVisitor) {
-            super(OpenedClassReader.ASM_API, new QuarkusClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS));
+            //Careful: the ASM API version needs to match the ASM version of Gizmo, not the one from Byte Buddy.
+            //Most often these match - but occasionally they will diverge which is acceptable as Byte Buddy is shading ASM.
+            super(Gizmo.ASM_API_VERSION, new QuarkusClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS));
             this.className = className;
             this.outputClassVisitor = outputClassVisitor;
             //note that as getLoadingClassLoader is resolved immediately this can't be created until transform time

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -153,7 +153,7 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                 continue;
             }
 
-            RecordedState recordedState = PersistenceUnitsHolder.getRecordedState(persistenceUnitName);
+            RecordedState recordedState = PersistenceUnitsHolder.popRecordedState(persistenceUnitName);
 
             if (recordedState.isReactive()) {
                 throw new IllegalStateException(

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
@@ -48,13 +48,13 @@ public final class PersistenceUnitsHolder {
         return persistenceUnits.units;
     }
 
-    public static RecordedState getRecordedState(String persistenceUnitName) {
+    public static RecordedState popRecordedState(String persistenceUnitName) {
         checkJPAInitialization();
         Object key = persistenceUnitName;
         if (persistenceUnitName == null) {
             key = NO_NAME_TOKEN;
         }
-        return persistenceUnits.recordedStates.get(key);
+        return persistenceUnits.recordedStates.remove(key);
     }
 
     private static List<PersistenceUnitDescriptor> convertPersistenceUnits(

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -49,6 +49,7 @@ public final class PrevalidatedQuarkusMetadata implements Metadata {
 
     public static PrevalidatedQuarkusMetadata validateAndWrap(final MetadataImpl original) {
         original.validate();
+        original.getBootstrapContext().getReflectionManager().reset();
         return new PrevalidatedQuarkusMetadata(original);
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/FlatClassLoaderService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/FlatClassLoaderService.java
@@ -99,6 +99,20 @@ public class FlatClassLoaderService implements ClassLoaderService {
     }
 
     @Override
+    public Package packageForNameOrNull(String packageName) {
+        try {
+            Class<?> aClass = Class.forName(packageName + ".package-info", false, getClassLoader());
+            return aClass == null ? null : aClass.getPackage();
+        } catch (ClassNotFoundException e) {
+            log.packageNotFound(packageName);
+            return null;
+        } catch (LinkageError e) {
+            log.warn("LinkageError while attempting to load Package named " + packageName, e);
+            return null;
+        }
+    }
+
+    @Override
     public <T> T workWithClassLoader(Work<T> work) {
         ClassLoader systemClassLoader = getClassLoader();
         return work.doWork(systemClassLoader);

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -123,7 +123,7 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                 continue;
             }
 
-            RecordedState recordedState = PersistenceUnitsHolder.getRecordedState(persistenceUnitName);
+            RecordedState recordedState = PersistenceUnitsHolder.popRecordedState(persistenceUnitName);
 
             final PrevalidatedQuarkusMetadata metadata = recordedState.getMetadata();
             final BuildTimeSettings buildTimeSettings = recordedState.getBuildTimeSettings();


### PR DESCRIPTION
This is what we'll need to upgrade Hibernate ORM to version `5.4.23.Final`.

[no longer a Draft: necessary dependencies should be in Maven Central now]

Changelog: - https://hibernate.atlassian.net/projects/HHH/versions/31887/tab/release-report-all-issues

Fixes #11975