### PR TITLE
Set the CurrentVertxRequest for reactive routes

### DIFF
--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -27,6 +27,7 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.vertx.web.runtime.MultiJsonArraySupport;
 import io.quarkus.vertx.web.runtime.MultiSseSupport;
 import io.quarkus.vertx.web.runtime.MultiSupport;
+import io.quarkus.vertx.web.runtime.RouteHandler;
 import io.quarkus.vertx.web.runtime.RouteHandlers;
 import io.quarkus.vertx.web.runtime.ValidationSupport;
 import io.smallrye.mutiny.Multi;
@@ -169,7 +170,7 @@ class Methods {
             .ofMethod(InjectableBean.class, "destroy",
                     void.class, Object.class,
                     CreationalContext.class);
-    static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
+    static final MethodDescriptor ROUTE_HANDLER_CONSTRUCTOR = MethodDescriptor.ofConstructor(RouteHandler.class);
 
     static final MethodDescriptor ROUTE_HANDLERS_SET_CONTENT_TYPE = MethodDescriptor
             .ofMethod(RouteHandlers.class, "setContentType", void.class, RoutingContext.class, String.class);

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -388,8 +388,6 @@ class VertxWebProcessor {
         }
 
         detectConflictingRoutes(matchers);
-
-        recorder.clearCacheOnShutdown(shutdown);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
@@ -522,7 +520,7 @@ class VertxWebProcessor {
                 + HashUtil.sha1(sigBuilder.toString() + hashSuffix);
 
         ClassCreator invokerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .interfaces(RouteHandler.class).build();
+                .superClass(RouteHandler.class).build();
 
         // Initialized state
         FieldCreator beanField = invokerCreator.getFieldCreator("bean", InjectableBean.class)
@@ -558,7 +556,7 @@ class VertxWebProcessor {
             FieldCreator containerField, FieldCreator validatorField) {
         MethodCreator constructor = invokerCreator.getMethodCreator("<init>", void.class);
         // Invoke super()
-        constructor.invokeSpecialMethod(Methods.OBJECT_CONSTRUCTOR, constructor.getThis());
+        constructor.invokeSpecialMethod(Methods.ROUTE_HANDLER_CONSTRUCTOR, constructor.getThis());
 
         ResultHandle containerHandle = constructor
                 .invokeStaticMethod(Methods.ARC_CONTAINER);

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
@@ -54,6 +54,7 @@ public class SimpleRouteTest {
         given().contentType("text/plain").body("world")
                 .post("/body").then().body(is("Hello world!"));
         when().get("/request").then().statusCode(200).body(is("HellO!"));
+        when().get("/inject?foo=Hey").then().statusCode(200).body(is("Hey"));
     }
 
     @Test
@@ -108,6 +109,11 @@ public class SimpleRouteTest {
             context.response().setStatusCode(200).end(transformer.transform("Hello!"));
         }
 
+        @Route
+        void inject(RoutingExchange exchange) {
+            exchange.ok(transformer.getFoo());
+        }
+
     }
 
     static class SimpleRoutesBean {
@@ -157,8 +163,15 @@ public class SimpleRouteTest {
     @RequestScoped
     static class Transformer {
 
+        @Inject
+        RoutingContext context;
+
         String transform(String message) {
             return message.replace('o', 'O');
+        }
+
+        String getFoo() {
+            return context.request().getParam("foo");
         }
 
     }

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandler.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandler.java
@@ -1,8 +1,12 @@
 package io.quarkus.vertx.web.runtime;
 
+import javax.enterprise.event.Event;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.quarkus.vertx.web.Route;
 import io.vertx.core.AsyncResult;
@@ -14,31 +18,40 @@ import io.vertx.ext.web.RoutingContext;
  * 
  * @see Route
  */
-public interface RouteHandler extends Handler<RoutingContext> {
+public abstract class RouteHandler implements Handler<RoutingContext> {
+
+    private final Event<SecurityIdentity> securityIdentityEvent;
+    private final CurrentVertxRequest currentVertxRequest;
+
+    public RouteHandler() {
+        this.securityIdentityEvent = Arc.container().beanManager().getEvent().select(SecurityIdentity.class);
+        this.currentVertxRequest = Arc.container().instance(CurrentVertxRequest.class).get();
+    }
 
     /**
      * Invokes the route method.
      * 
      * @param context
      */
-    void invoke(RoutingContext context);
+    public abstract void invoke(RoutingContext context);
 
     @Override
-    default void handle(RoutingContext context) {
+    public void handle(RoutingContext context) {
         QuarkusHttpUser user = (QuarkusHttpUser) context.user();
         ManagedContext requestContext = Arc.container().requestContext();
         //todo: how should we handle non-proactive authentication here?
         if (requestContext.isActive()) {
             if (user != null) {
-                RouteHandlers.fireSecurityIdentity(user.getSecurityIdentity());
+                securityIdentityEvent.fire(user.getSecurityIdentity());
             }
             invoke(context);
         } else {
             try {
                 // Activate the context, i.e. set the thread locals
                 requestContext.activate();
+                currentVertxRequest.setCurrent(context);
                 if (user != null) {
-                    RouteHandlers.fireSecurityIdentity(user.getSecurityIdentity());
+                    securityIdentityEvent.fire(user.getSecurityIdentity());
                 }
                 // Reactive routes can use async processing (e.g. mutiny Uni/Multi) and context propagation
                 // 1. Store the state (which is basically a shared Map instance)

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
@@ -1,10 +1,5 @@
 package io.quarkus.vertx.web.runtime;
 
-import javax.enterprise.event.Event;
-
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.impl.LazyValue;
-import io.quarkus.security.identity.SecurityIdentity;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
@@ -15,9 +10,6 @@ public final class RouteHandlers {
     }
 
     static final String CONTENT_TYPE = "content-type";
-
-    private static final LazyValue<Event<SecurityIdentity>> SECURITY_IDENTITY_EVENT = new LazyValue<>(
-            RouteHandlers::createEvent);
 
     public static void setContentType(RoutingContext context, String defaultContentType) {
         HttpServerResponse response = context.response();
@@ -35,18 +27,6 @@ public final class RouteHandlers {
                 }
             }
         });
-    }
-
-    static void fireSecurityIdentity(SecurityIdentity identity) {
-        SECURITY_IDENTITY_EVENT.get().fire(identity);
-    }
-
-    static void clear() {
-        SECURITY_IDENTITY_EVENT.clear();
-    }
-
-    private static Event<SecurityIdentity> createEvent() {
-        return Arc.container().beanManager().getEvent().select(SecurityIdentity.class);
     }
 
 }

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -3,7 +3,6 @@ package io.quarkus.vertx.web.runtime;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.Function;
 
-import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.RouterProducer;
 import io.vertx.core.Handler;
@@ -68,15 +67,6 @@ public class VertxWebRecorder {
                 return route;
             }
         };
-    }
-
-    public void clearCacheOnShutdown(ShutdownContext shutdown) {
-        shutdown.addShutdownTask(new Runnable() {
-            @Override
-            public void run() {
-                RouteHandlers.clear();
-            }
-        });
     }
 
 }


### PR DESCRIPTION
- resolves #13262

@cescoffier @johnaohara This PR may cause a slight perf drop in some basic benchmarks because the `CurrentVertxRequest` must be always initialized with the relevant `RoutingContext` (in order to make Context Propagation happy) and so we add few more logic per each request. It's not ideal but I don't see a way how to improve it and the convenient `@Inject RoutingContext` is what we offer for JAX-RS and so it might help some reactive routes users...