### PR TITLE
Add possibility to configure LDAP referral mode

### DIFF
--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
@@ -55,7 +55,7 @@ public class LdapRecorder {
                 dirContext.url,
                 dirContext.principal.orElse(null),
                 dirContext.password.orElse(null));
-        return () -> dirContextFactory.obtainDirContext(DirContextFactory.ReferralMode.IGNORE);
+        return () -> dirContextFactory.obtainDirContext(dirContext.referralMode);
     }
 
     private AttributeMapping[] createAttributeMappings(IdentityMappingConfig identityMappingConfig) {

--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/config/DirContextConfig.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/config/DirContextConfig.java
@@ -2,6 +2,8 @@ package io.quarkus.elytron.security.ldap.config;
 
 import java.util.Optional;
 
+import org.wildfly.security.auth.realm.ldap.DirContextFactory;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -26,12 +28,19 @@ public class DirContextConfig {
     @ConfigItem
     public Optional<String> password;
 
+    /**
+     * how ldap redirects are handled
+     */
+    @ConfigItem(defaultValue = "ignore")
+    public DirContextFactory.ReferralMode referralMode;
+
     @Override
     public String toString() {
         return "DirContextConfig{" +
                 "url='" + url + '\'' +
-                ", principal='" + principal + '\'' +
-                ", password='" + password + '\'' +
+                ", principal=" + principal +
+                ", password=" + password +
+                ", referralMode=" + referralMode +
                 '}';
     }
 }


### PR DESCRIPTION
This fixes #13184

I did not add tests because I think it's overpowered. We don't have to test elytron.
For testing this we would need a second ldap server which has references to the first one.