### PR TITLE
Fix widespread errors in "relativePath" use of our pom.xml parent definition

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-core-deployment</artifactId>

--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-extension-processor</artifactId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-core</artifactId>

--- a/core/test-extension/pom.xml
+++ b/core/test-extension/pom.xml
@@ -6,7 +6,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-devtools-all</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/devtools/platform-properties/pom.xml
+++ b/devtools/platform-properties/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-devtools-all</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-agroal-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-agroal-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/agroal/spi/pom.xml
+++ b/extensions/agroal/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-agroal-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/amazon-lambda-http/maven-archetype/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-amazon-lambda-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/amazon-lambda/maven-archetype/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-amazon-lambda-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-arc-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/arc/runtime/pom.xml
+++ b/extensions/arc/runtime/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-arc-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/azure-functions-http/deployment/pom.xml
+++ b/extensions/azure-functions-http/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-azure-functions-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/azure-functions-http/maven-archetype/pom.xml
+++ b/extensions/azure-functions-http/maven-archetype/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-azure-functions-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/azure-functions-http/runtime/pom.xml
+++ b/extensions/azure-functions-http/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-azure-functions-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-cache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-cache-deployment</artifactId>

--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-cache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-cache</artifactId>

--- a/extensions/config-yaml/deployment/pom.xml
+++ b/extensions/config-yaml/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-config-yaml-deployment</artifactId>

--- a/extensions/credentials/deployment/pom.xml
+++ b/extensions/credentials/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-credentials-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/credentials/runtime/pom.xml
+++ b/extensions/credentials/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-credentials-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/datasource/common/pom.xml
+++ b/extensions/datasource/common/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-datasource-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/datasource/deployment/pom.xml
+++ b/extensions/datasource/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-datasource-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/datasource/runtime/pom.xml
+++ b/extensions/datasource/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-datasource-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elasticsearch-rest-client-common/deployment/pom.xml
+++ b/extensions/elasticsearch-rest-client-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elasticsearch-rest-client-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elasticsearch-rest-client-common/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-client-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elasticsearch-rest-client-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-common/deployment/pom.xml
+++ b/extensions/elytron-security-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-common/runtime/pom.xml
+++ b/extensions/elytron-security-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-oauth2/deployment/pom.xml
+++ b/extensions/elytron-security-oauth2/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-oauth2-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-oauth2/runtime/pom.xml
+++ b/extensions/elytron-security-oauth2/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-oauth2-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-properties-file/deployment/pom.xml
+++ b/extensions/elytron-security-properties-file/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-properties-file-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-properties-file-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security/deployment/pom.xml
+++ b/extensions/elytron-security/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-elytron-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-amazon-lambda-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-amazon-lambda/maven-archetype/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/maven-archetype/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-amazon-lambda-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-amazon-lambda/runtime/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-amazon-lambda-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-google-cloud-functions/deployment/pom.xml
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-google-cloud-functions-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/pom.xml
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-google-cloud-functions-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-http/deployment/pom.xml
+++ b/extensions/funqy/funqy-http/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-http/runtime/pom.xml
+++ b/extensions/funqy/funqy-http/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-knative-events/deployment/pom.xml
+++ b/extensions/funqy/funqy-knative-events/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-knative-events-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-knative-events/runtime/pom.xml
+++ b/extensions/funqy/funqy-knative-events/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-knative-events-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-server-common/deployment/pom.xml
+++ b/extensions/funqy/funqy-server-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-server-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/funqy/funqy-server-common/runtime/pom.xml
+++ b/extensions/funqy/funqy-server-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-funqy-server-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/google-cloud-functions-http/deployment/pom.xml
+++ b/extensions/google-cloud-functions-http/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-google-cloud-functions-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/google-cloud-functions-http/runtime/pom.xml
+++ b/extensions/google-cloud-functions-http/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-google-cloud-functions-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/google-cloud-functions/deployment/pom.xml
+++ b/extensions/google-cloud-functions/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-google-cloud-functions-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/grpc/codegen/pom.xml
+++ b/extensions/grpc/codegen/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-grpc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-grpc-codegen</artifactId>

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-grpc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-grpc-deployment</artifactId>

