### PR TITLE
Implement JpaRepository return type Set<T>

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -81,6 +81,7 @@ public final class DotNames {
     public static final DotName ITERATOR = DotName.createSimple(Iterator.class.getName());
     public static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
     public static final DotName LIST = DotName.createSimple(List.class.getName());
+    public static final DotName SET = DotName.createSimple(Set.class.getName());
     public static final DotName STREAM = DotName.createSimple(Stream.class.getName());
     public static final DotName OPTIONAL = DotName.createSimple(Optional.class.getName());
     public static final DotName OBJECT = DotName.createSimple(Object.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
@@ -1,6 +1,8 @@
 package io.quarkus.spring.data.deployment.generate;
 
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -119,7 +121,7 @@ public abstract class AbstractMethodsAdder {
                     MethodDescriptor.ofMethod(Optional.class, "empty", Optional.class));
             catchBlock.returnValue(emptyOptional);
         } else if (DotNames.LIST.equals(returnType) || DotNames.COLLECTION.equals(returnType)
-                || DotNames.ITERATOR.equals(returnType)) {
+                || DotNames.SET.equals(returnType) || DotNames.ITERATOR.equals(returnType)) {
             ResultHandle list;
 
             if (customResultType == null) {
@@ -158,6 +160,10 @@ public abstract class AbstractMethodsAdder {
                         MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class),
                         list);
                 methodCreator.returnValue(iterator);
+            } else if (DotNames.SET.equals(returnType)) {
+                ResultHandle set = methodCreator.newInstance(
+                        MethodDescriptor.ofConstructor(LinkedHashSet.class, Collection.class), list);
+                methodCreator.returnValue(set);
             }
             methodCreator.returnValue(list);
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatRepository.java
@@ -3,6 +3,7 @@ package io.quarkus.it.spring.data.jpa;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.springframework.data.jpa.repository.Query;
@@ -45,4 +46,8 @@ public interface CatRepository extends CrudRepository<Cat, Long> {
     // issue 9192
     @Query(value = "SELECT c.distinctive FROM Cat c where c.id = :id")
     boolean customFindDistinctive(@Param("id") Long id);
+
+    // the DISTINCT statement was left out intentionally to verify that duplicates are eliminated by the Set
+    @Query(value = "SELECT c.color FROM Cat c WHERE c.color IS NOT NULL")
+    Set<String> customQueryCatColors();
 }

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.spring.data.jpa;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.GET;
@@ -125,5 +126,12 @@ public class CatResource {
     @Produces("text/plain")
     public Boolean customFindDistinctive(@PathParam("id") Long id) {
         return catRepository.customFindDistinctive(id);
+    }
+
+    @GET
+    @Path("/customQueryCatColors")
+    @Produces("application/json")
+    public Set<String> customQueryCatColors() {
+        return catRepository.customQueryCatColors();
     }
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatResourceTest.java
@@ -234,4 +234,14 @@ public class CatResourceTest {
                 .statusCode(200)
                 .body(Is.is("true"));
     }
+
+    @Test
+    void testCustomQueryCatColors() {
+        List<String> catColors = when().get("/cat/customQueryCatColors").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getList(".", String.class);
+        assertThat(catColors)
+                .containsOnlyOnce("Grey", "White", "Black")
+                .hasSize(3);
+    }
 }


### PR DESCRIPTION
This pull request adds support for the return type Set which is supported by Spring Data JPA (see https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.collections-and-iterables). This is typically used as return type of `SELECT DINSTINCT o.myProp from MyEntity o`.