### PR TITLE
Check X-Forwarded-Prefix when building OIDC redirect_uri

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -459,8 +459,19 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     private String buildUri(RoutingContext context, boolean forceHttps, String path) {
         final String scheme = forceHttps ? "https" : context.request().scheme();
+        String forwardedPrefix = "";
+        if (resolver.isEnableHttpForwardedPrefix()) {
+            String forwardedPrefixHeader = context.request().getHeader("X-Forwarded-Prefix");
+            if (forwardedPrefixHeader != null && !forwardedPrefixHeader.equals("/") && !forwardedPrefixHeader.equals("//")) {
+                forwardedPrefix = forwardedPrefixHeader;
+                if (forwardedPrefix.endsWith("/")) {
+                    forwardedPrefix = forwardedPrefix.substring(0, forwardedPrefix.length() - 1);
+                }
+            }
+        }
         return new StringBuilder(scheme).append("://")
                 .append(URI.create(context.request().absoluteURI()).getAuthority())
+                .append(forwardedPrefix)
                 .append(path)
                 .toString();
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -9,6 +9,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.OIDCException;
@@ -41,6 +42,10 @@ public class DefaultTenantConfigResolver {
 
     @Inject
     Event<SecurityEvent> securityEvent;
+
+    @Inject
+    @ConfigProperty(name = "quarkus.http.proxy.enable-forwarded-prefix")
+    boolean enableHttpForwardedPrefix;
 
     private volatile boolean securityEventObserved;
 
@@ -153,5 +158,9 @@ public class DefaultTenantConfigResolver {
         }
 
         return null;
+    }
+
+    boolean isEnableHttpForwardedPrefix() {
+        return enableHttpForwardedPrefix;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -146,6 +146,9 @@ quarkus.http.auth.permission.post-logout.policy=permit
 
 quarkus.http.cors=true
 quarkus.http.auth.proactive=false
+quarkus.http.proxy.enable-forwarded-prefix=true
+quarkus.http.proxy.allow-forwarded=true
+
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
 quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".level=TRACE
 #quarkus.log.category."org.apache.http".level=TRACE

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -680,6 +680,33 @@ public class CodeFlowTest {
     }
 
     @Test
+    public void testRedirectUriWithForwardedPrefix() throws IOException, InterruptedException {
+        //doTestRedirectUriWithForwardedPrefix("/service");
+        doTestRedirectUriWithForwardedPrefix("/service/");
+        //doTestRedirectUriWithForwardedPrefix("");
+        //doTestRedirectUriWithForwardedPrefix("/");
+        //doTestRedirectUriWithForwardedPrefix("//");
+    }
+
+    private void doTestRedirectUriWithForwardedPrefix(String prefix) throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.addRequestHeader("X-Forwarded-Prefix", prefix);
+            WebResponse webResponse = webClient
+                    .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/index.html").toURL()));
+            String loc = webResponse.getResponseHeaderValue("location");
+            String encodedPrefix;
+            if (prefix.isEmpty() || prefix.equals("/") || prefix.equals("//")) {
+                encodedPrefix = "%2F";
+            } else {
+                encodedPrefix = prefix.replaceAll("\\/", "%2F");
+            }
+            assertTrue(loc.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8081" + encodedPrefix + "web-app"));
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testJavaScriptRequest() throws IOException, InterruptedException {
         try (final WebClient webClient = createWebClient()) {
             try {


### PR DESCRIPTION
Fixes #13062.

It is a simple PR which uses `X-Forwarded-Prefix` to build OIDC redirect as well as post logout URIs if the user has enabled the processing of this header.

Unfortunately we can't just use `context.request.getRawPath()` (or the relative `context.request.uri()`) when calculating the URIs as the `redirect_uri` or `post_logout` relative paths may or will not be sub-paths of the current request URI.
But it is a small enhancement which is worth supporting IMHO...

I've tested it the same way it is tested in the existing `ForwardedPrefixHeaderTest` test