### PR TITLE
Update gradle documentation on native args settings

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -322,9 +322,28 @@ quarkusBuild {
 }
 ----
 
+or if you are using the Gradle Kotlin DSL:
+
+[source,kotlin,subs=attributes+]
+----
+tasks.quarkusBuild {
+    nativeArgs {
+        "container-build" to true <1>
+        "buildImage" to "quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}" <2>
+        "quarkus.native.java-home" to "/opt/java-11/"
+    }
+}
+----
+
 <1> Set `quarkus.native.containerBuild` property to `true`
 <2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
 
+[WARNING]
+====
+When using the Gradle Groovy DSL, property keys must follow lower camel case notation.
+e.g. `container-build` is not valid, and should be replaced by `containerBuild`.
+This limitation does not apply to the Gradle Kotlin DSL.
+====
 
 === Build a container friendly executable
 


### PR DESCRIPTION
The documentation about setting native args in the `build.gradle` was not very clear. 
This branch adds an example of the configuration using the kotlin DSL and a warning about the groovy limitations.