### PR TITLE
SmallRye Health and GraphQL UI configuration name update

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -47,7 +47,7 @@ public class SmallRyeGraphQLConfig {
     TypeAutoNameStrategy autoNameStrategy;
 
     /**
-     * UI configuration
+     * SmallRye GraphQL UI configuration
      */
     @ConfigItem
     @ConfigDocSection

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
@@ -38,7 +38,7 @@ public class SmallRyeHealthConfig {
     String wellnessPath;
 
     /**
-     * UI configuration
+     * SmallRye Health UI configuration
      */
     @ConfigItem
     @ConfigDocSection


### PR DESCRIPTION
SmallRye Health and GraphQL UI configuration name update
This JavaDoc update is reflected in generated SmallRyeHealthConfig.jdp and SmallRyeGraphQLConfig.jdp

ATM https://quarkus.io/guides/all-config#quarkus-smallrye-graphql_quarkus.smallrye-graphql.ui-ui-configuration and https://quarkus.io/guides/all-config#quarkus-smallrye-health_quarkus.smallrye-health.ui-ui-configuration titles as are just "UI configuration" without additional context

