### PR TITLE
Missing jboss-logging-jdk dependency in application bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -85,6 +85,7 @@
         <gizmo.version>1.0.6.Final</gizmo.version>
         <jackson.version>2.11.3</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
+        <jboss-logging-jdk.version>2.1.2.GA</jboss-logging-jdk.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
@@ -2226,6 +2227,11 @@
                         <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-jdk</artifactId>
+                <version>${jboss-logging-jdk.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I chose the last version I found for this dependency: `2.1.2.GA`