### PR TITLE
Qute: fix template extension validation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -802,7 +802,7 @@ public class QuteProcessor {
         Set<String> generatedTypes = new HashSet<>();
         generatedTypes.addAll(generator.getGeneratedTypes());
 
-        ExtensionMethodGenerator extensionMethodGenerator = new ExtensionMethodGenerator(classOutput);
+        ExtensionMethodGenerator extensionMethodGenerator = new ExtensionMethodGenerator(index, classOutput);
         Map<DotName, List<TemplateExtensionMethodBuildItem>> classToNamespaceExtensions = new HashMap<>();
         Map<String, DotName> namespaceToClass = new HashMap<>();
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ExtensionMethodCompletionStageTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ExtensionMethodCompletionStageTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.qute.deployment.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.deployment.Foo;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ExtensionMethodCompletionStageTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Foo.class, Extensions.class, FooParentService.class));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testTemplateExtensions() throws InterruptedException, ExecutionException {
+        CompletableFuture<String> result = engine.parse("{foo.parent.name}").data("foo", new Foo("alpha", 10l)).renderAsync()
+                .toCompletableFuture();
+        assertFalse(result.isDone());
+        FooParentService.parent.complete(new Foo("bravo", 1l));
+        assertEquals("bravo", result.toCompletableFuture().get());
+    }
+
+    @Singleton
+    public static class FooParentService {
+
+        static final CompletableFuture<Foo> parent = new CompletableFuture<Foo>();
+
+        CompletableFuture<Foo> getParent(Foo foo) {
+            return parent;
+        }
+
+    }
+
+    public static class Extensions {
+
+        @TemplateExtension(matchName = "parent")
+        static CompletableFuture<Foo> fooParentAsync(Foo foo) {
+            return CDI.current().select(FooParentService.class).get().getParent(foo);
+        }
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/InvalidExtensionMethodMatchRegexTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/InvalidExtensionMethodMatchRegexTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qute.deployment.extensions;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.deployment.Foo;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InvalidExtensionMethodMatchRegexTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Foo.class, Extensions.class))
+            .setExpectedException(TemplateException.class);
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    public static class Extensions {
+
+        // the method should have at least two params and the second one must be a string
+        @TemplateExtension(matchRegex = "bar")
+        static String fooRegex(Foo foo) {
+            return foo.name.toUpperCase();
+        }
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/TemplateExtensionMethodsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/TemplateExtensionMethodsTest.java
@@ -64,6 +64,12 @@ public class TemplateExtensionMethodsTest {
     }
 
     @Test
+    public void testMatchRegex() {
+        assertEquals("BRAVO=BAR",
+                engine.parse("{foo.bravo}={foo.bar}").data("foo", new Foo("pong", 10l)).render());
+    }
+
+    @Test
     public void testBuiltinExtensions() {
         Map<String, String> map = new HashMap<String, String>();
         map.put("alpha", "1");
@@ -118,6 +124,11 @@ public class TemplateExtensionMethodsTest {
 
         static int defaultScale(BigDecimal val) {
             return 2;
+        }
+
+        @TemplateExtension(matchRegex = "(bar|bravo)")
+        static String fooRegex(Foo foo, String name) {
+            return name.toUpperCase();
         }
     }
 

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
@@ -48,7 +48,7 @@ public class SimpleGeneratorTest {
         generator.generate();
         generatedTypes.addAll(generator.getGeneratedTypes());
 
-        ExtensionMethodGenerator extensionMethodGenerator = new ExtensionMethodGenerator(classOutput);
+        ExtensionMethodGenerator extensionMethodGenerator = new ExtensionMethodGenerator(index, classOutput);
         MethodInfo extensionMethod = index.getClassByName(DotName.createSimple(MyService.class.getName())).method(
                 "getDummy", Type.create(myServiceClazz.name(), Kind.CLASS), PrimitiveType.INT,
                 Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS));


### PR DESCRIPTION
- throw a correct exception if TemplateExtension#matchRegex() is used
and invalid params are used
- also add few more tests