### PR TITLE
Ensure that jib extra files directories retain the proper permissions

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerBuilderHelper.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerBuilderHelper.java
@@ -84,8 +84,8 @@ final class ContainerBuilderHelper {
 
                                 // Add with default permissions
                                 if (localPath.toFile().canExecute()) {
-                                    // make sure we can execute the file in the container
-                                    builder.addEntry(localPath, pathOnContainer, FilePermissions.fromOctalString("754"),
+                                    // make sure the file or directory can be executed
+                                    builder.addEntry(localPath, pathOnContainer, FilePermissions.fromOctalString("755"),
                                             modificationTime);
                                 } else {
                                     builder.addEntry(localPath, pathOnContainer, modificationTime);


### PR DESCRIPTION
When extra directory layers are added, they should not change the default
permissions of directories

Fixes: #13322