### PR TITLE
Simplify container testing

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -30,8 +30,8 @@ on:
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-containers -Dstart-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
-  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dformat.skip -DskipDocs"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-containers -Dstart-containers -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Dformat.skip -DskipDocs"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -30,8 +30,8 @@ on:
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-postgresql -Dtest-elasticsearch -Delasticsearch.hosts='localhost:9200' -Dtest-keycloak -Dtest-amazon-services -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-redis -Dtest-mailer -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
-  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-postgresql -Dtest-elasticsearch -Delasticsearch.hosts='localhost:9200' -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-mailer -Dtest-keycloak -Dtest-redis -Dformat.skip -DskipDocs -Ddocker"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dformat.skip -DskipDocs"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -30,7 +30,7 @@ on:
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-containers -Dstart-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
   JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Delasticsearch.hosts='localhost:9200' -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test' -Dformat.skip -DskipDocs"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
@@ -479,42 +479,27 @@ jobs:
         category: [IT-Main, IT-Data1, IT-Data2, IT-Data3, IT-Data4, IT-Data5, IT-Data6, IT-Security1, IT-Security2, IT-Security3, IT-Amazon, IT-Messaging, IT-Cache, IT-HTTP, IT-Misc1, IT-Misc2, IT-Misc3, IT-Misc4, IT-Spring, IT-gRPC]
         include:
           - category: IT-Main
-            postgres: "true"
             timeout: 40
           - category: IT-Data1
-            mariadb: "true"
-            mssql: "true"
             timeout: 65
           - category: IT-Data2
-            db2: "true"
-            mysql: "true"
-            mariadb: "true"
             timeout: 65
           - category: IT-Data3
-            postgres: "true"
             timeout: 70
           - category: IT-Data4
-            neo4j: "true"
-            redis: "true"
             timeout: 55
           - category: IT-Data5
-            postgres: "true"
             timeout: 65
           - category: IT-Data6
-            postgres: "true"
-            elasticsearch: "true"
             timeout: 40
           - category: IT-Amazon
-            amazonServices: "true"
             timeout: 45
           - category: IT-Messaging
             timeout: 85
           - category: IT-Security1
             timeout: 50
-            keycloak: "true"
           - category: IT-Security2
             timeout: 70
-            keycloak: "true"
           - category: IT-Security3
             timeout: 50
           - category: IT-Cache
@@ -535,67 +520,6 @@ jobs:
           - category: IT-gRPC
             timeout: 65
     steps:
