### PR TITLE
Bump supported-maven-versions to 3.6.3 as that's required by jbang-maven-plugin

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -51,7 +51,7 @@
         <!--
         Supported Maven versions, interpreted as a version range
          -->
-        <supported-maven-versions>[3.6.2,)</supported-maven-versions>
+        <supported-maven-versions>[3.6.3,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.6.3</proposed-maven-version>


### PR DESCRIPTION
Bump supported-maven-versions to 3.6.3 as that's required by jbang-maven-plugin

otherwise you get `[ERROR] Failed to execute goal dev.jbang:jbang-maven-plugin:0.0.5:run (generate-build-item-doc) on project quarkus-documentation: The plugin dev.jbang:jbang-maven-plugin:0.0.5 requires Maven version 3.6.3 -> [Help 1]`

@maxandersen fyi

Once this is merged I will update https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/versions.yaml#L6 and https://github.com/quarkusio/quarkusio.github.io/blob/develop/_guides/attributes.adoc#L6