### PR TITLE
Vert.x event-loop threads start as "vert.x-eventloop-thread-"

### DIFF
--- a/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
+++ b/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
@@ -91,7 +91,7 @@ public class MutinyTest {
                 throwable.set(err);
             }
             latch.countDown();
-        }, "vertx-eventloop-thread-0").start();
+        }, "vert.x-eventloop-thread-0").start();
 
         Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
         Assertions.assertNull(item.get());

--- a/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
+++ b/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.mutiny.runtime.MutinyInfrastructure;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -91,7 +92,7 @@ public class MutinyTest {
                 throwable.set(err);
             }
             latch.countDown();
-        }, "vert.x-eventloop-thread-0").start();
+        }, MutinyInfrastructure.VERTX_EVENT_LOOP_THREAD_PREFIX + "0").start();
 
         Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
         Assertions.assertNull(item.get());

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -12,6 +12,8 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 @Recorder
 public class MutinyInfrastructure {
 
+    public static final String VERTX_EVENT_LOOP_THREAD_PREFIX = "vert.x-eventloop-thread-";
+
     public void configureMutinyInfrastructure(ExecutorService exec) {
         Infrastructure.setDefaultExecutor(exec);
     }
@@ -36,7 +38,7 @@ public class MutinyInfrastructure {
                  * calling from a Vert.x event-loop context / thread.
                  */
                 String threadName = Thread.currentThread().getName();
-                return !threadName.startsWith("vert.x-eventloop-thread-");
+                return !threadName.startsWith(VERTX_EVENT_LOOP_THREAD_PREFIX);
             }
         });
     }

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -36,7 +36,7 @@ public class MutinyInfrastructure {
                  * calling from a Vert.x event-loop context / thread.
                  */
                 String threadName = Thread.currentThread().getName();
-                return !threadName.contains("vertx-eventloop-thread-");
+                return !threadName.startsWith("vert.x-eventloop-thread-");
             }
         });
     }


### PR DESCRIPTION
This typo causes a bug where blocking checks fail when run on a Vert.x event-loop.