-      # These should be services, but services do not (yet) allow conditional execution
-      - name: Postgres Service
-        run: |
-          docker run --rm --publish 5432:5432 --name build-postgres \
-          -e POSTGRES_USER=$DB_USER -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_DB=$DB_NAME \
-          -d postgres:10.5
-        if: matrix.postgres
-      - name: MySQL Service
-        run: |
-          sudo service mysql stop || true
-          docker run --rm --publish 3306:3306 --name build-mysql  \
-            -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_RANDOM_ROOT_PASSWORD=true \
-            -d mysql:5 --skip-ssl
-        if: matrix.mysql
-      - name: DB2 Service
-        run: |
-          docker run --rm --publish 50000:50000 --name build-db2 --privileged=true \
-            -e DB2INSTANCE=hreact -e DB2INST1_PASSWORD=hreact -e DBNAME=hreact -e LICENSE=accept -e AUTOCONFIG=false -e ARCHIVE_LOGS=false \
-            -d ibmcom/db2:11.5.0.0a
-        if: matrix.db2
-      - name: Maria DB Service
-        run: |
-          docker run --rm --publish 3308:3306 --name build-mariadb \
-            -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_ROOT_PASSWORD=secret \
-            -d mariadb:10.4
-        if: matrix.mariadb
-      - name: MS-SQL Service
-        run: |
-          docker run --rm --publish 1433:1433 --name build-mssql \
-            -e ACCEPT_EULA=Y -e SA_PASSWORD=ActuallyRequired11Complexity \
-            -d microsoft/mssql-server-linux:2017-CU13
-        if: matrix.mssql
-      - name: Amazon Services
-        run: |
-          docker run --rm --publish 8000:4569 --publish 8008:4572 --publish 8009:4575 --publish 8010:4576 --publish 8011:4599 --publish 8012:4566 --name build-amazon-service-clients -e SERVICES=s3,dynamodb,sns,sqs,kms,ses -e START_WEB=0 \
-            -d localstack/localstack:0.11.1
-        if: matrix.amazonServices
-      - name: Neo4j Service
-        run: |
-          docker run --rm --publish 7687:7687 --name build-neo4j \
-            -e NEO4J_AUTH=neo4j/secret -e NEO4J_dbms_memory_pagecache_size=10M -e NEO4J_dbms_memory_heap_initial__size=10M \
-            -d neo4j/neo4j-experimental:4.0.0-rc01
-        if: matrix.neo4j
-      - name: Redis Service
-        run: docker run --rm --publish 6379:6379 --name build-redis -d redis:5.0.8-alpine
-        if: matrix.redis
-      - name: Keycloak Service
-        run: |
-          docker run --rm --publish 8180:8080 --publish 8543:8443 --name build-keycloak \
-            -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e JAVA_OPTS=" \
-              -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M \
-              -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true \
-              -Dkeycloak.profile.feature.upload_scripts=enabled" \
-            -d quay.io/keycloak/keycloak:11.0.2
-        if: matrix.keycloak
-      - name: Elasticsearch Service
-        run: |
-          docker run --rm --publish 9200:9200 --name build-elasticsearch \
-          -e discovery.type=single-node \
-          -d docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.2
-        if: matrix.elasticsearch
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated

--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -55,7 +55,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-db2 -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-kafka -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test" -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
+        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }} -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test" -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
 
       - name: Report
         if: always()

--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -55,7 +55,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }} -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test" -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
+        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }} -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
 
       - name: Report
         if: always()

--- a/extensions/keycloak-authorization/deployment/pom.xml
+++ b/extensions/keycloak-authorization/deployment/pom.xml
@@ -87,7 +87,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -109,7 +109,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -112,7 +112,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -134,7 +134,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -125,7 +125,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -150,7 +150,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -109,7 +109,7 @@
             <id>test-mariadb</id>
             <activation>
                 <property>
-                    <name>test-mariadb</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -127,7 +127,7 @@
             <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -93,7 +93,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -112,7 +112,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/amazon-services/pom.xml
+++ b/integration-tests/amazon-services/pom.xml
@@ -264,7 +264,7 @@
             <id>test-amazon-services</id>
             <activation>
                 <property>
-                    <name>test-amazon-services</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -343,7 +343,7 @@
             <id>docker-aws-stack</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/container-image/maven-invoker-way/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/pom.xml
@@ -107,7 +107,7 @@
             <id>container-image-docker</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
                 <os>
                     <family>linux</family>

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -121,7 +121,7 @@
       <id>test-elasticsearch</id>
       <activation>
         <property>
-          <name>test-elasticsearch</name>
+          <name>test-containers</name>
         </property>
       </activation>
       <build>
@@ -146,7 +146,7 @@
       <id>docker-elasticsearch</id>
       <activation>
         <property>
-          <name>docker</name>
+          <name>start-containers</name>
         </property>
       </activation>
       <properties>

--- a/integration-tests/elasticsearch-rest-high-level-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-high-level-client/pom.xml
@@ -122,7 +122,7 @@
             <id>test-elasticsearch</id>
             <activation>
                 <property>
-                    <name>test-elasticsearch</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -147,7 +147,7 @@
             <id>docker-elasticsearch</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -142,7 +142,7 @@
             <id>test-db2</id>
             <activation>
                 <property>
-                    <name>test-db2</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -224,7 +224,7 @@
             <id>docker-db2</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -143,7 +143,7 @@
             <id>test-mariadb</id>
             <activation>
                 <property>
-                    <name>test-mariadb</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -224,7 +224,7 @@
             <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -296,7 +296,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -388,7 +388,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -143,7 +143,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -225,7 +225,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-search-orm-elasticsearch/README.md
