### PR TITLE
Fix the case where the webjar does not have a version in the jar path

### DIFF
--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -57,6 +57,12 @@
           <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.webjars.bowergithub.dc-js</groupId>
+            <artifactId>dc.js</artifactId>
+            <version>3.0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-resteasy-deployment</artifactId>
           <scope>test</scope>

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
@@ -63,6 +63,10 @@ public class WebJarLocatorDevModeTest {
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
                 .statusCode(404);
 
+        // Test webjar that does not have a version in the jar path
+        RestAssured.get("/webjars/dcjs/dc.min.js").then()
+                .statusCode(200);
+
         // Change a source file
         test.modifySourceFile(PostResource.class, s -> s.replace("Hello:", "Hi:"));
 

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -59,5 +59,9 @@ public class WebJarLocatorTest {
                 .statusCode(404);
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
                 .statusCode(404);
+
+        // Test webjar that does not have a version in the jar path
+        RestAssured.get("/webjars/dcjs/dc.min.js").then()
+                .statusCode(200);
     }
 }

--- a/extensions/webjars-locator/runtime/src/main/java/io/quarkus/webjar/locator/runtime/WebJarLocatorRecorder.java
+++ b/extensions/webjars-locator/runtime/src/main/java/io/quarkus/webjar/locator/runtime/WebJarLocatorRecorder.java
@@ -22,7 +22,8 @@ public class WebJarLocatorRecorder {
                         endOfVersion = rest.length();
                     }
                     String nextPathEntry = rest.substring(rest.indexOf('/') + 1, endOfVersion);
-                    if (nextPathEntry.equals(webjarNameToVersionMap.get(webjar))) {
+                    if (webjarNameToVersionMap.get(webjar) == null
+                            || nextPathEntry.equals(webjarNameToVersionMap.get(webjar))) {
                         // go to the next handler (which should be the static resource handler, if one exists)
                         event.next();
                     } else {


### PR DESCRIPTION
Some webjars does not have have the version in the path. If you mix these with ones that does have the version, and use webjars-locator, it does not work.

This PR fix this case.

Fix #13294

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>