### PR TITLE
Make REST Data HAL collection name configurable

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractGetMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractGetMethodTest.java
@@ -137,23 +137,25 @@ public abstract class AbstractGetMethodTest {
         given().accept("application/hal+json")
                 .when().get("/collections")
                 .then().statusCode(200)
-                .and().body("_embedded.collections.id", contains("empty", "full"))
-                .and().body("_embedded.collections.name", contains("empty collection", "full collection"))
-                .and().body("_embedded.collections.items.id[0]", is(empty()))
-                .and().body("_embedded.collections.items.id[1]", contains(1, 2))
-                .and().body("_embedded.collections.items.name[1]", contains("first", "second"))
+                .and().body("_embedded.item-collections.id", contains("empty", "full"))
+                .and().body("_embedded.item-collections.name", contains("empty collection", "full collection"))
+                .and().body("_embedded.item-collections.items.id[0]", is(empty()))
+                .and().body("_embedded.item-collections.items.id[1]", contains(1, 2))
+                .and().body("_embedded.item-collections.items.name[1]", contains("first", "second"))
                 .and()
-                .body("_embedded.collections._links.add.href", contains(endsWith("/collections"), endsWith("/collections")))
+                .body("_embedded.item-collections._links.add.href",
+                        contains(endsWith("/collections"), endsWith("/collections")))
                 .and()
-                .body("_embedded.collections._links.list.href", contains(endsWith("/collections"), endsWith("/collections")))
+                .body("_embedded.item-collections._links.list.href",
+                        contains(endsWith("/collections"), endsWith("/collections")))
                 .and()
-                .body("_embedded.collections._links.self.href",
+                .body("_embedded.item-collections._links.self.href",
                         contains(endsWith("/collections/empty"), endsWith("/collections/full")))
                 .and()
-                .body("_embedded.collections._links.update.href",
+                .body("_embedded.item-collections._links.update.href",
                         contains(endsWith("/collections/empty"), endsWith("/collections/full")))
                 .and()
-                .body("_embedded.collections._links.remove.href",
+                .body("_embedded.item-collections._links.remove.href",
                         contains(endsWith("/collections/empty"), endsWith("/collections/full")))
                 .and().body("_links.add.href", endsWith("/collections"))
                 .and().body("_links.list.href", endsWith("/collections"));

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractHotReloadTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractHotReloadTest.java
@@ -13,7 +13,7 @@ public abstract class AbstractHotReloadTest {
     @Test
     public void shouldModifyPathAndDisableHal() {
         getTestArchive().modifySourceFile(getResourceClass(),
-                s -> s.replace("@ResourceProperties(hal = true, paged = false)", "@ResourceProperties(path = \"col\")"));
+                s -> s.replaceAll(".*@ResourceProperties.*", "@ResourceProperties(path = \"col\")"));
         given().accept("application/json")
                 .when().get("/col")
                 .then().statusCode(200);

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsResource.java
@@ -3,6 +3,6 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true, paged = false)
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
 public interface CollectionsResource extends PanacheEntityResource<Collection, String> {
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
@@ -3,6 +3,6 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment.repository;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true, paged = false)
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
 public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
@@ -10,7 +10,6 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.methods.StandardMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
-import io.quarkus.rest.data.panache.deployment.utils.ResourceName;
 import io.quarkus.rest.data.panache.runtime.hal.HalCollectionWrapper;
 import io.quarkus.rest.data.panache.runtime.hal.HalEntityWrapper;
 
@@ -34,12 +33,11 @@ abstract class HalMethodImplementor extends StandardMethodImplementor {
         return creator.newInstance(MethodDescriptor.ofConstructor(HalEntityWrapper.class, Object.class), entity);
     }
 
-    protected ResultHandle wrapHalEntities(BytecodeCreator creator, ResultHandle entities,
-            ResourceMetadata resourceMetadata) {
-        String collectionName = ResourceName.fromClass(resourceMetadata.getResourceInterface());
+    protected ResultHandle wrapHalEntities(BytecodeCreator creator, ResultHandle entities, String entityType,
+            String collectionName) {
         return creator.newInstance(
                 MethodDescriptor.ofConstructor(HalCollectionWrapper.class, Collection.class, Class.class, String.class),
-                entities, creator.loadClass(resourceMetadata.getEntityType()),
+                entities, creator.loadClass(entityType),
                 creator.load(collectionName));
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -39,7 +39,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
      * Expose {@link RestDataResource#list(Page, Sort)} via HAL JAX-RS method.
      * Generated pseudo-code with enabled pagination is shown below. If pagination is disabled pageIndex and pageSize
      * query parameters are skipped and null {@link Page} instance is used.
-     * 
+     *
      * <pre>
      * {@code
      *     &#64;GET
@@ -114,7 +114,8 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
                 resource, page, sort);
 
         // Wrap and return response
-        ResultHandle wrapper = wrapHalEntities(methodCreator, entities, resourceMetadata);
+        ResultHandle wrapper = wrapHalEntities(methodCreator, entities, resourceMetadata.getEntityType(),
+                resourceProperties.getHalCollectionName());
         methodCreator.invokeVirtualMethod(
                 ofMethod(HalCollectionWrapper.class, "addLinks", void.class, Link[].class), wrapper, links);
         methodCreator.returnValue(ResponseImplementor.ok(methodCreator, wrapper, links));
@@ -141,7 +142,8 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
                 resource, methodCreator.loadNull(), sort);
 
         // Wrap and return response
-        ResultHandle wrapper = wrapHalEntities(methodCreator, entities, resourceMetadata);
+        ResultHandle wrapper = wrapHalEntities(methodCreator, entities, resourceMetadata.getEntityType(),
+                resourceProperties.getHalCollectionName());
         methodCreator.returnValue(ResponseImplementor.ok(methodCreator, wrapper));
         methodCreator.close();
     }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
@@ -10,12 +10,16 @@ public class ResourceProperties {
 
     private final boolean paged;
 
+    private final String halCollectionName;
+
     private final Map<String, MethodProperties> methodProperties;
 
-    public ResourceProperties(boolean hal, String path, boolean paged, Map<String, MethodProperties> methodProperties) {
+    public ResourceProperties(boolean hal, String path, boolean paged, String halCollectionName,
+            Map<String, MethodProperties> methodProperties) {
         this.hal = hal;
         this.path = path;
         this.paged = paged;
+        this.halCollectionName = halCollectionName;
         this.methodProperties = methodProperties;
     }
 
@@ -43,5 +47,9 @@ public class ResourceProperties {
             return methodProperties.get(methodName).isExposed();
         }
         return true;
+    }
+
+    public String getHalCollectionName() {
+        return halCollectionName;
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
@@ -36,7 +36,8 @@ public class ResourcePropertiesProvider {
         AnnotationInstance annotation = findResourcePropertiesAnnotation(resourceInterfaceName);
 
         return new ResourceProperties(isHal(annotation), getPath(annotation, resourceInterface),
-                isPaged(annotation), getMethodPropertiesInfoMap(resourceInterfaceName));
+                isPaged(annotation), getHalCollectionName(annotation, resourceInterface),
+                getMethodPropertiesInfoMap(resourceInterfaceName));
     }
 
     private AnnotationInstance findResourcePropertiesAnnotation(DotName className) {
@@ -115,6 +116,13 @@ public class ResourcePropertiesProvider {
     private String getPath(AnnotationInstance annotation, String resourceInterface) {
         if (annotation != null && annotation.value("path") != null) {
             return annotation.value("path").asString();
+        }
+        return ResourceName.fromClass(resourceInterface);
+    }
+
+    private String getHalCollectionName(AnnotationInstance annotation, String resourceInterface) {
+        if (annotation != null && annotation.value("halCollectionName") != null) {
+            return annotation.value("halCollectionName").asString();
         }
         return ResourceName.fromClass(resourceInterface);
     }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
@@ -16,16 +16,6 @@ import java.lang.annotation.Target;
 public @interface ResourceProperties {
 
     /**
-     * Generate operations that support HAL content type.
-     * HAL methods are generated in addition to the standard methods. They accept the same parameters but return a content of
-     * `application/hal+json` type.
-     * The operations that support HAL responses are `get`, `list`, `add` and `update`.
-     * <p>
-     * Default: false.
-     */
-    boolean hal() default false;
-
-    /**
      * URL path segment that should be used to access the resources.
      * This path segment is prepended to the segments specified with the {@link MethodProperties} annotations used on this
      * resource's methods.
@@ -42,4 +32,21 @@ public @interface ResourceProperties {
      * Default: true.
      */
     boolean paged() default true;
+
+    /**
+     * Generate operations that support HAL content type.
+     * HAL methods are generated in addition to the standard methods. They accept the same parameters but return a content of
+     * `application/hal+json` type.
+     * The operations that support HAL responses are `get`, `list`, `add` and `update`.
+     * <p>
+     * Default: false.
+     */
+    boolean hal() default false;
+
+    /**
+     * Name that should be used then generating a HAL collection response.
+     * <p>
+     * Default: hyphenated resource name without a suffix. Ignored suffixes are `Controller` and `Resource`.
+     */
+    String halCollectionName() default "";
 }


### PR DESCRIPTION
REST Data extension returns HAL collection response in this format:
```
{
    "_embedded": {
        "resource-name": [ ... resource entities ... ]
    },
    "_links": { ... }
}
```
where `resource-name` is derived from the resource interface name. This PR allows this resource name to be configurable with a `@ResourceProperties` annotation.