### PR TITLE
Blocking on the reactive route guide

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -336,7 +336,7 @@ String helloSync(RoutingContext context) {
 ----
 
 Be aware, the processing must be **non-blocking** as reactive routes are invoked on the IO Thread.
-Otherwise, use the `blocking` attribute of the `@Route` annotation or the `@Blocking` annotation.
+Otherwise, set the `type` attribute of the `@Route` annotation to `Route.HandlerType.BLOCKING`, or use the `@io.smallrye.common.annotation.Blocking` annotation.
 
 The method can return:
 


### PR DESCRIPTION
There is no `blocking` attribute on the `@Route` attribute.