### PR TITLE
Made JarResult.originalArtifact point to the actual original jar instead of where it should end up after renaming

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -140,7 +140,6 @@ public class JarResultBuildStep {
     public static final String APP = "app";
     public static final String QUARKUS = "quarkus";
     public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
-    public static final String RENAMED_JAR_EXTENSION = ".jar.original";
 
     @BuildStep
     OutputTargetBuildItem outputTarget(BuildSystemTargetBuildItem bst, PackageConfig packageConfig) {
@@ -256,13 +255,7 @@ public class JarResultBuildStep {
         final Path standardJar = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + ".jar");
 
-        final Path originalJar;
-        if (Files.exists(standardJar)) {
-            originalJar = outputTargetBuildItem.getOutputDirectory()
-                    .resolve(outputTargetBuildItem.getBaseName() + RENAMED_JAR_EXTENSION);
-        } else {
-            originalJar = null;
-        }
+        final Path originalJar = Files.exists(standardJar) ? standardJar : null;
 
         return new JarBuildItem(runnerJar, originalJar, null, PackageConfig.UBER_JAR,
                 suffixToClassifier(packageConfig.runnerSuffix));

--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -54,6 +54,9 @@
                             <goal>generate-code</goal>
                             <goal>generate-code-tests</goal>
                         </goals>
+                        <configuration>
+                            <skipOriginalJarRename>true</skipOriginalJarRename>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -84,11 +84,13 @@ public class BuildMojo extends QuarkusBootstrapMojo {
                 if (result.getJar() != null) {
 
                     if (result.getJar().isUberJar() && result.getJar().getOriginalArtifact() != null) {
-                        final Path standardJar = curatedApplication.getAppModel().getAppArtifact().getPaths().getSinglePath();
+                        final Path standardJar = result.getJar().getOriginalArtifact();
                         if (Files.exists(standardJar)) {
+                            final Path renamedOriginal = standardJar.getParent().toAbsolutePath()
+                                    .resolve(standardJar.getFileName() + ".original");
                             try {
-                                IoUtils.recursiveDelete(result.getJar().getOriginalArtifact());
-                                Files.move(standardJar, result.getJar().getOriginalArtifact());
+                                IoUtils.recursiveDelete(renamedOriginal);
+                                Files.move(standardJar, renamedOriginal);
                             } catch (IOException e) {
                                 throw new UncheckedIOException(e);
                             }

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -52,6 +52,10 @@ public class BuildMojo extends QuarkusBootstrapMojo {
     @Parameter(defaultValue = "false", property = "quarkus.build.skip")
     private boolean skip = false;
 
+    @Deprecated
+    @Parameter(property = "skipOriginalJarRename")
+    boolean skipOriginalJarRename;
+
     @Override
     protected boolean beforeExecute() throws MojoExecutionException {
         if (skip) {
@@ -83,7 +87,8 @@ public class BuildMojo extends QuarkusBootstrapMojo {
                 Artifact original = mavenProject().getArtifact();
                 if (result.getJar() != null) {
 
-                    if (result.getJar().isUberJar() && result.getJar().getOriginalArtifact() != null) {
+                    if (!skipOriginalJarRename && result.getJar().isUberJar()
+                            && result.getJar().getOriginalArtifact() != null) {
                         final Path standardJar = result.getJar().getOriginalArtifact();
                         if (Files.exists(standardJar)) {
                             final Path renamedOriginal = standardJar.getParent().toAbsolutePath()


### PR DESCRIPTION
This fixes an issue when building the uber-jar runner the target dir ends up containing the uber runner jar, the original jar and the "xxx.jar.original" directory which is a copy of the classes dir.