+++ b/integration-tests/hibernate-search-orm-elasticsearch/README.md
@@ -7,12 +7,12 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Elasticsearch started in the JVM, you can run the following command:
 
 ```
-mvn clean install -Dtest-elasticsearch
+mvn clean install -Dtest-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-elasticsearch -Dnative
+mvn clean install -Dtest-containers -Dnative
 ```
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -135,7 +135,7 @@
             <id>test-elasticsearch</id>
             <activation>
                 <property>
-                    <name>test-elasticsearch</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -160,7 +160,7 @@
             <id>docker-elasticsearch</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/hibernate-tenancy/README.md
+++ b/integration-tests/hibernate-tenancy/README.md
@@ -7,16 +7,16 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with MariaDB started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Please note that waiting on the availability of MariaDB port does not work on macOS.
-This module does not work with `-Ddocker` option on this operating system.
+This module does not work with `-Dstart-containers` option on this operating system.
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MariaDB as a Docker container, you can start your own MariaDB server. It needs to listen on the default port and have a database called `hibernate_orm_test` and a root user with the password `secret`.
@@ -24,7 +24,7 @@ If you don't want to run MariaDB as a Docker container, you can start your own M
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-mariadb
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dmariadb.base_url=jdbc:mariadb://...`.
@@ -48,5 +48,5 @@ N.B. it takes a while for MariaDB to be actually booted and accepting connection
 After it's fully booted, you can run all integration tests via
 
 ```
-mvn clean install -Dtest-mariadb -Dnative
+mvn clean install -Dtest-containers -Dnative
 ```

--- a/integration-tests/hibernate-tenancy/pom.xml
+++ b/integration-tests/hibernate-tenancy/pom.xml
@@ -178,7 +178,7 @@
             <id>test-mariadb</id>
             <activation>
                 <property>
-                    <name>test-mariadb</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -261,7 +261,7 @@
             <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/jpa-db2/README.md
+++ b/integration-tests/jpa-db2/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with DB2 started as a Docker container, you can run the following command:
 
 ```
-mvn verify -Dtest-db2 -Ddocker
+mvn verify -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn verify -Dtest-db2 -Ddocker -Dnative
+mvn verify -Dtest-containers -Dstart-containers -Dnative
 ```
 
 ## To manually run an equivalent DB2 container instead of through Testcontainers, do the following:
@@ -36,5 +36,5 @@ docker run \
 2. Run the test, specifying the JDBC URL for the container you started in the previous step
 
 ```
-mvn verify -Dtest-db2 -Djdbc-db2.url=jdbc:db2://localhost:50000/hreact
+mvn verify -Dtest-containers -Djdbc-db2.url=jdbc:db2://localhost:50000/hreact
 ```

--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -125,7 +125,7 @@
             <id>test-db2</id>
             <activation>
                 <property>
-                    <name>test-db2</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -206,7 +206,7 @@
             <id>docker-db2</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/jpa-mariadb/README.md
+++ b/integration-tests/jpa-mariadb/README.md
@@ -7,16 +7,16 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with MariaDB started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Please note that waiting on the availability of MariaDB port does not work on macOS.
-This module does not work with `-Ddocker` option on this operating system.
+This module does not work with `-Dstart-containers` option on this operating system.
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MariaDB as a Docker container, you can start your own MariaDB server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
@@ -24,7 +24,7 @@ If you don't want to run MariaDB as a Docker container, you can start your own M
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-mariadb
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dmariadb.url=jdbc:mariadb://...`.
@@ -46,5 +46,5 @@ N.B. it takes a while for MariaDB to be actually booted and accepting connection
 After it's fully booted, you can run all integration tests via
 
 ```
-mvn clean install -Dtest-mariadb -Dnative
+mvn clean install -Dtest-containers -Dnative
 ```

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -126,7 +126,7 @@
             <id>test-mariadb</id>
             <activation>
                 <property>
-                    <name>test-mariadb</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -209,7 +209,7 @@
             <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/jpa-mssql/README.md
