### PR TITLE
Copy registered services into the file system when using fast-jar

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
@@ -103,4 +103,8 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
     public String serviceDescriptorFile() {
         return SPI_ROOT + serviceInterface;
     }
+
+    public String serviceInterface() {
+        return serviceInterface;
+    }
 }


### PR DESCRIPTION
This allows the RunnerClassLoader to load these resources without having
to go through the jars

Relates to: #13256