### PR TITLE
Update removeExtension gradle tests to fix CI

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleKtsProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleKtsProjectTest.java
@@ -20,7 +20,7 @@ public class AddExtensionToModuleInMultiModuleKtsProjectTest extends QuarkusGrad
 
         final File projectDir = getProjectDir("add-extension-multi-module-kts");
 
-        runGradleWrapper(projectDir, ":application:addExtension", "--extensions=hibernate-orm");
+        runGradleWrapper(projectDir, ":application:addExtension", "--extensions=openshift");
 
         final Path applicationLib = projectDir.toPath().resolve("application").resolve("settings.gradle");
         assertThat(applicationLib).doesNotExist();
@@ -32,10 +32,10 @@ public class AddExtensionToModuleInMultiModuleKtsProjectTest extends QuarkusGrad
 
         final Path appBuildKts = projectDir.toPath().resolve("application").resolve("build.gradle.kts");
         assertThat(appBuildKts).exists();
-        assertThat(readFile(appBuildKts)).contains("implementation(\"io.quarkus:quarkus-hibernate-orm\")");
+        assertThat(readFile(appBuildKts)).contains("implementation(\"io.quarkus:quarkus-openshift\")");
 
-        runGradleWrapper(projectDir, ":application:removeExtension", "--extensions=hibernate-orm");
-        assertThat(readFile(appBuildKts)).doesNotContain("implementation(\"io.quarkus:quarkus-hibernate-orm\")");
+        runGradleWrapper(projectDir, ":application:removeExtension", "--extensions=openshift");
+        assertThat(readFile(appBuildKts)).doesNotContain("implementation(\"io.quarkus:quarkus-openshift\")");
     }
 
     private static String readFile(Path file) throws IOException {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleProjectTest.java
@@ -20,17 +20,17 @@ public class AddExtensionToModuleInMultiModuleProjectTest extends QuarkusGradleW
 
         final File projectDir = getProjectDir("add-extension-multi-module");
 
-        runGradleWrapper(projectDir, ":application:addExtension", "--extensions=hibernate-orm");
+        runGradleWrapper(projectDir, ":application:addExtension", "--extensions=openshift");
 
         final Path applicationLib = projectDir.toPath().resolve("application").resolve("settings.gradle");
         assertThat(applicationLib).doesNotExist();
 
         final Path appBuild = projectDir.toPath().resolve("application").resolve("build.gradle");
         assertThat(appBuild).exists();
-        assertThat(readFile(appBuild)).contains("implementation 'io.quarkus:quarkus-hibernate-orm'");
+        assertThat(readFile(appBuild)).contains("implementation 'io.quarkus:quarkus-openshift'");
 
-        runGradleWrapper(projectDir, ":application:removeExtension", "--extensions=hibernate-orm");
-        assertThat(readFile(appBuild)).doesNotContain("implementation 'io.quarkus:quarkus-hibernate-orm'");
+        runGradleWrapper(projectDir, ":application:removeExtension", "--extensions=openshift");
+        assertThat(readFile(appBuild)).doesNotContain("implementation 'io.quarkus:quarkus-openshift'");
     }
 
     private static String readFile(Path file) throws IOException {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
@@ -17,18 +17,19 @@ public class AddExtensionToSingleModuleKtsProjectTest extends QuarkusGradleWrapp
 
         final File projectDir = getProjectDir("add-remove-extension-single-module-kts");
 
-        runGradleWrapper(projectDir, ":addExtension", "--extensions=hibernate-orm");
+        runGradleWrapper(projectDir, ":addExtension", "--extensions=openshift");
 
         final Path buildKts = projectDir.toPath().resolve("build.gradle.kts");
         assertThat(buildKts).exists();
         assertThat(new String(Files.readAllBytes(buildKts)))
-                .contains("implementation(\"io.quarkus:quarkus-hibernate-orm\")")
+                .contains("implementation(\"io.quarkus:quarkus-openshift\")")
                 .doesNotContain("implementation(enforcedPlatform(\"io.quarkus:quarkus-bom:")
                 .doesNotContain("implementation(\"io.quarkus:quarkus-bom:");
 
-        runGradleWrapper(projectDir, ":removeExtension", "--extensions=hibernate-orm");
+        runGradleWrapper(projectDir, ":removeExtension", "--extensions=openshift");
+
         assertThat(new String(Files.readAllBytes(buildKts)))
-                .doesNotContain("implementation(\"io.quarkus:quarkus-hibernate-orm\")");
+                .doesNotContain("implementation(\"io.quarkus:quarkus-openshift\")");
 
         assertThat(projectDir.toPath().resolve("build.gradle")).doesNotExist();
     }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
@@ -17,17 +17,17 @@ public class AddExtensionToSingleModuleProjectTest extends QuarkusGradleWrapperT
 
         final File projectDir = getProjectDir("add-remove-extension-single-module");
 
-        runGradleWrapper(projectDir, ":addExtension", "--extensions=hibernate-orm");
+        runGradleWrapper(projectDir, ":addExtension", "--extensions=openshift");
 
         final Path build = projectDir.toPath().resolve("build.gradle");
         assertThat(build).exists();
         assertThat(new String(Files.readAllBytes(build)))
-                .contains("implementation 'io.quarkus:quarkus-hibernate-orm'")
+                .contains("implementation 'io.quarkus:quarkus-openshift'")
                 .doesNotContain("implementation enforcedPlatform('io.quarkus:quarkus-bom:")
                 .doesNotContain("implementation 'io.quarkus:quarkus-bom:");
 
-        runGradleWrapper(projectDir, ":removeExtension", "--extensions=hibernate-orm");
-        assertThat(new String(Files.readAllBytes(build))).doesNotContain("implementation 'io.quarkus:quarkus-hibernate-orm'");
+        runGradleWrapper(projectDir, ":removeExtension", "--extensions=openshift");
+        assertThat(new String(Files.readAllBytes(build))).doesNotContain("implementation 'io.quarkus:quarkus-openshift'");
 
     }
 


### PR DESCRIPTION
The snapshot ci job and the release test job are both failing due to failed gradle tests. 

All failed tests are happening on `./gradlew removeExtension --extensions="hibernate-orm"`. 

From what I saw, the remove extension command fails with the following exception: 

      Could not resolve all files for configuration ':runtimeClasspath'.
          > Could not find javax.persistence-api-2.2.jar (javax.persistence:javax.persistence-api:2.2).
             Searched in the following locations:
                 file:/Users/glefloch/.m2.tmp/repo/javax/persistence/javax.persistence-api/2.2/javax.persistence-api-2.2.jar

this dependency is a transitive dependency of the `hibernate-orm` extension previously added in the test. This exception is thrown at

    at io.quarkus.gradle.builder.QuarkusModelBuilder.collectDependencies(QuarkusModelBuilder.java:329)

When looking in my maven repo, the jar is missing, the pom is present and there is a `_remote.repositories` with the following content: 
 
    #NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice. 
    #Tue Nov 10 14:42:04 CET 2020
    javax.persistence-api-2.2.pom>central=

Removing this file fix tests.

In order to avoid failures, I updated tests to use the `openshift` extension instead of the `hibernate-orm` extension. 
The Release test job is green on my fork. 

If you have some explanation about that, I would be happy to understand :) and if you have any other alternative, that would be great!




