### PR TITLE
Attempt to fix Graylog CI issues

### DIFF
--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -151,6 +151,8 @@
                                             <name>graylog</name>
                                             <alias>elasticsearch</alias>
                                         </network>
+                                        <cpus>2</cpus>
+                                        <cpuShares>2048</cpuShares>
                                         <ports>
                                             <port>9200:9200</port>
                                         </ports>
@@ -178,6 +180,7 @@
                                             <name>graylog</name>
                                             <alias>mongo</alias>
                                         </network>
+                                        <cpus>1</cpus>
                                         <ports>
                                             <port>27017:27017</port>
                                         </ports>
@@ -206,6 +209,7 @@
                                         <env>
                                             <GRAYLOG_HTTP_EXTERNAL_URI>http://127.0.0.1:9000/</GRAYLOG_HTTP_EXTERNAL_URI>
                                         </env>
+                                        <cpus>1</cpus>
                                         <ports>
                                             <port>9000:9000</port>
                                             <port>12201:12201/udp</port>

--- a/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
+++ b/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
@@ -48,14 +48,14 @@ public class GelfLogHandlerTest {
         }
 
         // wait for the input to be running
-        await().during(5, TimeUnit.SECONDS);
+        await().during(10, TimeUnit.SECONDS);
     }
 
     @Test
     public void test() {
         RestAssured.given().when().get("/gelf-log-handler").then().statusCode(204);
 
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(20, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             RestAssured.given()


### PR DESCRIPTION
Fixes #13364

I was able to reproduce the CI error locally, by using `<cpu>1<cpus>` in the elasticsearch container configuration.
By then switching to:

```
<cpus>2</cpus>
<cpuShares>2048</cpuShares>
```

the problem went away