### PR TITLE
Introduce exact capturing of jar holding resources loaded in static-init

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -102,6 +102,14 @@ public class PackageConfig {
     @ConfigItem
     public Optional<String> userProvidersDirectory;
 
+    /**
+     * If set, results in the creation of additional index at build time that can slightly speed up boot time and reduce
+     * memory usage.
+     * This flag ONLY works when fast-jar is being used and is completely ignored otherwise.
+     */
+    @ConfigItem
+    public boolean preBoot;
+
     public boolean isAnyJarType() {
         return (type.equalsIgnoreCase(PackageConfig.LEGACY) ||
                 type.equalsIgnoreCase(PackageConfig.JAR) ||

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AddPreventRuntimeInitBlockBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AddPreventRuntimeInitBlockBuildItem.java
@@ -1,0 +1,14 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * When this build item has been generated, then the generated main class contains a
+ * guard that prevents any of the application's runtime-init {@code StartupTask}s from
+ * being run.
+ * The guard is activated by setting {@code quarkus.application.pre-boot} system-property to {@code true}
+ * and when set, effectively makes the application run the static-init {@code StartupTask}s
+ * and exit.
+ */
+public final class AddPreventRuntimeInitBlockBuildItem extends MultiBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AdditionalRunnerClassLoaderIndexBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AdditionalRunnerClassLoaderIndexBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker BuildItem to ensure that {@code io.quarkus.deployment.pkg.steps.PreBootBuildStep#preBootFastJar}
+ * is actually executed
+ */
+public final class AdditionalRunnerClassLoaderIndexBuildItem extends SimpleBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
@@ -125,8 +124,8 @@ public class AppCDSBuildStep {
             if (log.isDebugEnabled()) {
                 processBuilder.inheritIO();
             } else {
-                processBuilder.redirectError(NULL_FILE);
-                processBuilder.redirectOutput(NULL_FILE);
+                processBuilder.redirectError(StepUtil.NULL_FILE);
+                processBuilder.redirectOutput(StepUtil.NULL_FILE);
             }
             exitCode = processBuilder.start().waitFor();
         } catch (Exception e) {
@@ -185,8 +184,8 @@ public class AppCDSBuildStep {
             if (log.isDebugEnabled()) {
                 processBuilder.inheritIO();
             } else {
-                processBuilder.redirectError(NULL_FILE);
-                processBuilder.redirectOutput(NULL_FILE);
+                processBuilder.redirectError(StepUtil.NULL_FILE);
+                processBuilder.redirectOutput(StepUtil.NULL_FILE);
             }
             exitCode = processBuilder.start().waitFor();
         } catch (Exception e) {
@@ -233,9 +232,4 @@ public class AppCDSBuildStep {
             return true;
         }
     }
-
-    // copied from Java 9
-    // TODO remove when we move to Java 11
-
-    private static final File NULL_FILE = new File(SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null");
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -59,6 +59,7 @@ import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
 import io.quarkus.bootstrap.runner.SerializedApplication;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.bootstrap.util.ZipUtils;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -70,6 +71,7 @@ import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.AddPreventRuntimeInitBlockBuildItem;
 import io.quarkus.deployment.pkg.builditem.AppCDSRequestedBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -158,6 +160,13 @@ public class JarResultBuildStep {
                     Collections.singletonMap("library-dir", jarBuildItem.getLibraryDir()));
         } else {
             return new ArtifactResultBuildItem(jarBuildItem.getPath(), PackageConfig.JAR, Collections.emptyMap());
+        }
+    }
+
+    @BuildStep
+    void addPreventRuntimeInitBlock(PackageConfig packageConfig, BuildProducer<AddPreventRuntimeInitBlockBuildItem> producer) {
+        if (packageConfig.isFastJar()) {
+            producer.produce(new AddPreventRuntimeInitBlockBuildItem());
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/PreBootBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/PreBootBuildStep.java
@@ -1,0 +1,78 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.utilities.JavaBinFinder;
+
+public class PreBootBuildStep {
+
+    private static final Logger log = Logger.getLogger(PreBootBuildStep.class);
+
+    /**
+     * This build step actually launches the fast jar but enables the guard that makes sure that only static-init
+     * the {@link io.quarkus.runtime.StartupTask} operations are run.
+     * The point of this is to capture the classpath resources that are loaded by the aforementioned operations and
+     * thus build another index which can be used by the {@link io.quarkus.bootstrap.runner.RunnerClassLoader}
+     * in order to allow it load the those resources at runtime from the exact jars instead of simply relying on
+     * the index of the directory structure of those jars.
+     * Building this additional index requires additional support by {@link io.quarkus.bootstrap.runner.SerializedApplication}
+     * and {@link QuarkusEntryPoint}
+     */
+    @BuildStep
+    void preBootFastJar(PackageConfig packageConfig, JarBuildItem jarResult,
+            BuildProducer<ArtifactResultBuildItem> artifactResult) {
+        if (!packageConfig.isFastJar() || !packageConfig.preBoot) {
+            return;
+        }
+
+        List<String> command = new ArrayList<>(6);
+        command.add(JavaBinFinder.findBin());
+        command.add("-D" + QuarkusEntryPoint.PRE_BOOT_SYSTEM_PROPERTY + "=true");
+        command.add("-jar");
+        command.add(JarResultBuildStep.QUARKUS_RUN_JAR);
+
+        Path workingDirectory = jarResult.getPath().getParent();
+
+        if (log.isDebugEnabled()) {
+            log.debugf("Launching command: '%s' to create additional RunnerClassLoader index.", String.join(" ", command));
+        }
+
+        int exitCode;
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(command)
+                    .directory(workingDirectory.toFile());
+            if (log.isDebugEnabled()) {
+                processBuilder.inheritIO();
+            } else {
+                processBuilder.redirectError(StepUtil.NULL_FILE);
+                processBuilder.redirectOutput(StepUtil.NULL_FILE);
+            }
+            exitCode = processBuilder.start().waitFor();
+        } catch (Exception e) {
+            log.warn("Failed to launch process used to create additional RunnerClassLoader index.", e);
+            return;
+        }
+        if (exitCode != 0) {
+            log.warnf("The process that was supposed to create additional RunnerClassLoader index exited with error code: %d.",
+                    exitCode);
+            return;
+        } else {
+            log.debug("Create of additional RunnerClassLoader index complete.");
+        }
+
+        artifactResult.produce(
+                new ArtifactResultBuildItem(workingDirectory.resolve(QuarkusEntryPoint.QUARKUS_RUNNER_CL_ADDITIONAL_INDEX_DAT),
+                        "additionalRunnerClassloaderIndex", Collections.emptyMap()));
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/StepUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/StepUtil.java
@@ -1,0 +1,15 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.io.File;
+
+import org.apache.commons.lang3.SystemUtils;
+
+final class StepUtil {
+
+    private StepUtil() {
+    }
+
+    // copied from Java 9
+    // TODO remove when we move to Java 11
+    static final File NULL_FILE = new File(SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null");
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/CapturingRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/CapturingRunnerClassLoader.java
@@ -1,0 +1,49 @@
+package io.quarkus.bootstrap.runner;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CapturingRunnerClassLoader extends RunnerClassLoader {
+
+    private final Map<String, URL> capturedFindResource = new HashMap<>();
+    private final Map<String, List<URL>> capturedFindResources = new HashMap<>();
+
+    public CapturingRunnerClassLoader(ClassLoader parent, Map<String, ClassLoadingResource[]> resourceDirectoryMap,
+            Set<String> parentFirstPackages, Set<String> nonExistentResources) {
+        super(parent, resourceDirectoryMap, parentFirstPackages, nonExistentResources, Collections.emptyMap(),
+                Collections.emptyMap());
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        URL result = super.findResource(name);
+        capturedFindResource.put(name, result);
+        return result;
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        Enumeration<URL> results = super.findResources(name);
+        if ((results == null) || !results.hasMoreElements()) {
+            capturedFindResources.put(name, Collections.emptyList());
+            return results;
+        }
+        List<URL> list = Collections.list(results);
+        capturedFindResources.put(name, list);
+        return Collections.enumeration(list); // convert back to enumeration because the original one has already been consumed
+    }
+
+    public Map<String, URL> getCapturedFindResource() {
+        return capturedFindResource;
+    }
+
+    public Map<String, List<URL>> getCapturedFindResources() {
+        return capturedFindResources;
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
@@ -1,6 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.ProtectionDomain;
 
 public interface ClassLoadingResource {
@@ -12,6 +13,11 @@ public interface ClassLoadingResource {
     ManifestInfo getManifestInfo();
 
     ProtectionDomain getProtectionDomain(ClassLoader runnerClassLoader);
+
+    /**
+     * The {@link Path} which resulted in the creation of this {@code ClassLoadingResource}
+     */
+    Path getSource();
 
     void close();
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -122,6 +122,11 @@ public class JarResource implements ClassLoadingResource {
         return new ProtectionDomain(codesource, null, classLoader, null);
     }
 
+    @Override
+    public Path getSource() {
+        return jarPath;
+    }
+
     private JarFile readLockAcquireAndGetJarReference() {
         while (true) {
             readLock.lock();


### PR DESCRIPTION
This only works for fast-jar and for the time being is an opt-in
feature (by enabling quarkus.package.pre-boot=true at build time).
For the rationale of the whole idea, see:
https://github.com/quarkusio/quarkus/issues/13256#issuecomment-729559294