### PR TITLE
Upgrade jboss-logmanager-embedded to 1.0.6 and ban jboss-logmanager

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2182,11 +2182,25 @@
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>log4j2-jboss-logmanager</artifactId>
                 <version>${log4j2-jboss-logmanager.version}</version>
+                <exclusions>
+                    <!-- we use the embedded version -->
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>log4j-jboss-logmanager</artifactId>
                 <version>${log4j-jboss-logmanager.version}</version>
+                <exclusions>
+                    <!-- we use the embedded version -->
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -154,7 +154,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.0.3</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.5</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.6</jboss-logmanager.version>
         <jgit.version>5.8.0.202006091008-r</jgit.version>
         <flyway.version>7.0.4</flyway.version>
         <yasson.version>1.0.8</yasson.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -391,6 +391,8 @@
                                             <exclude>jakarta.json:jakarta.json-api</exclude>
                                             <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                                             <exclude>io.netty:netty-all</exclude>
+                                            <!-- Ban jboss-logmanager, we use jboss-logmanager-embedded -->
+                                            <exclude>org.jboss.logmanager:jboss-logmanager</exclude>
                                             <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
                                             <exclude>log4j:log4j</exclude>
                                             <exclude>org.apache.logging.log4j:log4j-core</exclude>


### PR DESCRIPTION
@dmlloyd I upgraded `jboss-logmanager-embedded` but I also banned `jboss-logmanager` as I suppose we shouldn't have it around, right?