### PR TITLE
Update OIDC web-app and multitenancy docs, remove the deprecated 'xhr-auto-redirect' property'

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -361,6 +361,55 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
 
 The `OidcTenantConfig` returned from this method is the same used to parse the `oidc` namespace configuration from the `application.properties`. You can populate it using any of the settings supported by the `quarkus-oidc` extension.
 
+== Tenant Resolution for OIDC 'web-app' applications
+
+Several options are available for selecting the tenant configuration which should be used to secure the current HTTP request for both `service` and `web-app` OIDC applications, such as:
+
+- Check URL paths, for example, a `tenant-service` configuration has to be used for the "/service" paths, while a `tenant-manage` configuration - for the "/management" paths
+- Check HTTP headers, for example, with a URL path always being '/service', a header such as "Realm: service" or "Realm: management" can help selecting between the `tenant-service` and `tenant-manage` configurations
+- Check URL query parameters - it can work similarly to the way the headers are used to select the tenant configuration
+
+All these options can be easily implemented with the custom `TenantResolver` and `TenantConfigResolver` implementations for the OIDC `service` applications.
+
+However, due to an HTTP redirect required to complete the code authentication flow for the OIDC `web-app` applications, a custom HTTP cookie may be needed to select the same tenant configuration before and after this redirect request because:
+
+- URL path may not be the same after the redirect request if a single redirect URL has been registered in the OIDC Provider - the original request path can be restored but after the the tenant configuration is resolved
+- HTTP headers used during the original request are not available after the redirect
+- Custom URL query parameters are restored after the redirect but after the tenant configuration is resolved
+
+One option to ensure the information for resolving the tenant configurations for `web-app` applications is available before and after the redirect is to use a cookie, for example:
+
+[source,java]
+----
+package org.acme.quickstart.oidc;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.TenantResolver;
+import io.vertx.core.http.Cookie;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantResolver implements TenantResolver {
+
+    @Override
+    public String resolve(RoutingContext context) {
+        List<String> tenantIdQuery = context.queryParam("tenantId");
+        if (!tenantIdQuery.isEmpty()) {
+            String tenantId = tenantIdQuery.get(0);
+            context.addCookie(Cookie.cookie("tenant", tenantId));
+            return tenantId;
+        } else if (context.cookieMap().containsKey("tenant")) {
+            return context.getCookie("tenant").getValue();
+        }
+
+        return null;
+    }
+}
+----
+
 [[disable-tenant]]
 == Disabling Tenant Configurations
 

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -362,6 +362,17 @@ You can have this process further optimized by having a simple JavaScript functi
 
 Note this user session can not be extended forever - the returning user with the expired ID token will have to re-authenticate at the OIDC provider endpoint once the refresh token has expired.
 
+=== TokenStateManager
+
+OIDC `CodeAuthenticationMechanism` is using the default `io.quarkus.oidc.TokenStateManager' interface implementation to keep the ID, access and refresh tokens returned in the authorization code or refresh grant responses in a session cookie. It makes Quarkus OIDC endpoints completely stateless.
+
+If all of these tokens are JWT tokens then combining them may produce a session cookie value larger than 4KB and the browsers may not keep this cookie.
+In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` to have a unique session token per each of these three tokens.
+
+Alternatively, if having an ID token only is sufficient for your Quarkus endpoint and no access or refresh tokens are used then set `quarkus.oidc.state-session-manager.stategy=id-token`.
+
+Register your own `io.quarkus.oidc.TokenStateManager' implementation as an ApplicationScoped CDI bean if you need to customize the way the tokens are associated with the session cookie. For exmaple, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
+
 == Listening to important authentication events
 
 One can register `@ApplicationScoped` bean which will observe important OIDC authentication events. The listener will be updated when a user has logged in for the first time or re-authenticated, as well as when the session has been refreshed. More events may be reported in the future. For example:

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -371,7 +371,7 @@ In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` 
 
 Alternatively, if having an ID token only is sufficient for your Quarkus endpoint and no access or refresh tokens are used then set `quarkus.oidc.state-session-manager.stategy=id-token`.
 
