### PR TITLE
Explicitly set gradle local repo in test projects

### DIFF
--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -1,8 +1,12 @@
 buildscript {
 
     repositories {
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            maven(url = System.getProperties().get("maven.repo.local")!!)
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -35,8 +39,12 @@ subprojects {
     }
 
     repositories {
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            maven(url = System.getProperties().get("maven.repo.local")!!)
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/settings.gradle.kts
@@ -1,7 +1,11 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        mavenLocal()
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            maven(url = System.getProperties().get("maven.repo.local")!!)
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module/build.gradle
@@ -1,8 +1,14 @@
 buildscript {
 
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -31,8 +37,14 @@ subprojects {
     }
 
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module/settings.gradle
@@ -1,7 +1,13 @@
 pluginManagement {
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/build.gradle.kts
@@ -4,8 +4,12 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.getProperties().containsKey("maven.repo.local")) {
+        maven(url = System.getProperties().get("maven.repo.local")!!)
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 val quarkusPlatformGroupId: String by project

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/settings.gradle.kts
@@ -1,7 +1,11 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        mavenLocal()
+        if (System.getProperties().containsKey("maven.repo.local")) {
+            maven(url = System.getProperties().get("maven.repo.local")!!)
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/build.gradle
@@ -4,8 +4,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/build.gradle
@@ -4,7 +4,13 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
@@ -5,7 +5,13 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-java-library-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-library-module/application/build.gradle
@@ -4,8 +4,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/basic-java-library-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-library-module/build.gradle
@@ -1,6 +1,12 @@
 buildscript {
      repositories {
-          mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }
@@ -12,7 +18,13 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/test/resources/basic-java-library-module/library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-library-module/library/build.gradle
@@ -3,8 +3,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/basic-java-library-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-library-module/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-java-native-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-native-module/build.gradle
@@ -4,8 +4,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/basic-java-native-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-native-module/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/application/build.gradle
@@ -4,8 +4,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/build.gradle
@@ -1,6 +1,12 @@
 buildscript {
      repositories {
-          mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }
@@ -12,7 +18,13 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/platform/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/platform/build.gradle
@@ -3,8 +3,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/settings.gradle
@@ -1,6 +1,12 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/build.gradle
@@ -1,12 +1,16 @@
 buildscript {
-
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -29,7 +33,13 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
         mavenCentral()
     }

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/settings.gradle
@@ -1,7 +1,13 @@
 pluginManagement {
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project/build.gradle
@@ -1,12 +1,16 @@
 buildscript {
-
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -26,8 +30,14 @@ subprojects {
     }
 
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project/settings.gradle
@@ -1,7 +1,13 @@
 pluginManagement {
     repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/test/resources/compile-only-lombok/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/compile-only-lombok/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/compile-only-lombok/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-config-java-module/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/custom-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-config-java-module/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/custom-filesystem-provider/build.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-filesystem-provider/build.gradle
@@ -1,8 +1,15 @@
 buildscript {
 
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -26,8 +33,15 @@ subprojects {
     }
 
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/custom-filesystem-provider/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-filesystem-provider/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/dotenv-config-java-module/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/dotenv-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/dotenv-config-java-module/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     jcenter()
-    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/test/resources/grpc-include-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-include-project/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-multi-module-project/build.gradle
@@ -1,12 +1,17 @@
 buildscript {
-
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -26,8 +31,15 @@ subprojects {
     }
 
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/grpc-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-multi-module-project/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/implementation-files/build.gradle
+++ b/integration-tests/gradle/src/test/resources/implementation-files/build.gradle
@@ -1,12 +1,17 @@
 buildscript {
-
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -26,8 +31,15 @@ subprojects {
     }
 
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/implementation-files/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/implementation-files/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/application/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/build.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/build.gradle
@@ -1,6 +1,13 @@
 buildscript {
      repositories {
-          mavenLocal()
+          // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }
@@ -12,7 +19,14 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+          if (System.properties.containsKey('maven.repo.local')) {
+               maven {
+                    url System.properties.get('maven.repo.local')
+               }
+          } else {
+               mavenLocal()
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/library/build.gradle
@@ -3,8 +3,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-bean-from-test-config/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/inject-quarkus-app-properties/build.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-quarkus-app-properties/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/inject-quarkus-app-properties/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/inject-quarkus-app-properties/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
@@ -1,13 +1,17 @@
 buildscript {
-
     repositories {
-
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -27,9 +31,15 @@ subprojects {
     }
 
     repositories {
-
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/build.gradle
@@ -5,8 +5,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/list-extension-single-module/build.gradle
@@ -4,7 +4,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/list-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/list-extension-single-module/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/build.gradle
@@ -25,7 +25,14 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/build.gradle
@@ -2,7 +2,14 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
+     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+     if (System.properties.containsKey('maven.repo.local')) {
+          maven {
+               url System.properties.get('maven.repo.local')
+          }
+     } else {
+          mavenLocal()
+     }
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/common/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/common/build.gradle
@@ -3,8 +3,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/quarkus/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/build.gradle
@@ -8,7 +8,14 @@ subprojects {
     version = '1.0.0-SNAPSHOT'
 
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/mutable-jar/build.gradle
+++ b/integration-tests/gradle/src/test/resources/mutable-jar/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/mutable-jar/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/mutable-jar/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
@@ -5,8 +5,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
@@ -4,7 +4,14 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/build.gradle
@@ -1,5 +1,12 @@
 repositories {
-    mavenLocal()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-1/build.gradle
@@ -4,7 +4,14 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/library-2/build.gradle
@@ -5,7 +5,14 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/build.gradle
@@ -1,12 +1,17 @@
 buildscript {
-
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'
@@ -21,8 +26,15 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-resources-vs-main-resources/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-vs-main-resources/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/test-resources-vs-main-resources/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-vs-main-resources/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/build.gradle
@@ -4,8 +4,15 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
-     mavenCentral()
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/settings.gradle
@@ -1,6 +1,13 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
@@ -1,12 +1,17 @@
 buildscript {
-
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
-
 }
 
 apply plugin: 'java'

--- a/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
         jcenter()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }


### PR DESCRIPTION
This branch replaces the `mavenLocal` by the repo specified in `maven.repo.local` system property if it exists. 

Running `mvn clean install -Dmaven.repo.local=/some/path` in the `integration-test/gradle` ends successfully on my machine.
This should fix the Release test build job. 

close #12620 