### PR TITLE
Handle default package name when generating class names

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -532,7 +532,7 @@ public class MessageBundleProcessor {
         }
 
         String targetPackage = DotNames.packageName(bundleInterface.name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + SUFFIX;
+        String generatedName = (targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName + SUFFIX;
 
         // MyMessages_Bundle implements MyMessages, Resolver
         Builder builder = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -238,7 +238,8 @@ public class SchedulerProcessor {
             sigBuilder.append(i.name().toString());
         }
         String targetPackage = DotNames.packageName(bean.getImplClazz().name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + INVOKER_SUFFIX + "_" + method.name() + "_"
+        String generatedName = (targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName
+                + INVOKER_SUFFIX + "_" + method.name() + "_"
                 + HashUtil.sha1(sigBuilder.toString());
 
         ClassCreator invokerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -516,7 +516,8 @@ class VertxWebProcessor {
         for (Type i : method.parameters()) {
             sigBuilder.append(i.name().toString());
         }
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + HANDLER_SUFFIX + "_" + method.name() + "_"
+        String generatedName = (targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName
+                + HANDLER_SUFFIX + "_" + method.name() + "_"
                 + HashUtil.sha1(sigBuilder.toString() + hashSuffix);
 
         ClassCreator invokerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
@@ -115,7 +115,8 @@ class EventBusConsumer {
         for (Type i : method.parameters()) {
             sigBuilder.append(i.name().toString());
         }
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + INVOKER_SUFFIX + "_" + method.name() + "_"
+        String generatedName = (targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName
+                + INVOKER_SUFFIX + "_" + method.name() + "_"
                 + HashUtil.sha1(sigBuilder.toString());
 
         ClassCreator invokerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
@@ -42,7 +42,7 @@ abstract class AbstractGenerator {
         if (targetPackage == null || targetPackage.isEmpty()) {
             return baseName + suffix;
         } else {
-            return targetPackage.replace('.', '/') + "/" + baseName + suffix;
+            return targetPackage.replace('.', '/') + "/") + baseName + suffix;
         }
     }
 

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -884,7 +884,7 @@ public class ValueResolverGenerator {
         } else if (targetPackage.startsWith("java")) {
             return "io/quarkus/qute" + "/" + baseName + suffix;
         } else {
-            return targetPackage.replace('.', '/') + "/" + baseName + suffix;
+            return (targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName + suffix;
         }
     }
 


### PR DESCRIPTION
Fixes #13540

Replaced all occurrences of `targetPackage.replace('.', '/') + "/" + baseName`
with `(targetPackage.isEmpty() ? "" : targetPackage.replace('.', '/') + "/") + baseName`
to avoid generating file names that goes to the root (/) of the file system.