### PR TITLE
Minor changes related to resteasy-reactive

### DIFF
--- a/extensions/quarkus-rest/quarkus-rest/deployment/src/test/java/io/quarkus/rest/server/test/simple/IllegalClassExceptionMapper.java
+++ b/extensions/quarkus-rest/quarkus-rest/deployment/src/test/java/io/quarkus/rest/server/test/simple/IllegalClassExceptionMapper.java
@@ -22,7 +22,7 @@ import org.objectweb.asm.util.TraceMethodVisitor;
 @Provider
 public class IllegalClassExceptionMapper implements ExceptionMapper<IncompatibleClassChangeError> {
 
-    public class MethodFindingClassVisitor extends ClassVisitor {
+    public static class MethodFindingClassVisitor extends ClassVisitor {
 
         private String method;
         private Textifier textifier;

--- a/extensions/quarkus-rest/quarkus-rest/deployment/src/test/java/io/quarkus/rest/server/test/simple/PortProviderUtil.java
+++ b/extensions/quarkus-rest/quarkus-rest/deployment/src/test/java/io/quarkus/rest/server/test/simple/PortProviderUtil.java
@@ -11,16 +11,6 @@ import io.quarkus.test.common.http.TestHTTPResourceManager;
 public class PortProviderUtil {
 
     /**
-     * Create a Resteasy client proxy with an empty base request path.
-     *
-     * @param clazz the client interface class
-     * @return the proxy object
-     */
-    public static <T> T createProxy(Class<T> clazz, String testName) {
-        return createProxy(clazz, "");
-    }
-
-    /**
      * Create a URI for the provided path, using the configured port
      *
      * @param path the request path

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -275,7 +275,6 @@ public class VertxCoreRecorder {
         if (vertx != null && vertx.v != null) {
             // Netty attaches a ThreadLocal to the main thread that can leak the QuarkusClassLoader which can be problematic in dev or test mode
             FastThreadLocal.destroy();
-            EventLoopGroup eventLoop = vertx.v.nettyEventLoopGroup();
             CountDownLatch latch = new CountDownLatch(1);
             AtomicReference<Throwable> problem = new AtomicReference<>();
             vertx.v.close(ar -> {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.mapping;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -169,7 +170,8 @@ public class RequestMapper<T> {
 
         @Override
         public String toString() {
-            return "RequestMatch{ value: " + value + ", template: " + template + ", pathParamValues: " + pathParamValues + " }";
+            return "RequestMatch{ value: " + value + ", template: " + template + ", pathParamValues: "
+                    + Arrays.toString(pathParamValues) + " }";
         }
     }
 


### PR DESCRIPTION
- Removal of infinite loop method, not used
- Removal of unused eventLoop local store
- Make inner class MethodFindingClassVisitor static to reduce reference…
- More descriptive toString method for RequestMapper 

@stuartwdouglas / @FroMage if you can take a look