### PR TITLE
Attempt to fix Graylog CI issues

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -145,6 +145,9 @@ jobs:
           java-version: ${{ matrix.java.java-version }}
           release: ${{ matrix.java.release }}
 
+      - name: Configure max network buffer
+        run: sysctl -w net.core.rmem_max=262144
+
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
This change is meant to address:

```
2020-11-19T15:25:44.9988248Z 15:25:44.993 Graylog:2020-11-19 15:25:44,992 WARN : org.graylog2.inputs.transports.UdpTransport - receiveBufferSize (SO_RCVBUF) for input GELFUDPInput{title=udp input, type=org.graylog2.inputs.gelf.udp.GELFUDPInput, nodeId=null} (channel [id: 0xe1836c0d, L:/0.0.0.0:12201]) should be 262144 but is 425984.
```

which is present in the CI logs