--- a/extensions/grpc/protoc/pom.xml
+++ b/extensions/grpc/protoc/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-grpc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-grpc-protoc-plugin</artifactId>

--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-grpc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-grpc-stubs</artifactId>

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/hibernate-validator/deployment/pom.xml
+++ b/extensions/hibernate-validator/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-validator-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-validator-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jackson/deployment/pom.xml
+++ b/extensions/jackson/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaeger/deployment/pom.xml
+++ b/extensions/jaeger/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaeger-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaeger-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaxb/deployment/pom.xml
+++ b/extensions/jaxb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaxp/deployment/pom.xml
+++ b/extensions/jaxp/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxp-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jaxp/runtime/pom.xml
+++ b/extensions/jaxp/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxp-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jgit/deployment/pom.xml
+++ b/extensions/jgit/deployment/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-jgit-deployment</artifactId>

--- a/extensions/jgit/runtime/pom.xml
+++ b/extensions/jgit/runtime/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-jgit</artifactId>

--- a/extensions/jsonb/deployment/pom.xml
+++ b/extensions/jsonb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jsonb/runtime/pom.xml
+++ b/extensions/jsonb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jsonp/deployment/pom.xml
+++ b/extensions/jsonp/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jsonp-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/jsonp/runtime/pom.xml
+++ b/extensions/jsonp/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jsonp-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/kafka-streams/deployment/pom.xml
+++ b/extensions/kafka-streams/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-kafka-streams-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/kafka-streams/runtime/pom.xml
+++ b/extensions/kafka-streams/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-kafka-streams-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/keycloak-admin-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-client/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-keycloak-admin-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/keycloak-admin-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-client/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-keycloak-admin-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/keycloak-authorization/deployment/pom.xml
+++ b/extensions/keycloak-authorization/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-keycloak-authorization-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/keycloak-authorization/runtime/pom.xml
+++ b/extensions/keycloak-authorization/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-keycloak-authorization-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/kotlin/deployment/pom.xml
+++ b/extensions/kotlin/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-kotlin-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/logging-json/deployment/pom.xml
+++ b/extensions/logging-json/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-logging-json-deployment</artifactId>

--- a/extensions/logging-json/runtime/pom.xml
+++ b/extensions/logging-json/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-logging-json</artifactId>

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-mailer-deployment</artifactId>

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-mailer</artifactId>

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-micrometer-deployment</artifactId>

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-micrometer</artifactId>

--- a/extensions/narayana-jta/deployment/pom.xml
+++ b/extensions/narayana-jta/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-narayana-jta-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-narayana-jta-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/narayana-stm/deployment/pom.xml
+++ b/extensions/narayana-stm/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-narayana-stm-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/narayana-stm/runtime/pom.xml
+++ b/extensions/narayana-stm/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-narayana-stm-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache-common/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-orm-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache-common/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-hibernate-orm-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-orm-panache-kotlin-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-hibernate-orm-panache-kotlin-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-orm-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-hibernate-orm-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>

--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>

--- a/extensions/panache/hibernate-reactive-panache-common/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-reactive-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-hibernate-reactive-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-hibernate-reactive-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-hibernate-reactive-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache-common/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache-common/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-kotlin-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-kotlin-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/mongodb-panache/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-mongodb-panache-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/panache-common/deployment/pom.xml
+++ b/extensions/panache/panache-common/deployment/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/panache-common/runtime/pom.xml
+++ b/extensions/panache/panache-common/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-panache-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/panache-hibernate-common/deployment/pom.xml
+++ b/extensions/panache/panache-hibernate-common/deployment/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-panache-hibernate-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/panache/panache-hibernate-common/runtime/pom.xml
+++ b/extensions/panache/panache-hibernate-common/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-panache-hibernate-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-jaxrs-client/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-jaxrs-client/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxrs-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-jaxrs-client/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-jaxrs-client/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-jaxrs-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-rest-common/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-rest-common/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-rest-jackson/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-jackson/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-jackson-deployment</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest-jackson/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-jackson/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-jackson</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest-jsonb/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-jsonb/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-jsonb-deployment</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest-jsonb/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-jsonb/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-jsonb</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest-qute/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-qute/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-qute-deployment</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest-qute/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest-qute/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-rest-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-rest-qute</artifactId>

