### PR TITLE
Print gradle error when test fails

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -38,9 +38,12 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
                 .start();
 
         p.waitFor(5, TimeUnit.MINUTES);
-
         try (InputStream is = new FileInputStream(logOutput)) {
-            return BuildResult.of(is);
+            final BuildResult commandResult = BuildResult.of(is);
+            if (p.exitValue() != 0) {
+                printCommandOutput(command, commandResult);
+            }
+            return commandResult;
         }
     }
 
@@ -61,5 +64,10 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
             systemProperties.add(String.format("-D%s=%s", MAVEN_REPO_LOCAL, System.getProperty(MAVEN_REPO_LOCAL)));
         }
         return systemProperties;
+    }
+
+    private void printCommandOutput(List<String> command, BuildResult commandResult) {
+        System.err.println("Command: " + String.join(" ", command) + " failed with the following output:");
+        System.err.println(commandResult.getOutput());
     }
 }


### PR DESCRIPTION
When a gradle test fails, it can be complicated to get the output. 

This prints the command output if the gradle wrapper process exit code is different from 0. 
