### PR TITLE
@JsonIgnore QuarkusJsonPlatformDescriptor.getManagedDependencies

### DIFF
--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
@@ -11,6 +11,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.maven.model.Dependency;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.quarkus.dependencies.Category;
 import io.quarkus.dependencies.Extension;
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -97,6 +101,12 @@ public class QuarkusJsonPlatformDescriptor implements QuarkusPlatformDescriptor,
     @Override
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    @Override
+    @JsonIgnore
+    public List<Dependency> getManagedDependencies() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Managed dependencies aren't in the JSON anyway.