--- a/extensions/quarkus-rest/quarkus-rest/deployment/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quarkus-rest/quarkus-rest/runtime/pom.xml
+++ b/extensions/quarkus-rest/quarkus-rest/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/quartz/deployment/pom.xml
+++ b/extensions/quartz/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-quartz-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-quartz-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/qute/deployment/pom.xml
+++ b/extensions/qute/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-qute-deployment</artifactId>

--- a/extensions/qute/runtime/pom.xml
+++ b/extensions/qute/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-qute</artifactId>

--- a/extensions/reactive-datasource/deployment/pom.xml
+++ b/extensions/reactive-datasource/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-reactive-datasource-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/reactive-datasource/runtime/pom.xml
+++ b/extensions/reactive-datasource/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-reactive-datasource-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/reactive-db2-client/deployment/pom.xml
+++ b/extensions/reactive-db2-client/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-db2-client-deployment</artifactId>

--- a/extensions/reactive-db2-client/runtime/pom.xml
+++ b/extensions/reactive-db2-client/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-db2-client</artifactId>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-mysql-client-deployment</artifactId>

--- a/extensions/reactive-mysql-client/runtime/pom.xml
+++ b/extensions/reactive-mysql-client/runtime/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-mysql-client</artifactId>

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-pg-client-deployment</artifactId>

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-reactive-pg-client</artifactId>

--- a/extensions/redis-client/deployment/pom.xml
+++ b/extensions/redis-client/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-redis-client-deployment</artifactId>

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-redis-client</artifactId>

--- a/extensions/rest-client-jackson/deployment/pom.xml
+++ b/extensions/rest-client-jackson/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-jackson/runtime/pom.xml
+++ b/extensions/rest-client-jackson/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-jaxb/deployment/pom.xml
+++ b/extensions/rest-client-jaxb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-jaxb/runtime/pom.xml
+++ b/extensions/rest-client-jaxb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-jsonb/deployment/pom.xml
+++ b/extensions/rest-client-jsonb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-jsonb/runtime/pom.xml
+++ b/extensions/rest-client-jsonb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-mutiny/deployment/pom.xml
+++ b/extensions/rest-client-mutiny/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-mutiny-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client-mutiny/runtime/pom.xml
+++ b/extensions/rest-client-mutiny/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-mutiny-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client/deployment/pom.xml
+++ b/extensions/rest-client/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-common/spi/pom.xml
+++ b/extensions/resteasy-common/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jackson/deployment/pom.xml
+++ b/extensions/resteasy-jackson/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jackson/runtime/pom.xml
+++ b/extensions/resteasy-jackson/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jaxb/deployment/pom.xml
+++ b/extensions/resteasy-jaxb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-jaxb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jaxb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jsonb/deployment/pom.xml
+++ b/extensions/resteasy-jsonb/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-jsonb/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-jsonb-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-multipart/deployment/pom.xml
+++ b/extensions/resteasy-multipart/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-multipart-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-multipart/runtime/pom.xml
+++ b/extensions/resteasy-multipart/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-multipart-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-mutiny-common/deployment/pom.xml
+++ b/extensions/resteasy-mutiny-common/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-mutiny-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>

--- a/extensions/resteasy-mutiny-common/runtime/pom.xml
+++ b/extensions/resteasy-mutiny-common/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-mutiny-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-common</artifactId>

--- a/extensions/resteasy-mutiny/deployment/pom.xml
+++ b/extensions/resteasy-mutiny/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-mutiny-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>

--- a/extensions/resteasy-mutiny/runtime/pom.xml
+++ b/extensions/resteasy-mutiny/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-mutiny-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny</artifactId>

--- a/extensions/resteasy-qute/deployment/pom.xml
+++ b/extensions/resteasy-qute/deployment/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-qute-deployment</artifactId>

--- a/extensions/resteasy-qute/runtime/pom.xml
+++ b/extensions/resteasy-qute/runtime/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-resteasy-qute-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-resteasy-qute</artifactId>

