### PR TITLE
Update multipart dependency used in S3 documentation to Quarkus extension

### DIFF
--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -98,8 +98,8 @@ Then, we'll add the following dependency to support `multipart/form-data` reques
 [source,xml]
 ----
 <dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-multipart-provider</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-multipart</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
Just a small documentation update to use the new multipart extension instead of directly using the dependency.