### PR TITLE
Add additional class to ImageIOProcessor

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ImageIOProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ImageIOProcessor.java
@@ -16,6 +16,7 @@ public class ImageIOProcessor {
         // (See https://github.com/quarkusio/quarkus/issues/12535)
         return Arrays.asList(
                 new RuntimeInitializedClassBuildItem("javax.imageio.ImageTypeSpecifier"),
-                new RuntimeInitializedClassBuildItem("com.sun.imageio.plugins.jpeg.JPEG$JCS"));
+                new RuntimeInitializedClassBuildItem("com.sun.imageio.plugins.jpeg.JPEG$JCS"),
+                new RuntimeInitializedClassBuildItem("java.awt.image.AreaAveragingScaleFilter"));
     }
 }


### PR DESCRIPTION
Fixes the following issue found for native builds on quay.io/quarkus/ubi-quarkus-native-image:20.3.0-java11
```
Error: No instances of java.awt.color.ICC_ColorSpace are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=java.awt.color.ICC_ColorSpace.
Detailed message:
Trace: Object was reached by 
        reading field java.awt.image.ColorModel.colorSpace of
                constant java.awt.image.DirectColorModel@52f9255c reached by 
        reading field java.awt.image.ColorModel.RGBdefault

com.oracle.svm.core.util.UserError$UserException: No instances of java.awt.color.ICC_ColorSpace are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=java.awt.color.ICC_ColorSpace.
Detailed message:
Trace: Object was reached by 
        reading field java.awt.image.ColorModel.colorSpace of
                constant java.awt.image.DirectColorModel@52f9255c reached by 
        reading field java.awt.image.ColorModel.RGBdefault

        at com.oracle.svm.core.util.UserError.abort(UserError.java:82)
        at com.oracle.svm.hosted.FallbackFeature.reportAsFallback(FallbackFeature.java:217)
        at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:768)
        at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:558)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:471)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: No instances of java.awt.color.ICC_ColorSpace are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=java.awt.color.ICC_ColorSpace.
Detailed message:
Trace: Object was reached by 
        reading field java.awt.image.ColorModel.colorSpace of
                constant java.awt.image.DirectColorModel@52f9255c reached by 
        reading field java.awt.image.ColorModel.RGBdefault

        at com.oracle.graal.pointsto.constraints.UnsupportedFeatures.report(UnsupportedFeatures.java:126)
        at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:765)
        ... 8 more
Error: Image build request failed with exit status 1
```