### PR TITLE
Make sure Maven commands use the effective project deps, props and managed deps

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/MavenProjectBuildFile.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MavenProjectBuildFile.java
@@ -1,0 +1,198 @@
+package io.quarkus.maven;
+
+import static io.quarkus.devtools.project.extensions.Extensions.toKey;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+
+import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.buildfile.BuildFile;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+
+public class MavenProjectBuildFile extends BuildFile {
+
+    private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{(.+)}");
+
+    private Supplier<Model> modelSupplier;
+    private Supplier<List<org.eclipse.aether.graph.Dependency>> projectDepsSupplier;
+    private Supplier<List<org.eclipse.aether.graph.Dependency>> projectManagedDepsSupplier;
+    private Properties projectProps;
+    protected List<AppArtifactCoords> dependencies;
+    protected List<AppArtifactCoords> managedDependencies;
+    protected Model model;
+
+    public MavenProjectBuildFile(Path projectDirPath, QuarkusPlatformDescriptor platformDescriptor, Supplier<Model> model,
+            Supplier<List<org.eclipse.aether.graph.Dependency>> projectDeps,
+            Supplier<List<org.eclipse.aether.graph.Dependency>> projectManagedDeps,
+            Properties projectProps) {
+        super(projectDirPath, platformDescriptor);
+        this.modelSupplier = model;
+        this.projectDepsSupplier = projectDeps;
+        this.projectManagedDepsSupplier = projectManagedDeps;
+        this.projectProps = projectProps;
+    }
+
+    @Override
+    public BuildTool getBuildTool() {
+        return BuildTool.MAVEN;
+    }
+
+    @Override
+    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+        final Dependency d = new Dependency();
+        d.setGroupId(coords.getGroupId());
+        d.setArtifactId(coords.getArtifactId());
+        if (!managed) {
+            d.setVersion(coords.getVersion());
+        }
+        // When classifier is empty, you get  <classifier></classifier> in the pom.xml
+        if (coords.getClassifier() != null && !coords.getClassifier().isEmpty()) {
+            d.setClassifier(coords.getClassifier());
+        }
+        d.setType(coords.getType());
+        if ("pom".equalsIgnoreCase(coords.getType())) {
+            d.setScope("import");
+            DependencyManagement dependencyManagement = model().getDependencyManagement();
+            if (dependencyManagement == null) {
+                dependencyManagement = new DependencyManagement();
+                model().setDependencyManagement(dependencyManagement);
+            }
+            if (dependencyManagement.getDependencies()
+                    .stream()
+                    .noneMatch(thisDep -> d.getManagementKey().equals(resolveKey(thisDep)))) {
+                dependencyManagement.addDependency(d);
+                // the effective managed dependencies set may already include it
+                if (!getManagedDependencies().contains(coords)) {
+                    getManagedDependencies().add(coords);
+                }
+                return true;
+            }
+        } else if (model().getDependencies()
+                .stream()
+                .noneMatch(thisDep -> d.getManagementKey().equals(thisDep.getManagementKey()))) {
+            model().addDependency(d);
+            // it could still be a transitive dependency or inherited from the parent
+            if (!getDependencies().contains(coords)) {
+                getDependencies().add(coords);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void removeDependency(AppArtifactKey key) throws IOException {
+        if (model() != null) {
+            final Iterator<AppArtifactCoords> i = getDependencies().iterator();
+            while (i.hasNext()) {
+                final AppArtifactCoords a = i.next();
+                if (a.getKey().equals(key)) {
+                    i.remove();
+                    break;
+                }
+                model().getDependencies().removeIf(d -> Objects.equals(toKey(d), key));
+            }
+        }
+    }
+
+    @Override
+    protected List<AppArtifactCoords> getDependencies() {
+        if (dependencies == null) {
+            final List<org.eclipse.aether.graph.Dependency> projectDeps = projectDepsSupplier.get();
+            projectDepsSupplier = null;
+            dependencies = new ArrayList<>(projectDeps.size());
+            for (org.eclipse.aether.graph.Dependency dep : projectDeps) {
+                org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
+                dependencies.add(new AppArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
+                        a.getExtension(), a.getVersion()));
+            }
+        }
+        return dependencies;
+    }
+
+    protected List<AppArtifactCoords> getManagedDependencies() {
+        if (managedDependencies == null) {
+            final List<org.eclipse.aether.graph.Dependency> managedDeps = projectManagedDepsSupplier.get();
+            projectManagedDepsSupplier = null;
+            managedDependencies = new ArrayList<>(managedDeps.size());
+            for (org.eclipse.aether.graph.Dependency dep : managedDeps) {
+                org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
+                managedDependencies.add(new AppArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
+                        a.getExtension(), a.getVersion()));
+            }
+        }
+        return dependencies;
+    }
+
+    @Override
+    protected void writeToDisk() throws IOException {
+        if (model == null) {
+            return;
+        }
+        try (ByteArrayOutputStream pomOutputStream = new ByteArrayOutputStream()) {
+            MojoUtils.write(model(), pomOutputStream);
+            writeToProjectFile(BuildTool.MAVEN.getDependenciesFile(), pomOutputStream.toByteArray());
+        }
+    }
+
+    @Override
+    protected String getProperty(String propertyName) {
+        return projectProps.getProperty(propertyName);
+    }
+
+    @Override
+    protected void refreshData() {
+    }
+
+    private Model model() {
+        if (model == null) {
+            model = modelSupplier.get().clone();
+            modelSupplier = null;
+        }
+        return model;
+    }
+
+    /**
+     * Resolves dependencies containing property references in the GAV
+     */
+    private String resolveKey(Dependency dependency) {
+        String resolvedGroupId = toResolvedProperty(dependency.getGroupId());
+        String resolvedArtifactId = toResolvedProperty(dependency.getArtifactId());
+        String resolvedVersion = toResolvedProperty(dependency.getVersion());
+        if (!resolvedGroupId.equals(dependency.getGroupId())
+                || !resolvedArtifactId.equals(dependency.getArtifactId())
+                || !resolvedVersion.equals(dependency.getVersion())) {
+            return resolvedGroupId + ":" + resolvedArtifactId + ":" + dependency.getType()
+                    + (dependency.getClassifier() != null ? ":" + dependency.getClassifier() : "");
+        }
+        return dependency.getManagementKey();
+    }
+
+    /**
+     * Resolves properties as ${quarkus.platform.version}
+     */
+    private String toResolvedProperty(String value) {
+        Matcher matcher = PROPERTY_PATTERN.matcher(value);
+        if (matcher.matches()) {
+            String property = getProperty(matcher.group(1));
+            return property == null ? value : property;
+        }
+        return value;
+    }
+}

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.maven.model.Dependency;
-
 import io.quarkus.dependencies.Category;
 import io.quarkus.dependencies.Extension;
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -29,7 +27,6 @@ public class QuarkusJsonPlatformDescriptor implements QuarkusPlatformDescriptor,
     private String quarkusVersion;
 
     private List<Extension> extensions = Collections.emptyList();
