### PR TITLE
Remove some unnecessary null statements

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -107,7 +107,7 @@ As you can see from the source code below it is just a regular JAX-RS resource:
 
 [source,java]
 ----
-package org.acme.security.keycloak.authorization;;
+package org.acme.security.keycloak.authorization;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -149,7 +149,7 @@ The source code for the `/api/admin` endpoint is also very simple:
 
 [source,java]
 ----
-package org.acme.security.keycloak.authorization;;
+package org.acme.security.keycloak.authorization;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
@@ -18,7 +18,7 @@ import io.smallrye.mutiny.Uni;
 public class ClientAndServerCallsTest {
 
     protected static final Duration TIMEOUT = Duration.ofSeconds(5);
-    private FakeServiceClient client = new FakeServiceClient();;
+    private FakeServiceClient client = new FakeServiceClient();
 
     @Test
     public void oneToOneSuccess() {

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
@@ -23,7 +23,7 @@ public class LazyAuthRolesAllowedJaxRsTestCase {
                             TestIdentityController.class,
                             UnsecuredSubResource.class)
                     .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
-                            "application.properties"));;
+                            "application.properties"));
 
     @BeforeAll
     public static void setupUsers() {

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase.java
@@ -24,7 +24,7 @@ public class ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase {
                             SecurityOverrideFilter.class,
                             UnsecuredSubResource.class)
                     .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
-                            "application.properties"));;
+                            "application.properties"));
 
     @BeforeAll
     public static void setupUsers() {

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/LazyAuthRolesAllowedServletTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/LazyAuthRolesAllowedServletTestCase.java
@@ -22,7 +22,7 @@ public class LazyAuthRolesAllowedServletTestCase {
                             TestIdentityProvider.class,
                             TestIdentityController.class)
                     .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
-                            "application.properties"));;
+                            "application.properties"));
 
     @BeforeAll
     public static void setupUsers() {


### PR DESCRIPTION
Removes some null statements in Java sources as well as fix some documentation examples with double semicolons.