### PR TITLE
Load Kotlin parent first

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -150,7 +150,7 @@
         <awssdk.version>2.15.29</awssdk.version>
         <aws-alexa-sdk.version>2.37.1</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.20</kotlin.version>
         <dekorate.version>0.13.6</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,7 +21,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.20</kotlin.version>
         <scala.version>2.12.8</scala.version>
         <scala-plugin.version>4.1.1</scala-plugin.version>
 

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
@@ -11,10 +11,13 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.kotlin.cli.common.ExitCode;
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation;
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity;
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation;
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector;
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler;
 import org.jetbrains.kotlin.config.Services;
@@ -102,7 +105,7 @@ public class KotlinCompilationProvider implements CompilationProvider {
             return !errors.isEmpty();
         }
 
-        @Override
+        //kotlin 1.3 version
         public void report(CompilerMessageSeverity severity, String s, CompilerMessageLocation location) {
             if (severity.isError()) {
                 if ((location != null) && (location.getLineContent() != null)) {
@@ -117,6 +120,20 @@ public class KotlinCompilationProvider implements CompilationProvider {
 
         public List<String> getErrors() {
             return errors;
+        }
+
+        @Override
+        public void report(@NotNull CompilerMessageSeverity severity, @NotNull String s,
+                @Nullable CompilerMessageSourceLocation location) {
+            if (severity.isError()) {
+                if ((location != null) && (location.getLineContent() != null)) {
+                    errors.add(String.format("%s%n%s:%d:%d%nReason: %s", location.getLineContent(), location.getPath(),
+                            location.getLine(),
+                            location.getColumn(), s));
+                } else {
+                    errors.add(s);
+                }
+            }
         }
     }
 }

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -43,4 +43,14 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -19,6 +19,20 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                 <configuration>
+                    <parentFirstArtifacts>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</parentFirstArtifact>
+                    </parentFirstArtifacts>
+                    <runnerParentFirstArtifacts>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</runnerParentFirstArtifact>
+                    </runnerParentFirstArtifacts>
                     <lesserPriorityArtifacts>
                         <!--
                         see https://github.com/quarkusio/quarkus/issues/8405

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache-common</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>quarkus-jackson</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/extensions/panache/mongodb-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/deployment/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mongodb-panache-kotlin</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
@@ -41,8 +41,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/integration-tests/hibernate-orm-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-orm-panache-kotlin/pom.xml
@@ -66,11 +66,6 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -42,10 +42,6 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -52,11 +52,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/integration-tests/mongodb-panache-kotlin/pom.xml
+++ b/integration-tests/mongodb-panache-kotlin/pom.xml
@@ -34,11 +34,6 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
Also change to 1.4, which I am not sure if want just yet or if it should be a different PR (although this is all inter-related, as you can't do 1.4 upgrade without these changes).

Also note that the existing Kotlin tests exhibit the failure from #11549 when the update to 1.4 is performed, so I did not add a specific test for this (as we already have tests).

Fixes #11549