-    private List<Dependency> managedDeps = Collections.emptyList();
     private List<Category> categories = Collections.emptyList();
     private Map<String, Object> metadata = Collections.emptyMap();
     private transient ResourceLoader resourceLoader;
@@ -54,10 +51,6 @@ public class QuarkusJsonPlatformDescriptor implements QuarkusPlatformDescriptor,
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
-    }
-
-    void setManagedDependencies(List<Dependency> managedDeps) {
-        this.managedDeps = managedDeps;
     }
 
     void setResourceLoader(ResourceLoader resourceLoader) {
@@ -94,11 +87,6 @@ public class QuarkusJsonPlatformDescriptor implements QuarkusPlatformDescriptor,
     @Override
     public String getQuarkusVersion() {
         return quarkusVersion;
-    }
-
-    @Override
-    public List<Dependency> getManagedDependencies() {
-        return managedDeps;
     }
 
     @Override

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderBootstrap.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderBootstrap.java
@@ -6,11 +6,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
-
-import org.apache.maven.model.Dependency;
 
 import io.quarkus.maven.utilities.MojoUtils;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
@@ -59,19 +56,6 @@ public class QuarkusJsonPlatformDescriptorLoaderBootstrap
                     Function<Path, T> processor) {
                 throw new UnsupportedOperationException();
             }