--- a/extensions/resteasy-server-common/deployment/pom.xml
+++ b/extensions/resteasy-server-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-server-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy-server-common/runtime/pom.xml
+++ b/extensions/resteasy-server-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-server-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/resteasy/runtime/pom.xml
+++ b/extensions/resteasy/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/scala/deployment/pom.xml
+++ b/extensions/scala/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-scala-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/scheduler/deployment/pom.xml
+++ b/extensions/scheduler/deployment/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-scheduler-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/scheduler/runtime/pom.xml
+++ b/extensions/scheduler/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-scheduler-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/security/deployment/pom.xml
+++ b/extensions/security/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/security/runtime-spi/pom.xml
+++ b/extensions/security/runtime-spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/security/spi/pom.xml
+++ b/extensions/security/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/security/test-utils/pom.xml
+++ b/extensions/security/test-utils/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-security-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-smallrye-context-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-context-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-fault-tolerance-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-fault-tolerance-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-health/deployment/pom.xml
+++ b/extensions/smallrye-health/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-health-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-health/runtime/pom.xml
+++ b/extensions/smallrye-health/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-health-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-health/spi/pom.xml
+++ b/extensions/smallrye-health/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-health-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-jwt-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-jwt-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-metrics/deployment/pom.xml
+++ b/extensions/smallrye-metrics/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-metrics-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-metrics/runtime/pom.xml
+++ b/extensions/smallrye-metrics/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-metrics-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-metrics/spi/pom.xml
+++ b/extensions/smallrye-metrics/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-metrics-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-openapi-common/deployment/pom.xml
+++ b/extensions/smallrye-openapi-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-openapi-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-smallrye-openapi-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-openapi/runtime/pom.xml
+++ b/extensions/smallrye-openapi/runtime/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-smallrye-openapi-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-openapi/spi/pom.xml
+++ b/extensions/smallrye-openapi/spi/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-openapi-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-opentracing/deployment/pom.xml
+++ b/extensions/smallrye-opentracing/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-opentracing-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-opentracing-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-smallrye-reactive-messaging-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-smallrye-reactive-messaging-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>quarkus-smallrye-reactive-messaging</artifactId>

--- a/extensions/spring-data-jpa/deployment/pom.xml
+++ b/extensions/spring-data-jpa/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-data-jpa-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-data-jpa/runtime/pom.xml
+++ b/extensions/spring-data-jpa/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-data-jpa-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-di/deployment/pom.xml
+++ b/extensions/spring-di/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-di-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-di/runtime/pom.xml
+++ b/extensions/spring-di/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-di-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-scheduled/deployment/pom.xml
+++ b/extensions/spring-scheduled/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-scheduled-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-scheduled/runtime/pom.xml
+++ b/extensions/spring-scheduled/runtime/pom.xml
@@ -6,7 +6,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-security/deployment/pom.xml
+++ b/extensions/spring-security/deployment/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-spring-security-deployment</artifactId>

--- a/extensions/spring-security/runtime/pom.xml
+++ b/extensions/spring-security/runtime/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-spring-security</artifactId>

--- a/extensions/spring-web/deployment/pom.xml
+++ b/extensions/spring-web/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-web-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/spring-web/runtime/pom.xml
+++ b/extensions/spring-web/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-spring-web-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/swagger-ui/deployment/pom.xml
+++ b/extensions/swagger-ui/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-swagger-ui-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/swagger-ui/runtime/pom.xml
+++ b/extensions/swagger-ui/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-swagger-ui-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/tika/deployment/pom.xml
+++ b/extensions/tika/deployment/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-tika-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-tika-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/undertow-websockets/deployment/pom.xml
+++ b/extensions/undertow-websockets/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-undertow-websockets-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-undertow-websockets-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vault/deployment/pom.xml
+++ b/extensions/vault/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vault-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vault/model/pom.xml
+++ b/extensions/vault/model/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vault-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vault/runtime/pom.xml
+++ b/extensions/vault/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vault-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-core/deployment/pom.xml
+++ b/extensions/vertx-core/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-core-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-core/runtime/pom.xml
+++ b/extensions/vertx-core/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-core-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-http-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-web/deployment/pom.xml
+++ b/extensions/vertx-web/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-web-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-web-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-vertx-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-webjars-locator-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/webjars-locator/runtime/pom.xml
+++ b/extensions/webjars-locator/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-webjars-locator-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>arc-processor</artifactId>

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>arc</artifactId>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>arc-tests</artifactId>

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -6,7 +6,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
     <name>Quarkus - Bootstrap - Maven plugin</name>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/runner/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>multimodule-main</artifactId>
 

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>1.0</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module1/submodule/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module1/submodule/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root-module1</artifactId>
         <version>1.0</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-submodule</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module2/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-alternate-pom/root/module2/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>1.0</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module2</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-changelist/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-changelist/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>${changelist}</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-multiple/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-multiple/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>${revision}${sha1}${changelist}</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-revision/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-revision/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>${revision}</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-sha1/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-sha1/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>${sha1}</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/break/nested-project/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>nested-project-parent</artifactId>
         <version>1.0</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>nested-project-module1</artifactId>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-with-dir-breaks/root/module1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>root</artifactId>
         <version>1.0</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>root-module1</artifactId>