+++ b/integration-tests/jpa-mssql/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with SQL Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Ddocker -Dtest-mssql
+mvn clean install -Dstart-containers -Dtest-containers
 ```
 
 To also test as a native image, add `-Dnative`:
 
 ```
-mvn clean install -Ddocker -Dtest-mssql -Dnative
+mvn clean install -Dstart-containers -Dtest-containers -Dnative
 ```
 
 Alternatively you can connect to your own SQL Server.

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -130,7 +130,7 @@
             <id>test-mssql</id>
             <activation>
                 <property>
-                    <name>test-mssql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -217,7 +217,7 @@
             <id>docker-mssql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/jpa-mysql/README.md
+++ b/integration-tests/jpa-mysql/README.md
@@ -7,16 +7,16 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with MySQL started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-mysql -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Please note that waiting on the availability of MySQL port does not work on macOS.
-This module does not work with `-Ddocker` option on this operating system.
+This module does not work with `-Dstart-containers` option on this operating system.
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-mysql -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MySQL as a Docker container, you can start your own MySQLDB server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
@@ -24,7 +24,7 @@ If you don't want to run MySQL as a Docker container, you can start your own MyS
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-mysql
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dmysql.url=jdbc:mysql://...`.
@@ -52,5 +52,5 @@ N.B. it takes a while for MySQL to be actually booted and accepting connections.
 After it's fully booted, you can run all integration tests via
 
 ```
-mvn clean install -Dtest-mysql -Dnative
+mvn clean install -Dtest-containers -Dnative
 ```

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -126,7 +126,7 @@
             <id>test-mysql</id>
             <activation>
                 <property>
-                    <name>test-mysql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -209,7 +209,7 @@
             <id>docker-mysql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/jpa-postgresql/README.md
+++ b/integration-tests/jpa-postgresql/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with PostgreSQL started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-postgresql -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-postgresql -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
@@ -21,7 +21,7 @@ If you don't want to run PostgreSQL as a Docker container, you can start your ow
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-postgresql
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dpostgres.url=jdbc:postgresql://...`.

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -125,7 +125,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -207,7 +207,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/kafka-avro/pom.xml
+++ b/integration-tests/kafka-avro/pom.xml
@@ -303,7 +303,7 @@
             <id>test-kafka</id>
             <activation>
                 <property>
-                    <name>test-kafka</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -227,7 +227,7 @@
             <id>test-kafka</id>
             <activation>
                 <property>
-                    <name>test-kafka</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/keycloak-authorization/README.md
+++ b/integration-tests/keycloak-authorization/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default port `8180`.
@@ -21,7 +21,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-keycloak
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=http://keycloak.server.domain:8180/auth`.

--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -159,7 +159,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -253,7 +253,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/logging-gelf/README.md
+++ b/integration-tests/logging-gelf/README.md
@@ -21,13 +21,13 @@ http://localhost:9000/api/system/inputs
 When everything is launched and ready, you can run the tests in a standard JVM with the following command:
 
 ```
-mvn clean test -Dtest-gelf
+mvn clean test -Dtest-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean integration-test -Dtest-gelf -Dnative
+mvn clean integration-test -Dtest-containers -Dnative
 ```
 
 ## Testing with ELK (Elasticsearch, Logstash, Kibana) aka the Elastic Stack
@@ -59,7 +59,7 @@ Then you can use the following commands to run an ELK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-elk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to ELK. You can use Kibana on http://localhost:5601/ to access those logs.
 
 
@@ -97,5 +97,5 @@ Then you can use the following commands to run an EFK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-efk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to EFK. You can use Kibana on http://localhost:5601/ to access those logs.

--- a/integration-tests/logging-gelf/README.md
+++ b/integration-tests/logging-gelf/README.md
@@ -21,13 +21,13 @@ http://localhost:9000/api/system/inputs
 When everything is launched and ready, you can run the tests in a standard JVM with the following command:
 
 ```
-mvn clean test -Dtest-containers
+mvn clean test -Dtest-gelf
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean integration-test -Dtest-containers -Dnative
+mvn clean integration-test -Dtest-gelf -Dnative
 ```
 
 ## Testing with ELK (Elasticsearch, Logstash, Kibana) aka the Elastic Stack