-
-            @Override
-            public List<Dependency> getManagedDependencies(String groupId, String artifactId, String classifier, String type,
-                    String version) {
-                if (Files.isDirectory(resourceRoot)) {
-                    return readManagedDeps(resourceRoot.resolve("quarkus-bom/pom.xml"));
-                }
-                try (FileSystem fs = FileSystems.newFileSystem(resourceRoot, null)) {
-                    return readManagedDeps(fs.getPath("/quarkus-bom/pom.xml"));
-                } catch (Exception e) {
-                    throw new IllegalStateException("Failed to open " + resourceRoot, e);
-                }
-            }
         };
 
         return new QuarkusJsonPlatformDescriptorLoaderImpl()
@@ -88,17 +72,6 @@ public class QuarkusJsonPlatformDescriptorLoaderBootstrap
                         }
                     }
                 });
-    }
-
-    private static List<Dependency> readManagedDeps(Path pom) {
-        if (!Files.exists(pom)) {
-            throw new IllegalStateException("Failed to locate " + pom);
-        }
-        try (InputStream is = Files.newInputStream(pom)) {
-            return MojoUtils.readPom(is).getDependencyManagement().getDependencies();
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read model of " + pom, e);
-        }
     }
 
     private static <T> T doParse(Path p, Function<InputStream, T> parser) {

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
@@ -29,11 +29,6 @@ public class QuarkusJsonPlatformDescriptorLoaderImpl
                         throw new RuntimeException("Failed to parse JSON stream", e);
                     }
                 });
-
-        if (context.getArtifactResolver() != null) {
-            platform.setManagedDependencies(context.getArtifactResolver().getManagedDependencies(platform.getBomGroupId(),
-                    platform.getBomArtifactId(), null, "pom", platform.getBomVersion()));
-        }
         platform.setResourceLoader(context.getResourceLoader());
         platform.setMessageWriter(context.getMessageWriter());
 

