### PR TITLE
Spring Data Repository nested camel-case properties resolution fix

### DIFF
--- a/extensions/spring-data-jpa/deployment/pom.xml
+++ b/extensions/spring-data-jpa/deployment/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -75,6 +75,16 @@ public final class DotNames {
     public static final DotName PRIMITIVE_LONG = DotName.createSimple(long.class.getName());
     public static final DotName INTEGER = DotName.createSimple(Integer.class.getName());
     public static final DotName PRIMITIVE_INTEGER = DotName.createSimple(int.class.getName());
+    public static final DotName SHORT = DotName.createSimple(Short.class.getName());
+    public static final DotName PRIMITIVE_SHORT = DotName.createSimple(short.class.getName());
+    public static final DotName CHARACTER = DotName.createSimple(Character.class.getName());
+    public static final DotName PRIMITIVE_CHAR = DotName.createSimple(char.class.getName());
+    public static final DotName BYTE = DotName.createSimple(Byte.class.getName());
+    public static final DotName PRIMITIVE_BYTE = DotName.createSimple(byte.class.getName());
+    public static final DotName DOUBLE = DotName.createSimple(Double.class.getName());
+    public static final DotName PRIMITIVE_DOUBLE = DotName.createSimple(double.class.getName());
+    public static final DotName FLOAT = DotName.createSimple(Float.class.getName());
+    public static final DotName PRIMITIVE_FLOAT = DotName.createSimple(float.class.getName());
     public static final DotName BOOLEAN = DotName.createSimple(Boolean.class.getName());
     public static final DotName PRIMITIVE_BOOLEAN = DotName.createSimple(boolean.class.getName());
     public static final DotName STRING = DotName.createSimple(String.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
@@ -7,11 +7,8 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
@@ -59,6 +56,17 @@ public class MethodNameParser {
             "IsContaining", "Containing", "Contains"));
 
     private static final Set<String> BOOLEAN_OPERATIONS = new HashSet<>(Arrays.asList("True", "False"));
+
+    private static final Set<DotName> SIMPLE_FIELD_TYPES = new HashSet<>(Arrays.asList(
+            DotNames.STRING,
+            DotNames.BOOLEAN, DotNames.PRIMITIVE_BOOLEAN,
+            DotNames.INTEGER, DotNames.PRIMITIVE_INTEGER,
+            DotNames.LONG, DotNames.PRIMITIVE_LONG,
+            DotNames.SHORT, DotNames.PRIMITIVE_SHORT,
+            DotNames.BYTE, DotNames.PRIMITIVE_BYTE,
+            DotNames.CHARACTER, DotNames.PRIMITIVE_CHAR,
+            DotNames.DOUBLE, DotNames.PRIMITIVE_DOUBLE,
+            DotNames.FLOAT, DotNames.PRIMITIVE_FLOAT));
 
     private final ClassInfo entityClass;
     private final IndexView indexView;
@@ -172,6 +180,7 @@ public class MethodNameParser {
             parts = Arrays.asList(afterByPart.split("Or"));
         }
 
+        MutableReference<List<ClassInfo>> mappedSuperClassInfoRef = MutableReference.of(mappedSuperClassInfos);
         StringBuilder where = new StringBuilder();
         int paramsCount = 0;
         for (String part : parts) {
@@ -192,64 +201,13 @@ public class MethodNameParser {
             } else {
                 fieldName = lowerFirstLetter(part.replaceAll(operation, ""));
             }
-            FieldInfo fieldInfo = getField(fieldName);
+            FieldInfo fieldInfo = getFieldInfo(fieldName, entityClass, mappedSuperClassInfoRef);
             if (fieldInfo == null) {
-                ClassInfo associatedEntityClassInfo;
-                String associatedEntityFieldName;
-                String simpleFieldName;
-                String parsingExceptionMethod = "Entity " + entityClass + " does not contain a field named: " + fieldName +
-                        ". " + "Offending method is " + methodName;
-
-                // determine if we are trying to use a field of one of the associated entities
-                int nextStartingIndex = 1;
-                while (true) {
-                    int fieldEndIndex = -1;
-                    for (int i = nextStartingIndex; i < fieldName.length() - 1; i++) {
-                        char c = fieldName.charAt(i);
-                        if ((c >= 'A' && c <= 'Z') || c == '_') {
-                            fieldEndIndex = i;
-                            break;
-                        }
-                    }
-
-                    if (fieldEndIndex == -1) {
-                        throw new UnableToParseMethodException(parsingExceptionMethod);
-                    }
-
-                    int associatedEntityFieldStartIndex = fieldName.charAt(fieldEndIndex) == '_' ? fieldEndIndex + 1
-                            : fieldEndIndex;
-                    if (associatedEntityFieldStartIndex >= fieldName.length() - 1) {
-                        throw new UnableToParseMethodException(parsingExceptionMethod);
-                    }
-
-                    simpleFieldName = fieldName.substring(0, fieldEndIndex);
-                    associatedEntityFieldName = lowerFirstLetter(fieldName.substring(associatedEntityFieldStartIndex));
-                    fieldInfo = getField(simpleFieldName);
-                    if ((fieldInfo == null) || !(fieldInfo.type() instanceof ClassType)) {
-                        nextStartingIndex = fieldEndIndex + 1;
-                    } else {
-                        break;
-                    }
-                }
-
-                associatedEntityClassInfo = indexView.getClassByName(fieldInfo.type().name());
-                if (associatedEntityClassInfo == null) {
-                    throw new IllegalStateException(
-                            "Entity class " + fieldInfo.type().name() + " was not part of the Quarkus index");
-                }
-                FieldInfo associatedEntityClassField = getAssociatedEntityClassField(associatedEntityFieldName,
-                        associatedEntityClassInfo);
-                if (associatedEntityClassField == null) {
-                    throw new UnableToParseMethodException(parsingExceptionMethod);
-                }
-
-                validateFieldWithOperation(operation, associatedEntityClassField, methodName);
-
-                // set the fieldName to the proper JPQL expression
-                fieldName = simpleFieldName + "." + associatedEntityFieldName;
-            } else {
-                validateFieldWithOperation(operation, fieldInfo, methodName);
+                StringBuilder fieldPathBuilder = new StringBuilder(fieldName.length() + 5);
+                fieldInfo = resolveNestedField(methodName, fieldName, fieldPathBuilder);
+                fieldName = fieldPathBuilder.toString();
             }
+            validateFieldWithOperation(operation, fieldInfo, fieldName, methodName);
             if ((ignoreCase || allIgnoreCase) && !DotNames.STRING.equals(fieldInfo.type().name())) {
                 throw new UnableToParseMethodException(
                         "IgnoreCase cannot be specified for field" + fieldInfo.name() + " of method "
@@ -262,12 +220,6 @@ public class MethodNameParser {
 
             String upperPrefix = (ignoreCase || allIgnoreCase) ? "UPPER(" : "";
             String upperSuffix = (ignoreCase || allIgnoreCase) ? ")" : "";
-
-            // If the fieldName is not a field in the class and in camelcase format,
-            // then split it as hierarchy of fields
-            if (entityClass.field(fieldName) == null) {
-                fieldName = handleFieldsHierarchy(fieldName, fieldInfo);
-            }
 
             where.append(upperPrefix).append(fieldName).append(upperSuffix);
             if ((operation == null) || "Equals".equals(operation) || "Is".equals(operation)) {
@@ -382,73 +334,75 @@ public class MethodNameParser {
                 topCount);
     }
 
-    private String handleFieldsHierarchy(String fieldName, FieldInfo currentField) {
-        StringBuilder finalName = new StringBuilder(fieldName);
+    /**
+     * See:
+     * https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-property-expressions
+     */
+    private FieldInfo resolveNestedField(String methodName, String fieldPathExpression, StringBuilder fieldPathBuilder) {
 
-        Set<String> childFields = new HashSet<>();
+        String fieldNotResolvableMessage = "Entity " + this.entityClass + " does not contain a field named: "
+                + fieldPathExpression + ". ";
+        String offendingMethodMessage = "Offending method is " + methodName + ".";
 
-        childFields.addAll(entityClass.fields().stream()
-                .map(FieldInfo::name)
-                .collect(Collectors.toList()));
+        ClassInfo parentClassInfo = this.entityClass;
+        FieldInfo fieldInfo = null;
 
-        // Collecting the current class fields
-        ClassInfo currentClassInfo = indexView.getClassByName(currentField.type().name());
-
-        if (currentClassInfo != null) {
-            childFields.addAll(
-                    currentClassInfo.fields()
-                            .stream()
-                            .map(FieldInfo::name)
-                            .collect(Collectors.toList()));
+        int fieldStartIndex = 0;
+        while (fieldStartIndex < fieldPathExpression.length()) {
+            if (fieldPathExpression.charAt(fieldStartIndex) == '_') {
+                fieldStartIndex++;
+                if (fieldStartIndex >= fieldPathExpression.length()) {
+                    throw new UnableToParseMethodException(fieldNotResolvableMessage + offendingMethodMessage);
+                }
+            }
+            MutableReference<List<ClassInfo>> parentSuperClassInfos = new MutableReference<>();
+            // the underscore character is treated as reserved character to manually define traversal points.
+            int firstSeparator = fieldPathExpression.indexOf('_', fieldStartIndex);
+            int fieldEndIndex = firstSeparator == -1 ? fieldPathExpression.length() : firstSeparator;
+            while (fieldEndIndex >= fieldStartIndex) {
+                String simpleFieldName = lowerFirstLetter(fieldPathExpression.substring(fieldStartIndex, fieldEndIndex));
+                fieldInfo = getFieldInfo(simpleFieldName, parentClassInfo, parentSuperClassInfos);
+                if (fieldInfo != null) {
+                    break;
+                }
+                fieldEndIndex = previousPotentialFieldEnd(fieldPathExpression, fieldStartIndex, fieldEndIndex);
+            }
+            if (fieldInfo == null) {
+                String detail = "";
+                if (fieldStartIndex > 0) {
+                    String notMatched = lowerFirstLetter(fieldPathExpression.substring(fieldStartIndex));
+                    detail = "Can not resolve " + parentClassInfo + "." + notMatched + ". ";
+                }
+                throw new UnableToParseMethodException(
+                        fieldNotResolvableMessage + detail + offendingMethodMessage);
+            }
+            if (fieldPathBuilder.length() > 0) {
+                fieldPathBuilder.append('.');
+            }
+            fieldPathBuilder.append(fieldInfo.name());
+            if (!isSupportedHibernateType(fieldInfo.type().name())) {
+                parentClassInfo = indexView.getClassByName(fieldInfo.type().name());
+                if (parentClassInfo == null) {
+                    throw new IllegalStateException(
+                            "Entity class " + fieldInfo.type().name() + " referenced by "
+                                    + this.entityClass + "." + fieldPathBuilder
+                                    + " was not part of the Quarkus index. " + offendingMethodMessage);
+                }
+            }
+            fieldStartIndex = fieldEndIndex;
         }
 
-        // Collecting the inherited fields from the superclass of the actual class
-        DotName superClassName = entityClass.superClassType().name();
-        ClassInfo superClassInfo = indexView.getClassByName(superClassName);
+        return fieldInfo;
+    }
 
-        ClassInfo classByName;
-
-        if (superClassName != null && superClassInfo != null && currentClassInfo != null &&
-                currentClassInfo.superClassType() != null &&
-                (classByName = indexView.getClassByName(currentClassInfo.superClassType().name())) != null) {
-
-            childFields.addAll(superClassInfo.fields()
-                    .stream()
-                    .map(FieldInfo::name).collect(Collectors.toList()));
-
-            childFields.addAll(classByName.fields()
-                    .stream()
-                    .map(FieldInfo::name).collect(Collectors.toList()));
-        }
-
-        // Collecting the inherited fields from the superclasses of the attributes
-        if (currentClassInfo != null && currentClassInfo.superClassType() != null
-                && (classByName = indexView.getClassByName(currentClassInfo.superClassType().name())) != null) {
-
-            childFields.addAll(
-                    classByName.fields()
-                            .stream()
-                            .map(FieldInfo::name).collect(Collectors.toList()));
-        }
-
-        // Building the fieldName from the members classes and their superclasses
-        for (String fieldInf : childFields) {
-            if (StringUtils.containsIgnoreCase(fieldName, fieldInf)) {
-                String newValue = finalName.toString()
-                        .replaceAll("(?i)" + fieldInf, lowerFirstLetter(fieldInf) + ".");
-                newValue = newValue.replace("..", "."); // this is just the easiest way to deal with fields of fields
-                finalName.delete(0, finalName.length());
-                finalName.append(newValue);
+    private int previousPotentialFieldEnd(String fieldName, int fieldStartIndex, int fieldEndIndexExclusive) {
+        for (int i = fieldEndIndexExclusive - 1; i > fieldStartIndex; i--) {
+            char c = fieldName.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                return i;
             }
         }
-
-        // In some cases, the built hierarchy is ending by a joining point. so we need to remove it
-        if (finalName.toString().charAt(finalName.length() - 1) == '.') {
-            fieldName = finalName.toString().replaceAll(".$", "");
-        } else {
-            fieldName = finalName.toString();
-        }
-        return fieldName;
+        return -1;
     }
 
     /**
@@ -469,38 +423,18 @@ public class MethodNameParser {
         return Character.isUpperCase(str.charAt(index + operatorStr.length()));
     }
 
-    /**
-     * Looks for the field in either the class itself or in a superclass that is annotated with @MappedSuperClass
-     */
-    private FieldInfo getAssociatedEntityClassField(String associatedEntityFieldName, ClassInfo associatedEntityClassInfo) {
-        FieldInfo fieldInfo = associatedEntityClassInfo.field(associatedEntityFieldName);
-        if (fieldInfo != null) {
-            return fieldInfo;
-        }
-        if (DotNames.OBJECT.equals(associatedEntityClassInfo.superName())) {
-            return null;
-        }
-
-        ClassInfo superClassInfo = indexView.getClassByName(associatedEntityClassInfo.superName());
-        if (superClassInfo.classAnnotation(DotNames.JPA_MAPPED_SUPERCLASS) == null) {
-            return null;
-        }
-
-        return getAssociatedEntityClassField(associatedEntityFieldName, superClassInfo);
-    }
-
-    private void validateFieldWithOperation(String operation, FieldInfo fieldInfo, String methodName) {
+    private void validateFieldWithOperation(String operation, FieldInfo fieldInfo, String fieldPath, String methodName) {
         DotName fieldTypeDotName = fieldInfo.type().name();
         if (STRING_LIKE_OPERATIONS.contains(operation) && !DotNames.STRING.equals(fieldTypeDotName)) {
             throw new UnableToParseMethodException(
-                    operation + " cannot be specified for field" + fieldInfo.name() + " of method "
+                    operation + " cannot be specified for field" + fieldPath + " of method "
                             + methodName + " because it is not a String type");
         }
 
         if (BOOLEAN_OPERATIONS.contains(operation) && !DotNames.BOOLEAN.equals(fieldTypeDotName)
                 && !DotNames.PRIMITIVE_BOOLEAN.equals(fieldTypeDotName)) {
             throw new UnableToParseMethodException(
-                    operation + " cannot be specified for field" + fieldInfo.name() + " of method "
+                    operation + " cannot be specified for field" + fieldPath + " of method "
                             + methodName + " because it is not a boolean type");
         }
     }
@@ -572,16 +506,14 @@ public class MethodNameParser {
         return false;
     }
 
-    private FieldInfo getField(String fieldName) {
-        // Before validating the fieldInfo,
-        // we need to split the camelcase format and grab the first item
+    private FieldInfo getFieldInfo(String fieldName, ClassInfo entityClass,
+            MutableReference<List<ClassInfo>> mappedSuperClassInfos) {
         FieldInfo fieldInfo = entityClass.field(fieldName);
         if (fieldInfo == null) {
-            String[] camelCaseStrings = StringUtils.splitByCharacterTypeCamelCase(fieldName);
-            fieldInfo = entityClass.field(camelCaseStrings[0]);
-        }
-        if (fieldInfo == null) {
-            for (ClassInfo superClass : mappedSuperClassInfos) {
+            if (mappedSuperClassInfos.isEmpty()) {
+                mappedSuperClassInfos.set(getMappedSuperClassInfos(indexView, entityClass));
+            }
+            for (ClassInfo superClass : mappedSuperClassInfos.get()) {
                 fieldInfo = superClass.field(fieldName);
                 if (fieldInfo != null) {
                     break;
@@ -608,6 +540,37 @@ public class MethodNameParser {
             }
         }
         return mappedSuperClassInfoElements;
+    }
+
+    private boolean isSupportedHibernateType(DotName dotName) {
+        return SIMPLE_FIELD_TYPES.contains(dotName);
+    }
+
+    private static class MutableReference<T> {
+        private T reference;
+
+        public static <T> MutableReference<T> of(T reference) {
+            return new MutableReference<>(reference);
+        }
+
+        public MutableReference() {
+        }
+
+        private MutableReference(T reference) {
+            this.reference = reference;
+        }
+
+        public T get() {
+            return reference;
+        }
+
+        public void set(T value) {
+            this.reference = value;
+        }
+
+        public boolean isEmpty() {
+            return reference == null;
+        }
     }
 
     public static class Result {

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.spring.data.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.api.AbstractStringAssert;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+
+public class MethodNameParserTest {
+
+    private final Class<?> repositoryClass = PersonRepository.class;
+    private final Class<?> entityClass = Person.class;
+    private final Class[] additionalClasses = new Class[] { Person.Address.class, Person.Country.class };
+
+    @Test
+    public void testFindAllByAddressZipCode() throws Exception {
+        MethodNameParser.Result result = parseMethod(repositoryClass, "findAllByAddressZipCode", entityClass,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), entityClass);
+        assertThat(result.getQuery()).isEqualTo("FROM Person WHERE address.zipCode = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindAllByAddressCountry() throws Exception {
+        MethodNameParser.Result result = parseMethod(repositoryClass, "findAllByAddressCountry", entityClass,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), entityClass);
+        assertThat(result.getQuery()).isEqualTo("FROM Person WHERE addressCountry = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindAllByAddress_Country() throws Exception {
+        MethodNameParser.Result result = parseMethod(repositoryClass, "findAllByAddress_Country", entityClass,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), entityClass);
+        assertThat(result.getQuery()).isEqualTo("FROM Person WHERE address.country = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindAllByAddressCountryIsoCode() throws Exception {
+        UnableToParseMethodException exception = assertThrows(UnableToParseMethodException.class,
+                () -> parseMethod(repositoryClass, "findAllByAddressCountryIsoCode", entityClass, additionalClasses));
+        assertThat(exception).hasMessageContaining("Person does not contain a field named: addressCountryIsoCode");
+    }
+
+    @Test
+    public void testFindAllByAddress_CountryIsoCode() throws Exception {
+        MethodNameParser.Result result = parseMethod(repositoryClass, "findAllByAddress_CountryIsoCode", entityClass,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), entityClass);
+        assertThat(result.getQuery()).isEqualTo("FROM Person WHERE address.country.isoCode = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindAllByAddress_Country_IsoCode() throws Exception {
+        MethodNameParser.Result result = parseMethod(repositoryClass, "findAllByAddress_Country_IsoCode", entityClass,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), entityClass);
+        assertThat(result.getQuery()).isEqualTo("FROM Person WHERE address.country.isoCode = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFindAllByAddress_CountryInvalid() throws Exception {
+        UnableToParseMethodException exception = assertThrows(UnableToParseMethodException.class,
+                () -> parseMethod(repositoryClass, "findAllByAddress_CountryInvalid", entityClass, additionalClasses));
+        assertThat(exception).hasMessageContaining("Person does not contain a field named: address_CountryInvalid");
+        assertThat(exception).hasMessageContaining("Country.invalid");
+    }
+
+    @Test
+    public void testFindAllBy_() throws Exception {
+        UnableToParseMethodException exception = assertThrows(UnableToParseMethodException.class,
+                () -> parseMethod(repositoryClass, "findAllBy_", entityClass, additionalClasses));
+        assertThat(exception).hasMessageContaining("Person does not contain a field named: _");
+    }
+
+    private AbstractStringAssert<?> assertSameClass(ClassInfo classInfo, Class<?> aClass) {
+        return assertThat(classInfo.name().toString()).isEqualTo(aClass.getName());
+    }
+
+    private MethodNameParser.Result parseMethod(Class<?> repositoryClass, String methodToParse,
+            Class<?> entityClass, Class<?>... additionalClasses) throws IOException {
+        IndexView indexView = index(ArrayUtils.addAll(additionalClasses, repositoryClass, entityClass));
+        DotName repository = DotName.createSimple(repositoryClass.getName());
+        DotName entity = DotName.createSimple(entityClass.getName());
+        ClassInfo entityClassInfo = indexView.getClassByName(entity);
+        ClassInfo repositoryClassInfo = indexView.getClassByName(repository);
+        MethodNameParser methodNameParser = new MethodNameParser(entityClassInfo, indexView);
+        MethodInfo repositoryMethod = repositoryClassInfo.firstMethod(methodToParse);
+        MethodNameParser.Result result = methodNameParser.parse(repositoryMethod);
+        return result;
+    }
+
+    public static Index index(Class<?>... classes) throws IOException {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            try (InputStream stream = MethodNameParserTest.class.getClassLoader()
+                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                indexer.index(stream);
+            }
+        }
+        return indexer.complete();
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/Person.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/Person.java
@@ -1,0 +1,33 @@
+package io.quarkus.spring.data.deployment;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class Person {
+    @Id
+    private Integer id;
+
+    private Address address;
+
+    private String addressCountry;
+
+    @Entity
+    public static class Address {
+        @Id
+        private Integer id;
+
+        private String zipCode;
+
+        private Country country;
+    }
+
+    @Entity
+    public static class Country {
+        @Id
+        private Integer id;
+
+        private String isoCode;
+    }
+
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/PersonRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/PersonRepository.java
@@ -1,0 +1,25 @@
+package io.quarkus.spring.data.deployment;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+// issue 13067:
+public interface PersonRepository extends Repository<Person, Integer> {
+
+    List<Person> findAllByAddressZipCode(String zipCode);
+
+    List<Person> findAllByAddressCountry(String zipCode);
+
+    List<Person> findAllByAddress_Country(String zipCode);
+
+    List<Person> findAllByAddressCountryIsoCode(String zipCode);
+
+    List<Person> findAllByAddress_CountryIsoCode(String zipCode);
+
+    List<Person> findAllByAddress_Country_IsoCode(String zipCode);
+
+    List<Person> findAllByAddress_CountryInvalid(String zipCode);
+
+    List<Person> findAllBy_(String zipCode);
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Employee.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Employee.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "employee")
+public class Employee extends AbstractEntity {
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team belongsToTeam;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public Team getBelongsToTeam() {
+        return belongsToTeam;
+    }
+
+    @Entity
+    @Table(name = "team")
+    public static class Team extends AbstractEntity {
+
+        private String name;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "unit_id", nullable = false)
+        private OrgUnit organizationalUnit;
+
+        public String getName() {
+            return name;
+        }
+
+        public OrgUnit getOrganizationalUnit() {
+            return organizationalUnit;
+        }
+    }
+
+    @Entity
+    @Table(name = "unit")
+    public static class OrgUnit extends AbstractEntity {
+
+        private String name;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/EmployeeRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/EmployeeRepository.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+
+    List<Employee> findByBelongsToTeamOrganizationalUnitName(String orgUnitName);
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/EmployeeResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/EmployeeResource.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@Path("/employee")
+@Produces("application/json")
+public class EmployeeResource {
+
+    private final EmployeeRepository employeeRepository;
+
+    public EmployeeResource(EmployeeRepository employeeRepository) {
+        this.employeeRepository = employeeRepository;
+    }
+
+    @GET
+    public List<Employee> findAll() {
+        return this.employeeRepository.findAll();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Employee findById(@PathParam("id") Long id) {
+        return this.employeeRepository.findById(id).orElse(null);
+    }
+
+    @GET
+    @Path("/unit/{orgUnitName}")
+    public List<Employee> findByManagerOfManager(@PathParam("orgUnitName") String orgUnitName) {
+        return this.employeeRepository.findByBelongsToTeamOrganizationalUnitName(orgUnitName);
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/resources/import.sql
+++ b/integration-tests/spring-data-jpa/src/main/resources/import.sql
@@ -69,3 +69,11 @@ INSERT INTO cart(id, customer_id, status) VALUES (3, 3, 'CANCELED');
 
 INSERT INTO orders(id, cart_id) VALUES (1, 1);
 INSERT INTO orders(id, cart_id) VALUES (2, 2);
+
+INSERT INTO unit(id, name) VALUES (1, 'Delivery Unit');
+INSERT INTO unit(id, name) VALUES (2, 'Sales and Marketing Unit');
+INSERT INTO team(id, name, unit_id) VALUES (10, 'Development Team', 1);
+INSERT INTO team(id, name, unit_id) VALUES (11, 'Sales Team', 2);
+INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (100, 'johdoe', 'John', 'Doe', 10);
+INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (101, 'petdig', 'Peter', 'Digger', 10);
+INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (102, 'stesmi', 'Stella', 'Smith', 11);

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/EmployeeResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/EmployeeResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.spring.data.jpa;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class EmployeeResourceIT extends EmployeeResourceTest {
+}

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/EmployeeResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/EmployeeResourceTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.spring.data.jpa;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class EmployeeResourceTest {
+
+    @Test
+    public void testFindEmployeesByOrganizationalUnit() {
+        List<Employee> employees = when().get("/employee/unit/Delivery Unit").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getList(".", Employee.class);
+
+        assertThat(employees).extracting("userId").containsExactlyInAnyOrder("johdoe", "petdig");
+    }
+
+}


### PR DESCRIPTION
Fix #13067.
I re-implemented the resolution of nested properties now they should be resolved as described here https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-property-expressions. I also widened the allowed types for the resolved properties to the types supported by JPA.
The property resolution is now done iteratively and tries to find the longest match (but at most to the next underscore because the underscore is treated as reserved character according to the Spring Data JPA documentation).