### PR TITLE
WP: Quarkus Unleash extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -208,6 +208,8 @@
         <log4j2-jboss-logmanager.version>1.0.0.Beta1</log4j2-jboss-logmanager.version>
         <log4j-jboss-logmanager.version>1.2.0.Final</log4j-jboss-logmanager.version>
         <avro.version>1.10.0</avro.version>
+        
+        <unleash.version>3.3.3</unleash.version>
     </properties>
 
     <dependencyManagement>
@@ -4726,6 +4728,23 @@
                 <artifactId>quarkus-builder</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            
+            <!-- Feature toggle -->
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-unleash</artifactId>
+                <version>${project.version}</version>
+             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-unleash-deployment</artifactId>
+                <version>${project.version}</version>
+             </dependency>
+            <dependency>
+                <groupId>no.finn.unleash</groupId>
+                <artifactId>unleash-client-java</artifactId>
+                <version>3.3.3</version>
+            </dependency>            
         </dependencies>
     </dependencyManagement>
 </project>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
@@ -122,6 +122,7 @@ public enum Feature {
     SWAGGER_UI,
     TIKA,
     UNDERTOW_WEBSOCKETS,
+    UNLEASH,
     VAULT,
     VERTX,
     VERTX_WEB,

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -190,6 +190,9 @@
         <module>google-cloud-functions-http</module>
         <module>google-cloud-functions</module>
         <module>grpc-common</module>
+        
+        <!-- Feature toggle service -->
+        <module>unleash</module>
     </modules>
 
     <build>

--- a/extensions/unleash/deployment/pom.xml
+++ b/extensions/unleash/deployment/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-unleash-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-unleash-deployment</artifactId>
+    <name>Quarkus - Unleash - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-unleash</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/unleash/deployment/src/main/java/io/quarkus/unleash/UnleashProcessor.java
+++ b/extensions/unleash/deployment/src/main/java/io/quarkus/unleash/UnleashProcessor.java
@@ -1,0 +1,48 @@
+package io.quarkus.unleash;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.unleash.runtime.UnleashProducer;
+import io.quarkus.unleash.runtime.UnleashRecorder;
+import io.quarkus.unleash.runtime.UnleashRuntimeTimeConfig;
+
+public class UnleashProcessor {
+
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    void configureRuntimeProperties(UnleashRecorder recorder, UnleashRuntimeTimeConfig runtimeConfig,
+            BeanContainerBuildItem beanContainer) {
+        recorder.initializeProducers(beanContainer.getValue(), runtimeConfig);
+    }
+
+    @Record(STATIC_INIT)
+    @BuildStep
+    void build(UnleashRecorder recorder,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildItem,
+            BuildProducer<FeatureBuildItem> featureProducer) {
+        featureProducer.produce(new FeatureBuildItem(Feature.UNLEASH));
+
+        additionalBeanBuildItemBuildItem.produce(AdditionalBeanBuildItem.unremovableOf(UnleashProducer.class));
+    }
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    @Record(STATIC_INIT)
+    void nativeImageConfiguration(UnleashRecorder recorder,
+            BuildProducer<ReflectiveClassBuildItem> reflective) {
+        reflective.produce(new ReflectiveClassBuildItem(true, true, true,
+                no.finn.unleash.metric.ClientRegistration.class.getName(),
+                no.finn.unleash.metric.ClientMetrics.class.getName(),
+                no.finn.unleash.repository.ToggleCollection.class.getName()));
+    }
+
+}

--- a/extensions/unleash/pom.xml
+++ b/extensions/unleash/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-unleash-parent</artifactId>
+    <name>Quarkus - Unleash</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+</project>

--- a/extensions/unleash/runtime/pom.xml
+++ b/extensions/unleash/runtime/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-unleash-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-unleash</artifactId>
+    <name>Quarkus - Unleash - Runtime</name>
+    <description>Unleash is a feature toggle system</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.finn.unleash</groupId>
+            <artifactId>unleash-client-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.arc</groupId>
+            <artifactId>arc</artifactId>
+            <version>999-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashCreator.java
+++ b/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashCreator.java
@@ -1,0 +1,28 @@
+package io.quarkus.unleash.runtime;
+
+import no.finn.unleash.DefaultUnleash;
+import no.finn.unleash.Unleash;
+import no.finn.unleash.util.UnleashConfig;
+
+public class UnleashCreator {
+
+    private final UnleashRuntimeTimeConfig unleashRuntimeTimeConfig;
+
+    public UnleashCreator(UnleashRuntimeTimeConfig unleashRuntimeTimeConfig) {
+        this.unleashRuntimeTimeConfig = unleashRuntimeTimeConfig;
+    }
+
+    public Unleash createUnleash() {
+        UnleashConfig.Builder builder = UnleashConfig.builder()
+                .unleashAPI(unleashRuntimeTimeConfig.api)
+                .appName(unleashRuntimeTimeConfig.appName);
+
+        unleashRuntimeTimeConfig.instanceId.ifPresent(builder::instanceId);
+
+        if (unleashRuntimeTimeConfig.disableMetrics) {
+            builder.disableMetrics();
+        }
+
+        return new DefaultUnleash(builder.build());
+    }
+}

--- a/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashProducer.java
+++ b/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashProducer.java
@@ -1,0 +1,31 @@
+package io.quarkus.unleash.runtime;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import io.quarkus.arc.DefaultBean;
+import no.finn.unleash.Unleash;
+
+@ApplicationScoped
+public class UnleashProducer {
+
+    private Unleash unleash;
+
+    void initialize(UnleashRuntimeTimeConfig config) {
+        unleash = new UnleashCreator(config).createUnleash();
+    }
+
+    @Produces
+    @DefaultBean
+    public Unleash createUnleash() {
+        return unleash;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (unleash != null) {
+            unleash.shutdown();
+        }
+    }
+}

--- a/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashRecorder.java
+++ b/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashRecorder.java
@@ -1,0 +1,14 @@
+package io.quarkus.unleash.runtime;
+
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class UnleashRecorder {
+
+    public void initializeProducers(BeanContainer container, UnleashRuntimeTimeConfig config) {
+        UnleashProducer producer = container.instance(UnleashProducer.class);
+        producer.initialize(config);
+    }
+
+}

--- a/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashRuntimeTimeConfig.java
+++ b/extensions/unleash/runtime/src/main/java/io/quarkus/unleash/runtime/UnleashRuntimeTimeConfig.java
@@ -1,0 +1,35 @@
+package io.quarkus.unleash.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "unleash", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class UnleashRuntimeTimeConfig {
+
+    /**
+     * Unleash API service endpoint
+     */
+    @ConfigItem
+    public String api;
+
+    /**
+     * Application name
+     */
+    @ConfigItem
+    public String appName;
+
+    /**
+     * Instance ID.
+     */
+    @ConfigItem
+    public Optional<String> instanceId = Optional.empty();
+
+    /**
+     * Disable Unleash metrics flag
+     */
+    @ConfigItem
+    public boolean disableMetrics = false;
+}


### PR DESCRIPTION
Hi,

we do continue rolling out the Quarkus as a new technology stack in the projects. The next missing piece for us is the [Unleash](https://github.com/Unleash/unleash) feature toggle extension. I created a base structure for the extension which contains one producer for the `Unleash` object. It would be great if you could give feedback to this PR.

To-do:
- [x] register classes for reflection
- [x] native image
- [ ] extend unleash configuration
- [ ] unit test
- [ ] integration test
- [ ] documentation

The `Unleash` java SDK client is a rest client which call the `Unleash` service. What could I use in the unit and integration test to mock the service endpoint? (Testcontainers, Mock-server, Wiremock, ...)

My test application: https://github.com/andrejpetras/quarkus-unleash-test

BR
Andrej
