### PR TITLE
Upgrade to Hibernate Search 6.0.0.CR1 / Elasticsearch 7.9.2

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -594,7 +594,7 @@ jobs:
         run: |
           docker run --rm --publish 9200:9200 --name build-elasticsearch \
           -e discovery.type=single-node \
-          -d docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.0
+          -d docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.2
         if: matrix.elasticsearch
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <hibernate-orm.version>5.4.23.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha11</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Beta11</hibernate-search.version>
+        <hibernate-search.version>6.0.0.CR1</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -95,7 +95,7 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.9.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.9.2</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.20</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,7 +75,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>7.9.0</elasticsearch-server.version>
+        <elasticsearch-server.version>7.9.2</elasticsearch-server.version>
         <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss:${elasticsearch-server.version}</elasticsearch.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -168,7 +168,7 @@ public class HibernateSearchElasticsearchRecorder {
         private void contributeBackendIndexBuildTimeProperties(BiConsumer<String, Object> propertyCollector,
                 String backendName, String indexName, ElasticsearchIndexBuildTimeConfig indexConfig) {
             addBackendIndexConfig(propertyCollector, backendName, indexName,
-                    ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+                    ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
                     indexConfig.analysis.configurer,
                     Optional::isPresent, c -> c.get().getName());
         }


### PR DESCRIPTION
Nothing much to report, it's mostly just a version bump.

To be added to the migration guide:

``````
## Hibernate Search ORM + Elasticsearch (Preview)

* Many deprecated methods and classes were removed. For more information: https://in.relation.to/2020/11/04/hibernate-search-6-0-0-CR1/#breaking_changes
* Async/reactive methods now return `CompletionStage` instead of `CompletableFuture`. To convert a `CompletionStage` to a `Future`, call `.toCompletableFuture()`.
``````