--- a/independent-projects/qute/core/pom.xml
+++ b/independent-projects/qute/core/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>qute-core</artifactId>

--- a/independent-projects/qute/generator/pom.xml
+++ b/independent-projects/qute/generator/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>qute-generator</artifactId>

--- a/integration-tests/amazon-lambda-http-resteasy/pom.xml
+++ b/integration-tests/amazon-lambda-http-resteasy/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/amazon-lambda-http/pom.xml
+++ b/integration-tests/amazon-lambda-http/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/amazon-lambda-stream-handler/pom.xml
+++ b/integration-tests/amazon-lambda-stream-handler/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/amazon-lambda/pom.xml
+++ b/integration-tests/amazon-lambda/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/amazon-services/pom.xml
+++ b/integration-tests/amazon-services/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/bootstrap-config/application/pom.xml
+++ b/integration-tests/bootstrap-config/application/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-bootstrap-config</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-bootstrap-config-application</artifactId>

--- a/integration-tests/bootstrap-config/extension/deployment/pom.xml
+++ b/integration-tests/bootstrap-config/extension/deployment/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-bootstrap-config-extension-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-bootstrap-config-extension-deployment</artifactId>

--- a/integration-tests/bootstrap-config/extension/runtime/pom.xml
+++ b/integration-tests/bootstrap-config/extension/runtime/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-bootstrap-config-extension-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-bootstrap-config-extension</artifactId>

--- a/integration-tests/bootstrap-config/pom.xml
+++ b/integration-tests/bootstrap-config/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-bootstrap-config</artifactId>

--- a/integration-tests/bouncycastle-fips/pom.xml
+++ b/integration-tests/bouncycastle-fips/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/bouncycastle-jsse/pom.xml
+++ b/integration-tests/bouncycastle-jsse/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/bouncycastle/pom.xml
+++ b/integration-tests/bouncycastle/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/cache/pom.xml
+++ b/integration-tests/cache/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-cache</artifactId>

--- a/integration-tests/class-transformer/deployment/pom.xml
+++ b/integration-tests/class-transformer/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-test-class-transformer-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/class-transformer/pom.xml
+++ b/integration-tests/class-transformer/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/class-transformer/runtime/pom.xml
+++ b/integration-tests/class-transformer/runtime/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-integration-test-class-transformer-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/common-jpa-entities/pom.xml
+++ b/integration-tests/common-jpa-entities/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/consul-config/pom.xml
+++ b/integration-tests/consul-config/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-consul-config</artifactId>

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -6,7 +6,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/devtools/pom.xml
+++ b/integration-tests/devtools/pom.xml
@@ -6,7 +6,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>quarkus-integration-tests-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>quarkus-integration-test-elasticsearch-rest-client</artifactId>

--- a/integration-tests/elasticsearch-rest-high-level-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-high-level-client/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/elytron-resteasy/pom.xml
+++ b/integration-tests/elytron-resteasy/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-elytron-resteasy</artifactId>

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/elytron-security/pom.xml
+++ b/integration-tests/elytron-security/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/elytron-undertow/pom.xml
+++ b/integration-tests/elytron-undertow/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-elytron-undertow</artifactId>

