### PR TITLE
Optimise memory retention in production: tuning of RunnerClassLoader

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -20,6 +20,7 @@ import org.graalvm.nativeimage.ImageInfo;
 import org.jboss.logging.Logger;
 import org.wildfly.common.lock.Locks;
 
+import io.quarkus.bootstrap.runner.RunnerClassLoader;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.runtime.graal.DiagnosticPrinter;
 import sun.misc.Signal;
@@ -129,6 +130,7 @@ public class ApplicationLifecycleManager {
                     }
                 }
             } else {
+                longLivedPostBootCleanup();
                 stateLock.lock();
                 try {
                     while (!shutdownRequested) {
@@ -179,6 +181,18 @@ public class ApplicationLifecycleManager {
             application.stop(); //this could have already been called
         }
         (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(getExitCode(), null); //this may not be called if shutdown was initiated by a signal
+    }
+
+    /**
+     * Run some background cleanup once after the application has booted.
+     * This will not be invoked for command mode, as it's not worth it for a short lived process.
+     */
+    private static void longLivedPostBootCleanup() {
+        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl instanceof RunnerClassLoader) {
+            RunnerClassLoader rcl = (RunnerClassLoader) cl;
+            rcl.resetInternalCaches();
+        }
     }
 
     private static void registerHooks(final BiConsumer<Integer, Throwable> exitCodeHandler) {

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
@@ -15,4 +15,16 @@ public interface ClassLoadingResource {
 
     void close();
 
+    /**
+     * This is an optional hint to release internal caches, if possible.
+     * It is different than {@link #close()} as it's possible that
+     * this ClassLoadingResource will still be used after this,
+     * so it needs to be able to rebuild any lost state in case of need.
+     * However one can assume that when this is invoked, there is
+     * some reasonable expectation that this resource is no longer going
+     * to be necessary.
+     */
+    default void resetInternalCaches() {
+        //no-op
+    }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -130,4 +130,9 @@ public class JarResource implements ClassLoadingResource {
             this.zipFile = null;
         }
     }
+
+    @Override
+    public synchronized void resetInternalCaches() {
+        close();
+    }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -120,12 +120,14 @@ public class JarResource implements ClassLoadingResource {
 
     @Override
     public void close() {
-        if (zipFile != null) {
+        JarFile zipFileLocal = this.zipFile;
+        if (zipFileLocal != null) {
             try {
-                zipFile.close();
+                zipFileLocal.close();
             } catch (IOException e) {
                 //ignore
             }
+            this.zipFile = null;
         }
     }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -99,18 +99,23 @@ public class JarResource implements ClassLoadingResource {
     }
 
     private JarFile file() {
-        if (zipFile == null) {
+        JarFile zipFileLocal = this.zipFile;
+        if (zipFileLocal == null) {
             synchronized (this) {
-                if (zipFile == null) {
+                zipFileLocal = this.zipFile;
+                if (zipFileLocal == null) {
                     try {
-                        return zipFile = JarFiles.create(jarPath.toFile());
+                        return this.zipFile = JarFiles.create(jarPath.toFile());
                     } catch (IOException e) {
                         throw new RuntimeException("Failed to open " + jarPath, e);
                     }
+                } else {
+                    return zipFileLocal;
                 }
             }
+        } else {
+            return zipFileLocal;
         }
-        return zipFile;
     }
 
     @Override

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -70,7 +70,7 @@ public class JarResource implements ClassLoadingResource {
                 realName = realName.substring(0, realName.length() - 1);
             }
             URI jarUri = jarPath.toUri();
-            return new URL("jar", null, jarUri.getScheme() + ":" + jarUri.getPath() + "!/" + resource);
+            return new URL("jar", null, jarUri.getScheme() + ':' + jarUri.getPath() + "!/" + resource);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
@@ -87,7 +87,7 @@ public class JarResource implements ClassLoadingResource {
         try {
             String path = jarPath.toAbsolutePath().toString();
             if (!path.startsWith("/")) {
-                path = "/" + path;
+                path = '/' + path;
             }
             URI uri = new URI("file", null, path, null);
             url = uri.toURL();

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -12,6 +12,9 @@ import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
@@ -24,55 +27,76 @@ public class JarResource implements ClassLoadingResource {
 
     private final ManifestInfo manifestInfo;
     private final Path jarPath;
+
+    private final Lock readLock;
+    private final Lock writeLock;
+
+    //Guarded by the read/write lock; open/close operations on the JarFile require the exclusive lock,
+    //while using an existing open reference can use the shared lock.
+    //If a lock is acquired, and as long as it's owned, we ensure that the zipFile reference
+    //points to an open JarFile instance, and read operations are valid.
+    //To close the jar, the exclusive lock must be owned, and reference will be set to null before releasing it.
+    //Likewise, opening a JarFile requires the exclusive lock.
     private volatile JarFile zipFile;
 
     public JarResource(ManifestInfo manifestInfo, Path jarPath) {
         this.manifestInfo = manifestInfo;
         this.jarPath = jarPath;
+        final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+        this.readLock = readWriteLock.readLock();
+        this.writeLock = readWriteLock.writeLock();
     }
 
     @Override
     public byte[] getResourceData(String resource) {
-        ZipFile zipFile = file();
-        ZipEntry entry = zipFile.getEntry(resource);
-        if (entry == null) {
-            return null;
-        }
-        try (InputStream is = zipFile.getInputStream(entry)) {
-            byte[] data = new byte[(int) entry.getSize()];
-            int pos = 0;
-            int rem = data.length;
-            while (rem > 0) {
-                int read = is.read(data, pos, rem);
-                if (read == -1) {
-                    throw new RuntimeException("Failed to read all data for " + resource);
-                }
-                pos += read;
-                rem -= read;
+        final ZipFile zipFile = readLockAcquireAndGetJarReference();
+        try {
+            ZipEntry entry = zipFile.getEntry(resource);
+            if (entry == null) {
+                return null;
             }
-            return data;
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to read zip entry " + resource, e);
+            try (InputStream is = zipFile.getInputStream(entry)) {
+                byte[] data = new byte[(int) entry.getSize()];
+                int pos = 0;
+                int rem = data.length;
+                while (rem > 0) {
+                    int read = is.read(data, pos, rem);
+                    if (read == -1) {
+                        throw new RuntimeException("Failed to read all data for " + resource);
+                    }
+                    pos += read;
+                    rem -= read;
+                }
+                return data;
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read zip entry " + resource, e);
+            }
+        } finally {
+            readLock.unlock();
         }
     }
 
     @Override
     public URL getResourceURL(String resource) {
-        JarFile zipFile = file();
-        JarEntry entry = zipFile.getJarEntry(resource);
-        if (entry == null) {
-            return null;
-        }
+        final JarFile jarFile = readLockAcquireAndGetJarReference();
         try {
-            String realName = JarEntries.getRealName(entry);
-            // Avoid ending the URL with / to avoid breaking compatibility
-            if (realName.endsWith("/")) {
-                realName = realName.substring(0, realName.length() - 1);
+            JarEntry entry = jarFile.getJarEntry(resource);
+            if (entry == null) {
+                return null;
             }
-            URI jarUri = jarPath.toUri();
-            return new URL("jar", null, jarUri.getScheme() + ':' + jarUri.getPath() + "!/" + resource);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            try {
+                String realName = JarEntries.getRealName(entry);
+                // Avoid ending the URL with / to avoid breaking compatibility
+                if (realName.endsWith("/")) {
+                    realName = realName.substring(0, realName.length() - 1);
+                }
+                URI jarUri = jarPath.toUri();
+                return new URL("jar", null, jarUri.getScheme() + ':' + jarUri.getPath() + "!/" + resource);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        } finally {
+            readLock.unlock();
         }
     }
 
@@ -83,7 +107,7 @@ public class JarResource implements ClassLoadingResource {
 
     @Override
     public ProtectionDomain getProtectionDomain(ClassLoader classLoader) {
-        URL url = null;
+        final URL url;
         try {
             String path = jarPath.toAbsolutePath().toString();
             if (!path.startsWith("/")) {
@@ -98,41 +122,67 @@ public class JarResource implements ClassLoadingResource {
         return new ProtectionDomain(codesource, null, classLoader, null);
     }
 
-    private JarFile file() {
-        JarFile zipFileLocal = this.zipFile;
-        if (zipFileLocal == null) {
-            synchronized (this) {
-                zipFileLocal = this.zipFile;
-                if (zipFileLocal == null) {
-                    try {
-                        return this.zipFile = JarFiles.create(jarPath.toFile());
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to open " + jarPath, e);
-                    }
-                } else {
-                    return zipFileLocal;
+    private JarFile readLockAcquireAndGetJarReference() {
+        while (true) {
+            readLock.lock();
+            final JarFile zipFileLocal = this.zipFile;
+            if (zipFileLocal != null) {
+                //Expected fast path: returns a reference to the open JarFile while owning the readLock
+                return zipFileLocal;
+            } else {
+                //This Lock implementation doesn't allow upgrading a readLock to a writeLock, so release it
+                //as we're going to need the WriteLock.
+                readLock.unlock();
+                //trigger the JarFile being (re)opened.
+                ensureJarFileIsOpen();
+                //Now since we no longer own any lock, we need to try again to obtain the readLock
+                //and check for the reference still being valid.
+                //This exposes us to a race with closing the just-opened JarFile;
+                //however this should be extremely rare, so we can trust we won't loop much;
+                //A counter doesn't seem necessary, as in fact we know that methods close()
+                //and resetInternalCaches() are invoked each at most once, which limits the amount
+                //of loops here in practice.
+            }
+        }
+    }
+
+    private void ensureJarFileIsOpen() {
+        writeLock.lock();
+        try {
+            if (this.zipFile == null) {
+                try {
+                    this.zipFile = JarFiles.create(jarPath.toFile());
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to open " + jarPath, e);
                 }
             }
-        } else {
-            return zipFileLocal;
+        } finally {
+            writeLock.unlock();
         }
     }
 
     @Override
     public void close() {
-        JarFile zipFileLocal = this.zipFile;
-        if (zipFileLocal != null) {
-            try {
-                zipFileLocal.close();
-            } catch (IOException e) {
-                //ignore
+        writeLock.lock();
+        try {
+            final JarFile zipFileLocal = this.zipFile;
+            if (zipFileLocal != null) {
+                try {
+                    zipFileLocal.close();
+                } catch (IOException e) {
+                    //ignore
+                }
+                this.zipFile = null;
             }
-            this.zipFile = null;
+        } finally {
+            writeLock.unlock();
         }
     }
 
     @Override
-    public synchronized void resetInternalCaches() {
+    public void resetInternalCaches() {
+        //Currently same implementations as #close
         close();
     }
+
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -214,4 +214,12 @@ public class RunnerClassLoader extends ClassLoader {
             }
         }
     }
+
+    public void resetInternalCaches() {
+        for (Map.Entry<String, ClassLoadingResource[]> entry : resourceDirectoryMap.entrySet()) {
+            for (ClassLoadingResource i : entry.getValue()) {
+                i.resetInternalCaches();
+            }
+        }
+    }
 }


### PR DESCRIPTION
The main change here is the commit b8c2f922b19137c25a4d969e03d5a7b64cfab150; this is able to significantly reduce the amount of retained memory of a Quarkus application, assuming it's running in production mode and using "fast-jars" for the build.

While at it I polished the code a bit to be safer against races; that's in separate commits.

# Supporting Data

## Keycloak

Retained memory of a just-started Keycloack instance is:
  
- 30 MB without patch
- 24 MB with this patch

## Hibernate ORM Quickstart

- 10.2 MB without patch
- 8.7 MB with this patch

I have not measured native image or RSS.

Discussion: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Retained.20heap.20optimisations 