### PR TITLE
Remove package namespacing for core examples, clean path & class names

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus-jbang/code/jbang-resteasy-code/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus-jbang/code/jbang-resteasy-code/codestart.yml
@@ -5,9 +5,9 @@ language:
   base:
     data:
       resource:
-        class-name: ExampleResource
-        path: "/resteasy/hello"
-        response: "hello"
+        class-name: GreetingResource
+        path: "/hello-resteasy"
+        response: "Hello RESTEasy"
     dependencies:
       - io.quarkus:quarkus-resteasy
 

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus-jbang/project/quarkus-jbang/base/README.tpl.qute.md
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus-jbang/project/quarkus-jbang/base/README.tpl.qute.md
@@ -1,5 +1,5 @@
 # JBang Quarkus Project
 
 ```shell script
-./jbang src/ExampleResource.java 
+./jbang src/GreetingResource.java 
 ```

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/commandmode-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/commandmode-example/codestart.yml
@@ -7,9 +7,9 @@ language:
     data:
       main:
         class-name: HelloCommando
-      package-name: org.acme.commandmode
+      package-name: org.acme
       greeting:
-        message: "hello"
-        default-name: "commando"
+        message: "Hello"
+        default-name: "Commando"
     dependencies:
       - io.quarkus:quarkus-arc

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/resteasy-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/resteasy-example/codestart.yml
@@ -9,10 +9,10 @@ language:
       description: |
         <p>A Hello World RESTEasy resource</p>
       resource:
-        class-name: ExampleResource
-        path: "/resteasy/hello"
-        response: "hello"
-      package-name: org.acme.resteasy
+        class-name: GreetingResource
+        path: "/hello-resteasy"
+        response: "Hello RESTEasy"
+      package-name: org.acme
       guide: https://quarkus.io/guides/rest-json
     dependencies:
       - io.quarkus:quarkus-resteasy

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/spring-web-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/examples/spring-web-example/codestart.yml
@@ -9,10 +9,10 @@ language:
       description: |
         <p>A Hello World Spring Web Controller</p>
       resource:
-        class-name: ExampleController
-        path: "/springweb/hello"
-        response: "hello"
-      package-name: org.acme.spring.web
+        class-name: SpringGreetingController
+        path: "/hello-spring"
+        response: "Hello Spring"
+      package-name: org.acme
       guide: https://quarkus.io/guides/spring-web
     dependencies:
       - io.quarkus:quarkus-spring-web

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartGenerationTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartGenerationTest.java
@@ -30,7 +30,7 @@ class QuarkusJBangCodestartGenerationTest extends PlatformAwareTestBase {
         getCatalog().createProject(input).generate(projectDir);
 
         assertThat(projectDir.resolve("jbang")).exists();
-        assertThat(projectDir.resolve("src/ExampleResource.java")).exists();
+        assertThat(projectDir.resolve("src/GreetingResource.java")).exists();
 
     }
 

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -94,7 +94,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/commandmode/HelloCommando.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/HelloCommando.java")).exists();
     }
 
     @Test
@@ -169,18 +169,18 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/ExampleResourceTest.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/NativeExampleResourceIT.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/GreetingResourceTest.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/NativeGreetingResourceIT.java")).exists();
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/spring/web/ExampleController.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/spring/web/ExampleControllerTest.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/spring/web/NativeExampleControllerIT.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/SpringGreetingController.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/SpringGreetingControllerTest.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/NativeSpringGreetingControllerIT.java")).exists();
 
         assertThat(projectDir.resolve("src/main/resources/META-INF/resources/index.html")).exists()
-                .satisfies(checkContains("\"/resteasy/hello\""))
+                .satisfies(checkContains("\"/hello-resteasy\""))
                 .satisfies(checkContains("quarkus.io/guides/rest-json"))
-                .satisfies(checkContains("\"/springweb/hello\""))
+                .satisfies(checkContains("\"/hello-spring\""))
                 .satisfies(checkContains("quarkus.io/guides/spring-web"));
     }
 
@@ -287,9 +287,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/ExampleResourceTest.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/NativeExampleResourceIT.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/GreetingResourceTest.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/NativeGreetingResourceIT.java")).exists();
     }
 
     @Test
@@ -306,9 +306,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/ExampleResourceTest.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/NativeExampleResourceIT.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/GreetingResourceTest.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/NativeGreetingResourceIT.java")).exists();
     }
 
     @Test
@@ -343,9 +343,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/kotlin/org/acme/resteasy/ExampleResource.kt")).exists();
-        assertThat(projectDir.resolve("src/test/kotlin/org/acme/resteasy/ExampleResourceTest.kt")).exists();
-        assertThat(projectDir.resolve("src/test/kotlin/org/acme/resteasy/NativeExampleResourceIT.kt")).exists();
+        assertThat(projectDir.resolve("src/main/kotlin/org/acme/GreetingResource.kt")).exists();
+        assertThat(projectDir.resolve("src/test/kotlin/org/acme/GreetingResourceTest.kt")).exists();
+        assertThat(projectDir.resolve("src/test/kotlin/org/acme/NativeGreetingResourceIT.kt")).exists();
     }
 
     @Test