--- a/integration-tests/flyway/pom.xml
+++ b/integration-tests/flyway/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/funqy-amazon-lambda/pom.xml
+++ b/integration-tests/funqy-amazon-lambda/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/funqy-google-cloud-functions/pom.xml
+++ b/integration-tests/funqy-google-cloud-functions/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/google-cloud-functions/pom.xml
+++ b/integration-tests/google-cloud-functions/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/grpc-health/pom.xml
+++ b/integration-tests/grpc-health/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-health</artifactId>

--- a/integration-tests/grpc-interceptors/pom.xml
+++ b/integration-tests/grpc-interceptors/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-interceptors</artifactId>

--- a/integration-tests/grpc-mutual-auth/pom.xml
+++ b/integration-tests/grpc-mutual-auth/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-mutual-auth</artifactId>

--- a/integration-tests/grpc-plain-text-mutiny/pom.xml
+++ b/integration-tests/grpc-plain-text-mutiny/pom.xml
@@ -8,7 +8,6 @@
     <artifactId>quarkus-integration-tests-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>quarkus-integration-test-grpc-plain-text-mutiny</artifactId>

--- a/integration-tests/grpc-plain-text/pom.xml
+++ b/integration-tests/grpc-plain-text/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-plain-text</artifactId>

--- a/integration-tests/grpc-proto-v2/pom.xml
+++ b/integration-tests/grpc-proto-v2/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-proto-v2</artifactId>

--- a/integration-tests/grpc-streaming/pom.xml
+++ b/integration-tests/grpc-streaming/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-streaming</artifactId>

--- a/integration-tests/grpc-tls/pom.xml
+++ b/integration-tests/grpc-tls/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-grpc-tls</artifactId>

--- a/integration-tests/hibernate-orm-envers/pom.xml
+++ b/integration-tests/hibernate-orm-envers/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-orm-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-orm-panache-kotlin/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-tenancy/pom.xml
+++ b/integration-tests/hibernate-tenancy/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/ide-launcher/pom.xml
+++ b/integration-tests/ide-launcher/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-ide-launcher</artifactId>

--- a/integration-tests/infinispan-cache-jpa/pom.xml
+++ b/integration-tests/infinispan-cache-jpa/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jackson/pom.xml
+++ b/integration-tests/jackson/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-jackson</artifactId>

--- a/integration-tests/jaxp/pom.xml
+++ b/integration-tests/jaxp/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jgit/pom.xml
+++ b/integration-tests/jgit/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-integration-test-jgit</artifactId>
     <name>Quarkus - Integration Tests - JGit</name>

--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-derby/pom.xml
+++ b/integration-tests/jpa-derby/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-h2/pom.xml
+++ b/integration-tests/jpa-h2/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jpa/pom.xml
+++ b/integration-tests/jpa/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jsch/pom.xml
+++ b/integration-tests/jsch/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-integration-test-jsch</artifactId>
     <name>Quarkus - Integration Tests - JSch</name>

--- a/integration-tests/jsonb/pom.xml
+++ b/integration-tests/jsonb/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-jsonb</artifactId>

--- a/integration-tests/kafka-avro/pom.xml
+++ b/integration-tests/kafka-avro/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/kafka-streams/pom.xml
+++ b/integration-tests/kafka-streams/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-kotlin</artifactId>

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-kubernetes-client</artifactId>

--- a/integration-tests/kubernetes/maven-invoker-way/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-kubernetes-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-kubernetes-invoker</artifactId>

--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-integration-tests-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>quarkus-integration-test-kubernetes-parent</artifactId>

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-kubernetes-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-kubernetes-standard</artifactId>

--- a/integration-tests/liquibase/pom.xml
+++ b/integration-tests/liquibase/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/logging-json/pom.xml
+++ b/integration-tests/logging-json/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/mailer/pom.xml
+++ b/integration-tests/mailer/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/maven/src/test/resources/projects/arc-exclude-dependencies/library/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/arc-exclude-dependencies/library/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-lib</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/arc-exclude-dependencies/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/arc-exclude-dependencies/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>acme</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/pom.xml
@@ -6,7 +6,6 @@
         <groupId>cp.acme</groupId>
         <artifactId>multimodule-cp-resources</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>multimodule-cp-resources-html</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-classpath/rest/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-classpath/rest/pom.xml
