### PR TITLE
Enable quarkus native debug process ip/host to be configured

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -75,6 +75,13 @@ public class NativeConfig {
     public boolean debugBuildProcess;
 
     /**
+     * When native image build debugger is enabled, this option configures the host or IP address to which the debugger binds.
+     * This is useful for debugging the native image building process that executes in a remote node.
+     */
+    @ConfigItem
+    public Optional<String> debugBuildProcessAddress;
+
+    /**
      * If the debug port should be published when building with docker and debug-build-process is true
      */
     @ConfigItem(defaultValue = "true")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -193,7 +193,9 @@ public class NativeImageBuildStep {
                 }
             }
             if (nativeConfig.debugBuildProcess) {
-                command.add("-J-Xrunjdwp:transport=dt_socket,address=" + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");
+                String debugBuildAddress = nativeConfig.debugBuildProcessAddress
+                        .map(address -> address + ":" + DEBUG_BUILD_PROCESS_PORT).orElse(DEBUG_BUILD_PROCESS_PORT);
+                command.add("-J-Xrunjdwp:transport=dt_socket,address=" + debugBuildAddress + ",server=y,suspend=y");
             }
             if (nativeConfig.enableReports) {
                 command.add("-H:+PrintAnalysisCallTree");


### PR DESCRIPTION
As discussed in [Zulip](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/quarkus.2Enative.2Edebug-build-process).