### PR TITLE
Add the Maven and Gradle binary jars for the wrapper to generated .gitignore.

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/BuildTool.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/BuildTool.java
@@ -13,12 +13,12 @@ import java.nio.file.Path;
 public enum BuildTool {
 
     /** Maven build tool */
-    MAVEN("\n# Maven\ntarget/\npom.xml.tag\npom.xml.releaseBackup\npom.xml.versionsBackup\nrelease.properties",
+    MAVEN("\n# Maven\ntarget/\n!.mvn/wrapper/maven-wrapper.jar\npom.xml.tag\npom.xml.releaseBackup\npom.xml.versionsBackup\nrelease.properties",
             "target",
             new String[] { "pom.xml" }),
 
     /** Gradle build tool */
-    GRADLE("\n# Gradle\n.gradle/\nbuild/",
+    GRADLE("\n# Gradle\n.gradle/\nbuild/\n!gradle/wrapper/gradle-wrapper.jar",
             "build",
             new String[] { "build.gradle", "settings.gradle", "gradle.properties" }),
 


### PR DESCRIPTION
This adds the binaries for the Maven and Gradle wrappers to the generated .gitignore. They belong there as the binaries should not be included into the generated projects. Both wrappers will download the jars anyway.