### PR TITLE
Handle gradle multiple source directories in test extension

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import org.gradle.api.Project;
@@ -57,6 +58,12 @@ public class QuarkusPluginExtension {
                     .resolveModel(getAppArtifact());
             final Path serializedModel = QuarkusGradleUtils.serializeAppModel(appModel, task);
             props.put(BootstrapConstants.SERIALIZED_APP_MODEL, serializedModel.toString());
+
+            StringJoiner outputSourcesDir = new StringJoiner(",");
+            for (File outputSourceDir : outputSourcesDir()) {
+                outputSourcesDir.add(outputSourceDir.getAbsolutePath());
+            }
+            props.put(BootstrapConstants.OUTPUT_SOURCES_DIR, outputSourcesDir.toString());
 
             // Identify the folder containing the sources associated with this test task
             String fileList = getSourceSets().stream()
@@ -171,6 +178,10 @@ public class QuarkusPluginExtension {
 
     public Set<File> resourcesDir() {
         return getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getResources().getSrcDirs();
+    }
+
+    public Set<File> outputSourcesDir() {
+        return getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDirs().getFiles();
     }
 
     public AppArtifact getAppArtifact() {

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.util.Set;
+
 import org.gradle.api.Project;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -52,5 +55,21 @@ public class QuarkusPluginTest {
                 .contains(tasks.getByName(JavaPlugin.CLASSES_TASK_NAME));
         assertThat(tasks.getByName(QuarkusPlugin.QUARKUS_DEV_TASK_NAME).getDependsOn())
                 .contains(tasks.getByName(JavaPlugin.CLASSES_TASK_NAME));
+    }
+
+    @Test
+    public void shouldReturnMutlipleOutputSourceDirectories() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(QuarkusPlugin.ID);
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply("scala");
+
+        final QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
+
+        final Set<File> outputSourceDirs = extension.outputSourcesDir();
+        assertThat(outputSourceDirs).hasSize(2);
+        assertThat(outputSourceDirs).contains(new File(project.getBuildDir(), "classes/java/main"),
+                new File(project.getBuildDir(), "classes/scala/main"));
+
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -17,6 +17,8 @@ public interface BootstrapConstants {
      */
     String TEST_TO_MAIN_MAPPINGS = "TEST_TO_MAIN_MAPPINGS";
 
+    String OUTPUT_SOURCES_DIR = "OUTPUT_SOURCES_DIR";
+
     @Deprecated
     String EXTENSION_PROPS_JSON_FILE_NAME = "quarkus-extension.json";
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
@@ -57,7 +57,6 @@ public class MultiModuleUberJarTest extends QuarkusGradleWrapperTestBase {
 
     private void assertThatOutputWorksCorrectly(String logs) {
         assertThat(logs.isEmpty()).isFalse();
-        //String infoLogLevel = "INFO";
         assertThat(logs.contains("INFO")).isTrue();
         assertThat(logs.contains("cdi, resteasy")).isTrue();
     }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiSourceProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiSourceProjectTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class MultiSourceProjectTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void shouldRunTest() throws Exception {
+        final File projectDir = getProjectDir("multi-source-project");
+        final BuildResult buildResult = runGradleWrapper(projectDir, ":test");
+
+        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'java'
+    id 'org.jetbrains.kotlin.jvm' version "1.3.72"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.3.72"
+    id 'io.quarkus'
+}
+
+repositories {
+    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'io.quarkus:quarkus-kotlin'
+    implementation 'io.quarkus:quarkus-grpc'
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:kotlin-extensions'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+allOpen {
+    annotation("javax.ws.rs.Path")
+    annotation("javax.enterprise.context.ApplicationScoped")
+    annotation("io.quarkus.test.junit.QuarkusTest")
+}
+
+compileKotlin {
+    kotlinOptions.javaParameters = true
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/test/resources/multi-source-project/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/multi-source-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/main/java/org/acme/service/SimpleService.java
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/main/java/org/acme/service/SimpleService.java
@@ -1,0 +1,13 @@
+package org.acme.service;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SimpleService {
+    @NotNull
+    public String hello() {
+        return "hello from JavaComponent";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/main/kotlin/org/acme/ExampleResource.kt
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/main/kotlin/org/acme/ExampleResource.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+import org.acme.service.SimpleService
+
+@Path("/hello")
+class ExampleResource {
+
+    @Inject
+    lateinit var service: SimpleService
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello(): String = service.hello()
+}

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>code-with-quarkus - 1.0.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>Do you like Quarkus?</h2>
+        <p>Go give it a star on <a href="https://github.com/quarkusio/quarkus">GitHub</a>.</p>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme</li>
+                <li>ArtifactId: code-with-quarkus</li>
+                <li>Version: 1.0.0-SNAPSHOT</li>
+                <li>Quarkus Version: 1.7.2.Final</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.NativeImageTest
+
+@NativeImageTest
+class NativeExampleResourceIT : ExampleResourceTest()

--- a/integration-tests/gradle/src/test/resources/multi-source-project/src/test/kotlin/org/acme/ExampleResourceTest.kt
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/src/test/kotlin/org/acme/ExampleResourceTest.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class ExampleResourceTest {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(`is`("hello"))
+    }
+
+}


### PR DESCRIPTION
Gradle source output depends on the language: 

- `java` output goes to `build/classes/java/main`
- `kotlin` output goes to `build/classes/kotlin/main`
- `scala` output goes to `build/classes/scala/main`

In the `QuarkusTestExtension`, there is a one-to-one matching that is done from the test class directory to find the corresponding `main` source directory. 
In a gradle project, if there is more than just one language, only one source output will be added to the context.

close #13155