### PR TITLE
Configure label in Spring Cloud Config Client extension

### DIFF
--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DefaultSpringCloudConfigClientGateway.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DefaultSpringCloudConfigClientGateway.java
@@ -191,6 +191,9 @@ class DefaultSpringCloudConfigClientGateway implements SpringCloudConfigClientGa
         List<String> finalPathSegments = new ArrayList<>(result.getPathSegments());
         finalPathSegments.add(applicationName);
         finalPathSegments.add(profile);
+        if (springCloudConfigClientConfig.label.isPresent()) {
+            finalPathSegments.add(springCloudConfigClientConfig.label.get());
+        }
         result.setPathSegments(finalPathSegments);
         return result.build();
     }

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
@@ -33,6 +33,14 @@ public class SpringCloudConfigClientConfig {
     public String url;
 
     /**
+     * The label to be used to pull remote configuration properties.
+     * The default is set on the Spring Cloud Config Server
+     * (generally "master" when the server uses a Git backend).
+     */
+    @ConfigItem
+    public Optional<String> label;
+
+    /**
      * The amount of time to wait when initially establishing a connection before giving up and timing out.
      * <p>
      * Specify `0` to wait indefinitely.

--- a/extensions/spring-cloud-config-client/runtime/src/test/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientGatewayTest.java
+++ b/extensions/spring-cloud-config-client/runtime/src/test/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientGatewayTest.java
@@ -22,8 +22,9 @@ class SpringCloudConfigClientGatewayTest {
     private static final int MOCK_SERVER_PORT = 9300;
     private static final WireMockServer wireMockServer = new WireMockServer(MOCK_SERVER_PORT);
 
+    private static final SpringCloudConfigClientConfig springCloudConfigClientConfig = configForTesting();
     private final SpringCloudConfigClientGateway sut = new DefaultSpringCloudConfigClientGateway(
-            configForTesting());
+            springCloudConfigClientConfig);
 
     @BeforeAll
     static void start() {
@@ -39,7 +40,9 @@ class SpringCloudConfigClientGatewayTest {
     void testBasicExchange() throws Exception {
         final String applicationName = "foo";
         final String profile = "dev";
-        wireMockServer.stubFor(WireMock.get(String.format("/%s/%s", applicationName, profile)).willReturn(WireMock
+        final String springCloudConfigUrl = String.format(
+                "/%s/%s/%s", applicationName, profile, springCloudConfigClientConfig.label.get());
+        wireMockServer.stubFor(WireMock.get(springCloudConfigUrl).willReturn(WireMock
                 .okJson(getJsonStringForApplicationAndProfile(applicationName, profile))));
 
         final Response response = sut.exchange(applicationName, profile);
@@ -73,6 +76,7 @@ class SpringCloudConfigClientGatewayTest {
     private static SpringCloudConfigClientConfig configForTesting() {
         SpringCloudConfigClientConfig springCloudConfigClientConfig = new SpringCloudConfigClientConfig();
         springCloudConfigClientConfig.url = "http://localhost:" + MOCK_SERVER_PORT;
+        springCloudConfigClientConfig.label = Optional.of("master");
         springCloudConfigClientConfig.connectionTimeout = Duration.ZERO;
         springCloudConfigClientConfig.readTimeout = Duration.ZERO;
         springCloudConfigClientConfig.username = Optional.empty();


### PR DESCRIPTION
Add configuration property `quarkus.spring-cloud-config.label` to request
a specific label rather than let Spring Cloud Config Server choose a
default label.

Fixes #11211