### PR TITLE
CI: Don't run 'Deploy Snapshots' or 'Release Test Build' in forks

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -10,6 +10,7 @@ jobs:
   build-and-deploy:
     name: "Build and deploy"
     runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: "Prepare release"
     runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
I'm frequently getting error mails from GH that "Deploy Snapshots" or "Release Test Build" has failed in my fork due to 401 errors ("Bad credentials").

I don't think those jobs should run at all in forks (no?) and this PR tries to disable them.