### PR TITLE
Use Uni to run OIDC Refresh token calls

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -257,7 +257,10 @@ See <<oidc-cookies, Dealing with Cookies>> for more information.
 
 == Accessing ID and Access Tokens
 
-ID Token is always a JWT token. One can access ID Token claims by injecting `JsonWebToken` with an `IdToken` qualifier:
+OIDC Code Authentication Mechanism acquires three tokens during the authorization code flow: https://openid.net/specs/openid-connect-core-1_0.html#IDToken[IDToken], Access Token and Refresh Token.
+
+ID Token is always a JWT token and is used to represent a user authentication with the JWT claims.
+One can access ID Token claims by injecting `JsonWebToken` with an `IdToken` qualifier:
 
 [source, java]
 ----
@@ -317,12 +320,14 @@ Note that `AccessTokenCredential` will have to be used if the Access Token issue
 
 Injection of the `JsonWebToken` and `AccessTokenCredential` is supported in both `@RequestScoped` and `@ApplicationScoped` contexts.
 
+RefreshToken is only used to refresh the current ID and access tokens as part of its link:#session_management[session management] process.
+
 [[user-info]]
 == User Info
 
-Set `quarkus.oidc.user-info-required=true` if a UserInfo JSON object from the OIDC userinfo endpoint has to be requested.
-A request will be sent to the OpenId Provider UserInfo endpont and  an `io.quarkus.oidc.UserInfo` (a simple `javax.json.JsonObject` wrapper) object will be created.
-`io.quarkus.oidc.UserInfo` can be either injected or accessed as a SecurityIdentity `userinfo` attribute.
+If IdToken does not provide enough information about the currently authenticated user then you can set a `quarkus.oidc.user-info-required=true` property for a https://openid.net/specs/openid-connect-core-1_0.html#UserInfo[UserInfo] JSON object from the OIDC userinfo endpoint to be requested.
+
+A request will be sent to the OpenId Provider UserInfo endpoint using the access token returned with the authorization code grant response and an `io.quarkus.oidc.UserInfo` (a simple `javax.json.JsonObject` wrapper) object will be created. `io.quarkus.oidc.UserInfo` can be either injected or accessed as a SecurityIdentity `userinfo` attribute.
 
 == Token Claims And SecurityIdentity Roles
 
@@ -335,6 +340,27 @@ If only the access token contains the roles and this access token is not meant t
 If UserInfo is the source of the roles then set `quarkus.oidc.authentication.user-info-required=true` and `quarkus.oidc.roles.source=userinfo`, and if needed, `quarkus.oidc.roles.role-claim-path`.
 
 Additionally a custom `SecurityIdentityAugmentor` can also be used to add the roles as documented link:security#security-identity-customization[here].
+
+[[session-management]]
+== Session Management
+
+If you have a link:security-openid-connect#single-page-applications[Single Page Application for Service Applications] where your OpenId Connect Provider script such as `keycloak.js` is managing an authoriization code flow then that script will also control the SPA authentication session lifespan.
+
+If your work with a Quarkus OIDC `web-app` application then it is Quarkus OIDC Code Authentication mechanism which is managing the user session lifespan.
+
+The session age is calculated by adding the lifespan value of the current IDToken and the values of the `quarkus.oidc.authentication.session-age-extension` and `quarkus.oidc.token.lifespan-grace` properties. Of the last two properties only `quarkus.oidc.authentication.session-age-extension` should be used to significantly extend the session lifespan if required since `quarkus.oidc.token.lifespan-grace` is only meant for taking some small clock skews into consideration.
+
+When the currently authenticated user returns to the protected Quarkus endpoint and the ID token associated with the session cookie has expired then, by default, the user will be auto-redirected to the OIDC Authorization endpoint to re-authenticate. Most likely the OIDC provider will challenge the user again though not necessarily if the session between the user and this OIDC provider is still active which may happen if it is configured to last longer than the ID token.
+
+If the `quarkus.oidc.token.refresh-expired` then the expired ID token (as well as the access token) will be refreshed using the refresh token returned with the authorization code grant response. This refresh token may also be recycled (refreshed) itself as part of this process. As a result the new session cookie will be created and the session will be extended.
+
+Note, `quarkus.oidc.authentication.session-age-extension` can be important when dealing with expired ID tokens, when the user is not very active. In such cases, if the ID token expires, then the session cookie may not be returned back to the Quarkus endpoint during the next user request and Quarkus will assume it is the first authentication request. Therefore using `quarkus.oidc.authentication.session-age-extension` is important if you need to have even the expired ID tokens refreshed.
+
+You can also complement refreshing the expired ID tokens by proactively refreshing the valid ID tokens which are about to be expired within the `quarkus.oidc.token.auto-refresh-interval` value. If, during the current user request, it is calculated that the current ID token will expire within this `quarkus.oidc.token.auto-refresh-interval` then it will be refreshed and the new session cookie will be created. This property should be set to a value which is less than the ID token lifespan; the closer it is to this lifespan value the more often the ID token will be refreshed.
+
+You can have this process further optimized by having a simple JavaScript function periodically emulating the user activity by pinging your Quarkus endpoint thus minimizing the window during which the user may have to be re-authenticated.
+
+Note this user session can not be extended forever - the returning user with the expired ID token will have to re-authenticate at the OIDC provider endpoint once the refresh token has expired.
 
 == Listening to important authentication events
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -98,7 +98,7 @@ public class HttpSecurityRecorder {
                     }
                 });
 
