### PR TITLE
Add support for setting vert.x address resolver options

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -29,6 +29,7 @@ import io.quarkus.runtime.IOThreadDetector;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
 import io.quarkus.vertx.core.runtime.config.ClusterConfiguration;
 import io.quarkus.vertx.core.runtime.config.EventBusConfiguration;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
@@ -38,6 +39,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.http.ClientAuth;
@@ -216,6 +218,8 @@ public class VertxCoreRecorder {
             System.setProperty(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME, "true");
         }
 
+        setAddressResolverOptions(conf, options);
+
         if (allowClustering) {
             // Order matters, as the cluster options modifies the event bus options.
             setEventBusOptions(conf, options);
@@ -339,6 +343,16 @@ public class VertxCoreRecorder {
         configurePfxTrustOptions(opts, eb.trustCertificatePfx);
 
         options.setEventBusOptions(opts);
+    }
+
+    private static void setAddressResolverOptions(VertxConfiguration conf, VertxOptions options) {
+        AddressResolverConfiguration ar = conf.resolver;
+        AddressResolverOptions opts = new AddressResolverOptions();
+        opts.setCacheMaxTimeToLive(ar.cacheMaxTimeToLive);
+        opts.setCacheMinTimeToLive(ar.cacheMinTimeToLive);
+        opts.setCacheNegativeTimeToLive(ar.cacheNegativeTimeToLive);
+
+        options.setAddressResolverOptions(opts);
     }
 
     public Supplier<EventLoopGroup> bossSupplier() {

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.core.runtime.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class AddressResolverConfiguration {
+
+    /**
+     * The maximum amount of time in seconds that a successfully resolved address will be cached.
+     * <p>
+     * If not set explicitly, resolved addresses may be cached forever.
+     */
+    @ConfigItem(defaultValue = "2147483647")
+    public int cacheMaxTimeToLive;
+
+    /**
+     * The minimum amount of time in seconds that a successfully resolved address will be cached.
+     */
+    @ConfigItem(defaultValue = "0")
+    public int cacheMinTimeToLive;
+
+    /**
+     * The amount of time in seconds that an unsuccessful attempt to resolve an address will be cached.
+     */
+    @ConfigItem(defaultValue = "0")
+    public int cacheNegativeTimeToLive;
+
+}

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -77,6 +77,12 @@ public class VertxConfiguration {
     public ClusterConfiguration cluster;
 
     /**
+     * The address resolver configuration.
+     */
+    @ConfigItem
+    public AddressResolverConfiguration resolver;
+
+    /**
      * Enable or disable native transport
      */
     @ConfigItem

--- a/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
+import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
 import io.quarkus.vertx.core.runtime.config.ClusterConfiguration;
 import io.quarkus.vertx.core.runtime.config.EventBusConfiguration;
 import io.quarkus.vertx.core.runtime.config.JksConfiguration;
@@ -22,6 +23,7 @@ import io.quarkus.vertx.core.runtime.config.PfxConfiguration;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
 
 public class VertxCoreProducerTest {
 
@@ -59,6 +61,28 @@ public class VertxCoreProducerTest {
             Assertions.assertTrue(e.getMessage().contains("No ClusterManagerFactory"),
                     "The message should contain ''. Message: " + e.getMessage());
         }
+    }
+
+    @Test
+    public void shouldConfigureAddressResolver() {
+        VertxConfiguration configuration = createDefaultConfiguration();
+        AddressResolverConfiguration ar = configuration.resolver;
+        ar.cacheMaxTimeToLive = 3;
+        ar.cacheNegativeTimeToLive = 1;
+
+        VertxOptionsCustomizer customizers = new VertxOptionsCustomizer(Arrays.asList(
+                new Consumer<VertxOptions>() {
+                    @Override
+                    public void accept(VertxOptions vertxOptions) {
+                        Assertions.assertEquals(3, vertxOptions.getAddressResolverOptions().getCacheMaxTimeToLive());
+                        Assertions.assertEquals(
+                                AddressResolverOptions.DEFAULT_CACHE_MIN_TIME_TO_LIVE,
+                                vertxOptions.getAddressResolverOptions().getCacheMinTimeToLive());
+                        Assertions.assertEquals(1, vertxOptions.getAddressResolverOptions().getCacheNegativeTimeToLive());
+                    }
+                }));
+
+        VertxCoreRecorder.initialize(configuration, customizers);
     }
 
     @Test
@@ -129,6 +153,10 @@ public class VertxCoreProducerTest {
         vc.cluster.clustered = false;
         vc.cluster.pingInterval = Duration.ofSeconds(20);
         vc.cluster.pingReplyInterval = Duration.ofSeconds(20);
+        vc.resolver = new AddressResolverConfiguration();
+        vc.resolver.cacheMaxTimeToLive = Integer.MAX_VALUE;
+        vc.resolver.cacheMinTimeToLive = 0;
+        vc.resolver.cacheNegativeTimeToLive = 0;
         return vc;
     }
 }


### PR DESCRIPTION
Fixes #13214 

The properties of vert.x AddressResolverOptions can now be set using
Quarkus properties.

This is my first PR for Quarkus. I only added a few properties for now in order to check if this is going in the right direction. Once I am on the right track, I will add the remaining properties as well ...