### PR TITLE
Qute: add @CheckedTemplate#basePath()

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateBasePathTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateBasePathTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CheckedTemplateBasePathTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Monks.class)
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/foo/monk.txt")
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/Monks/monk.txt"));
+
+    @Test
+    public void testBasePath() {
+        assertEquals("Hello Ondrej!",
+                Monks.Templates.monk("Ondrej").render());
+        assertEquals("Hello Ondrej!",
+                Monks.OtherTemplates.monk("Ondrej").render());
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateConflictTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CheckedTemplateConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Templates.class)
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/CheckedTemplateConflictTest/monk.txt"))
+            .setExpectedException(TemplateException.class);
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @CheckedTemplate
+    static class Templates {
+
+        static native TemplateInstance monk(String name);
+
+        static native TemplateInstance monk(Integer age);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Monks.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Monks.java
@@ -1,0 +1,22 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+
+public class Monks {
+
+    @CheckedTemplate(basePath = "foo")
+    static class Templates {
+
+        static native TemplateInstance monk(String name);
+
+    }
+
+    @CheckedTemplate
+    static class OtherTemplates {
+
+        static native TemplateInstance monk(String name);
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/CheckedTemplate.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/CheckedTemplate.java
@@ -9,18 +9,21 @@ import java.lang.annotation.Target;
 import io.quarkus.qute.TemplateInstance;
 
 /**
- * <p>
  * If you place this annotation on a class, all its <code>native static</code> methods will be used to declare
  * templates and the list of parameters they require.
  * <p>
- * If this is placed on an inner class of the class with a simple name <code>X</code>, a <code>native static</code> method of
- * the name
- * <code>foo</code> will refer to a template at the path <code>X/foo</code> (template file extensions are
- * not part of the method name) relative to your templates root.
- * <p>
- * If this is placed on a toplevel class, a <code>native static</code> method of the name
- * <code>foo</code> will refer to a template at the path <code>foo</code> (template file extensions are
- * not part of the method name) at the toplevel of your templates root.
+ * The name of a method and the base path are used to locate the template contents.
+ * By default, the base path is derived from the annotation target:
+ * <ul>
+ * <li>If this is placed on a static nested class of an enclosing class with a simple name <code>X</code>, a
+ * <code>native static</code> method of the name <code>foo</code> will refer to a template at the path <code>X/foo</code>
+ * (template file extensions are
+ * not part of the method name) relative to the templates root.</li>
+ * <li>If this is placed on a top-level class, a <code>native static</code> method of the name <code>foo</code> will refer to a
+ * template at the path <code>foo</code> (template file extensions are
+ * not part of the method name) at the toplevel of the templates root.</li>
+ * </ul>
+ * The base path can be also specified via {@link #basePath()}.
  * <p>
  * Each parameter of the <code>native static</code> will be used to validate the template at build time, to
  * make sure that those parameters are used properly in a type-safe manner. The return type of each
@@ -30,24 +33,21 @@ import io.quarkus.qute.TemplateInstance;
  * <p>
  * 
  * <pre>
- * {
- *     &#64;code
- *     &#64;Path("item")
- *     public class ItemResource {
+ * &#64;Path("item")
+ * public class ItemResource {
  * 
- *         &#64;CheckedTemplate
- *         class Templates {
- *             // defines a template at ItemResource/item, taking an Item parameter named item
- *             static native TemplateInstance item(Item item);
- *         }
+ *     &#64;CheckedTemplate
+ *     static class Templates {
+ *         // defines a template at ItemResource/item, taking an Item parameter named item
+ *         static native TemplateInstance item(Item item);
+ *     }
  * 
- *         &#64;GET
- *         &#64;Path("{id}")
- *         &#64;Produces(MediaType.TEXT_HTML)
- *         public TemplateInstance get(@PathParam("id") Integer id) {
- *             // instantiate that template and pass it the required template parameter
- *             return Templates.item(service.findItem(id));
- *         }
+ *     &#64;GET
+ *     &#64;Path("{id}")
+ *     &#64;Produces(MediaType.TEXT_HTML)
+ *     public TemplateInstance get(@PathParam("id") Integer id) {
+ *         // instantiate that template and pass it the required template parameter
+ *         return Templates.item(service.findItem(id));
  *     }
  * }
  * </pre>
@@ -56,5 +56,32 @@ import io.quarkus.qute.TemplateInstance;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface CheckedTemplate {
+
+    /**
+     * Constant value for {@link #basePath()} indicating that the default strategy should be used.
+     */
+    String DEFAULTED = "<<defaulted>>";
+
+    /**
+     * Example:
+     * 
+     * <pre>
+     * &#64;Path("item")
+     * public class ItemResource {
+     * 
+     *     &#64;CheckedTemplate(basePath = "items_v1")
+     *     static class Templates {
+     *         // defines a template at items_v1/item
+     *         static native TemplateInstance item(Item item);
+     * 
+     *         // defines a template at items_v1/allItems
+     *         static native TemplateInstance allItems(List&lt;Item&gt; items);
+     *     }
+     * }
+     * </pre>
+     * 
+     * @return the base path relative to the templates root
+     */
+    String basePath() default DEFAULTED;
 
 }


### PR DESCRIPTION
- this makes type-safe templates more flexible
- also fail the build if multiple checked template methods for the same
template path exist