### PR TITLE
Upgrade to Hibernate ORM 5.4.24.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.23.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.24.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha11</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.CR1</hibernate-search.version>

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
@@ -876,7 +876,7 @@ class TestEndpoint {
         Person.deleteAll()
         Assertions.assertEquals(0, Person.count())
 
-        val person: Person = makeSavedPerson()
+        val person: Person = makeSavedPerson("")
         val trackingPerson = person as SelfDirtinessTracker
 
         var dirtyAttributes = trackingPerson.`$$_hibernate_getDirtyAttributes`()

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1054,7 +1054,7 @@ public class TestEndpoint {
     public String testModel1() {
         Assertions.assertEquals(0, Person.count());
 
-        Person person = makeSavedPerson();
+        Person person = makeSavedPerson("");
         SelfDirtinessTracker trackingPerson = (SelfDirtinessTracker) person;
 
         String[] dirtyAttributes = trackingPerson.$$_hibernate_getDirtyAttributes();

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
@@ -1365,7 +1365,7 @@ public class TestEndpoint {
                 .flatMap(count -> {
                     Assertions.assertEquals(0, count);
 
-                    return makeSavedPerson();
+                    return makeSavedPerson("");
                 }).flatMap(person -> {
                     SelfDirtinessTracker trackingPerson = (SelfDirtinessTracker) person;
 


### PR DESCRIPTION
Fixes CVE-2020-25638 via https://hibernate.atlassian.net/browse/HHH-14225 cc/ @sberyozkin 
Fixes #13234 via https://hibernate.atlassian.net/browse/HHH-14329
Fixes #12980 via https://hibernate.atlassian.net/browse/HHH-14312

And others: https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20%3D%205.4.24

@gsmet your NPE improvements are included too. I don't think there was Quarkus issue to link them to?


For context: the second commit is fixing a Panache test; this is necessary as side-effect of HHH-14329

