### PR TITLE
Centralize jar location generation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/RunnerJarLocationBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/RunnerJarLocationBuildItem.java
@@ -1,0 +1,38 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import java.nio.file.Path;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class RunnerJarLocationBuildItem extends SimpleBuildItem {
+
+    private final String classifier;
+    private final String fullName;
+    private final Path fullPath;
+
+    public RunnerJarLocationBuildItem(Path outputDirectory, String baseName, String runnerSuffix) {
+        this.classifier = suffixToClassifier(runnerSuffix);
+        this.fullName = baseName + runnerSuffix + ".jar";
+        this.fullPath = outputDirectory.resolve(fullName);
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public Path getFullPath() {
+        return fullPath;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    private String suffixToClassifier(String runnerSuffix) {
+        if (runnerSuffix == null || runnerSuffix.isEmpty()) {
+            return null;
+        }
+
+        return runnerSuffix.startsWith("-") ? runnerSuffix.substring(1) : runnerSuffix;
+    }
+}

--- a/extensions/kubernetes/minikube/deployment/src/main/java/io/quarkus/minikube/deployment/MinikubeProcessor.java
+++ b/extensions/kubernetes/minikube/deployment/src/main/java/io/quarkus/minikube/deployment/MinikubeProcessor.java
@@ -32,8 +32,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.kubernetes.deployment.AddNodePortDecorator;
 import io.quarkus.kubernetes.deployment.ApplyContainerImageDecorator;
 import io.quarkus.kubernetes.deployment.ApplyHttpGetActionPortDecorator;
@@ -92,9 +91,8 @@ public class MinikubeProcessor {
 
     @BuildStep
     public List<DecoratorBuildItem> createDecorators(ApplicationInfoBuildItem applicationInfo,
-            OutputTargetBuildItem outputTarget,
+            RunnerJarLocationBuildItem runnerJarLocation,
             KubernetesConfig config,
-            PackageConfig packageConfig,
             Optional<MetricsCapabilityBuildItem> metricsConfiguration,
             List<KubernetesAnnotationBuildItem> annotations,
             List<KubernetesLabelBuildItem> labels,
@@ -111,7 +109,7 @@ public class MinikubeProcessor {
         List<DecoratorBuildItem> result = new ArrayList<>();
         String name = ResourceNameUtil.getResourceName(config, applicationInfo);
 
-        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, outputTarget, packageConfig);
+        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, runnerJarLocation);
         result.addAll(KubernetesCommonHelper.createDecorators(project, MINIKUBE, name, config, metricsConfiguration,
                 annotations, labels, command,
                 ports, livenessPath, readinessPath, roles, roleBindings));

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -36,8 +36,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesAnnotationBuildItem;
@@ -90,9 +89,8 @@ public class KnativeProcessor {
 
     @BuildStep
     public List<DecoratorBuildItem> createDecorators(ApplicationInfoBuildItem applicationInfo,
-            OutputTargetBuildItem outputTarget,
+            RunnerJarLocationBuildItem runnerJarLocation,
             KnativeConfig config,
-            PackageConfig packageConfig,
             Optional<MetricsCapabilityBuildItem> metricsConfiguration,
             List<KubernetesAnnotationBuildItem> annotations,
             List<KubernetesLabelBuildItem> labels,
@@ -109,7 +107,7 @@ public class KnativeProcessor {
         List<DecoratorBuildItem> result = new ArrayList<>();
         String name = ResourceNameUtil.getResourceName(config, applicationInfo);
 
-        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, outputTarget, packageConfig);
+        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, runnerJarLocation);
         result.addAll(KubernetesCommonHelper.createDecorators(project, KNATIVE, name, config, metricsConfiguration, annotations,
                 labels, command,
                 ports, livenessPath, readinessPath, roles, roleBindings));

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -52,8 +52,7 @@ import io.dekorate.project.ScmInfo;
 import io.dekorate.utils.Annotations;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.kubernetes.deployment.Annotations.Prometheus;
 import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
@@ -68,12 +67,8 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 
 public class KubernetesCommonHelper {
 
-    private static final String OUTPUT_ARTIFACT_FORMAT = "%s%s.jar";
-
-    public static Optional<Project> createProject(ApplicationInfoBuildItem app, OutputTargetBuildItem outputTarget,
-            PackageConfig packageConfig) {
-        return createProject(app, outputTarget.getOutputDirectory()
-                .resolve(String.format(OUTPUT_ARTIFACT_FORMAT, outputTarget.getBaseName(), packageConfig.runnerSuffix)));
+    public static Optional<Project> createProject(ApplicationInfoBuildItem app, RunnerJarLocationBuildItem runnerJarLocation) {
+        return createProject(app, runnerJarLocation.getFullPath());
     }
 
     public static Optional<Project> createProject(ApplicationInfoBuildItem app, Path artifactPath) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -38,8 +38,8 @@ import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedFileSystemResourceBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
@@ -51,7 +51,6 @@ class KubernetesProcessor {
 
     private static final Logger log = Logger.getLogger(KubernetesProcessor.class);
 
-    private static final String OUTPUT_ARTIFACT_FORMAT = "%s%s.jar";
     public static final String DEFAULT_HASH_ALGORITHM = "SHA-256";
 
     @BuildStep
@@ -78,7 +77,7 @@ class KubernetesProcessor {
     @BuildStep
     public void build(ApplicationInfoBuildItem applicationInfo,
             OutputTargetBuildItem outputTarget,
-            PackageConfig packageConfig,
+            RunnerJarLocationBuildItem runnerJarLocationBuildItem,
             KubernetesConfig kubernetesConfig,
             OpenshiftConfig openshiftConfig,
             KnativeConfig knativeConfig,
@@ -113,8 +112,7 @@ class KubernetesProcessor {
                 .map(DeploymentTargetEntry::getName)
                 .collect(Collectors.toSet());
 
-        Path artifactPath = outputTarget.getOutputDirectory()
-                .resolve(String.format(OUTPUT_ARTIFACT_FORMAT, outputTarget.getBaseName(), packageConfig.runnerSuffix));
+        Path artifactPath = runnerJarLocationBuildItem.getFullPath();
 
         try {
             // by passing false to SimpleFileWriter, we ensure that no files are actually written during this phase

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -38,8 +38,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesAnnotationBuildItem;
@@ -106,9 +105,8 @@ public class OpenshiftProcessor {
 
     @BuildStep
     public List<DecoratorBuildItem> createDecorators(ApplicationInfoBuildItem applicationInfo,
-            OutputTargetBuildItem outputTarget,
+            RunnerJarLocationBuildItem runnerJarLocation,
             OpenshiftConfig config,
-            PackageConfig packageConfig,
             Optional<MetricsCapabilityBuildItem> metricsConfiguration,
             Capabilities capabilities,
             List<KubernetesAnnotationBuildItem> annotations,
@@ -126,7 +124,7 @@ public class OpenshiftProcessor {
         List<DecoratorBuildItem> result = new ArrayList<>();
         String name = ResourceNameUtil.getResourceName(config, applicationInfo);
 
-        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, outputTarget, packageConfig);
+        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, runnerJarLocation);
         result.addAll(KubernetesCommonHelper.createDecorators(project, OPENSHIFT, name, config, metricsConfiguration,
                 annotations, labels, command,
                 ports, livenessPath, readinessPath, roles, roleBindings));

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -29,8 +29,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.RunnerJarLocationBuildItem;
 import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesAnnotationBuildItem;
@@ -88,7 +87,7 @@ public class VanillaKubernetesProcessor {
 
     @BuildStep
     public List<DecoratorBuildItem> createDecorators(ApplicationInfoBuildItem applicationInfo,
-            OutputTargetBuildItem outputTarget, KubernetesConfig config, PackageConfig packageConfig,
+            RunnerJarLocationBuildItem runnerJarLocation, KubernetesConfig config,
             Optional<MetricsCapabilityBuildItem> metricsConfiguration, List<KubernetesAnnotationBuildItem> annotations,
             List<KubernetesLabelBuildItem> labels, List<KubernetesEnvBuildItem> envs,
             Optional<ContainerImageInfoBuildItem> image, Optional<KubernetesCommandBuildItem> command,
@@ -99,7 +98,7 @@ public class VanillaKubernetesProcessor {
         final List<DecoratorBuildItem> result = new ArrayList<>();
         final String name = ResourceNameUtil.getResourceName(config, applicationInfo);
 
-        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, outputTarget, packageConfig);
+        Optional<Project> project = KubernetesCommonHelper.createProject(applicationInfo, runnerJarLocation);
         result.addAll(KubernetesCommonHelper.createDecorators(project, KUBERNETES, name, config, metricsConfiguration,
                 annotations, labels, command, ports, livenessPath, readinessPath, roles, roleBindings));
 


### PR DESCRIPTION
Currently it is spread in several places of the code base.

I didn't get as far as allowing `runnerSuffix` to be empty, as it's not as simple as just making it `Optional` (I tried and some classes are missing from the generated jar, the original classes) but I think this is still worth it as is.