### PR TITLE
Create a new Resteasy Context Map

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -3,6 +3,8 @@ package io.quarkus.resteasy.runtime.standalone;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import javax.enterprise.inject.Instance;
@@ -126,9 +128,10 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                     hostSupplier,
                     dispatcher.getDispatcher(), vertxResponse, requestContext, executor);
             vertxRequest.setInputStream(is);
-            try {
-                ResteasyContext.pushContext(SecurityContext.class, new QuarkusResteasySecurityContext(request, routingContext));
-                ResteasyContext.pushContext(RoutingContext.class, routingContext);
+            Map<Class<?>, Object> map = new HashMap<>();
+            map.put(SecurityContext.class, new QuarkusResteasySecurityContext(request, routingContext));
+            map.put(RoutingContext.class, routingContext);
+            try (ResteasyContext.CloseableContext restCtx = ResteasyContext.addCloseableContextDataLevel(map)) {
                 ContextUtil.pushContext(routingContext);
                 dispatcher.service(ctx, request, response, vertxRequest, vertxResponse, true);
             } catch (Failure e1) {


### PR DESCRIPTION
This provides a slight performance advantage,
but most importantly will prevent an existing
client context from interfering with the server one.

This can happen if the authentication layer is using
the REST client to access external services.

Fixes #13317