### PR TITLE
Improve documentation of quarkus.http.access-log.pattern

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
@@ -15,27 +15,17 @@ public class AccessLogConfig {
     public boolean enabled;
 
     /**
-     * The access log pattern:
+     * The access log pattern.
      *
-     * If this is the string 'common', 'combined' or 'long' then this will use one of the specified named formats:
-     * <ul>
-     * <li>
-     * common:<br />
-     * %h %l %u %t "%r" %s %b
-     * </li>
-     * <li>
-     * combined:<br />
-     * %h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"
-     * </li>
-     * <li>
-     * long:<br />
-     * %r<br />
-     * %{ALL_REQUEST_HEADERS}<br />
-     * </li>
-     * </ul>
+     * If this is the string `common`, `combined` or `long` then this will use one of the specified named formats:
+     *
+     * - common: `%h %l %u %t "%r" %s %b`
+     * - combined: `%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"`
+     * - long: `%r\n%{ALL_REQUEST_HEADERS}`
      *
      * Otherwise consult the Quarkus documentation for the full list of variables that can be used.
      *
+     * @asciidoclet
      */
     @ConfigItem(defaultValue = "common")
     public String pattern;


### PR DESCRIPTION
The Javadoc was not properly translated to Asciidoc so let's use
Asciidoc directly.