### PR TITLE
Prepare removal of transformed caching interceptor bindings

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
@@ -9,6 +9,7 @@ import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.cache.CacheInvalidateAll;
 import io.quarkus.cache.CacheKey;
 import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.runtime.CacheKeyParameterPositions;
 
 public class CacheDeploymentConstants {
 
@@ -23,10 +24,11 @@ public class CacheDeploymentConstants {
             CACHE_RESULT, CACHE_INVALIDATE, CACHE_INVALIDATE_ALL);
     public static final List<DotName> API_METHODS_ANNOTATIONS_LISTS = Arrays.asList(
             CACHE_INVALIDATE_LIST, CACHE_INVALIDATE_ALL_LIST);
+    public static final DotName CACHE_KEY_PARAMETER_POSITIONS = DotName
+            .createSimple(CacheKeyParameterPositions.class.getName());
 
     // Annotations parameters.
     public static final String CACHE_NAME_PARAM = "cacheName";
-    public static final String CACHE_KEY_PARAMETER_POSITIONS_PARAM = "cacheKeyParameterPositions";
     public static final String LOCK_TIMEOUT_PARAM = "lockTimeout";
 
     // Caffeine.

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInterceptor.java
@@ -19,7 +19,7 @@ public abstract class CacheInterceptor {
     protected CacheRepository cacheRepository;
 
     @SuppressWarnings("unchecked")
-    protected <T> List<T> getInterceptorBindings(InvocationContext context, Class<T> bindingClass) {
+    protected <T extends Annotation> List<T> getInterceptorBindings(InvocationContext context, Class<T> bindingClass) {
         List<T> bindings = new ArrayList<>();
         for (Annotation binding : InterceptorBindings.getInterceptorBindings(context)) {
             if (bindingClass.isInstance(binding)) {
@@ -29,12 +29,21 @@ public abstract class CacheInterceptor {
         return bindings;
     }
 
-    protected <T> T getInterceptorBinding(InvocationContext context, Class<T> bindingClass) {
+    protected <T extends Annotation> T getInterceptorBinding(InvocationContext context, Class<T> bindingClass) {
         return getInterceptorBindings(context, bindingClass).get(0);
     }
 
+    protected short[] getCacheKeyParameterPositions(InvocationContext context) {
+        List<CacheKeyParameterPositions> bindings = getInterceptorBindings(context, CacheKeyParameterPositions.class);
+        if (bindings.isEmpty()) {
+            return new short[0];
+        } else {
+            return bindings.get(0).value();
+        }
+    }
+
     protected Object getCacheKey(CaffeineCache cache, short[] cacheKeyParameterPositions, Object[] methodParameterValues) {
-        if (methodParameterValues.length == 0) {
+        if (methodParameterValues == null || methodParameterValues.length == 0) {
             // If the intercepted method doesn't have any parameter, then the default cache key will be used.
             return cache.getDefaultKey();
         } else if (cacheKeyParameterPositions.length == 1) {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInvalidateInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInvalidateInterceptor.java
@@ -19,11 +19,12 @@ public class CacheInvalidateInterceptor extends CacheInterceptor {
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         Object key = null;
+        short[] cacheKeyParameterPositions = getCacheKeyParameterPositions(context);
         for (CacheInvalidateInterceptorBinding binding : getInterceptorBindings(context,
                 CacheInvalidateInterceptorBinding.class)) {
             CaffeineCache cache = cacheRepository.getCache(binding.cacheName());
             if (key == null) {
-                key = getCacheKey(cache, binding.cacheKeyParameterPositions(), context.getParameters());
+                key = getCacheKey(cache, cacheKeyParameterPositions, context.getParameters());
             }
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debugf("Invalidating entry with key [%s] from cache [%s]", key, cache.getName());

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInvalidateInterceptorBinding.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInvalidateInterceptorBinding.java
@@ -20,9 +20,6 @@ public @interface CacheInvalidateInterceptorBinding {
     @Nonbinding
     String cacheName() default "";
 
-    @Nonbinding
-    short[] cacheKeyParameterPositions() default {};
-
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @interface List {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyParameterPositions.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyParameterPositions.java
@@ -1,0 +1,29 @@
+package io.quarkus.cache.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * This interceptor binding is added at build time on a method if:
+ * <ul>
+ * <li>it is annotated with {@link io.quarkus.cache.CacheResult CacheResult} or {@link io.quarkus.cache.CacheInvalidate
+ * CacheInvalidate}</li>
+ * <li>at least one of its arguments is annotated with {@link io.quarkus.cache.CacheKey CacheKey}</li>
+ * </ul>
+ * It helps improving performances by storing at build time the positions of {@link io.quarkus.cache.CacheKey
+ * CacheKey}-annotated arguments instead of relying on reflection at run time (which is bad for performances) to identify these
+ * positions.
+ */
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface CacheKeyParameterPositions {
+
+    @Nonbinding
+    short[] value() default {};
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -27,7 +27,8 @@ public class CacheResultInterceptor extends CacheInterceptor {
         CacheResultInterceptorBinding binding = getInterceptorBinding(context, CacheResultInterceptorBinding.class);
 
         CaffeineCache cache = cacheRepository.getCache(binding.cacheName());
-        Object key = getCacheKey(cache, binding.cacheKeyParameterPositions(), context.getParameters());
+        short[] cacheKeyParameterPositions = getCacheKeyParameterPositions(context);
+        Object key = getCacheKey(cache, cacheKeyParameterPositions, context.getParameters());
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debugf("Loading entry with key [%s] from cache [%s]", key, cache.getName());
         }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptorBinding.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptorBinding.java
@@ -17,8 +17,5 @@ public @interface CacheResultInterceptorBinding {
     String cacheName() default "";
 
     @Nonbinding
-    short[] cacheKeyParameterPositions() default {};
-
-    @Nonbinding
     long lockTimeout() default 0;
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
@@ -75,13 +75,13 @@ public class CaffeineCache {
                 cache.asMap().remove(key, newCacheValue);
                 newCacheValue.complete(new CaffeineComputationThrowable(t));
             }
-            return unwrapCacheValueOrThrowable(key, newCacheValue);
+            return unwrapCacheValueOrThrowable(newCacheValue);
         } else {
-            return unwrapCacheValueOrThrowable(key, existingCacheValue);
+            return unwrapCacheValueOrThrowable(existingCacheValue);
         }
     }
 
-    private CompletableFuture<Object> unwrapCacheValueOrThrowable(Object key, CompletableFuture<Object> cacheValue) {
+    private CompletableFuture<Object> unwrapCacheValueOrThrowable(CompletableFuture<Object> cacheValue) {
         return cacheValue.thenApply(new Function<Object, Object>() {
             @Override
             public Object apply(Object value) {


### PR DESCRIPTION
The interceptor bindings added using `AnnotationTransformer` in the cache extension are preventing the extension from being compatible with MicroProfile REST Client because of a CDI context which is not provided by Arc. This PR is the first step towards the removal of these transformed bindings (which will fix #8221).

The second step will be part of another PR, but  #13332 needs to be addressed first. The dev is already done and successfully tested locally.

After that, `@CacheResultInterceptorBinding`, `@CacheInvalidateInterceptorBinding` and `@CacheInvalidateAllInterceptorBinding` will be gone for good and the extension will be compatible with MicroProfile REST Client (and also simpler in terms of code).