@@ -6,7 +6,6 @@
         <groupId>cp.acme</groupId>
         <artifactId>multimodule-cp-resources</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>multimodule-cp-resources-rest</artifactId>
     <version>1.0-SNAPSHOT</version>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-classpath/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-classpath/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>cp.acme</groupId>
         <artifactId>multimodule-cp-resources</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>multimodule-cp-resources-main</artifactId>
     <version>1.0-SNAPSHOT</version>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level1/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level1/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-level1</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level2/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level2/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-level2</artifactId>
     <packaging>pom</packaging>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level2/submodule/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/level2/submodule/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-level2</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-level2-submodule</artifactId>
 </project>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-runner</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>${revision}</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-quickstart-multimodule-html</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/rest/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/rest/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>${revision}</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-rest</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>${revision}</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-quickstart-multimodule-main</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/rest/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/rest/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-rest</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-main</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/html/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/html/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/rest/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/rest/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-rest</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-main</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/common-transitive/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/common-transitive/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/common/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/common/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>acme-common</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/library/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/library/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>acme-library</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-main</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/property-overrides/bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/property-overrides/bom/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>acme-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>acme-bom</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/property-overrides/local-dep/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/property-overrides/local-dep/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>acme-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>acme-local-dep</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/property-overrides/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/property-overrides/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>acme-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <artifactId>acme-main</artifactId>
 

--- a/integration-tests/maven/src/test/resources/projects/quarkus-index-dependencies/library/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/quarkus-index-dependencies/library/pom.xml
@@ -6,7 +6,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-lib</artifactId>

--- a/integration-tests/maven/src/test/resources/projects/quarkus-index-dependencies/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/quarkus-index-dependencies/runner/pom.xml
@@ -5,7 +5,6 @@
         <groupId>org.acme</groupId>
         <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <groupId>org.acme</groupId>
     <artifactId>quarkus-quickstart-multimodule-main</artifactId>

--- a/integration-tests/micrometer-jmx/pom.xml
+++ b/integration-tests/micrometer-jmx/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-micrometer-jmx</artifactId>

--- a/integration-tests/micrometer-mp-metrics/pom.xml
+++ b/integration-tests/micrometer-mp-metrics/pom.xml
@@ -7,7 +7,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-micrometer-mp-metrics</artifactId>

--- a/integration-tests/micrometer-native/pom.xml
+++ b/integration-tests/micrometer-native/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-micrometer-native</artifactId>

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-micrometer-prometheus</artifactId>

--- a/integration-tests/narayana-jta/pom.xml
+++ b/integration-tests/narayana-jta/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/narayana-stm/pom.xml
+++ b/integration-tests/narayana-stm/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/oidc-wiremock/pom.xml
+++ b/integration-tests/oidc-wiremock/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/openshift-client/pom.xml
+++ b/integration-tests/openshift-client/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-openshift-client</artifactId>

--- a/integration-tests/picocli-native/pom.xml
+++ b/integration-tests/picocli-native/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/picocli/pom.xml
+++ b/integration-tests/picocli/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/quartz/pom.xml
+++ b/integration-tests/quartz/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/qute/pom.xml
+++ b/integration-tests/qute/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/reactive-db2-client/pom.xml
+++ b/integration-tests/reactive-db2-client/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-reactive-db2-client</artifactId>

--- a/integration-tests/reactive-messaging-amqp/pom.xml
+++ b/integration-tests/reactive-messaging-amqp/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-reactive-mysql-client</artifactId>

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-reactive-pg-client</artifactId>

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>quarkus-integration-test-rest-client</artifactId>

--- a/integration-tests/resteasy-jackson/pom.xml
+++ b/integration-tests/resteasy-jackson/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-resteasy-jackson</artifactId>

--- a/integration-tests/resteasy-mutiny/pom.xml
+++ b/integration-tests/resteasy-mutiny/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-resteasy-mutiny</artifactId>

--- a/integration-tests/scala/pom.xml
+++ b/integration-tests/scala/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-scala</artifactId>

