### PR TITLE
Remove private modifier from injection point in MP FT guide

### DIFF
--- a/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
@@ -172,7 +172,7 @@ public class CoffeeResource {
     private static final Logger LOGGER = Logger.getLogger(CoffeeResource.class);
 
     @Inject
-    private CoffeeRepositoryService coffeeRepository;
+    CoffeeRepositoryService coffeeRepository;
 
     private AtomicLong counter = new AtomicLong(0);
 


### PR DESCRIPTION
This causes a warning in IDE and terminal (unrecommended).