### PR TITLE
Let kubernetes-client to use the quarkus-config-yaml extension

### DIFF
--- a/extensions/kubernetes-client/deployment/pom.xml
+++ b/extensions/kubernetes-client/deployment/pom.xml
@@ -21,6 +21,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>
@@ -64,10 +68,6 @@
         <dependency>
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
             <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config-source-yaml</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I'm working on windup's rules (https://github.com/windup, downstream Migration Toolkit for Applications https://red.ht/mta) to support users in applications modernization path toward Quarkus.
I created a rule to suggest adopting Quarkus Config YAML extension and running this rule against Quarkus' extensions itself, the rule suggested to "modernize" Quarkus Kubernetes Client suggestion to replace SmallRye Config YAML dependency with Quarkus Config YAML extension.