### PR TITLE
Make Amazon Services interceptors config a list of string

### DIFF
--- a/extensions/amazon-services/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AmazonServicesClientsProcessor.java
+++ b/extensions/amazon-services/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AmazonServicesClientsProcessor.java
@@ -69,8 +69,9 @@ public class AmazonServicesClientsProcessor {
         for (AmazonClientBuildItem client : amazonClients) {
             SdkBuildTimeConfig clientSdkConfig = client.getBuildTimeSdkConfig();
             if (clientSdkConfig != null) {
-                clientSdkConfig.interceptors.orElse(Collections.emptyList()).forEach(interceptorClass -> {
-                    if (!knownInterceptorImpls.contains(interceptorClass.getName())) {
+                clientSdkConfig.interceptors.orElse(Collections.emptyList()).forEach(interceptorClassName -> {
+                    interceptorClassName = interceptorClassName.trim();
+                    if (!knownInterceptorImpls.contains(interceptorClassName)) {
                         throw new ConfigurationError(
                                 String.format(
                                         "quarkus.%s.interceptors (%s) - must list only existing implementations of software.amazon.awssdk.core.interceptor.ExecutionInterceptor",

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientRecorder.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientRecorder.java
@@ -72,18 +72,19 @@ public class AmazonClientRecorder {
         config.apiCallAttemptTimeout.ifPresent(overrides::apiCallAttemptTimeout);
 
         buildConfig.interceptors.orElse(Collections.emptyList()).stream()
+                .map(String::trim)
                 .map(this::createInterceptor)
                 .filter(Objects::nonNull)
                 .forEach(overrides::addExecutionInterceptor);
         builder.overrideConfiguration(overrides.build());
     }
 
-    private ExecutionInterceptor createInterceptor(Class<?> interceptorClass) {
+    private ExecutionInterceptor createInterceptor(String interceptorClassName) {
         try {
             return (ExecutionInterceptor) Class
-                    .forName(interceptorClass.getName(), false, Thread.currentThread().getContextClassLoader()).newInstance();
+                    .forName(interceptorClassName, false, Thread.currentThread().getContextClassLoader()).newInstance();
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            LOG.error("Unable to create interceptor", e);
+            LOG.error("Unable to create interceptor " + interceptorClassName, e);
             return null;
         }
     }

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkBuildTimeConfig.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkBuildTimeConfig.java
@@ -22,5 +22,5 @@ public class SdkBuildTimeConfig {
      * @see software.amazon.awssdk.core.interceptor.ExecutionInterceptor
      */
     @ConfigItem
-    public Optional<List<Class<?>>> interceptors;
+    public Optional<List<String>> interceptors; // cannot be classes as can be runtime initialized (e.g. XRay interceptor)
 }


### PR DESCRIPTION
If it's a list of classes, they are initialized at build time by
SmallRye Config whereas some of the interceptors (the XRay one for
instance) are initialized at runtime.

Making it a list of strings allows to initialize interceptors at runtime
for native executables.

Fixes #13078