### PR TITLE
Use Uni to resolve TenantContextConfig

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -257,7 +257,7 @@ public class OidcTenantConfig {
          * Default TokenStateManager strategy.
          */
         @ConfigItem(defaultValue = "keep_all_tokens")
-        public Strategy strategy;
+        public Strategy strategy = Strategy.KEEP_ALL_TOKENS;
 
         /**
          * Default TokenStateManager keeps all tokens (ID, access and refresh)
@@ -1085,5 +1085,13 @@ public class OidcTenantConfig {
          * and Authorization Code Flow - if not.
          */
         HYBRID
+    }
+
+    public ApplicationType getApplicationType() {
+        return applicationType;
+    }
+
+    public void setApplicationType(ApplicationType type) {
+        this.applicationType = type;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -19,7 +19,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
 
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager) {
-        String token = extractBearerToken(context, resolver.resolve(context, false).oidcConfig);
+        String token = extractBearerToken(context, resolver.resolveConfig(context));
 
         // if a bearer token is provided try to authenticate
         if (token != null) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -1,8 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -18,21 +15,23 @@ import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.quarkus.oidc.TenantResolver;
 import io.quarkus.oidc.TokenStateManager;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
 public class DefaultTenantConfigResolver {
 
     private static final Logger LOG = Logger.getLogger(DefaultTenantConfigResolver.class);
-    private static final String CURRENT_TENANT_CONFIG = "io.quarkus.oidc.current.tenant.config";
+    private static final String CURRENT_STATIC_TENANT_ID = "static.tenant.id";
+    private static final String CURRENT_STATIC_TENANT_ID_NULL = "static.tenant.id.null";
+    private static final String CURRENT_DYNAMIC_TENANT_CONFIG = "dynamic.tenant.config";
+    private static final String CURRENT_DYNAMIC_TENANT_CONFIG_NULL = "dynamic.tenant.config.null";
 
     @Inject
     Instance<TenantResolver> tenantResolver;
 
     @Inject
     Instance<TenantConfigResolver> tenantConfigResolver;
-
-    private final Map<String, TenantConfigContext> dynamicTenantsConfig = new ConcurrentHashMap<>();
 
     @Inject
     TenantConfigBean tenantConfigBean;
@@ -62,33 +61,40 @@ public class DefaultTenantConfigResolver {
         }
     }
 
-    /**
-     * Resolve {@linkplain TenantConfigContext} which contains the tenant configuration and
-     * the active OIDC connection instance which may be null.
-     * 
-     * @param context the current request context
-     * @param create if true then the OIDC connection must be available or established
-     *        for the resolution to be successful
-     * @return
-     */
-    TenantConfigContext resolve(RoutingContext context, boolean create) {
-        TenantConfigContext config = getTenantConfigFromConfigResolver(context, create);
-
-        if (config == null) {
-            config = getTenantConfigFromTenantResolver(context);
-        } else if (create && config.auth == null && !config.oidcConfig.getPublicKey().isPresent()) {
-            throw new OIDCException("OIDC IDP connection must be available");
+    OidcTenantConfig resolveConfig(RoutingContext context) {
+        OidcTenantConfig tenantConfig = getDynamicTenantConfig(context);
+        if (tenantConfig == null) {
+            TenantConfigContext tenant = getStaticTenantContext(context);
+            if (tenant != null) {
+                tenantConfig = tenant.oidcConfig;
+            }
         }
-
-        return config;
+        return tenantConfig;
     }
 
-    private TenantConfigContext getTenantConfigFromTenantResolver(RoutingContext context) {
+    Uni<TenantConfigContext> resolveContext(RoutingContext context) {
+        Uni<TenantConfigContext> tenantContext = getDynamicTenantContext(context);
+
+        if (tenantContext == null) {
+            tenantContext = Uni.createFrom().item(getStaticTenantContext(context));
+        }
+        return tenantContext;
+    }
+
+    private TenantConfigContext getStaticTenantContext(RoutingContext context) {
 
         String tenantId = null;
 
         if (tenantResolver.isResolvable()) {
-            tenantId = tenantResolver.get().resolve(context);
+            tenantId = context.get(CURRENT_STATIC_TENANT_ID);
+            if (tenantId == null && context.get(CURRENT_STATIC_TENANT_ID_NULL) == null) {
+                tenantId = tenantResolver.get().resolve(context);
+                if (tenantId != null) {
+                    context.put(CURRENT_STATIC_TENANT_ID, tenantId);
+                } else {
+                    context.put(CURRENT_STATIC_TENANT_ID_NULL, true);
+                }
+            }
         }
 
         TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
@@ -99,13 +105,6 @@ public class DefaultTenantConfigResolver {
             configContext = tenantConfigBean.getDefaultTenant();
         }
         return configContext;
-    }
-
-    boolean isBlocking(RoutingContext context) {
-        TenantConfigContext resolver = resolve(context, false);
-        return resolver != null
-                && (resolver.auth == null || resolver.oidcConfig.token.refreshExpired
-                        || resolver.oidcConfig.authentication.userInfoRequired);
     }
 
     boolean isSecurityEventObserved() {
@@ -124,36 +123,34 @@ public class DefaultTenantConfigResolver {
         return tokenStateManager.get();
     }
 
-    private TenantConfigContext getTenantConfigFromConfigResolver(RoutingContext context, boolean create) {
+    private OidcTenantConfig getDynamicTenantConfig(RoutingContext context) {
+        OidcTenantConfig oidcConfig = null;
         if (tenantConfigResolver.isResolvable()) {
-            OidcTenantConfig tenantConfig;
-
-            if (context.get(CURRENT_TENANT_CONFIG) != null) {
-                tenantConfig = context.get(CURRENT_TENANT_CONFIG);
-            } else {
-                tenantConfig = this.tenantConfigResolver.get().resolve(context);
-                if (tenantConfig != null) {
-                    context.put(CURRENT_TENANT_CONFIG, tenantConfig);
+            oidcConfig = context.get(CURRENT_DYNAMIC_TENANT_CONFIG);
+            if (oidcConfig == null && context.get(CURRENT_DYNAMIC_TENANT_CONFIG_NULL) == null) {
+                oidcConfig = tenantConfigResolver.get().resolve(context);
+                if (oidcConfig != null) {
+                    context.put(CURRENT_DYNAMIC_TENANT_CONFIG, oidcConfig);
+                } else {
+                    context.put(CURRENT_DYNAMIC_TENANT_CONFIG_NULL, true);
                 }
             }
+        }
+        return oidcConfig;
+    }
 
-            if (tenantConfig != null) {
-                String tenantId = tenantConfig.getTenantId()
-                        .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
-                TenantConfigContext tenantContext = dynamicTenantsConfig.get(tenantId);
+    private Uni<TenantConfigContext> getDynamicTenantContext(RoutingContext context) {
 
-                if (tenantContext == null) {
-                    if (create) {
-                        synchronized (dynamicTenantsConfig) {
-                            tenantContext = dynamicTenantsConfig.computeIfAbsent(tenantId,
-                                    clientId -> tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig));
-                        }
-                    } else {
-                        tenantContext = new TenantConfigContext(null, tenantConfig);
-                    }
-                }
+        OidcTenantConfig tenantConfig = getDynamicTenantConfig(context);
+        if (tenantConfig != null) {
+            String tenantId = tenantConfig.getTenantId()
+                    .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
+            TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
 
-                return tenantContext;
+            if (tenantContext == null) {
+                return tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig);
+            } else {
+                return Uni.createFrom().item(tenantContext);
             }
         }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JwkSetRefreshHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JwkSetRefreshHandler.java
@@ -11,7 +11,7 @@ public class JwkSetRefreshHandler implements Handler<String> {
     private static final Logger LOG = Logger.getLogger(JwkSetRefreshHandler.class);
     private OAuth2Auth auth;
     private volatile long lastForcedRefreshTime;
-    private long forcedJwksRefreshIntervalMilliSecs;
+    private volatile long forcedJwksRefreshIntervalMilliSecs;
 
     public JwkSetRefreshHandler(OAuth2Auth auth, Duration forcedJwksRefreshInterval) {
         this.auth = auth;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -37,37 +37,37 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager) {
-        TenantConfigContext tenantContext = resolve(context);
-        if (tenantContext.oidcConfig.tenantEnabled == false) {
+        OidcTenantConfig oidcConfig = resolve(context);
+        if (oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(context, tenantContext) ? codeAuth.authenticate(context, identityProviderManager)
+        return isWebApp(context, oidcConfig) ? codeAuth.authenticate(context, identityProviderManager)
                 : bearerAuth.authenticate(context, identityProviderManager);
     }
 
     @Override
     public Uni<ChallengeData> getChallenge(RoutingContext context) {
-        TenantConfigContext tenantContext = resolve(context);
-        if (tenantContext.oidcConfig.tenantEnabled == false) {
+        OidcTenantConfig oidcConfig = resolve(context);
+        if (oidcConfig.tenantEnabled == false) {
             return Uni.createFrom().nullItem();
         }
-        return isWebApp(context, tenantContext) ? codeAuth.getChallenge(context)
+        return isWebApp(context, oidcConfig) ? codeAuth.getChallenge(context)
                 : bearerAuth.getChallenge(context);
     }
 
-    private TenantConfigContext resolve(RoutingContext context) {
-        TenantConfigContext tenantContext = resolver.resolve(context, false);
-        if (tenantContext == null) {
-            throw new OIDCException("Tenant configuration context has not been resolved");
+    private OidcTenantConfig resolve(RoutingContext context) {
+        OidcTenantConfig oidcConfig = resolver.resolveConfig(context);
+        if (oidcConfig == null) {
+            throw new OIDCException("Tenant configuration has not been resolved");
         }
-        return tenantContext;
+        return oidcConfig;
     }
 
-    private boolean isWebApp(RoutingContext context, TenantConfigContext tenantContext) {
-        if (OidcTenantConfig.ApplicationType.HYBRID == tenantContext.oidcConfig.applicationType) {
+    private boolean isWebApp(RoutingContext context, OidcTenantConfig oidcConfig) {
+        if (OidcTenantConfig.ApplicationType.HYBRID == oidcConfig.applicationType) {
             return context.request().getHeader("Authorization") == null;
         }
-        return OidcTenantConfig.ApplicationType.WEB_APP == tenantContext.oidcConfig.applicationType;
+        return OidcTenantConfig.ApplicationType.WEB_APP == oidcConfig.applicationType;
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -4,6 +4,7 @@ import static io.quarkus.oidc.runtime.OidcUtils.validateAndCreateIdentity;
 
 import java.security.Principal;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -48,28 +49,35 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         OidcTokenCredential credential = (OidcTokenCredential) request.getToken();
         RoutingContext vertxContext = credential.getRoutingContext();
         vertxContext.put(AuthenticationRequestContext.class.getName(), context);
-        return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
-            @Override
-            public Uni<SecurityIdentity> get() {
-                if (tenantResolver.isBlocking(vertxContext)) {
-                    return context.runBlocking(new Supplier<SecurityIdentity>() {
-                        @Override
-                        public SecurityIdentity get() {
-                            return authenticate(request, vertxContext).await().indefinitely();
-                        }
-                    });
-                }
 
-                return authenticate(request, vertxContext);
-            }
-        });
+        Uni<TenantConfigContext> tenantConfigContext = tenantResolver.resolveContext(vertxContext);
 
+        return tenantConfigContext.onItem()
+                .transformToUni(new Function<TenantConfigContext, Uni<? extends SecurityIdentity>>() {
+                    @Override
+                    public Uni<SecurityIdentity> apply(TenantConfigContext tenantConfigContext) {
+                        return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
+                            @Override
+                            public Uni<SecurityIdentity> get() {
+                                if (isTenantBlocking(tenantConfigContext)) {
+                                    return context.runBlocking(new Supplier<SecurityIdentity>() {
+                                        @Override
+                                        public SecurityIdentity get() {
+                                            return authenticate(request, vertxContext, tenantConfigContext).await()
+                                                    .indefinitely();
+                                        }
+                                    });
+                                }
+                                return authenticate(request, vertxContext, tenantConfigContext);
+                            }
+                        });
+                    }
+                });
     }
 
     private Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request,
-            RoutingContext vertxContext) {
-        TenantConfigContext resolvedContext = tenantResolver.resolve(vertxContext, true);
-
+            RoutingContext vertxContext,
+            TenantConfigContext resolvedContext) {
         if (resolvedContext.oidcConfig.publicKey.isPresent()) {
             return validateTokenWithoutOidcServer(request, resolvedContext);
         } else {
@@ -282,5 +290,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                         });
                     }
                 }).await().indefinitely();
+    }
+
+    private static boolean isTenantBlocking(TenantConfigContext resolvedContext) {
+        return resolvedContext.oidcConfig.token.refreshExpired || resolvedContext.oidcConfig.authentication.userInfoRequired;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -18,6 +19,8 @@ import io.quarkus.oidc.OidcTenantConfig.Credentials;
 import io.quarkus.oidc.OidcTenantConfig.Credentials.Secret;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTenantConfig.Tls.Verification;
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
@@ -39,9 +42,11 @@ public class OidcRecorder {
 
     private static final Logger LOG = Logger.getLogger(OidcRecorder.class);
 
+    private static final Map<String, TenantConfigContext> dynamicTenantsConfig = new ConcurrentHashMap<>();
+
     public Supplier<TenantConfigBean> setup(OidcConfig config, Supplier<Vertx> vertx) {
         final Vertx vertxValue = vertx.get();
-        Map<String, TenantConfigContext> tenantsConfig = new HashMap<>();
+        Map<String, TenantConfigContext> staticTenantsConfig = new HashMap<>();
 
         for (Map.Entry<String, OidcTenantConfig> tenant : config.namedTenants.entrySet()) {
             if (config.defaultTenant.getTenantId().isPresent()
@@ -52,23 +57,53 @@ public class OidcRecorder {
                 throw new OIDCException("Configuration has 2 different tenant-id values: '"
                         + tenant.getKey() + "' and '" + tenant.getValue().getTenantId().get() + "'");
             }
-            tenantsConfig.put(tenant.getKey(), createTenantContext(vertxValue, tenant.getValue(), tenant.getKey()));
+            staticTenantsConfig.put(tenant.getKey(), createTenantContext(vertxValue, tenant.getValue(), tenant.getKey()));
         }
+
         TenantConfigContext tenantContext = createTenantContext(vertxValue, config.defaultTenant, "Default");
         return new Supplier<TenantConfigBean>() {
             @Override
             public TenantConfigBean get() {
-                return new TenantConfigBean(tenantsConfig, tenantContext,
-                        new Function<OidcTenantConfig, TenantConfigContext>() {
+                return new TenantConfigBean(staticTenantsConfig, dynamicTenantsConfig, tenantContext,
+                        new Function<OidcTenantConfig, Uni<TenantConfigContext>>() {
                             @Override
-                            public TenantConfigContext apply(OidcTenantConfig config) {
-                                // OidcTenantConfig resolved by TenantConfigResolver must have its optional tenantId
-                                // initialized which is also enforced by DefaultTenantConfigResolver
-                                return createTenantContext(vertxValue, config, config.getTenantId().get());
+                            public Uni<TenantConfigContext> apply(OidcTenantConfig config) {
+                                if (BlockingOperationControl.isBlockingAllowed()) {
+                                    try {
+                                        return Uni.createFrom().item(createDynamicTenantContext(vertxValue, config,
+                                                config.getTenantId().get()));
+                                    } catch (Throwable t) {
+                                        return Uni.createFrom().failure(t);
+                                    }
+                                } else {
+                                    return Uni.createFrom().emitter(new Consumer<UniEmitter<? super TenantConfigContext>>() {
+                                        @Override
+                                        public void accept(UniEmitter<? super TenantConfigContext> uniEmitter) {
+                                            ExecutorRecorder.getCurrent().execute(new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    try {
+                                                        uniEmitter.complete(createDynamicTenantContext(vertxValue, config,
+                                                                config.getTenantId().get()));
+                                                    } catch (Throwable t) {
+                                                        uniEmitter.fail(t);
+                                                    }
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
                             }
                         });
             }
         };
+    }
+
+    private TenantConfigContext createDynamicTenantContext(Vertx vertx, OidcTenantConfig oidcConfig, String tenantId) {
+        if (!dynamicTenantsConfig.containsKey(tenantId)) {
+            dynamicTenantsConfig.putIfAbsent(tenantId, createTenantContext(vertx, oidcConfig, tenantId));
+        }
+        return dynamicTenantsConfig.get(tenantId);
     }
 
     private TenantConfigContext createTenantContext(Vertx vertx, OidcTenantConfig oidcConfig, String tenantId) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -4,16 +4,22 @@ import java.util.Map;
 import java.util.function.Function;
 
 import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
 
     private final Map<String, TenantConfigContext> staticTenantsConfig;
+    private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
-    private final Function<OidcTenantConfig, TenantConfigContext> tenantConfigContextFactory;
+    private final Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory;
 
-    public TenantConfigBean(Map<String, TenantConfigContext> staticTenantsConfig, TenantConfigContext defaultTenant,
-            Function<OidcTenantConfig, TenantConfigContext> tenantConfigContextFactory) {
+    public TenantConfigBean(
+            Map<String, TenantConfigContext> staticTenantsConfig,
+            Map<String, TenantConfigContext> dynamicTenantsConfig,
+            TenantConfigContext defaultTenant,
+            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
         this.staticTenantsConfig = staticTenantsConfig;
+        this.dynamicTenantsConfig = dynamicTenantsConfig;
         this.defaultTenant = defaultTenant;
         this.tenantConfigContextFactory = tenantConfigContextFactory;
     }
@@ -26,7 +32,11 @@ public class TenantConfigBean {
         return defaultTenant;
     }
 
-    public Function<OidcTenantConfig, TenantConfigContext> getTenantConfigContextFactory() {
+    public Function<OidcTenantConfig, Uni<TenantConfigContext>> getTenantConfigContextFactory() {
         return tenantConfigContextFactory;
+    }
+
+    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
+        return dynamicTenantsConfig;
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -10,6 +10,12 @@ public class CustomTenantResolver implements TenantResolver {
 
     @Override
     public String resolve(RoutingContext context) {
+        // Make sure this resolver is called only once during a given request
+        if (context.get("static_config_resolved") != null) {
+            throw new RuntimeException();
+        }
+        context.put("static_config_resolved", "true");
+
         if (context.request().path().endsWith("/tenant-public-key")) {
             return "tenant-public-key";
         }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -56,7 +56,8 @@ public class TenantResource {
     @Path("webapp")
     @RolesAllowed("user")
     public String userNameWebApp(@PathParam("tenant") String tenant) {
-        if (!tenant.equals("tenant-web-app") && !tenant.equals("tenant-web-app-no-discovery")) {
+        if (!tenant.equals("tenant-web-app") && !tenant.equals("tenant-web-app-dynamic")
+                && !tenant.equals("tenant-web-app-no-discovery")) {
             throw new OIDCException("Wrong tenant");
         }
         UserInfo userInfo = getUserInfo();


### PR DESCRIPTION
Fixes #12754
Fixes #13040

This PR is big enough but it simply properly addresses #12754 with the help from Clement. So in this PR:
- `TenantConfigContext` is resolved as Uni in OidcRecorder which avoids various blocked Vert.x issues when OIDC connections are established dynamically and also should make it faster since only part of the call runs on the executor thread. This is why PR affects so much code as now `Uni<TenantConfigContext>` gets transformed into another Uni completing the call.
- Cleaned up `DefaultTenantConfigResolver`: 1) instead of `resolve(vertxContext, true/false)` it is now either `resolveConfig` or `resolveTenant` 2) isBlocking has been moved out which now only blocks if user info or refreshing the tokens is required (this will be optimized to the just in time blocking call) 3) updated it to avoid calling the resolvers more than once during the current request 

I hope it make it to 10.0.0.CR1 as it has to settle a bit and it brings some good improvements

CC @cescoffier 