--- a/integration-tests/shared-library/pom.xml
+++ b/integration-tests/shared-library/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/simple with space/pom.xml
+++ b/integration-tests/simple with space/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/smallrye-config/pom.xml
+++ b/integration-tests/smallrye-config/pom.xml
@@ -8,7 +8,6 @@
     <artifactId>quarkus-integration-tests-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>quarkus-integration-test-smallrye-config</artifactId>

--- a/integration-tests/smallrye-context-propagation/pom.xml
+++ b/integration-tests/smallrye-context-propagation/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-smallrye-context-propagation</artifactId>

--- a/integration-tests/smallrye-graphql/pom.xml
+++ b/integration-tests/smallrye-graphql/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-smallrye-graphql</artifactId>

--- a/integration-tests/smallrye-metrics/pom.xml
+++ b/integration-tests/smallrye-metrics/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/spring-data-jpa/pom.xml
+++ b/integration-tests/spring-data-jpa/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-spring-data-jpa</artifactId>

--- a/integration-tests/spring-di/pom.xml
+++ b/integration-tests/spring-di/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-spring-di</artifactId>

--- a/integration-tests/spring-web/pom.xml
+++ b/integration-tests/spring-web/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-spring-web</artifactId>

--- a/integration-tests/test-extension/pom.xml
+++ b/integration-tests/test-extension/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>quarkus-integration-tests-parent</artifactId>
     <groupId>io.quarkus</groupId>
     <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/tika/pom.xml
+++ b/integration-tests/tika/pom.xml
@@ -5,7 +5,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/vault-agroal/pom.xml
+++ b/integration-tests/vault-agroal/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-vault-agroal</artifactId>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-vault</artifactId>

--- a/integration-tests/vertx-http/pom.xml
+++ b/integration-tests/vertx-http/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-vertx-http</artifactId>

--- a/integration-tests/vertx-web/pom.xml
+++ b/integration-tests/vertx-web/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-vertx-web</artifactId>

--- a/integration-tests/vertx/pom.xml
+++ b/integration-tests/vertx/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-vertx</artifactId>

--- a/integration-tests/virtual-http-resteasy/pom.xml
+++ b/integration-tests/virtual-http-resteasy/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-virtual-http-resteasy</artifactId>

--- a/integration-tests/virtual-http/pom.xml
+++ b/integration-tests/virtual-http/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-virtual-http</artifactId>

--- a/integration-tests/webjars-locator/pom.xml
+++ b/integration-tests/webjars-locator/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-integration-test-webjars-locator</artifactId>

--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-arquillian</artifactId>

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-common</artifactId>

--- a/test-framework/derby/pom.xml
+++ b/test-framework/derby/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-derby</artifactId>

--- a/test-framework/devmode-test-utils/pom.xml
+++ b/test-framework/devmode-test-utils/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-test-framework</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-framework/h2/pom.xml
+++ b/test-framework/h2/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-h2</artifactId>

--- a/test-framework/junit5-internal/pom.xml
+++ b/test-framework/junit5-internal/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-junit5-internal</artifactId>

--- a/test-framework/junit5-mockito/pom.xml
+++ b/test-framework/junit5-mockito/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-junit5-mockito</artifactId>

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-junit5</artifactId>

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-kubernetes-client</artifactId>

--- a/test-framework/ldap/pom.xml
+++ b/test-framework/ldap/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-ldap</artifactId>

--- a/test-framework/maven/pom.xml
+++ b/test-framework/maven/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-test-framework</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-framework/openshift-client/pom.xml
+++ b/test-framework/openshift-client/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-openshift-client</artifactId>

--- a/test-framework/vault/pom.xml
+++ b/test-framework/vault/pom.xml
@@ -8,7 +8,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-framework</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>quarkus-test-vault</artifactId>


### PR DESCRIPTION
(I closed the previous PR by mistake, here it goes again)

The `relativePath` element of the parent in pom.xml files is required to point to a `pom.xml` file - not to the directory containing the pom.xml file.

This is causing numerous errors in IDEA, and swallowed exceptions during the build.

Ironically, we most often use this to point to the parent directory - while the default is better in this case, as it points to the pom.xml file within the parent directory.

Such issues can be identified by running:

    ag relativePath | grep relativePath | grep -v .java | grep -v "pom.xml</relativePath"

