### PR TITLE
Cleanup the local cache of redis connections after closing them

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
@@ -52,6 +52,8 @@ class RedisAPIProducer {
         for (RedisAPIContainer container : REDIS_APIS.values()) {
             container.close();
         }
+
+        REDIS_APIS.clear();
     }
 
 }


### PR DESCRIPTION
The Redis extension crashes when using quarkus-dev after a hot reload. While it correctly closes all connections on shutdown, it forgets to clear the cache of reused redis connections. But since they are already closed, all calls from the new hot-reloaded application will fail with a `java.lang.IllegalStateException: Client is closed`.

The quick fix is to delete all `RedisAPIContainer` instances after closing them.