@@ -59,7 +59,7 @@ Then you can use the following commands to run an ELK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-elk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to ELK. You can use Kibana on http://localhost:5601/ to access those logs.
 
 
@@ -97,5 +97,5 @@ Then you can use the following commands to run an EFK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-efk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to EFK. You can use Kibana on http://localhost:5601/ to access those logs.

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -97,7 +97,7 @@
         <id>test-gelf</id>
             <activation>
                 <property>
-                    <name>test-containers</name>
+                    <name>test-gelf</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -97,7 +97,7 @@
         <id>test-gelf</id>
             <activation>
                 <property>
-                    <name>test-gelf</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/mailer/pom.xml
+++ b/integration-tests/mailer/pom.xml
@@ -148,7 +148,7 @@
             <id>test-mailer</id>
             <activation>
                 <property>
-                    <name>test-mailer</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -528,7 +528,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <properties>
@@ -618,7 +618,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/neo4j/README.md
+++ b/integration-tests/neo4j/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Neo4j started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-neo4j -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 To also test as a native image, add `-Dnative`:
 
 ```
-mvn clean install -Dtest-neo4j -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 Alternatively you can connect to your own Neo4j instance or cluster.

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -159,7 +159,7 @@
             <id>test-neo4j</id>
             <activation>
                 <property>
-                    <name>test-neo4j</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -238,7 +238,7 @@
             <id>docker-neo4j</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/oidc-code-flow/README.md
+++ b/integration-tests/oidc-code-flow/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default port `8180`.
@@ -21,7 +21,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-keycloak
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=http://keycloak.server.domain:8180/auth`.

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -149,7 +149,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -251,7 +251,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/oidc-tenancy/README.md
+++ b/integration-tests/oidc-tenancy/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default port `8180`.
@@ -21,7 +21,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-keycloak
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=http://keycloak.server.domain:8180/auth`.

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -126,7 +126,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -226,7 +226,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/oidc/README.md
+++ b/integration-tests/oidc/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-keycloak -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default https port `8543`.
@@ -21,7 +21,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-keycloak
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=https://keycloak.server.domain:8543/auth`.

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -125,7 +125,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -226,7 +226,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/picocli/pom.xml
+++ b/integration-tests/picocli/pom.xml
@@ -61,7 +61,7 @@
             <id>test-vault</id>
             <activation>
                 <property>
-                    <name>test-vault</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/reactive-db2-client/README.md
+++ b/integration-tests/reactive-db2-client/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with DB2 started as a Docker container, you can run the following command:
 
 ```
-mvn verify -Dtest-db2 -Ddocker
+mvn verify -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn verify -Dtest-db2 -Ddocker -Dnative
+mvn verify -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run DB2 as a Docker container, you can start your own DB2 server. It needs to listen on the default port (50000) and have a database called `hreact` accessible to the user `hreact` with the password `hreact`.
@@ -21,7 +21,7 @@ If you don't want to run DB2 as a Docker container, you can start your own DB2 s
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn verify -Dtest-db2
+mvn verify -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dreactive-db2.url=vertx-reactive:db2://localhost:50000/hreact`.

--- a/integration-tests/reactive-db2-client/pom.xml
+++ b/integration-tests/reactive-db2-client/pom.xml
@@ -126,7 +126,7 @@
             <id>test-db2</id>
             <activation>
                 <property>
-                    <name>test-db2</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -207,7 +207,7 @@
             <id>docker-db2</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/reactive-messaging-kafka/pom.xml
+++ b/integration-tests/reactive-messaging-kafka/pom.xml
@@ -219,7 +219,7 @@
             <id>test-kafka</id>
             <activation>
                 <property>
