### PR TITLE
Make isTraceEnabled calls be computed at build time #12938

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -172,6 +172,7 @@ public class NativeImageBuildStep {
             command.add(
                     "-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime"); //the default collection policy results in full GC's 50% of the time
             command.add("-H:+JNI");
+            command.add("-H:+AllowFoldMethods");
             command.add("-jar");
             command.add(runnerJarName);
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryBuildTimeConfig.java
@@ -1,0 +1,23 @@
+package io.quarkus.runtime.logging;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class CategoryBuildTimeConfig {
+    /**
+     * Specifies whether <code>isTraceEnabled</code> for a given category will return true or false for a given category.
+     * This check is computed at build time to provide better hints on code paths that won't be used at runtime.
+     *
+     * It's common to see <code>isTraceEnabled</code> calls in sections that include building complex or expensive messages.
+     * By using <code>isTraceEnabled</code> checks, users can double check that trace enabled before computing such a message.
+     * Otherwise, complex messages could be constructed but then not used by the logging library if the runtime log level is not trace.
+     * This build time option controls whether `isTraceEnabled` returns true or false at build time and makes that a constant at runtime,
+     * irrespective of the runtime log level.
+     *
+     * Calls to <code>trace()</code> not preceded by <code>isTraceEnabled</code> are still governed by the runtime log level.
+     * The message will only be printed if runtime log level for a given category is <code>TRACE</code>.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean buildTimeTraceEnabled;
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -1,5 +1,8 @@
 package io.quarkus.runtime.logging;
 
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -12,4 +15,15 @@ public class LogBuildTimeConfig {
      */
     @ConfigItem(name = "metrics.enabled", defaultValue = "false")
     public boolean metricsEnabled;
+
+    /**
+     * Logging categories.
+     * <p>
+     * Logging is done on a per-category basis. Each category can be independently configured.
+     * A configuration which applies to a category will also apply to all sub-categories of that category,
+     * unless there is a more specific matching sub-category configuration.
+     */
+    @ConfigItem(name = "category")
+    @ConfigDocSection
+    public Map<String, CategoryBuildTimeConfig> categories;
 }


### PR DESCRIPTION
Closes #12938 

Logging documentation guide still needs updating, but I've tried to make the javadoc `CategoryBuildTimeConfig` as explicit as possible.

In essence, this change pushes all `isTraceEnabled` calls to be computed at build time making them eagerly folded. This means that if no build time trace is enabled, all runtime `isTraceEnabled` calls will be precomputed to `false`, leading to the `true` branches to be dead code eliminated (along with any strings created inside of them). Whether those return true/false are controlled by the newly added build time configuration option. 

The only exception are those `isTraceEnabled` calls made in static blocks or initializing static fields. These will always return true and that's not changing. Any users of `isTraceEnabled` caching in static fields should be changed.

Note that `log.trace()` still works as usual. This means that any messages passed are only printed if runtime log level is `TRACE`.

Finally, note that I've changed slightly the name from my suggestion in [here](https://groups.google.com/g/quarkus-dev/c/s7FqI8ZOCiM/m/mYJnyPweCAAJ).

TODO:
- [ ] Update documentation (once PR approved).