### PR TITLE
Remove dependency on quarkus-oidc from keycloak-admin-client

### DIFF
--- a/extensions/keycloak-admin-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-client/deployment/pom.xml
@@ -16,10 +16,6 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client</artifactId>
         </dependency>
         <dependency>

--- a/extensions/keycloak-admin-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-client/runtime/pom.xml
@@ -17,10 +17,6 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Mentioned in #13056