-                    <name>test-kafka</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/reactive-mysql-client/README.md
+++ b/integration-tests/reactive-mysql-client/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with MariaDB started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-mariadb -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MariaDB as a Docker container, you can start your own MariaDB or MySQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
@@ -21,7 +21,7 @@ If you don't want to run MariaDB as a Docker container, you can start your own M
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-mariadb
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dreactive-mysql.url=vertx-reactive:mysql://localhost:3308/hibernate_orm_test`.

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -142,7 +142,7 @@
             <id>test-mariadb</id>
             <activation>
                 <property>
-                    <name>test-mariadb</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -223,7 +223,7 @@
             <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/reactive-pg-client/README.md
+++ b/integration-tests/reactive-pg-client/README.md
@@ -7,13 +7,13 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with PostgreSQL started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-postgresql -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-postgresql -Ddocker -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
@@ -21,7 +21,7 @@ If you don't want to run PostgreSQL as a Docker container, you can start your ow
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-postgresql
+mvn clean install -Dtest-containers
 ```
 
 If you have specific requirements, you can define a specific connection URL with `-Dreactive-postgres.url=vertx-reactive:postgresql://:5431/hibernate_orm_test`.

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -135,7 +135,7 @@
             <id>test-postgresql</id>
             <activation>
                 <property>
-                    <name>test-postgresql</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -216,7 +216,7 @@
             <id>docker-postgresql</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/redis-client/README.md
+++ b/integration-tests/redis-client/README.md
@@ -2,24 +2,24 @@
 
 ## Running the tests
 
-By default, the tests of this module are disabled. To activate the test, use the `-Dtest-redis` option. 
+By default, the tests of this module are disabled. To activate the test, use the `-Dtest-containers` option. 
 
 NB: Tests in this module will attempt a connection to a local Redis listening on the default port. 
 If you have specific requirements, you can define a specific connection URL with `-Dquarkus.redis.hosts=host:port`.
-Or, you can use the `-Ddocker` option to start the Redis Server container automatically. 
+Or, you can use the `-Dstart-containers` option to start the Redis Server container automatically. 
 
 ### Running tests in JVM mode
 
 To run, you can run the following command:
 
 ```
-mvn clean install -Dtest-redis
+mvn clean install -Dtest-containers
 ```
 
 Alternatively, to run the tests in JVM mode with Redis Server started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-redis -Ddocker
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 ### Running tests in native mode
@@ -27,11 +27,11 @@ mvn clean install -Dtest-redis -Ddocker
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-redis -Dnative
+mvn clean install -Dtest-containers -Dnative
 ```
 
-You can also use the `-Ddocker` system property (as shown below), if you want the Redis Server container to be started automatically.
+You can also use the `-Dstart-containers` system property (as shown below), if you want the Redis Server container to be started automatically.
 
 ```
-mvn clean install -Dtest-redis -Dnative -Ddocker
+mvn clean install -Dtest-containers -Dnative -Dstart-containers
 ```

--- a/integration-tests/redis-client/pom.xml
+++ b/integration-tests/redis-client/pom.xml
@@ -122,7 +122,7 @@
             <id>test-redis</id>
             <activation>
                 <property>
-                    <name>test-redis</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -146,7 +146,7 @@
             <id>docker-redis</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/vault-agroal/pom.xml
+++ b/integration-tests/vault-agroal/pom.xml
@@ -73,7 +73,7 @@
             <id>test-vault</id>
             <activation>
                 <property>
-                    <name>test-vault</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -160,7 +160,7 @@
             <id>test-vault</id>
             <activation>
                 <property>
-                    <name>test-vault</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -53,7 +53,7 @@
             <id>test-vault</id>
             <activation>
                 <property>
-                    <name>test-vault</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
This is a follow-up from a discussion we had months ago. Names were suggested by @stuartwdouglas and I think they make sense.

It's a bit longer to type but at least you don't have to check in the pom if it should be `test-pgsql` or `test-postgresql`/`test-mariadb` or `test-mysql` and everything is consistent.

Use:
-Dtest-containers to enable container testing rather than all variants
of -Dtest-postgresql, -Dtest-mariadb and so on
-Dstart-containers to start the containers rather than -Ddocker

I also make the native builds consistently use containers.

Let's see what CI has to say.

/cc @zakkak 