### PR TITLE
Fix the name of registerHealthUiHandler method

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -402,7 +402,7 @@ class SmallRyeHealthProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void registerGraphQLUiHandler(
+    void registerHealthUiHandler(
             BuildProducer<RouteBuildItem> routeProducer,
             SmallRyeHealthRecorder recorder,
             SmallRyeHealthRuntimeConfig runtimeConfig,


### PR DESCRIPTION
This method has nothing to do with GraphQL, so the name is confusing.