-                Uni<SecurityIdentity> potentialUser = authenticator.attemptAuthentication(event).cache();
+                Uni<SecurityIdentity> potentialUser = authenticator.attemptAuthentication(event).memoize().indefinitely();
                 if (proactiveAuthentication) {
                     potentialUser
                             .subscribe().withSubscriber(new UniSubscriber<SecurityIdentity>() {
@@ -168,7 +168,7 @@ public class HttpSecurityRecorder {
                                     }
                                     return Uni.createFrom().item(securityIdentity);
                                 }
-                            }).on().termination(new Functions.TriConsumer<SecurityIdentity, Throwable, Boolean>() {
+                            }).onTermination().invoke(new Functions.TriConsumer<SecurityIdentity, Throwable, Boolean>() {
                                 @Override
                                 public void accept(SecurityIdentity identity, Throwable throwable, Boolean aBoolean) {
                                     if (identity != null) {
@@ -186,7 +186,7 @@ public class HttpSecurityRecorder {
                                         }
                                     }
                                 }
-                            }).cache();
+                            }).memoize().indefinitely();
                     event.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, lazyUser);
                     event.next();
                 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -93,7 +93,7 @@ quarkus.oidc.tenant-autorefresh.credentials.secret=secret
 quarkus.oidc.tenant-autorefresh.application-type=web-app
 quarkus.oidc.tenant-autorefresh.authentication.cookie-path=/tenant-autorefresh
 quarkus.oidc.tenant-autorefresh.token.refresh-expired=true