@@ -363,9 +363,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.MAVEN);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/scala/org/acme/resteasy/ExampleResource.scala")).exists();
-        assertThat(projectDir.resolve("src/test/scala/org/acme/resteasy/ExampleResourceTest.scala")).exists();
-        assertThat(projectDir.resolve("src/test/scala/org/acme/resteasy/NativeExampleResourceIT.scala")).exists();
+        assertThat(projectDir.resolve("src/main/scala/org/acme/GreetingResource.scala")).exists();
+        assertThat(projectDir.resolve("src/test/scala/org/acme/GreetingResourceTest.scala")).exists();
+        assertThat(projectDir.resolve("src/test/scala/org/acme/NativeGreetingResourceIT.scala")).exists();
     }
 
     @Test
@@ -384,9 +384,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java")).exists();
-        assertThat(projectDir.resolve("src/test/java/org/acme/resteasy/ExampleResourceTest.java")).exists();
-        assertThat(projectDir.resolve("src/native-test/java/org/acme/resteasy/NativeExampleResourceIT.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java")).exists();
+        assertThat(projectDir.resolve("src/test/java/org/acme/GreetingResourceTest.java")).exists();
+        assertThat(projectDir.resolve("src/native-test/java/org/acme/NativeGreetingResourceIT.java")).exists();
     }
 
     @Test
@@ -406,9 +406,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/kotlin/org/acme/resteasy/ExampleResource.kt")).exists();
-        assertThat(projectDir.resolve("src/test/kotlin/org/acme/resteasy/ExampleResourceTest.kt")).exists();
-        assertThat(projectDir.resolve("src/native-test/kotlin/org/acme/resteasy/NativeExampleResourceIT.kt")).exists();
+        assertThat(projectDir.resolve("src/main/kotlin/org/acme/GreetingResource.kt")).exists();
+        assertThat(projectDir.resolve("src/test/kotlin/org/acme/GreetingResourceTest.kt")).exists();
+        assertThat(projectDir.resolve("src/native-test/kotlin/org/acme/NativeGreetingResourceIT.kt")).exists();
     }
 
     @Test
@@ -427,9 +427,9 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/scala/org/acme/resteasy/ExampleResource.scala")).exists();
-        assertThat(projectDir.resolve("src/test/scala/org/acme/resteasy/ExampleResourceTest.scala")).exists();
-        assertThat(projectDir.resolve("src/native-test/scala/org/acme/resteasy/NativeExampleResourceIT.scala")).exists();
+        assertThat(projectDir.resolve("src/main/scala/org/acme/GreetingResource.scala")).exists();
+        assertThat(projectDir.resolve("src/test/scala/org/acme/GreetingResourceTest.scala")).exists();
+        assertThat(projectDir.resolve("src/native-test/scala/org/acme/NativeGreetingResourceIT.scala")).exists();
     }
 
     @Test
@@ -447,7 +447,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE_KOTLIN_DSL);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java")).exists();
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java")).exists();
     }
 
     @Test
@@ -466,7 +466,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE_KOTLIN_DSL);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/kotlin/org/acme/resteasy/ExampleResource.kt")).exists();
+        assertThat(projectDir.resolve("src/main/kotlin/org/acme/GreetingResource.kt")).exists();
     }
 
     @Test
@@ -485,7 +485,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         checkDockerfiles(projectDir, BuildTool.GRADLE_KOTLIN_DSL);
         checkConfigProperties(projectDir);
 
-        assertThat(projectDir.resolve("src/main/scala/org/acme/resteasy/ExampleResource.scala")).exists();
+        assertThat(projectDir.resolve("src/main/scala/org/acme/GreetingResource.scala")).exists();
     }
 
     @Test

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
@@ -109,16 +109,16 @@ public class CreateProjectTest extends PlatformAwareTestBase {
                 .satisfies(checkContains("<artifactId>quarkus-spring-web</artifactId>"))
                 .satisfies(checkContains("<artifactId>quarkus-resteasy</artifactId>"));
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/spring/web/ExampleController.java"))
+        assertThat(projectDir.resolve("src/main/java/org/acme/SpringGreetingController.java"))
                 .exists()
                 .satisfies(checkContains("@RestController"))
-                .satisfies(checkContains("class ExampleController"))
-                .satisfies(checkContains("@RequestMapping(\"/springweb/hello\")"));
+                .satisfies(checkContains("class SpringGreetingController"))
+                .satisfies(checkContains("@RequestMapping(\"/hello-spring\")"));
 
-        assertThat(projectDir.resolve("src/main/java/org/acme/resteasy/ExampleResource.java"))
+        assertThat(projectDir.resolve("src/main/java/org/acme/GreetingResource.java"))
                 .exists()
-                .satisfies(checkContains("class ExampleResource"))
-                .satisfies(checkContains("@Path(\"/resteasy/hello\")"));
+                .satisfies(checkContains("class GreetingResource"))
+                .satisfies(checkContains("@Path(\"/hello-resteasy\")"));
     }
 
     @Test


### PR DESCRIPTION
RESTEasy: `org.acme.GreetingResource`
Spring: `org.acme.SpringGreetingController`

and update tests accordingly.

cc @maxandersen @gastaldi @FroMage @emmanuelbernard 