### PR TITLE
Terminate gRPC channels and handle gRPC client invocations on the IO Thread when needed

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -83,6 +83,21 @@ public class ReactiveHelloService extends MutinyGreeterGrpc.GreeterImplBase {
 }
 ----
 
+== Blocking service implementation
+
+By default, all the methods from a gRPC service run on the event loop.
+As a consequence, you must **not** block.
+If your service logic must block, annotate the method with `io.smallrye.common.annotation.Blocking`:
+
+[source, java]
+----
+@Override
+@Blocking
+public Uni<HelloReply> sayHelloBlocking(HelloRequest request) {
+    // Do something blocking before returning the Uni
+}
+----
+
 == Handling streams
 
 gRPC allows receiving and returning streams:

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -33,6 +33,7 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.grpc.runtime.GrpcClientInterceptorContainer;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
 import io.quarkus.grpc.runtime.supports.GrpcClientConfigProvider;
+import io.quarkus.grpc.runtime.supports.IOThreadClientInterceptor;
 
 public class GrpcClientProcessor {
 
@@ -43,6 +44,7 @@ public class GrpcClientProcessor {
         beans.produce(AdditionalBeanBuildItem.unremovableOf(GrpcService.class));
         beans.produce(AdditionalBeanBuildItem.unremovableOf(GrpcClientConfigProvider.class));
         beans.produce(AdditionalBeanBuildItem.unremovableOf(GrpcClientInterceptorContainer.class));
+        beans.produce(AdditionalBeanBuildItem.unremovableOf(IOThreadClientInterceptor.class));
     }
 
     @BuildStep

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.grpc.runtime.GrpcClientInterceptorContainer;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.grpc.runtime.supports.Channels;
 import io.quarkus.grpc.runtime.supports.GrpcClientConfigProvider;
 import io.quarkus.grpc.runtime.supports.IOThreadClientInterceptor;
 
@@ -132,7 +133,8 @@ public class GrpcClientProcessor {
                         public void accept(MethodCreator mc) {
                             GrpcClientProcessor.this.generateChannelProducer(mc, svc);
                         }
-                    });
+                    })
+                    .destroyer(Channels.ChannelDestroyer.class);
             channelProducer.done();
             beans.produce(new BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem(channelProducer));
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcClientInterceptorContainer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcClientInterceptorContainer.java
@@ -1,6 +1,5 @@
 package io.quarkus.grpc.runtime;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,14 +13,11 @@ import io.grpc.ClientInterceptor;
 
 @ApplicationScoped
 public class GrpcClientInterceptorContainer {
+    // Cannot be empty, as we have the IO Thread client interceptor
     @Inject
     Instance<ClientInterceptor> interceptors;
 
     public List<ClientInterceptor> getSortedInterceptors() {
-        if (interceptors.isUnsatisfied()) {
-            return Collections.emptyList();
-        }
-
         return interceptors.stream().sorted(new Comparator<ClientInterceptor>() { // NOSONAR
             @Override
             public int compare(ClientInterceptor si1, ClientInterceptor si2) {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/IOThreadClientInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/IOThreadClientInterceptor.java
@@ -1,0 +1,42 @@
+package io.quarkus.grpc.runtime.supports;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Prioritized;
+
+import io.grpc.*;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class IOThreadClientInterceptor implements ClientInterceptor, Prioritized {
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions, Channel next) {
+
+        Context context = Vertx.currentContext();
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onMessage(RespT message) {
+                        if (context != null) {
+                            context.runOnContext(unused -> super.onMessage(message));
+                        } else {
+                            super.onMessage(message);
+                        }
+                    }
+                }, headers);
+            }
+        };
+    }
+
+    @Override
+    public int getPriority() {
+        // MAX to be sure to be called first.
+        return Integer.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
Several gRPC related fixes:

- gRPC Client emissions should be on the event loop if the subscription is executed on the event loop
- Terminate managed channels on shutdown
- Document the usage of @Blocking in gRPC service implementation


Fix #13404
Fix #13357
