### PR TITLE
Update smallrye-openapi version

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -40,7 +40,7 @@
         <smallrye-config.version>1.9.3</smallrye-config.version>
         <smallrye-health.version>2.2.5</smallrye-health.version>
         <smallrye-metrics.version>2.4.4</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.14</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.15</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.15</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>


### PR DESCRIPTION
Fix #13323

This PR pulls in a small update in smallrye openapi that fixes a bug in the Spring extension when using request mapping.

See https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.15

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>