-quarkus.oidc.tenant-autorefresh.token.auto-refresh-interval=4S
+quarkus.oidc.tenant-autorefresh.token.auto-refresh-interval=30S
 
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
 quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -200,7 +201,7 @@ public class CodeFlowTest {
             assertNotNull(sessionCookie);
             String idToken = getIdToken(sessionCookie);
 
-            //wait now so that we reach the refresh timeout
+            //wait now so that we reach the ID token timeout
             await().atMost(10, TimeUnit.SECONDS)
                     .pollInterval(Duration.ofSeconds(1))
                     .until(new Callable<Boolean>() {
@@ -267,24 +268,28 @@ public class CodeFlowTest {
             assertNotNull(sessionCookie);
             String idToken = getIdToken(sessionCookie);
 
-            //wait now so that we reach the refresh timeout
-            await().atMost(5, TimeUnit.SECONDS)
-                    .pollInterval(Duration.ofSeconds(1))
-                    .until(new Callable<Boolean>() {
-                        @Override
-                        public Boolean call() throws Exception {
-                            webClient.getOptions().setRedirectEnabled(false);
-                            WebResponse webResponse = webClient
-                                    .loadWebResponse(
-                                            new WebRequest(URI.create("http://localhost:8081/tenant-autorefresh").toURL()));
-                            assertEquals(200, webResponse.getStatusCode());
-                            assertTrue(webResponse.getContentAsString().contains("Tenant AutoRefresh"));
-                            // Should not redirect to OP but silently refresh token
-                            Cookie newSessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
-                            assertNotNull(newSessionCookie);
-                            return !idToken.equals(getIdToken(newSessionCookie));
-                        }
-                    });
+            // Auto-refresh-interval is 30 secs so every call auto-refreshes the token
+            // Right now the original ID token is still valid but will be auto-refreshed
+            page = webClient.getPage("http://localhost:8081/tenant-autorefresh");
+            assertTrue(page.getBody().asText().contains("Tenant AutoRefresh"));
+            sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
+            assertNotNull(sessionCookie);
+            String nextIdToken = getIdToken(sessionCookie);
+            assertNotEquals(idToken, nextIdToken);
+            idToken = nextIdToken;
+
+            //wait now so that we reach the ID token timeout
+            await().atLeast(6, TimeUnit.SECONDS);
+
+            // ID token has expired, must be refreshed, auto-refresh-interval must not cause
+            // an auto-refresh loop even though it is larger than the ID token lifespan
+            page = webClient.getPage("http://localhost:8081/tenant-autorefresh");
+            assertTrue(page.getBody().asText().contains("Tenant AutoRefresh"));
+            sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
+            assertNotNull(sessionCookie);
+            nextIdToken = getIdToken(sessionCookie);
+            assertNotEquals(idToken, nextIdToken);
+
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
`quarkus-oidc` may optionally refresh the current ID, access and the refresh token itself when the ID token has expired or about to be expired.

This PR attempts to optimize how `Uni` and refresh token calls are combined.

**Here is how it is done now**:

1. The whole `OidcidentityProvider.authenticate` [call](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java#L69) [is blocking](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java#L405) if `refreshToken` is supported - even if in this specific call there will be no need to refresh a token. This is obviously not ideal.

2. `recoverWithItem` [code branch](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L137) starts

3. `trySilentRefresh` [function](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L522) is called, it returns `SecurityIdentity` hence it [awaits here](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L572).

4. `trySilentRefresh` Uni emitter action is structured like this:
    - an async Vert.x `refreshToken` [is called](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L533)
    - inside of this `refreshToken` handler, `quarkus-oidc` `authenticate` [is called](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L541) which returns `Uni<SecurityIdentity>` and this `SecurityIdentity` is captured [here](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L543).

I'm not sure it is optimal and think it is better be composed into two Unis.

5. if `trySilentRefresh` fails then a possible fallback is tried: 
   - if it failed while trying to auto-refresh a still valid IDToken (before it has expired), then it returns the already verified `SecurityIdentity` [here](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L169).
  - if it failed to refresh an already expired IDToken then the exception is returned [here](https://github.com/quarkusio/quarkus/blob/master/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L160)

Unfortunately, it does not look like step 5 works - since `trySilentRefresh` is expected to throw an exception and not return `null` in case of a failure.

**Here is how PR changes it**:

1. Just in time blocking call (more on it below), [no more](https://github.com/quarkusio/quarkus/pull/13287/files#diff-388f77046db5cd2e0db7f309af720fadaa4a6fd8c9dede10f3503f015ab91346L69) `OidcIdentityProvider` level blocking for all the calls where refreshing may be required but not necessarily done

2. `recoverWithUni` [code branch](https://github.com/quarkusio/quarkus/pull/13287/files#diff-d6d40795b1093d6a39a62041f2567d0931b1f7fa30ebfea44e6663f45441df75R143) starts.

3. `refreshSecurityIdentity` [function](https://github.com/quarkusio/quarkus/pull/13287/files#diff-d6d40795b1093d6a39a62041f2567d0931b1f7fa30ebfea44e6663f45441df75R514) is called, it returns `Uni<SecurityIdentity>` and [combines](https://github.com/quarkusio/quarkus/pull/13287/files#diff-d6d40795b1093d6a39a62041f2567d0931b1f7fa30ebfea44e6663f45441df75R520) the output of [trySilentRefreshUni](https://github.com/quarkusio/quarkus/pull/13287/files#diff-d6d40795b1093d6a39a62041f2567d0931b1f7fa30ebfea44e6663f45441df75R579) with `OidcidentityProvider.authenticate` returning `Uni<SecurityIdentity>`.

4. Only [trySilentRefreshUni](https://github.com/quarkusio/quarkus/pull/13287/files#diff-d6d40795b1093d6a39a62041f2567d0931b1f7fa30ebfea44e6663f45441df75R579) is blocking just in time when refreshing the token is actually needed

Fixes #8559
Fixes #13401