--- a/devtools/platform-descriptor-json/src/test/java/io/quarkus/platform/descriptor/tests/PlatformDescriptorLoaderTest.java
+++ b/devtools/platform-descriptor-json/src/test/java/io/quarkus/platform/descriptor/tests/PlatformDescriptorLoaderTest.java
@@ -7,11 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 
-import org.apache.maven.model.Dependency;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.platform.descriptor.loader.json.ArtifactResolver;
@@ -33,12 +30,6 @@ class PlatformDescriptorLoaderTest {
             public <T> T process(String groupId, String artifactId, String classifier, String type, String version,
                     Function<Path, T> processor) {
                 throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public List<Dependency> getManagedDependencies(String groupId, String artifactId, String classifier,
-                    String type, String version) {
-                return Collections.emptyList();
             }
         };
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/descriptor/loader/json/ArtifactResolver.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/descriptor/loader/json/ArtifactResolver.java
@@ -2,9 +2,7 @@ package io.quarkus.platform.descriptor.loader.json;
 
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.function.Function;
-import org.apache.maven.model.Dependency;
 
 public interface ArtifactResolver {
 
@@ -15,6 +13,4 @@ public interface ArtifactResolver {
 
     <T> T process(String groupId, String artifactId, String classifier, String type, String version,
             Function<Path, T> processor) throws AppModelResolverException;
-
-    List<Dependency> getManagedDependencies(String groupId, String artifactId, String classifier, String type, String version);
 }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/CombinedQuarkusPlatformDescriptorTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/CombinedQuarkusPlatformDescriptorTest.java
@@ -11,7 +11,6 @@ import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.maven.model.Dependency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,8 +45,6 @@ public class CombinedQuarkusPlatformDescriptorTest extends PlatformAwareTestBase
         assertCategories(combined);
 
         assertExtensions(expectedExtensions, combined);
-
-        assertManagedDeps(combined);
 
         assertEquals("dominating pom.xml template", combined.getTemplate("dir/some-other-file.template"));
         assertEquals(defaultPlatform.getTemplate("dir/some-file.template"),
@@ -88,29 +85,11 @@ public class CombinedQuarkusPlatformDescriptorTest extends PlatformAwareTestBase
         assertEquals(DOMINATING_VERSION, ext.getVersion());
     }
 
-    private void assertManagedDeps(QuarkusPlatformDescriptor descriptor) {
-        final List<Dependency> deps = descriptor.getManagedDependencies();
-        assertFalse(deps.isEmpty());
-        final Map<String, Dependency> actualMap = deps.stream().collect(Collectors.toMap(d -> getGa(d), d -> d));
-
-        Dependency dep = actualMap.get("io.quarkus:quarkus-jdbc-h2");
-        assertNotNull(dep);
-        assertEquals(defaultPlatform.getQuarkusVersion(), dep.getVersion());
-
-        dep = actualMap.get("io.quarkus:quarkus-resteasy");
-        assertNotNull(dep);
-        assertEquals(DOMINATING_VERSION, dep.getVersion());
-    }
-
     private static Map<String, Extension> toMap(final List<Extension> extensions) {
         return extensions.stream().collect(Collectors.toMap(e -> getGa(e), e -> e));
     }
 
     private static String getGa(Extension e) {
         return e.getGroupId() + ":" + e.getArtifactId();
-    }
-
-    private static String getGa(Dependency d) {
-        return d.getGroupId() + ":" + d.getArtifactId();
     }
 }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/TestDominatingQuarkusPlatformDescriptor.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/TestDominatingQuarkusPlatformDescriptor.java
@@ -12,13 +12,11 @@ import io.quarkus.platform.descriptor.ResourcePathConsumer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.maven.model.Dependency;
 
 public class TestDominatingQuarkusPlatformDescriptor implements QuarkusPlatformDescriptor {
 
     private final List<Category> categories = new ArrayList<>();
     private final List<Extension> extensions = new ArrayList<>();
-    private final List<Dependency> bomDeps = new ArrayList<>();
 
     public TestDominatingQuarkusPlatformDescriptor() {
 
@@ -26,8 +24,7 @@ public class TestDominatingQuarkusPlatformDescriptor implements QuarkusPlatformD
         addCategory("web", "Dominating Web", categories);
 
         addExtension(new AppArtifactCoords("io.quarkus", "quarkus-resteasy", "dominating-version"), "Dominating RESTEasy",
-                "dominating/guide",
-                "reasteasy", extensions, bomDeps);
+                "dominating/guide", "reasteasy", extensions);
     }
 
     @Override
@@ -48,11 +45,6 @@ public class TestDominatingQuarkusPlatformDescriptor implements QuarkusPlatformD
     @Override
     public String getQuarkusVersion() {
         return "dominating.quarkus.version";
-    }
-
-    @Override
-    public List<Dependency> getManagedDependencies() {
-        return bomDeps;
     }
 
     @Override

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/loader/QuarkusTestPlatformDescriptorLoader.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/test/platform/descriptor/loader/QuarkusTestPlatformDescriptorLoader.java
@@ -24,13 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import org.apache.maven.model.Dependency;
 
 public class QuarkusTestPlatformDescriptorLoader
         implements QuarkusPlatformDescriptorLoader<QuarkusPlatformDescriptor, QuarkusPlatformDescriptorLoaderContext> {
 
     private static final List<Extension> extensions = new ArrayList<>();
-    private static final List<Dependency> bomDeps = new ArrayList<>();
     private static final Properties quarkusProps;
 
     private static final String quarkusVersion;
@@ -91,11 +89,11 @@ public class QuarkusTestPlatformDescriptorLoader
     }
 
     private static void addExtension(AppArtifactCoords coords, String name, String guide, String codestart) {
-        addExtension(coords, name, guide, codestart, extensions, bomDeps);
+        addExtension(coords, name, guide, codestart, extensions);
     }
 
     public static void addExtension(AppArtifactCoords coords, String name, String guide, String codestart,
-            List<Extension> extensions, List<Dependency> bomDeps) {
+            List<Extension> extensions) {
         final Extension e = new Extension(coords.getGroupId(), coords.getArtifactId(), coords.getVersion())
                 .setName(name)
                 .setGuide(guide);
@@ -103,12 +101,6 @@ public class QuarkusTestPlatformDescriptorLoader
             e.setCodestart(codestart);
         }
         extensions.add(e);
-
-        final Dependency d = new Dependency();
-        d.setGroupId(coords.getGroupId());
-        d.setArtifactId(coords.getArtifactId());
-        d.setVersion(coords.getVersion());
-        bomDeps.add(d);
     }
 
     private static void addCategory(String id, String name) {
@@ -176,11 +168,6 @@ public class QuarkusTestPlatformDescriptorLoader
             @Override
             public String getQuarkusVersion() {
                 return Objects.toString(version, quarkusVersion);
-            }
-
-            @Override
-            public List<Dependency> getManagedDependencies() {
-                return bomDeps;
             }
 
             @Override

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/CombinedQuarkusPlatformDescriptor.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/CombinedQuarkusPlatformDescriptor.java
@@ -53,7 +53,6 @@ public class CombinedQuarkusPlatformDescriptor implements QuarkusPlatformDescrip
 
     private final QuarkusPlatformDescriptor master;
     private final List<QuarkusPlatformDescriptor> platforms;
-    private List<Dependency> managedDeps;
     private List<Extension> extensions;
     private List<Category> categories;
     private Map<String, Object> metadata;
@@ -96,23 +95,6 @@ public class CombinedQuarkusPlatformDescriptor implements QuarkusPlatformDescrip
             metadata.putAll(platforms.get(i).getMetadata());
         }
         return this.metadata = metadata;
