### PR TITLE
Revert testing GELF

### DIFF
--- a/integration-tests/logging-gelf/README.md
+++ b/integration-tests/logging-gelf/README.md
@@ -1,10 +1,8 @@
 # JAX-RS example using Graylog central log management
 
-By default, the test of this module is enabled for Graylog using `mvn clean test -Dstart-containers -Dtest-containers`.
+## Running the tests
 
-If you want to launch central logging stack by yourself, you can use the following instructions.
-
-## Testing with Graylog
+By default, the tests of this module are disabled.
 
 To run them, you first need to start a Graylog server and it's needed dependencies.
 

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
@@ -98,10 +94,10 @@
 
     <profiles>
         <profile>
-            <id>test-gelf</id>
+        <id>test-gelf</id>
             <activation>
                 <property>
-                    <name>test-containers</name>
+                    <name>test-gelf</name>
                 </property>
             </activation>
             <build>
@@ -117,156 +113,6 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-gelf</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <elasticsearch.hosts>localhost:9200</elasticsearch.hosts>
-                <elasticsearch.protocol>http</elasticsearch.protocol>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
-                            <images>
-                                <image>
-                                    <!-- Graylog 3 only works with Elasticsearch 6 -->
-                                    <name>docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9</name>
-                                    <alias>elasticsearch</alias>
-                                    <run>
-                                        <network>
-                                            <mode>custom</mode>
-                                            <name>graylog</name>
-                                            <alias>elasticsearch</alias>
-                                        </network>
-                                        <cpus>2</cpus>
-                                        <cpuShares>2048</cpuShares>
-                                        <ports>
-                                            <port>9200:9200</port>
-                                        </ports>
-                                        <log>
-                                            <prefix>Elasticsearch: </prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:9200</url>
-                                                <method>GET</method>
-                                                <status>200</status>
-                                            </http>
-                                            <time>20000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                                <image>
-                                    <name>mongo:4.2</name>
-                                    <alias>mongo</alias>
-                                    <run>
-                                        <network>
-                                            <mode>custom</mode>
-                                            <name>graylog</name>
-                                            <alias>mongo</alias>
-                                        </network>
-                                        <cpus>1</cpus>
-                                        <ports>
-                                            <port>27017:27017</port>
-                                        </ports>
-                                        <log>
-                                            <prefix>Mongo: </prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <tcp>
-                                                <host>127.0.0.1</host>
-                                                <ports>
-                                                    <port>27017</port>
-                                                </ports>
-                                            </tcp>
-                                        </wait>
-                                    </run>
-                                </image>
-                                <image>
-                                    <name>graylog/graylog:3.3.8</name>
-                                    <run>
-                                        <network>
-                                            <mode>custom</mode>
-                                            <name>graylog</name>
-                                        </network>
-                                        <env>
-                                            <GRAYLOG_HTTP_EXTERNAL_URI>http://127.0.0.1:9000/</GRAYLOG_HTTP_EXTERNAL_URI>
-                                        </env>
-                                        <cpus>1</cpus>
-                                        <ports>
-                                            <port>9000:9000</port>
-                                            <port>12201:12201/udp</port>
-                                            <port>1514:1514</port>
-                                        </ports>
-                                        <log>
-                                            <prefix>Graylog: </prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <log>Graylog server up and running.</log>
-                                            <!-- Keep this value high, it takes at least 50s on CI -->
-                                            <time>90000</time>
-                                        </wait>
-                                        <dependsOn>
-                                            <container>elasticsearch</container>
-                                            <container>mongo</container>
-                                        </dependsOn>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>process-test-classes</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${basedir}/../../.github/docker-prune.sh</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
+++ b/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
@@ -1,19 +1,7 @@
 package io.quarkus.logging.gelf.it;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasItem;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -30,40 +18,18 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class GelfLogHandlerTest {
 
-    @BeforeAll
-    static void init() throws IOException, InterruptedException {
-        HttpPost request = new HttpPost("http://localhost:9000/api/system/inputs");
-        request.setHeader("Content-Type", "application/json");
-        request.setHeader("Authorization", "Basic YWRtaW46YWRtaW4=");
-        request.setHeader("X-Requested-By", "Apache");
-        HttpEntity entity = new StringEntity(
-                "{\"title\":\"udp input\",\"configuration\":{\"recv_buffer_size\":262144,\"bind_address\":\"0.0.0.0\",\"port\":12201,\"decompress_size_limit\":8388608},\"type\":\"org.graylog2.inputs.gelf.udp.GELFUDPInput\",\"global\":true}",
-                ContentType.APPLICATION_JSON);
-        request.setEntity(entity);
-
-        HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpResponse response = httpClient.execute(request);
-        if (response.getStatusLine().getStatusCode() >= 400) {
-            throw new RuntimeException("Unable to create the Graylog UDP input: " + response.getStatusLine());
-        }
-
-        // wait for the input to be running
-        await().during(10, TimeUnit.SECONDS);
-    }
-
     @Test
-    public void test() {
+    public void test() throws InterruptedException {
         RestAssured.given().when().get("/gelf-log-handler").then().statusCode(204);
 
-        await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            RestAssured.given()
-                                    .when()
-                                    .auth().basic("admin", "admin")
-                                    .get("http://127.0.0.1:9000/api/search/universal/relative?query=message")
-                                    .then().statusCode(200)
-                                    .body("messages.message.message", hasItem("Some useful log message"));
-                        });
+        //wait two seconds for the log events to be processed
+        Thread.sleep(2000);
+
+        RestAssured.given()
+                .when()
+                .auth().basic("admin", "admin")
+                .get("http://127.0.0.1:9000/api/search/universal/relative?query=")
+                .then().statusCode(200)
+                .body("messages.message.message", hasItem("Some useful log message"));
     }
 }

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -2,20 +2,19 @@ version: '3.2'
 
 services:
   elasticsearch:
-    # Graylog 3 only works with Elasticsearch 6
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     networks:
       - graylog
 
   mongo:
-    image: mongo:4.2
+    image: mongo:4.0
     networks:
       - graylog
 
   graylog:
-    image: graylog/graylog:3.3.8
+    image: graylog/graylog:3.1
     ports:
       - "9000:9000"
       - "12201:12201/udp"


### PR DESCRIPTION
It's unstable, we need to make it stable before testing it properly on
CI.

This reverts https://github.com/quarkusio/quarkus/pull/13286 (and some additional changes made afterwards). It's in the way.

/cc @geoand @loicmathieu 

I'll merge as soon as CI is green and rebase as many PRs as possible to get green status for tomorrow.

(Note that some of the improvements can probably be done anyway but I prefer reverting this entirely)