### PR TITLE
Disable Jackson's FAIL_ON_UNKNOWN_PROPERTIES by default

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -186,7 +186,14 @@ It will allow to narrow down the number of JAX-RS providers (which can be seen a
 
 ==== Jackson
 
-Quarkus makes it very easy to configure various Jackson settings via CDI beans. The simplest (and suggested) approach is to define a CDI bean of type `io.quarkus.jackson.ObjectMapperCustomizer`
+In Quarkus, the default Jackson `ObjectMapper` obtained via CDI (and consumed by the Quarkus extensions) is configured to ignore unknown properties
+(by disabling the `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` feature).
+
+You can restore the default behavior of Jackson by setting `quarkus.jackson.fail-on-unknown-properties=true` in your `application.properties`
+or on a per class basis via `@JsonIgnoreProperties(ignoreUnknown = false)`.
+
+Also, Quarkus makes it very easy to configure various Jackson settings via CDI beans.
+The simplest (and suggested) approach is to define a CDI bean of type `io.quarkus.jackson.ObjectMapperCustomizer`
 inside of which any Jackson configuration can be applied.
 
 An example where a custom module needs to be registered would look like so:

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
@@ -15,7 +15,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
-import io.quarkus.jackson.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.runtime.LaunchMode;
 
 @SuppressWarnings("unchecked")

--- a/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
@@ -19,7 +19,7 @@ import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.gcp.functions.FunqyCloudFunctionsBindingRecorder;
 import io.quarkus.funqy.runtime.FunqyConfig;
-import io.quarkus.jackson.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
 
 public class FunqyCloudFunctionsBuildStep {
     private static final String FEATURE_NAME = "funqy-google-cloud-functions";

--- a/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
+++ b/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
@@ -21,7 +21,7 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.runtime.bindings.http.FunqyHttpBindingRecorder;
-import io.quarkus.jackson.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;

--- a/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
@@ -23,7 +23,7 @@ import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.runtime.FunqyConfig;
 import io.quarkus.funqy.runtime.bindings.knative.events.FunqyKnativeEventsConfig;
 import io.quarkus.funqy.runtime.bindings.knative.events.KnativeEventsBindingRecorder;
-import io.quarkus.jackson.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;

--- a/extensions/jackson/deployment/pom.xml
+++ b/extensions/jackson/deployment/pom.xml
@@ -30,6 +30,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -29,9 +29,12 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -43,6 +46,9 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.jackson.runtime.JacksonBuildTimeConfig;
+import io.quarkus.jackson.runtime.JacksonConfigSupport;
+import io.quarkus.jackson.runtime.JacksonRecorder;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
@@ -166,6 +172,16 @@ public class JacksonProcessor {
             classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(moduleClassName));
         } catch (Exception ignored) {
         }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    SyntheticBeanBuildItem pushConfigurationBean(JacksonRecorder jacksonRecorder,
+            JacksonBuildTimeConfig jacksonBuildTimeConfig) {
+        return SyntheticBeanBuildItem.configure(JacksonConfigSupport.class)
+                .scope(Singleton.class)
+                .supplier(jacksonRecorder.jacksonConfigSupport(jacksonBuildTimeConfig))
+                .done();
     }
 
     // Generate a ObjectMapperCustomizer bean that registers each serializer / deserializer as well as detected modules with the ObjectMapper

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -43,7 +43,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.jackson.ObjectMapperCustomizer;
-import io.quarkus.jackson.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonFailOnUnknownPropertiesTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonFailOnUnknownPropertiesTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.jackson.deployment;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonFailOnUnknownPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-fail-on-unknown-properties.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testFailOnUnknownProperties() throws JsonMappingException, JsonProcessingException {
+        Assertions.assertThrows(UnrecognizedPropertyException.class,
+                () -> objectMapper.readValue("{\"property\": \"name\", \"unknownProperty\": \"unknown\"}", Pojo.class));
+    }
+
+    public static class Pojo {
+
+        public String property;
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonIgnoreUnknownPropertiesTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonIgnoreUnknownPropertiesTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.jackson.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonIgnoreUnknownPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testIgnoreUnknownProperties() throws JsonMappingException, JsonProcessingException {
+        Pojo pojo = objectMapper.readValue("{\"property\": \"name\", \"unknownProperty\": \"unknown\"}", Pojo.class);
+        assertEquals("name", pojo.property);
+    }
+
+    public static class Pojo {
+
+        public String property;
+    }
+}

--- a/extensions/jackson/deployment/src/test/resources/application-fail-on-unknown-properties.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-fail-on-unknown-properties.properties
@@ -1,0 +1,1 @@
+quarkus.jackson.fail-on-unknown-properties=true

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperCustomizer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperCustomizer.java
@@ -2,6 +2,8 @@ package io.quarkus.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.quarkus.jackson.runtime.ObjectMapperProducer;
+
 /**
  * Meant to be implemented by a CDI bean that provides arbitrary customization for the default {@link ObjectMapper}.
  * <p>

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.jackson.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class JacksonBuildTimeConfig {
+
+    /**
+     * If enabled, Jackson will fail when encountering unknown properties.
+     * <p>
+     * You can still override it locally with {@code @JsonIgnoreProperties(ignoreUnknown = false)}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean failOnUnknownProperties;
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
@@ -1,0 +1,14 @@
+package io.quarkus.jackson.runtime;
+
+public class JacksonConfigSupport {
+
+    private boolean failOnUnknownProperties;
+
+    public JacksonConfigSupport(boolean failOnUnknownProperties) {
+        this.failOnUnknownProperties = failOnUnknownProperties;
+    }
+
+    public boolean isFailOnUnknownProperties() {
+        return failOnUnknownProperties;
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
@@ -1,0 +1,19 @@
+package io.quarkus.jackson.runtime;
+
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class JacksonRecorder {
+
+    public Supplier<JacksonConfigSupport> jacksonConfigSupport(JacksonBuildTimeConfig jacksonBuildTimeConfig) {
+        return new Supplier<JacksonConfigSupport>() {
+
+            @Override
+            public JacksonConfigSupport get() {
+                return new JacksonConfigSupport(jacksonBuildTimeConfig.failOnUnknownProperties);
+            }
+        };
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -9,6 +9,7 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.DefaultBean;
@@ -20,8 +21,13 @@ public class ObjectMapperProducer {
     @DefaultBean
     @Singleton
     @Produces
-    public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers) {
+    public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers,
+            JacksonConfigSupport jacksonConfigSupport) {
         ObjectMapper objectMapper = new ObjectMapper();
+        if (!jacksonConfigSupport.isFailOnUnknownProperties()) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        }
         List<ObjectMapperCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
         for (ObjectMapperCustomizer customizer : sortedCustomizers) {
             customizer.customize(objectMapper);

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -1,4 +1,4 @@
-package io.quarkus.jackson;
+package io.quarkus.jackson.runtime;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -12,6 +12,7 @@ import javax.inject.Singleton;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.jackson.ObjectMapperCustomizer;
 
 @ApplicationScoped
 public class ObjectMapperProducer {


### PR DESCRIPTION
This is what was discussed on the mailing list.

Commits should be reviewed separately as the first one is a cleanup commit, renaming a file.

/cc @maxandersen @loicmathieu @geoand 