### PR TITLE
Remove Uni await for OIDC code access token validation and user info calls

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -1,5 +1,7 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.concurrent.Executor;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -159,5 +161,9 @@ public class DefaultTenantConfigResolver {
 
     boolean isEnableHttpForwardedPrefix() {
         return enableHttpForwardedPrefix;
+    }
+
+    public Executor getBlockingExecutor() {
+        return tenantConfigBean.getBlockingExecutor();
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -68,42 +68,42 @@ public class OidcRecorder {
                         new Function<OidcTenantConfig, Uni<TenantConfigContext>>() {
                             @Override
                             public Uni<TenantConfigContext> apply(OidcTenantConfig config) {
-                                if (BlockingOperationControl.isBlockingAllowed()) {
-                                    try {
-                                        return Uni.createFrom().item(createDynamicTenantContext(vertxValue, config,
-                                                config.getTenantId().get()));
-                                    } catch (Throwable t) {
-                                        return Uni.createFrom().failure(t);
-                                    }
-                                } else {
-                                    return Uni.createFrom().emitter(new Consumer<UniEmitter<? super TenantConfigContext>>() {
-                                        @Override
-                                        public void accept(UniEmitter<? super TenantConfigContext> uniEmitter) {
+
+                                return Uni.createFrom().emitter(new Consumer<UniEmitter<? super TenantConfigContext>>() {
+                                    @Override
+                                    public void accept(UniEmitter<? super TenantConfigContext> uniEmitter) {
+                                        if (BlockingOperationControl.isBlockingAllowed()) {
+                                            createDynamicTenantContext(uniEmitter, vertxValue, config,
+                                                    config.getTenantId().get());
+                                        } else {
                                             ExecutorRecorder.getCurrent().execute(new Runnable() {
                                                 @Override
                                                 public void run() {
-                                                    try {
-                                                        uniEmitter.complete(createDynamicTenantContext(vertxValue, config,
-                                                                config.getTenantId().get()));
-                                                    } catch (Throwable t) {
-                                                        uniEmitter.fail(t);
-                                                    }
+                                                    createDynamicTenantContext(uniEmitter, vertxValue, config,
+                                                            config.getTenantId().get());
                                                 }
                                             });
                                         }
-                                    });
-                                }
+                                    }
+                                });
+
                             }
-                        });
+                        },
+                        ExecutorRecorder.getCurrent());
             }
         };
     }
 
-    private TenantConfigContext createDynamicTenantContext(Vertx vertx, OidcTenantConfig oidcConfig, String tenantId) {
-        if (!dynamicTenantsConfig.containsKey(tenantId)) {
-            dynamicTenantsConfig.putIfAbsent(tenantId, createTenantContext(vertx, oidcConfig, tenantId));
+    private void createDynamicTenantContext(UniEmitter<? super TenantConfigContext> uniEmitter, Vertx vertx,
+            OidcTenantConfig oidcConfig, String tenantId) {
+        try {
+            if (!dynamicTenantsConfig.containsKey(tenantId)) {
+                dynamicTenantsConfig.putIfAbsent(tenantId, createTenantContext(vertx, oidcConfig, tenantId));
+            }
+            uniEmitter.complete(dynamicTenantsConfig.get(tenantId));
+        } catch (Throwable t) {
+            uniEmitter.fail(t);
         }
-        return dynamicTenantsConfig.get(tenantId);
     }
 
     private TenantConfigContext createTenantContext(Vertx vertx, OidcTenantConfig oidcConfig, String tenantId) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.runtime;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import io.quarkus.oidc.OidcTenantConfig;
@@ -12,16 +13,19 @@ public class TenantConfigBean {
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
     private final Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory;
+    private final Executor blockingExecutor;
 
     public TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
             Map<String, TenantConfigContext> dynamicTenantsConfig,
             TenantConfigContext defaultTenant,
-            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
+            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory,
+            Executor blockingExecutor) {
         this.staticTenantsConfig = staticTenantsConfig;
         this.dynamicTenantsConfig = dynamicTenantsConfig;
         this.defaultTenant = defaultTenant;
         this.tenantConfigContextFactory = tenantConfigContextFactory;
+        this.blockingExecutor = blockingExecutor;
     }
 
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
@@ -38,5 +42,9 @@ public class TenantConfigBean {
 
     public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
         return dynamicTenantsConfig;
+    }
+
+    public Executor getBlockingExecutor() {
+        return blockingExecutor;
     }
 }


### PR DESCRIPTION
Fixes #13249.

This PR follows the earlier PR improving OIDC Uni related code:
- code access token verification and user info calls are totally async now; 
- user-info calls are always blocking hence they will run by the blocking executor
- code access token as well as a bearer access token will also be run by the blocking executor if the token is opaque - right now the introspection requests initiated internally by Vert.x would run on the IO thread

Changes look extensive but they are really not, it is just related to me having to collapse some code into reusable functions to minimize the duplication.

Also, `BlockingOperationControl` code branches will be gone as soon as I make sure that refreshing the tokens does not require a blocking call, but until then I have to check it to avoid re-dispatching to the executor (as explained by Stuart).

We already have the tests for all the affected combinations (code access token is a source of roles, opaque tokens, user-info)   

My Uni confidence is high now thanks to @cescoffier so this PR should be good to go once it will go green :-)

CC @cescoffier @gsmet 