### PR TITLE
Make Quarkus Maven plugin smart create consistent with codestarts

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartData.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartData.java
@@ -101,6 +101,7 @@ public final class QuarkusCodestartData {
         }
     }
 
+    // TODO remove the class_name convertion when its removed
     private static String convertClassName(final Map<String, Object> legacyData) {
         Optional<String> classNameValue = NestedMaps.getValue(legacyData, "class_name");
         if (classNameValue.isPresent()) {
@@ -119,6 +120,7 @@ public final class QuarkusCodestartData {
         if (packageNameValue.isPresent()) {
             return packageNameValue.get();
         }
+        // TODO remove this block when class_name is removed
         Optional<String> classNameValue = NestedMaps.getValue(legacyData, "class_name");
         if (classNameValue.isPresent()) {
             final String className = classNameValue.get();
@@ -126,6 +128,12 @@ public final class QuarkusCodestartData {
             if (idx >= 0) {
                 return className.substring(0, idx);
             }
+        }
+
+        // Default to cleaned groupId if packageName not set
+        Optional<String> groupIdValue = NestedMaps.getValue(legacyData, "project_groupId");
+        if (groupIdValue.isPresent()) {
+            return groupIdValue.get().replace("-", ".").replace("_", ".");
         }
         return null;
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -95,6 +95,10 @@ public class CreateProject {
         return this;
     }
 
+    /**
+     * Use packageName instead as this one is only working with RESTEasy and SpringWeb
+     */
+    @Deprecated
     public CreateProject className(String className) {
         if (className == null) {
             return this;
@@ -103,6 +107,17 @@ public class CreateProject {
             throw new IllegalArgumentException(className + " is not a valid class name");
         }
         setValue(CLASS_NAME, className);
+        return this;
+    }
+
+    public CreateProject packageName(String packageName) {
+        if (packageName == null) {
+            return this;
+        }
+        if (!(SourceVersion.isName(packageName) && !SourceVersion.isKeyword(packageName))) {
+            throw new IllegalArgumentException(packageName + " is not a  package name");
+        }
+        setValue(PACKAGE_NAME, packageName);
         return this;
     }
 
@@ -219,7 +234,6 @@ public class CreateProject {
             setValue(IS_SPRING, true);
             if (containsRESTEasy(extensions)) {
                 values.remove(CLASS_NAME);
-                values.remove(PACKAGE_NAME);
                 values.remove(RESOURCE_PATH);
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/LegacyCreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/LegacyCreateProjectCommandHandler.java
@@ -67,6 +67,13 @@ public class LegacyCreateProjectCommandHandler implements QuarkusCommandHandler 
                 invocation.setValue(CLASS_NAME, className);
             }
 
+            // Default to cleaned groupId if packageName not set
+            final String pkgName = invocation.getStringValue(PACKAGE_NAME);
+            final String groupId = invocation.getStringValue(PROJECT_GROUP_ID);
+            if (pkgName == null && groupId != null) {
+                invocation.setValue(PACKAGE_NAME, groupId.replace("-", ".").replace("_", "."));
+            }
+
             final List<AppArtifactCoords> extensionsToAdd = computeCoordsFromQuery(invocation, extensionsQuery);
 
             // extensionsToAdd is null when an error occurred while matching extensions

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -60,7 +60,7 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         Properties properties = new Properties();
         properties.put("projectGroupId", "org.acme");
         properties.put("projectArtifactId", "acme");
-        properties.put("projectVersion", "1.0-SNAPSHOT");
+        properties.put("projectVersion", "1.0.0-SNAPSHOT");
         InvocationResult result = setup(properties);
 
         assertThat(result.getExitCode()).isZero();
@@ -374,9 +374,9 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
 
         assertThat(result.getExitCode()).isZero();
         // As the directory is not empty (log) navigate to the artifactID directory
-        testDir = new File(testDir, "my-quarkus-project");
-        check(new File(testDir, "src/main/java/org/acme/quarkus/sample/MyGreatResource.java"),
-                "package org.acme.quarkus.sample;");
+        testDir = new File(testDir, "code-with-quarkus");
+        check(new File(testDir, "src/main/java/org/acme/MyGreatResource.java"),
+                "package org.acme;");
     }
 
     private void check(final File resource, final String contentsToFind) throws IOException {
@@ -419,7 +419,7 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         String resp = DevModeTestUtils.getHttpResponse();
 
         assertThat(resp).containsIgnoringCase("ready").containsIgnoringCase("application").containsIgnoringCase("org.acme")
-                .containsIgnoringCase("1.0-SNAPSHOT");
+                .containsIgnoringCase("1.0.0-SNAPSHOT");
 
         String greeting = DevModeTestUtils.getHttpResponse("/hello");
         assertThat(greeting).containsIgnoringCase("hello");


### PR DESCRIPTION
Fixes #13272

Change the interactive questions when legacyCodegen is not used:
```
Set the project groupId [org.acme]: 
Set the project artifactId [code-with-quarkus]: 
Set the project version [1.0.0-SNAPSHOT]: 
What extensions do you wish to add (comma separated list): [resteasy]
Do you want example code to get started (yes), or just an empty project (no) [yes]?
```

Change the defaults in the Quarkus Maven plugin to be consistent with code.quarkus.io:
- groupId -> org.acme
- artifactId -> code-with-quarkus
- version -> 1.0.0-SNAPSHOT

Deprecate the `className` parameter in the Quarkus Maven plugin and introduce the `packageName` instead (defaulted to groupId).