-Register your own `io.quarkus.oidc.TokenStateManager' implementation as an ApplicationScoped CDI bean if you need to customize the way the tokens are associated with the session cookie. For exmaple, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
+Register your own `io.quarkus.oidc.TokenStateManager' implementation as an `@ApplicationScoped` CDI bean if you need to customize the way the tokens are associated with the session cookie. For example, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
 
 == Listening to important authentication events
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -747,29 +747,6 @@ public class OidcTenantConfig {
 
         /**
          * If this property is set to 'true' then a normal 302 redirect response will be returned
-         * if the request was initiated via XMLHttpRequest and the current user needs to be
-         * (re)authenticated which may not be desirable for Single Page Applications since
-         * XMLHttpRequest automatically following the redirect may not work given that OIDC
-         * authorization endpoints typically do not support CORS.
-         * If this property is set to `false` then a status code of '499' will be returned to allow
-         * the client to handle the redirect manually
-         *
-         * This property is deprecated. Please use a 'javaScriptAutoRedirect' property instead.
-         */
-        @Deprecated
-        @ConfigItem(defaultValue = "true")
-        public boolean xhrAutoRedirect = true;
-
-        public boolean isXhrAutoRedirect() {
-            return xhrAutoRedirect;
-        }
-
-        public void setXhrAutoredirect(boolean autoRedirect) {
-            this.xhrAutoRedirect = autoRedirect;
-        }
-
-        /**
-         * If this property is set to 'true' then a normal 302 redirect response will be returned
          * if the request was initiated via JavaScript API such as XMLHttpRequest or Fetch and the current user needs to be
          * (re)authenticated which may not be desirable for Single Page Applications since
          * it automatically following the redirect may not work given that OIDC authorization endpoints typically do not support

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -181,10 +181,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     // user has set the auto direct application property to false indicating that
     // the client application will manually handle the redirect to account for SPA behavior
     private boolean shouldAutoRedirect(TenantConfigContext configContext, RoutingContext context) {
-        return isJavaScript(context)
-                ? configContext.oidcConfig.authentication.javaScriptAutoRedirect
-                        && configContext.oidcConfig.authentication.xhrAutoRedirect
-                : true;
+        return isJavaScript(context) ? configContext.oidcConfig.authentication.javaScriptAutoRedirect : true;
     }
 
     public Uni<ChallengeData> getChallenge(RoutingContext context) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -105,12 +105,6 @@ quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
 quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 
-quarkus.oidc.tenant-xhr.auth-server-url=${keycloak.url}/realms/quarkus
-quarkus.oidc.tenant-xhr.client-id=quarkus-app
-quarkus.oidc.tenant-xhr.credentials.secret=secret
-quarkus.oidc.tenant-xhr.authentication.xhr-auto-redirect=false
-quarkus.oidc.tenant-xhr.application-type=web-app
-
 quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-javascript.client-id=quarkus-app
 quarkus.oidc.tenant-javascript.credentials.secret=secret
@@ -140,9 +134,6 @@ quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.http.auth.permission.autorefresh.paths=/tenant-autorefresh
 quarkus.http.auth.permission.autorefresh.policy=authenticated
-
-quarkus.http.auth.permission.xhr.paths=/tenant-xhr
-quarkus.http.auth.permission.xhr.policy=authenticated
 
 quarkus.http.auth.permission.javascript.paths=/tenant-javascript
 quarkus.http.auth.permission.javascript.policy=authenticated

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -669,22 +669,6 @@ public class CodeFlowTest {
     }
 
     @Test
-    public void testXhrRequest() throws IOException, InterruptedException {
-        try (final WebClient webClient = createWebClient()) {
-            try {
-                webClient.addRequestHeader("X-Requested-With", "XMLHttpRequest");
-                webClient.getPage("http://localhost:8081/tenant-xhr");
-                fail("499 status error is expected");
-            } catch (FailingHttpStatusCodeException ex) {
-                assertEquals(499, ex.getStatusCode());
-                assertEquals("OIDC", ex.getResponse().getResponseHeaderValue("WWW-Authenticate"));
-            }
-
-            webClient.getCookieManager().clearCookies();
-        }
-    }
-
-    @Test
     public void testRedirectUriWithForwardedPrefix() throws IOException, InterruptedException {
         //doTestRedirectUriWithForwardedPrefix("/service");
         doTestRedirectUriWithForwardedPrefix("/service/");


### PR DESCRIPTION
This PR updates the multi-tenancy doc (after a Zulip conversation), the web-app docs (more information about managing the tokens) plus removed the deprecated `xhr-auto-redirect` property (`javascript-auto-redirect` has been a newer property since some users use `Fetch` instead of `XHR`) - I removed it from the docs before the earlier release (`1.9.0.Final` ?), and now we can clean up the code a bit.