### PR TITLE
Avoid ObjectMapper CDI warning in Funky Google Cloud Functions

### DIFF
--- a/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
@@ -6,7 +6,11 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -15,6 +19,7 @@ import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.gcp.functions.FunqyCloudFunctionsBindingRecorder;
 import io.quarkus.funqy.runtime.FunqyConfig;
+import io.quarkus.jackson.ObjectMapperProducer;
 
 public class FunqyCloudFunctionsBuildStep {
     private static final String FEATURE_NAME = "funqy-google-cloud-functions";
@@ -36,7 +41,7 @@ public class FunqyCloudFunctionsBuildStep {
             FunqyCloudFunctionsBindingRecorder recorder,
             Optional<FunctionInitializedBuildItem> hasFunctions,
             BeanContainerBuildItem beanContainer) throws Exception {
-        if (!hasFunctions.isPresent() || hasFunctions.get() == null)
+        if (!hasFunctions.isPresent())
             return;
 
         recorder.init(beanContainer.getValue());
@@ -46,5 +51,13 @@ public class FunqyCloudFunctionsBuildStep {
     @Record(RUNTIME_INIT)
     public void choose(FunqyConfig config, FunqyCloudFunctionsBindingRecorder recorder) {
         recorder.chooseInvoker(config);
+    }
+
+    @BuildStep
+    public void markObjectMapperUnremovable(BuildProducer<UnremovableBeanBuildItem> unremovable) {
+        unremovable.produce(new UnremovableBeanBuildItem(
+                new UnremovableBeanBuildItem.BeanClassNameExclusion(ObjectMapper.class.getName())));
+        unremovable.produce(new UnremovableBeanBuildItem(
+                new UnremovableBeanBuildItem.BeanClassNameExclusion(ObjectMapperProducer.class.getName())));
     }
 }

--- a/integration-tests/funqy-google-cloud-functions/src/main/resources/application.properties
+++ b/integration-tests/funqy-google-cloud-functions/src/main/resources/application.properties
@@ -1,4 +1,2 @@
-quarkus.funqy.export=helloHttpWorld
-#quarkus.funqy.export=helloHttpWorldAsync
+quarkus.funqy.export=helloGCSWorld
 #quarkus.funqy.export=helloPubSubWorld
-#quarkus.funqy.export=helloGCSWorld


### PR DESCRIPTION
This avoid a nasty CDI warning on startup

```
================================================================================
CDI: programmatic lookup problem detected
-----------------------------------------
At least one bean matched the required type and qualifiers but was marked as unused and removed during build
Removed beans:
  - PRODUCER_METHOD bean io.quarkus.jackson.ObjectMapperProducer#objectMapper() [types=[interface java.io.Serializable, class com.fasterxml.jackson.core.TreeCodec, class com.fasterxml.jackson.core.ObjectCodec, class com.fasterxml.jackson.databind.ObjectMapper, interface com.fasterxml.jackson.core.Versioned], qualifiers=[@javax.enterprise.inject.Default(), @javax.enterprise.inject.Any()]]
Required type: class com.fasterxml.jackson.databind.ObjectMapper
Required qualifiers: [@javax.enterprise.inject.Default()]
Solutions:
  - Application developers can eliminate false positives via the @Unremovable annotation
  - Extensions can eliminate false positives via build items, e.g. using the UnremovableBeanBuildItem
  - See also https://quarkus.io/guides/cdi-reference#remove_unused_beans
================================================================================
```