### PR TITLE
Expose metrics for kafka-streams with Micrometer

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
@@ -37,6 +38,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.Startup;
@@ -85,6 +87,13 @@ public class KafkaStreamsProducer {
         this.kafkaStreams = initializeKafkaStreams(kafkaStreamsProperties, runtimeConfig, kafkaAdminClient, topology.get(),
                 kafkaClientSupplier, stateListener, globalStateRestoreListener, executorService);
         this.kafkaStreamsTopologyManager = new KafkaStreamsTopologyManager(kafkaAdminClient);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        if (kafkaStreams != null) {
+            Arc.container().beanManager().getEvent().select(KafkaStreams.class).fire(kafkaStreams);
+        }
     }
 
     @Produces

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/KafkaBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/KafkaBinderProcessor.java
@@ -8,7 +8,7 @@ import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 
 /**
- * Add support for Kafka Producer and Consumer instrumentation. Note that
+ * Add support for Kafka Producer, Consumer and Streams instrumentation. Note that
  * various bits of support may not be present at deploy time. Avoid referencing
  * classes that in turn import optional dependencies.
  */
@@ -16,7 +16,12 @@ public class KafkaBinderProcessor {
     static final String KAFKA_CONSUMER_CLASS_NAME = "org.apache.kafka.clients.consumer.Consumer";
     static final Class<?> KAFKA_CONSUMER_CLASS_CLASS = MicrometerRecorder.getClassForName(KAFKA_CONSUMER_CLASS_NAME);
 
+    static final String KAFKA_STREAMS_CLASS_NAME = "org.apache.kafka.streams.KafkaStreams";
+    static final Class<?> KAFKA_STREAMS_CLASS_CLASS = MicrometerRecorder.getClassForName(KAFKA_STREAMS_CLASS_NAME);
+
     static final String KAFKA_EVENT_CONSUMER_CLASS_NAME = "io.quarkus.micrometer.runtime.binder.kafka.KafkaEventObserver";
+
+    static final String KAFKA_STREAMS_METRICS_PRODUCER_CLASS_NAME = "io.quarkus.micrometer.runtime.binder.kafka.KafkaStreamsEventObserver";
 
     static class KafkaSupportEnabled implements BooleanSupplier {
         MicrometerConfig mConfig;
@@ -26,10 +31,25 @@ public class KafkaBinderProcessor {
         }
     }
 
+    static class KafkaStreamsSupportEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+
+        public boolean getAsBoolean() {
+            return KAFKA_STREAMS_CLASS_CLASS != null && mConfig.checkBinderEnabledWithDefault(mConfig.binder.kafka);
+        }
+    }
+
     @BuildStep(onlyIf = KafkaSupportEnabled.class)
     AdditionalBeanBuildItem createCDIEventConsumer() {
         return AdditionalBeanBuildItem.builder()
                 .addBeanClass(KAFKA_EVENT_CONSUMER_CLASS_NAME)
+                .setUnremovable().build();
+    }
+
+    @BuildStep(onlyIf = KafkaStreamsSupportEnabled.class)
+    AdditionalBeanBuildItem createKafkaStreamsEventObserver() {
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(KAFKA_STREAMS_METRICS_PRODUCER_CLASS_NAME)
                 .setUnremovable().build();
     }
 }

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaClientMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaClientMetricsDisabledTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.micrometer.runtime.binder.kafka.KafkaEventObserver;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class KafkaClientMetricsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder.kafka.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Instance<KafkaEventObserver> kafkaEventObservers;
+
+    @Test
+    void testNoInstancePresentIfNoKafkaClientsClass() {
+        assertTrue(kafkaEventObservers.isUnsatisfied(),
+                "No kafkaEventObservers expected, because we don't have dependency to kafka-clients");
+    }
+
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaStreamsMetricsDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/KafkaStreamsMetricsDisabledTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.micrometer.runtime.binder.kafka.KafkaStreamsEventObserver;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class KafkaStreamsMetricsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder.kafka.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Instance<KafkaStreamsEventObserver> kafkaStreamEventObservers;
+
+    @Test
+    void testNoInstancePresentIfNoKafkaStreamsClass() {
+        assertTrue(kafkaStreamEventObservers.isUnsatisfied(),
+                "No kafkaStreamEventObservers expected, because we don't have dependency to kafka-streams");
+    }
+
+}

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>kafka-clients</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test -->
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaEventObserver.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaEventObserver.java
@@ -13,12 +13,21 @@ import org.jboss.logging.Logger;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+import io.quarkus.runtime.ShutdownEvent;
 