-    }
-
-    @Override
-    public List<Dependency> getManagedDependencies() {
-        if (managedDeps != null) {
-            return managedDeps;
-        }
-        final List<Dependency> deps = new ArrayList<>();
-        final Set<DepKey> depKeys = new HashSet<>();
-        for (QuarkusPlatformDescriptor platform : platforms) {
-            for (Dependency dep : platform.getManagedDependencies()) {
-                if (depKeys.add(new DepKey(dep))) {
-                    deps.add(dep);
-                }
-            }
-        }
-        return managedDeps = deps;
     }
 
     @Override

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/QuarkusPlatformDescriptor.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/QuarkusPlatformDescriptor.java
@@ -18,7 +18,13 @@ public interface QuarkusPlatformDescriptor {
 
     String getQuarkusVersion();
 
-    List<Dependency> getManagedDependencies();
+    /**
+     *
+     * @return platform's dependencyManagement
+     */
+    default List<Dependency> getManagedDependencies() {
+        throw new UnsupportedOperationException();
+    }
 
     List<Extension> getExtensions();
 

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/test/java/io/quarkus/platform/descriptor/resolver/json/test/TestJsonPlatformDescriptorLoader.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/test/java/io/quarkus/platform/descriptor/resolver/json/test/TestJsonPlatformDescriptorLoader.java
@@ -14,7 +14,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import org.apache.maven.model.Dependency;
 
 public class TestJsonPlatformDescriptorLoader implements QuarkusJsonPlatformDescriptorLoader<QuarkusPlatformDescriptor> {
 
@@ -51,11 +50,6 @@ public class TestJsonPlatformDescriptorLoader implements QuarkusJsonPlatformDesc
             @Override
             public String getQuarkusVersion() {
                 return quarkusVersion;
-            }
-
-            @Override
-            public List<Dependency> getManagedDependencies() {
-                return Collections.emptyList();
             }
 
             @Override


### PR DESCRIPTION
This adds a MavenProject-based implementation of the BuildFile which provides the effective lists of the project dependencies, managed dependencies and properties instead of relying on the project's pom.xml, which is not complete from that perspective.

This change also "unsupports" `QuarkusPlatformDescriptor.getManagedDependencies()`, this method doesn't seem to be used and should be completely removed in the future versions.