### PR TITLE
Vastly speed up lookup of META-INF/microprofile-config.properties for the common case (where the file is missing)

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -24,6 +24,7 @@ public class RunnerClassLoader extends ClassLoader {
     private final Map<String, ClassLoadingResource[]> resourceDirectoryMap;
 
     private final Set<String> parentFirstPackages;
+    private final Set<String> nonExistentResources;
 
     private final ConcurrentMap<ClassLoadingResource, ProtectionDomain> protectionDomains = new ConcurrentHashMap<>();
 
@@ -32,10 +33,11 @@ public class RunnerClassLoader extends ClassLoader {
     }
 
     RunnerClassLoader(ClassLoader parent, Map<String, ClassLoadingResource[]> resourceDirectoryMap,
-            Set<String> parentFirstPackages) {
+            Set<String> parentFirstPackages, Set<String> nonExistentResources) {
         super(parent);
         this.resourceDirectoryMap = resourceDirectoryMap;
         this.parentFirstPackages = parentFirstPackages;
+        this.nonExistentResources = nonExistentResources;
     }
 
     @Override
@@ -96,6 +98,9 @@ public class RunnerClassLoader extends ClassLoader {
     @Override
     protected URL findResource(String name) {
         name = sanitizeName(name);
+        if (nonExistentResources.contains(name)) {
+            return null;
+        }
         ClassLoadingResource[] resources = getClassLoadingResources(name);
         if (resources == null)
             return null;
@@ -133,6 +138,9 @@ public class RunnerClassLoader extends ClassLoader {
     @Override
     protected Enumeration<URL> findResources(String name) throws IOException {
         name = sanitizeName(name);
+        if (nonExistentResources.contains(name)) {
+            return Collections.emptyEnumeration();
+        }
         ClassLoadingResource[] resources = getClassLoadingResources(name);
         if (resources == null)
             return null;

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -51,7 +51,7 @@ public class SerializedApplication {
     }
 
     public static void write(OutputStream outputStream, String mainClass, Path applicationRoot, List<Path> classPath,
-            List<Path> parentFirst)
+            List<Path> parentFirst, List<String> nonExistentResources)
             throws IOException {
         try (DataOutputStream data = new DataOutputStream(outputStream)) {
             data.writeInt(MAGIC);
@@ -71,6 +71,10 @@ public class SerializedApplication {
             data.writeInt(parentFirstPackages.size());
             for (String p : parentFirstPackages) {
                 data.writeUTF(p.replace("/", ".").replace("\\", "."));
+            }
+            data.writeInt(nonExistentResources.size());
+            for (String nonExistentResource : nonExistentResources) {
+                data.writeUTF(nonExistentResource);
             }
             data.flush();
         }
@@ -115,8 +119,14 @@ public class SerializedApplication {
             for (int i = 0; i < packages; ++i) {
                 parentFirstPackages.add(in.readUTF());
             }
+            Set<String> nonExistentResources = new HashSet<>();
+            int nonExistentResourcesSize = in.readInt();
+            for (int i = 0; i < nonExistentResourcesSize; i++) {
+                nonExistentResources.add(in.readUTF());
+            }
             return new SerializedApplication(
-                    new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap, parentFirstPackages),
+                    new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap, parentFirstPackages,
+                            nonExistentResources),
                     mainClass);
         }
     }


### PR DESCRIPTION
This file is always looked up during boot (as part of the spec) and most of the time
it doesn't exist.
Due to it's location under `META-INF`, it forces the RunnerClassLoader to look
into every jar order to determine whether the resource exists or not.
In order to avoid that lookup, we add a fail-fast path which is almost certainly
going to be used in most applications (which just use `application.properties`)