### PR TITLE
Fix gRPC Server port configuration in kubernetes descriptor

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -64,7 +64,7 @@ public class GrpcServerProcessor {
     @BuildStep(onlyIf = IsNormal.class)
     public KubernetesPortBuildItem registerGrpcServiceInKubernetes(List<BindableServiceBuildItem> bindables) {
         if (!bindables.isEmpty()) {
-            int port = ConfigProvider.getConfig().getOptionalValue("quarkus.grpc-server.port", Integer.class)
+            int port = ConfigProvider.getConfig().getOptionalValue("quarkus.grpc.server.port", Integer.class)
                     .orElse(9000);
             return new KubernetesPortBuildItem(port, GRPC_SERVER);
         }


### PR DESCRIPTION
Fix the name of the property to retrieve the gRPC server port when computing the Kubernetes descriptor.

Fixes #13416.
