### PR TITLE
Document how to disable wildcard imports in IDEA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,10 @@ Select _Use the Eclipse Code Formatter_, then change the _Eclipse Java Formatter
 `eclipse-format.xml` file in the `independent-projects/ide-config` directory. Make sure the _Optimize Imports_ box is ticked, and
 select the `eclipse.importorder` file as the import order config file.
 
+Next, disable wildcard imports:
+navigate to _Editor_ -> _Code Style_ -> _Java_ -> _Imports_
+and set _Class count to use import with '\*'_ to `999`.
+Do the same with _Names count to use static import with '\*'_.
 
 ## Build
 


### PR DESCRIPTION
Without this, the configuration documented in CONTRIBUTING.md will lead to the IDE automatically replace multiple (5+) imports from the same package with a wildcard import.

From what I gathered, PRs with such imports will be rejected, so we'd better explain how to set this up.

I didn't explain how to do it in Eclipse because I don't have an Eclipse install right now. But from what I remember, Eclipse probably doesn't do this by default.