+/**
+ * Observer to create and register KafkaClientMetrics.
+ *
+ * This observer uses only classes from "kafka-clients" and none from "kafka-streams".
+ *
+ * Must be separated from KafkaStreamsEventObserver, because they use different dependencies and if only kafka-client is used,
+ * the classes from kafka-streams aren't loaded.
+ */
 @ApplicationScoped
 public class KafkaEventObserver {
     private static final Logger log = Logger.getLogger(KafkaEventObserver.class);
 
-    MeterRegistry registry = Metrics.globalRegistry;
+    final MeterRegistry registry = Metrics.globalRegistry;
     Map<Object, KafkaClientMetrics> clientMetrics = new HashMap<>();
 
     /**
@@ -67,6 +76,10 @@ public class KafkaEventObserver {
         } else {
             tryToClose(metrics);
         }
+    }
+
+    void onStop(@Observes ShutdownEvent event) {
+        clientMetrics.values().forEach(this::tryToClose);
     }
 
     void tryToClose(AutoCloseable c) {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaStreamsEventObserver.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaStreamsEventObserver.java
@@ -1,0 +1,61 @@
+package io.quarkus.micrometer.runtime.binder.kafka;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.jboss.logging.Logger;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.kafka.KafkaStreamsMetrics;
+import io.quarkus.runtime.ShutdownEvent;
+
+/**
+ * Observer to create and register KafkaStreamsMetrics.
+ * 
+ * Must be separated from KafkaEventObserver, because they use different dependencies and if only "kafka-client" is used, the
+ * classes from "kafka-streams" aren't loaded.
+ */
+@ApplicationScoped
+public class KafkaStreamsEventObserver {
+    private static final Logger log = Logger.getLogger(KafkaStreamsEventObserver.class);
+
+    final MeterRegistry registry = Metrics.globalRegistry;
+    KafkaStreamsMetrics kafkaStreamsMetrics;
+
+    /**
+     * Manage bind/close of KafkaStreamsMetrics for the specified KafkaStreams client.
+     * If the kafkaStreams has not been seen before, it will be bound to the
+     * Micrometer registry and instrumented using a Kafka MeterBinder.
+     * If the kafkaStreams has been seen before, the MeterBinder will be closed.
+     *
+     * @param kafkaStreams Observed KafkaStreams instance
+     */
+    public synchronized void kafkaStreamsCreated(@Observes KafkaStreams kafkaStreams) {
+        if (kafkaStreamsMetrics == null) {
+            kafkaStreamsMetrics = new KafkaStreamsMetrics(kafkaStreams);
+            try {
+                kafkaStreamsMetrics.bindTo(registry);
+            } catch (Throwable t) {
+                log.warnf(t, "Unable to register metrics for KafkaStreams %s", kafkaStreams);
+                tryToClose(kafkaStreamsMetrics);
+            }
+        } else {
+            tryToClose(kafkaStreamsMetrics);
+        }
+    }
+
+    void onStop(@Observes ShutdownEvent event) {
+        tryToClose(kafkaStreamsMetrics);
+    }
+
+    void tryToClose(AutoCloseable c) {
+        try {
+            c.close();
+        } catch (Exception e) {
+            // intentionally empty
+        }
+    }
+
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaEventObserverTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaEventObserverTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.micrometer.runtime.binder.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+import io.quarkus.runtime.ShutdownEvent;
+
+class KafkaEventObserverTest {
+
+    @Test
+    void testAllKafkaClientMetricsClosed() {
+        KafkaEventObserver sut = new KafkaEventObserver();
+
+        KafkaClientMetrics firstClientMetrics = Mockito.mock(KafkaClientMetrics.class);
+        KafkaClientMetrics secondClientMetrics = Mockito.mock(KafkaClientMetrics.class);
+        sut.clientMetrics.put(firstClientMetrics, firstClientMetrics);
+        sut.clientMetrics.put(secondClientMetrics, secondClientMetrics);
+
+        sut.onStop(new ShutdownEvent());
+
+        Mockito.verify(firstClientMetrics).close();
+        Mockito.verify(secondClientMetrics).close();
+    }
+
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaStreamsEventObserverTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/kafka/KafkaStreamsEventObserverTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.micrometer.runtime.binder.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.micrometer.core.instrument.binder.kafka.KafkaStreamsMetrics;
+import io.quarkus.runtime.ShutdownEvent;
+
+class KafkaStreamsEventObserverTest {
+
+    @Test
+    void testKafkaStreamsMetricsClosedAfterShutdownEvent() {
+        KafkaStreamsEventObserver sut = new KafkaStreamsEventObserver();
+        sut.kafkaStreamsMetrics = Mockito.mock(KafkaStreamsMetrics.class);
+
+        sut.onStop(new ShutdownEvent());
+
+        Mockito.verify(sut.kafkaStreamsMetrics).close();
+    }
+
+}

--- a/integration-tests/kafka-streams/pom.xml
+++ b/integration-tests/kafka-streams/pom.xml
@@ -50,6 +50,16 @@
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
 
+        <!-- Micrometer -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -134,6 +144,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEventCounter.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEventCounter.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.concurrent.atomic.LongAdder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.apache.kafka.streams.KafkaStreams;
+
+@ApplicationScoped
+public class KafkaStreamsEventCounter {
+
+    LongAdder eventCount = new LongAdder();
+
+    void onKafkaStreamsEvent(@Observes KafkaStreams kafkaStreams) {
+        eventCount.increment();
+    }
+
+    public int getEventCount() {
+        return eventCount.intValue();
+    }
+}

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsCdiEventTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsCdiEventTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.kafka.streams;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTestResource(KafkaTestResource.class)
+@QuarkusTest
+public class KafkaStreamsCdiEventTest {
+
+    @Inject
+    KafkaStreamsEventCounter eventCounter;
+
+    @Test
+    void testEventShouldBePublished() {
+        Assertions.assertEquals(1, eventCounter.getEventCount(),
+                "There should be one event for creating KafakStreams in the producder.");
+    }
+}

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.kafka.streams;
 
+import static org.hamcrest.Matchers.containsString;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -136,9 +138,18 @@ public class KafkaStreamsTest {
         testKafkaStreamsAliveAndReady();
         RestAssured.when().get("/kafkastreams/state").then().body(CoreMatchers.is("RUNNING"));
 
+        testMetricsPresent();
+
         // explicitly stopping the pipeline *before* the broker is shut down, as it
         // otherwise will time out
         RestAssured.post("/kafkastreams/stop");
+    }
+
+    private void testMetricsPresent() {
+        // Look for kafka consumer metrics (add .log().all() to examine what they are
+        RestAssured.when().get("/metrics").then()
+                .statusCode(200)
+                .body(containsString("kafka_stream_"));
     }
 
     public void testKafkaStreamsNotAliveAndNotReady() throws Exception {


### PR DESCRIPTION
Implementation for #13163 

- Use the same configuration as for kafka clients (quarkus.micrometer.binder.kafka.enabled + class must be present)
- Publish KafkaStreamsMetrics (Micrometer binder) via CDI producer