### PR TITLE
Build time minimum log level

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -95,7 +95,7 @@
         {
             "category": "Misc1",
             "timeout": 65,
-            "test-modules": "maven jackson jsonb jsch jgit quartz qute consul-config"
+            "test-modules": "maven jackson jsonb jsch jgit quartz qute consul-config logging-min-level-unset logging-min-level-set"
         },
         {
             "category": "Misc2",

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -168,6 +168,7 @@ public class NativeImageBuildStep {
             command.add(
                     "-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime"); //the default collection policy results in full GC's 50% of the time
             command.add("-H:+JNI");
+            command.add("-H:+AllowFoldMethods");
             command.add("-jar");
             command.add(runnerJarName);
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryBuildTimeConfig.java
@@ -1,0 +1,22 @@
+package io.quarkus.runtime.logging;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class CategoryBuildTimeConfig {
+    /**
+     * The minimum log level for this category.
+     * By default all categories are configured with <code>INFO</code> minimum level.
+     *
+     * To get runtime logging below <code>INFO</code>, e.g. <code>DEBUG</code> or <code>TRACE</code>,
+     * the minimum level has to be adjusted at build time, the right log level needs to be provided at runtime.
+     *
+     * As an example, to get <code>TRACE</code> logging,
+     * minimum level needs to be at <code>TRACE</code> and the runtime log level needs to match that.
+     * To get <code>DEBUG</code> logging,
+     * minimum level needs to be set at <code>DEBUG</code> or <code>TRACE</code> (as well as runtime log level).
+     */
+    @ConfigItem(defaultValue = "inherit")
+    public InheritableLevel minLevel;
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
@@ -10,7 +10,10 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class CategoryConfig {
 
     /**
-     * The log level level for this category
+     * The log level for this category.
+     *
+     * Note that to get log levels below <code>INFO</code>,
+     * the minimum level build time configuration option needs to be adjusted as well.
      */
     @ConfigItem(defaultValue = "inherit")
     InheritableLevel level;

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -1,5 +1,9 @@
 package io.quarkus.runtime.logging;
 
+import java.util.Map;
+import java.util.logging.Level;
+
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -12,4 +16,21 @@ public class LogBuildTimeConfig {
      */
     @ConfigItem(name = "metrics.enabled", defaultValue = "false")
     public boolean metricsEnabled;
+
+    /**
+     * The default minimum log level.
+     */
+    @ConfigItem(defaultValue = "INFO")
+    public Level minLevel;
+
+    /**
+     * Minimum logging categories.
+     * <p>
+     * Logging is done on a per-category basis. Each category can be independently configured.
+     * A configuration which applies to a category will also apply to all sub-categories of that category,
+     * unless there is a more specific matching sub-category configuration.
+     */
+    @ConfigItem(name = "category")
+    @ConfigDocSection
+    public Map<String, CategoryBuildTimeConfig> categories;
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
@@ -34,15 +34,6 @@ public final class LogConfig {
     public Level level;
 
     /**
-     * The default minimum log level
-     * 
-     * @deprecated this functionality was never implemented, it may be deleted or implemented in a future release.
-     */
-    @ConfigItem(defaultValue = "INFO")
-    @Deprecated
-    public Level minLevel;
-
-    /**
      * Console logging.
      * <p>
      * Console logging is enabled by default.

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -441,6 +441,7 @@ When using the dev mode (running `./mvnw clean compile quarkus:dev`), you can se
 by enabling additional logging via the following line in your `application.properties`.
 
 ----
+quarkus.log.category."io.quarkus.arc.processor".min-level=DEBUG
 quarkus.log.category."io.quarkus.arc.processor".level=DEBUG
 ----
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -128,8 +128,18 @@ for example, to set the default log level to `INFO` logging and include Hibernat
 [source, properties]
 ----
 quarkus.log.level=INFO
+quarkus.log.category."org.hibernate".min-level=DEBUG
 quarkus.log.category."org.hibernate".level=DEBUG
 ----
+
+Setting a log level below `INFO` requires the minimum log level to be adjusted,
+either globally via the `quarkus.log.min-level` property or per-category as shown in the example above,
+as well as adjusting the log level itself.
+
+Minimum logging level sets a floor level that Quarkus will be needed to potentially generate,
+opening the door to optimization opportunities.
+As an example, in native execution the minimum level enables lower level checks (e.g. `isTraceEnabled`) to be folded to `false`,
+resulting in dead code elimination for code that will never to be executed.
 
 All possible properties are listed in <<loggingConfigurationReference, the logging configuration reference>>.
 
@@ -148,6 +158,7 @@ These can also be overridden by attaching a one or more named handlers to a cate
 |===
 |Property Name|Default|Description
 |quarkus.log.category."<category-name>".level|INFO footnote:[Some extensions may define customized default log levels for certain categories, in order to reduce log noise by default.  Setting the log level in configuration will override any extension-defined log levels.]|The level to use to configure the category named `<category-name>`.  The quotes are necessary.
+|quarkus.log.category."<category-name>".min-level|INFO |The minimum logging level to use to configure the category named `<category-name>`.  The quotes are necessary.
 |quarkus.log.category."<category-name>".use-parent-handlers|true|Specify whether or not this logger should send its output to its parent logger.
 |quarkus.log.category."<category-name>".handlers=[<handler>]|empty footnote:[By default the configured category gets the same handlers attached as the one on the root logger.]|The names of the handlers that you want to attach to a specific category.
 |===
@@ -162,7 +173,8 @@ The root logger category is handled separately, and is configured via the follow
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.log.level|INFO|The default minimum log level for every log category.
+|quarkus.log.level|INFO|The default log level for every log category.
+|quarkus.log.min-level|INFO|The default minimum log level for every log category.
 |===
 
 If no level configuration exists for a given logger category, the enclosing (parent) category is examined. If no categories are configured which enclose the category in question, then the root logger configuration is used.
@@ -307,6 +319,7 @@ quarkus.log.file.path=/tmp/trace.log
 quarkus.log.file.level=TRACE
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 # Set 2 categories (io.quarkus.smallrye.jwt, io.undertow.request.security) to TRACE level
+quarkus.log.min-level=TRACE
 quarkus.log.category."io.quarkus.smallrye.jwt".level=TRACE
 quarkus.log.category."io.undertow.request.security".level=TRACE
 ----

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -647,6 +647,7 @@ This can be achieved by setting to DEBUG the following log category inside your 
 
 [source,properties]
 ----
+quarkus.log.category."io.quarkus.mongodb.panache.runtime".min-level=DEBUG
 quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG
 ----
 

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -828,6 +828,7 @@ change the logging in the `application.properties` file or with a `-D` system pr
 
 [source,properties]
 ----
+quarkus.log.category."org.optaplanner".min-level=debug
 quarkus.log.category."org.optaplanner".level=debug
 ----
 

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -759,7 +759,7 @@ See <<generate-jwt-tokens, Generate JWT tokens with SmallRye JWT>> and learn how
 
 == How to check the errors in the logs ==
 
-Set `quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE` to see more details about the token verification or decryption errors.
+Set `quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE` and `quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".min-level=TRACE` to see more details about the token verification or decryption errors.
 
 == Custom Factories
 

--- a/docs/src/main/asciidoc/vault-auth.adoc
+++ b/docs/src/main/asciidoc/vault-auth.adoc
@@ -334,6 +334,7 @@ quarkus.datasource.jdbc.url = jdbc:postgresql://<host>:5432/mydatabase
 
 quarkus.vault.authentication.kubernetes.role=vault-quickstart-role
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 ----
 

--- a/extensions/elytron-security-properties-file/deployment/src/test/resources/application-form-auth.properties
+++ b/extensions/elytron-security-properties-file/deployment/src/test/resources/application-form-auth.properties
@@ -6,7 +6,9 @@
 #quarkus.log.file.path=/tmp/trace.log
 #quarkus.log.file.level=TRACE
 #quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
+#quarkus.log.category."io.quarkus.arc".min-level=TRACE
 #quarkus.log.category."io.quarkus.arc".level=TRACE
+#quarkus.log.category."io.undertow.request.security".min-level=TRACE
 #quarkus.log.category."io.undertow.request.security".level=TRACE
 
 # Identities

--- a/extensions/elytron-security-properties-file/deployment/src/test/resources/application.properties
+++ b/extensions/elytron-security-properties-file/deployment/src/test/resources/application.properties
@@ -12,5 +12,7 @@ quarkus.security.users.file.plain-text=true
 #quarkus.log.file.level=TRACE
 #quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
 # Set 2 categories (io.quarkus.smallrye.jwt, io.undertow.request.security) to TRACE level
+#quarkus.log.category."io.quarkus.arc".min-level=TRACE
 #quarkus.log.category."io.quarkus.arc".level=TRACE
+#quarkus.log.category."io.undertow.request.security".min-level=TRACE
 #quarkus.log.category."io.undertow.request.security".level=TRACE

--- a/extensions/flyway/deployment/src/test/resources/migrate-at-start-config-named-datasource.properties
+++ b/extensions/flyway/deployment/src/test/resources/migrate-at-start-config-named-datasource.properties
@@ -1,4 +1,6 @@
+#quarkus.log.category."org.flywaydb.core".min-level=DEBUG
 #quarkus.log.category."org.flywaydb.core".level=DEBUG
+#quarkus.log.category."io.quarkus.flyway".min-level=DEBUG
 #quarkus.log.category."io.quarkus.flyway".level=DEBUG
 quarkus.datasource.users.db-kind=h2
 quarkus.datasource.users.username=sa

--- a/extensions/micrometer/deployment/src/test/resources/test-logging.properties
+++ b/extensions/micrometer/deployment/src/test/resources/test-logging.properties
@@ -1,4 +1,6 @@
+#quarkus.log.category."io.quarkus.micrometer".min-level=DEBUG
 #quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.bootstrap".level=INFO
+#quarkus.log.category."io.quarkus.arc".min-level=DEBUG
 #quarkus.log.category."io.quarkus.arc".level=DEBUG
 quarkus.log.category."io.netty".level=INFO

--- a/extensions/reactive-messaging-http/deployment/src/test/resources/websocket-sink-test-application.properties
+++ b/extensions/reactive-messaging-http/deployment/src/test/resources/websocket-sink-test-application.properties
@@ -5,4 +5,5 @@ mp.messaging.outgoing.ws-sink-with-serializer.connector=quarkus-websocket
 mp.messaging.outgoing.ws-sink-with-serializer.url=ws://localhost:${quarkus.http.test-port:8081}/ws-target-url
 mp.messaging.outgoing.ws-sink-with-serializer.serializer=io.quarkus.reactivemessaging.utils.ToUpperCaseSerializer
 
+quarkus.log.category."io.quarkus.reactivemessaging".min-level=DEBUG
 quarkus.log.category."io.quarkus.reactivemessaging".level=DEBUG

--- a/integration-tests/bouncycastle-jsse/src/main/resources/application.properties
+++ b/integration-tests/bouncycastle-jsse/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.http.ssl.certificate.trust-store-password=password
 quarkus.http.ssl.client-auth=REQUIRED
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.jks
 
+quarkus.log.category."org.bouncycastle.jsse".min-level=TRACE
 quarkus.log.category."org.bouncycastle.jsse".level=TRACE
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n

--- a/integration-tests/flyway/src/main/resources/application.properties
+++ b/integration-tests/flyway/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.log.console.level=DEBUG
+quarkus.log.category."org.flywaydb.core".min-level=DEBUG
 quarkus.log.category."org.flywaydb.core".level=DEBUG
+quarkus.log.category."io.quarkus.flyway".min-level=DEBUG
 quarkus.log.category."io.quarkus.flyway".level=DEBUG
 # Agroal config
 quarkus.datasource.db-kind=h2

--- a/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
@@ -5,4 +5,5 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
+quarkus.log.category."org.hibernate.SQL".min-level=DEBUG
 quarkus.log.category."org.hibernate.SQL".level=DEBUG

--- a/integration-tests/hibernate-reactive-panache/src/main/resources/nopaging.properties
+++ b/integration-tests/hibernate-reactive-panache/src/main/resources/nopaging.properties
@@ -5,6 +5,7 @@ quarkus.datasource.reactive.url=${postgres.reactive.url}
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
+quarkus.log.category."org.hibernate.SQL".min-level=DEBUG
 quarkus.log.category."org.hibernate.SQL".level=DEBUG
 # this is required otherwise SQL logs are formatted on multiple lines and we can't match them
 quarkus.hibernate-orm.log.sql=false

--- a/integration-tests/liquibase/src/main/resources/application.properties
+++ b/integration-tests/liquibase/src/main/resources/application.properties
@@ -13,5 +13,7 @@ quarkus.liquibase.database-change-log-table-name=TEST_LOG
 
 # Debug logging
 #quarkus.log.console.level=DEBUG
+#quarkus.log.category."liquibase".min-level=DEBUG
 #quarkus.log.category."liquibase".level=DEBUG
+#quarkus.log.category."io.quarkus.liquibase".min-level=DEBUG
 #quarkus.log.category."io.quarkus.liquibase".level=DEBUG

--- a/integration-tests/logging-min-level-set/pom.xml
+++ b/integration-tests/logging-min-level-set/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-logging-min-level-set</artifactId>
+    <name>Quarkus - Integration Tests - Logging when minimum level is set</name>
+    <description>
+        A integration test that verifies logging expectations when minimum logging level is set
+    </description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+<!--                            <execution>-->
+<!--                                <id>warn</id>-->
+<!--                                <goals>-->
+<!--                                    <goal>integration-test</goal>-->
+<!--                                    <goal>verify</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <systemPropertyVariables>-->
+<!--                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>-->
+<!--                                        <quarkus.log.level>WARN</quarkus.log.level>-->
+<!--                                    </systemPropertyVariables>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/LoggingWitness.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/LoggingWitness.java
@@ -1,0 +1,44 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import java.util.function.BiConsumer;
+
+import org.jboss.logging.Logger;
+
+public class LoggingWitness {
+
+    public static boolean loggedError(String msg, Logger logger) {
+        return logged(msg, logger::error);
+    }
+
+    public static boolean loggedWarn(String msg, Logger logger) {
+        return logged(msg, logger::warn);
+    }
+
+    public static boolean loggedInfo(String msg, Logger logger) {
+        return logged(msg, logger::info);
+    }
+
+    public static boolean loggedDebug(String msg, Logger logger) {
+        return logged(msg, logger::debug);
+    }
+
+    public static boolean loggedTrace(String msg, Logger logger) {
+        return logged(msg, logger::trace);
+    }
+
+    private static boolean logged(String msg, BiConsumer<String, Throwable> logFunction) {
+        final LoggingWitnessThrowable throwable = new LoggingWitnessThrowable();
+        logFunction.accept(msg, throwable);
+        return throwable.logged;
+    }
+
+    private static final class LoggingWitnessThrowable extends Throwable {
+        boolean logged;
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            logged = true;
+            return new StackTraceElement[] {};
+        }
+    }
+}

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/above/LoggingMinLevelAbove.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/above/LoggingMinLevelAbove.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.logging.minlevel.set.above;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/above")
+public class LoggingMinLevelAbove {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelAbove.class);
+
+    @GET
+    @Path("/not-info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotInfo() {
+        return !LOG.isInfoEnabled() && !LoggingWitness.loggedInfo("should not print", LOG);
+    }
+
+    @GET
+    @Path("/warn")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isWarn() {
+        return LoggingWitness.loggedWarn("warn message", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/below/LoggingMinLevelBelow.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/below/LoggingMinLevelBelow.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.logging.minlevel.set.below;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/below")
+public class LoggingMinLevelBelow {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelBelow.class);
+
+    @GET
+    @Path("/trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isTrace() {
+        return LOG.isTraceEnabled() && LoggingWitness.loggedTrace("trace-message", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/bydefault/LoggingMinLevelByDefault.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/bydefault/LoggingMinLevelByDefault.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.logging.minlevel.set.bydefault;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/bydefault")
+public class LoggingMinLevelByDefault {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelByDefault.class);
+
+    @GET
+    @Path("/debug")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isDebug() {
+        return LOG.isDebugEnabled() && LoggingWitness.loggedDebug("debug message", LOG);
+    }
+
+    @GET
+    @Path("/not-trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotTrace() {
+        return !LOG.isTraceEnabled() && !LoggingWitness.loggedTrace("should not print", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/promote/LoggingMinLevelPromote.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/promote/LoggingMinLevelPromote.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.logging.minlevel.set.promote;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/promote")
+public class LoggingMinLevelPromote {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelPromote.class);
+
+    @GET
+    @Path("/not-info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotInfo() {
+        return !LOG.isInfoEnabled() && !LoggingWitness.loggedInfo("should not print", LOG);
+    }
+
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isError() {
+        return LoggingWitness.loggedError("error message", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/promote/sub/LoggingMinLevelPromoteSub.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/promote/sub/LoggingMinLevelPromoteSub.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.logging.minlevel.set.promote.sub;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/promote/sub")
+public class LoggingMinLevelPromoteSub {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelPromoteSub.class);
+
+    @GET
+    @Path("/not-info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotInfo() {
+        return !LOG.isInfoEnabled() && !LoggingWitness.loggedInfo("should not print", LOG);
+    }
+
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isError() {
+        return LoggingWitness.loggedError("error message", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/resources/application.properties
+++ b/integration-tests/logging-min-level-set/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.log.min-level=DEBUG
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.above".min-level=INFO
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.below".min-level=TRACE
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.promote".min-level=ERROR

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/Asserts.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/Asserts.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.BiConsumer;
+
+final class Asserts {
+    private static boolean assertLogged(boolean expected, String msg, BiConsumer<String, Throwable> logFunction) {
+        try (AssertThrowable t = new AssertThrowable(expected)) {
+            logFunction.accept(msg, t);
+            if (t.expected)
+                return t.executed;
+            else
+                return t.executed;
+        }
+    }
+
+    private static final class AssertThrowable extends Throwable implements AutoCloseable {
+
+        final boolean expected;
+        boolean executed;
+
+        private AssertThrowable(boolean expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            executed = true;
+            return new StackTraceElement[] {};
+        }
+
+        @Override
+        public void close() {
+            if (expected) {
+                assertTrue(executed, "Expected message to be printed but didn't get printed");
+            } else {
+                assertFalse(executed, "Expected message not to be printed but got printed");
+            }
+        }
+    }
+
+    private Asserts() {
+    }
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelAboveTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelAboveTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Test that verifies that min-level can go higher than default min-level,
+ * and this can be further tweaked at runtime to go to above to an even higher level.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelAboveTest {
+
+    @Test
+    public void testNotInfo() {
+        given()
+                .when().get("/log/above/not-info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testWarn() {
+        given()
+                .when().get("/log/above/warn")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Test verifies that a min-level override that goes below the default min-level is applied correctly.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelBelowTest {
+
+    @Test
+    public void testTrace() {
+        given()
+                .when().get("/log/below/trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelByDefaultTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelByDefaultTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests that verify that changes to the default min-level are applied correctly.
+ *
+ * If unset, the default is INFO,
+ * so this test verifies that when the default min-level is changed,
+ * say to DEBUG, the code works as expected.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelByDefaultTest {
+
+    @Test
+    public void testDebug() {
+        given()
+                .when().get("/log/bydefault/debug")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testNotTrace() {
+        given()
+                .when().get("/log/bydefault/not-trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteSubTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteSubTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * This test verifies that log levels are promoted to min-level when set below, even for subpackages.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelPromoteSubTest {
+
+    @Test
+    public void testNotInfo() {
+        given()
+                .when().get("/log/promote/sub/not-info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testError() {
+        given()
+                .when().get("/log/promote/sub/error")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * This test verifies that log levels are promoted to min-level when set below.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelPromoteTest {
+
+    @Test
+    public void testNotInfo() {
+        given()
+                .when().get("/log/promote/not-info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testError() {
+        given()
+                .when().get("/log/promote/error")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelAboveIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelAboveIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelAboveIT extends LoggingMinLevelAboveTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelBelowIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelBelowIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelBelowIT extends LoggingMinLevelBelowTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelByDefaultIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelByDefaultIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelByDefaultIT extends LoggingMinLevelByDefaultTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelPromoteIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelPromoteIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelPromoteIT extends LoggingMinLevelPromoteTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelPromoteSubIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelPromoteSubIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelPromoteSubIT extends LoggingMinLevelPromoteSubTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/SetRuntimeLogLevels.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/SetRuntimeLogLevels.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public final class SetRuntimeLogLevels implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        final Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.bydefault\".level", "DEBUG");
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.above\".level", "WARN");
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.below\".level", "TRACE");
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.promote\".level", "INFO");
+        return systemProperties;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/pom.xml
+++ b/integration-tests/logging-min-level-unset/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-logging-min-level-unset</artifactId>
+    <name>Quarkus - Integration Tests - Logging when minimum level is unset</name>
+    <description>
+        A integration test that verifies logging expectations when minimum logging level is unset
+    </description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+<!--                            <execution>-->
+<!--                                <id>warn</id>-->
+<!--                                <goals>-->
+<!--                                    <goal>integration-test</goal>-->
+<!--                                    <goal>verify</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <systemPropertyVariables>-->
+<!--                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>-->
+<!--                                        <quarkus.log.level>WARN</quarkus.log.level>-->
+<!--                                    </systemPropertyVariables>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/LoggingWitness.java
+++ b/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/LoggingWitness.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import java.util.function.BiConsumer;
+
+import org.jboss.logging.Logger;
+
+public class LoggingWitness {
+    public static boolean loggedInfo(String msg, Logger logger) {
+        return logged(msg, logger::info);
+    }
+
+    public static boolean notLoggedInfo(String msg, Logger logger) {
+        return !loggedInfo(msg, logger);
+    }
+
+    public static boolean loggedWarn(String msg, Logger logger) {
+        return logged(msg, logger::warn);
+    }
+
+    public static boolean notLoggedTrace(String msg, Logger logger) {
+        return !logged(msg, logger::trace);
+    }
+
+    private static boolean logged(String msg, BiConsumer<String, Throwable> logFunction) {
+        final LoggingWitnessThrowable throwable = new LoggingWitnessThrowable();
+        logFunction.accept(msg, throwable);
+        return throwable.logged;
+    }
+
+    private static final class LoggingWitnessThrowable extends Throwable {
+        boolean logged;
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            logged = true;
+            return new StackTraceElement[] {};
+        }
+    }
+}

--- a/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/above/LoggingMinLevelAbove.java
+++ b/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/above/LoggingMinLevelAbove.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.logging.minlevel.unset.above;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.unset.LoggingWitness;
+
+@Path("/log/above")
+public class LoggingMinLevelAbove {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelAbove.class);
+
+    @GET
+    @Path("/not-info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotInfo() {
+        return !LOG.isInfoEnabled() && LoggingWitness.notLoggedInfo("should not print", LOG);
+    }
+
+    @GET
+    @Path("/warn")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isWarn() {
+        return LoggingWitness.loggedWarn("warn message", LOG);
+    }
+
+    @GET
+    @Path("/not-trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotTrace() {
+        return !LOG.isTraceEnabled() && LoggingWitness.notLoggedTrace("should not print", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/bydefault/LoggingMinLevelByDefault.java
+++ b/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/bydefault/LoggingMinLevelByDefault.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.logging.minlevel.unset.bydefault;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.unset.LoggingWitness;
+
+@Path("/log/bydefault")
+public class LoggingMinLevelByDefault {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelByDefault.class);
+
+    @GET
+    @Path("/info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isInfo() {
+        return LOG.isInfoEnabled() && LoggingWitness.loggedInfo("info message", LOG);
+    }
+
+    @GET
+    @Path("/warn")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isWarn() {
+        return LoggingWitness.loggedWarn("warn message", LOG);
+    }
+
+    @GET
+    @Path("/not-trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotTrace() {
+        return !LOG.isTraceEnabled() && LoggingWitness.notLoggedTrace("should not print", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/promote/LoggingMinLevelPromote.java
+++ b/integration-tests/logging-min-level-unset/src/main/java/io/quarkus/it/logging/minlevel/unset/promote/LoggingMinLevelPromote.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.logging.minlevel.unset.promote;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.unset.LoggingWitness;
+
+@Path("/log/promote")
+public class LoggingMinLevelPromote {
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelPromote.class);
+
+    @GET
+    @Path("/info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isInfo() {
+        return LOG.isInfoEnabled() && LoggingWitness.loggedInfo("info message", LOG);
+    }
+
+    @GET
+    @Path("/warn")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isWarn() {
+        return LoggingWitness.loggedWarn("warn message", LOG);
+    }
+
+    @GET
+    @Path("/not-trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isNotTrace() {
+        return !LOG.isTraceEnabled() && LoggingWitness.notLoggedTrace("should not print", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/Asserts.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/Asserts.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.BiConsumer;
+
+final class Asserts {
+    private static boolean assertLogged(boolean expected, String msg, BiConsumer<String, Throwable> logFunction) {
+        try (AssertThrowable t = new AssertThrowable(expected)) {
+            logFunction.accept(msg, t);
+            if (t.expected)
+                return t.executed;
+            else
+                return t.executed;
+        }
+    }
+
+    private static final class AssertThrowable extends Throwable implements AutoCloseable {
+
+        final boolean expected;
+        boolean executed;
+
+        private AssertThrowable(boolean expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            executed = true;
+            return new StackTraceElement[] {};
+        }
+
+        @Override
+        public void close() {
+            if (expected) {
+                assertTrue(executed, "Expected message to be printed but didn't get printed");
+            } else {
+                assertFalse(executed, "Expected message not to be printed but got printed");
+            }
+        }
+    }
+
+    private Asserts() {
+    }
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * This test verifies that a runtime log level can go above the default min-level,
+ * and only messages at same runtime log level or above are shown.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelAboveTest {
+
+    @Test
+    public void testNotInfo() {
+        given()
+                .when().get("/log/above/not-info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testWarn() {
+        given()
+                .when().get("/log/above/warn")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testNotTrace() {
+        given()
+                .when().get("/log/above/not-trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests that logging works as expected when min-level is default,
+ * and there's no applicable runtime log level override.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelByDefaultTest {
+
+    @Test
+    public void testInfo() {
+        given()
+                .when().get("/log/bydefault/info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testWarn() {
+        given()
+                .when().get("/log/bydefault/warn")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testNotTrace() {
+        given()
+                .when().get("/log/bydefault/not-trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelPromoteTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelPromoteTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * This test verifies that log levels are promoted to min-level when set below the default min-level.
+ * 
+ * So given the default min-level is INFO,
+ * so if log level is set to TRACE,
+ * it will be automatically promoted to INFO.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelPromoteTest {
+
+    @Test
+    public void testInfo() {
+        given()
+                .when().get("/log/promote/info")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testWarn() {
+        given()
+                .when().get("/log/promote/warn")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+    @Test
+    public void testNotTrace() {
+        given()
+                .when().get("/log/promote/not-trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingMinLevelByDefaultIT.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingMinLevelByDefaultIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelByDefaultIT extends LoggingMinLevelByDefaultTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingMinLevelPromoteIT.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingMinLevelPromoteIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelPromoteIT extends LoggingMinLevelPromoteTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingWarnResourceIT.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/NativeLoggingWarnResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingWarnResourceIT extends LoggingMinLevelAboveTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetRuntimeLogLevels.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetRuntimeLogLevels.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public final class SetRuntimeLogLevels implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        final Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.unset.above\".level", "WARN");
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.unset.promote\".level", "TRACE");
+        return systemProperties;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+}

--- a/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
+++ b/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+#quarkus.log.category."io.quarkus.micrometer".min-level=DEBUG
 #quarkus.log.category."io.quarkus.micrometer".level=DEBUG
 quarkus.log.category."io.quarkus.micrometer.runtime.binder.vertx".level=INFO
 

--- a/integration-tests/mongodb-panache-kotlin/src/main/resources/application.properties
+++ b/integration-tests/mongodb-panache-kotlin/src/main/resources/application.properties
@@ -6,4 +6,5 @@ quarkus.mongodb.database=books
 quarkus.mongodb.cl2.connection-string=mongodb://localhost:27018
 quarkus.mongodb.cl2.write-concern.journal=false
 
+#quarkus.log.category."io.quarkus.mongodb.panache.runtime".min-level=DEBUG
 #quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG

--- a/integration-tests/mongodb-panache/src/main/resources/application.properties
+++ b/integration-tests/mongodb-panache/src/main/resources/application.properties
@@ -6,5 +6,6 @@ quarkus.mongodb.database=books
 quarkus.mongodb.cl2.connection-string=mongodb://localhost:27018
 quarkus.mongodb.cl2.write-concern.journal=false
 
+#quarkus.log.category."io.quarkus.mongodb.panache.runtime".min-level=DEBUG
 #quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG
 quarkus.mongodb.metrics.enabled=true

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -146,6 +146,9 @@ quarkus.http.auth.proactive=false
 quarkus.http.proxy.enable-forwarded-prefix=true
 quarkus.http.proxy.allow-forwarded=true
 
+quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".min-level=TRACE
 quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".level=TRACE
+#quarkus.log.category."org.apache.http".min-level=TRACE
 #quarkus.log.category."org.apache.http".level=TRACE

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -151,6 +151,8 @@
         <module>jaxp</module>
         <module>mailer</module>
         <module>native-config-profile</module>
+        <module>logging-min-level-unset</module>
+        <module>logging-min-level-set</module>
 
         <!-- gRPC tests -->
         <module>grpc-tls</module>

--- a/integration-tests/reactive-pg-client/src/test/resources/application-tl.properties
+++ b/integration-tests/reactive-pg-client/src/test/resources/application-tl.properties
@@ -3,4 +3,5 @@ quarkus.datasource.username=hibernate_orm_test
 quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.reactive.url=${reactive-postgres.url}
 quarkus.datasource.reactive.thread-local=true
+quarkus.log.category."io.quarkus.reactive.datasource".min-level=DEBUG
 quarkus.log.category."io.quarkus.reactive.datasource".level=DEBUG

--- a/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
+++ b/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
@@ -22,7 +22,9 @@ quarkus.datasource.dynamicDS.credentials-provider=dynamic-ds
 quarkus.datasource.dynamicDS.credentials-provider-name=vault-credentials-provider
 quarkus.datasource.dynamicDS.jdbc.url=jdbc:postgresql://localhost:6543/mydb
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
+quarkus.log.category."io.quarkus.vault.runtime.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault.runtime.vault".level=DEBUG
 
 #quarkus.log.min-level=DEBUG

--- a/integration-tests/vault-app/src/main/resources/application.properties
+++ b/integration-tests/vault-app/src/main/resources/application.properties
@@ -14,6 +14,7 @@ quarkus.vault.secret-config-kv-path=config
 quarkus.vault.health.enabled=true
 quarkus.vault.health.stand-by-ok=true
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 quarkus.datasource.db-kind=postgresql

--- a/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
@@ -10,6 +10,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault-approle.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle.properties
@@ -10,6 +10,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
@@ -9,6 +9,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
@@ -10,6 +10,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
@@ -13,6 +13,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
@@ -10,6 +10,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -17,6 +17,7 @@ quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
+quarkus.log.category."io.quarkus.vault".min-level=DEBUG
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default


### PR DESCRIPTION
FAO @dmlloyd @Sanne. This is a follow up to #13102 PR. Closes #12938. 

It adds a new optional build time per category configuration called `min-level`. It controls the minimum level of logging defined at build time. 

By default all categories' `min-level` is set to `INFO`, in which case the code generates an substratevm substitution that folds `isTraceEnabled` and `isDebugEnabled` calls to return `false`.

To keep things simple, the moment any `min-level` is configured, a different substitution is created that computes whether a given log level is enabled based on a combination of both the `min-level` set and the runtime log `level`. So, as an example, if you want to get `TRACE` on a given category, say `org.example.table`, you need to provide both:

* Build time `quarkus.log.category."org.example.table".min-level=TRACE`
* Run time `quarkus.log.category."org.example.table".level=TRACE`

When deciding the logic 👆, I pondered about the need for the runtime log level to be set, but it felt awkward to have code that had been built with `min-level` set to TRACE, and runtime log level to be say `INFO` and for `isTraceEnabled` to return true but nothing be logged when calling `log.trace`.

To exercise this, I've been using [this project](https://github.com/galderz/mendrugo/tree/master/quarkus-logging/no-min-level) to test the behaviour when no `min-level` has been set, and [this other](https://github.com/galderz/mendrugo/tree/master/quarkus-logging/min-level) with the example above. I'd like to convert these two into Quarkus integration tests, but first I'd like to make sure we have agreement on the logic.

Further optimisations are also applicable:

1. If all `min-level` set in config are `INFO` or above, the same logic as with no `min-level` set could be applied. The moment `min-level` is configured, the current logic does attempt to fold any calls.
2. If all `min-level` set in config are `WARN` or above and the logic in 👆 was applied, one could also fold `isInfoEnabled` calls to false.

Unit testing wise, I had the following doubt: to test both the branches of the logic (no `min-level` set and a `min-level` set to TRACE or some other), it seems to me that I'd need 2 maven integration test projects. Is that right? Could it be somehow done in a single one? Not sure...

Aside from unit testing, and possible further optimisations, documentation needs to be updated.