### PR TITLE
Upgrade to Hibernate Search 6.0.0.CR2 / Elasticsearch 7.10.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -92,7 +92,7 @@
         <hibernate-orm.version>5.4.24.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha11</hibernate-reactive.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.CR1</hibernate-search.version>
+        <hibernate-search.version>6.0.0.CR2</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,7 +97,7 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.9.2</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.10.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.20</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,7 +75,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>7.9.2</elasticsearch-server.version>
+        <elasticsearch-server.version>7.10.0</elasticsearch-server.version>
         <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss:${elasticsearch-server.version}</elasticsearch.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
 

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -557,8 +557,7 @@ quarkus.hibernate-orm.sql-load-script=import.sql <4>
 quarkus.hibernate-search-orm.elasticsearch.version=7 <5>
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer <6>
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
-quarkus.hibernate-search-orm.elasticsearch.schema-management.required-status=yellow <8>
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <9>
+quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8>
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
 <2> Let's create a PostgreSQL datasource.
@@ -569,10 +568,7 @@ It is important because there are significant differences between Elasticsearch 
 Since the mapping is created at build time to reduce startup time, Hibernate Search cannot connect to the cluster to automatically detect the version.
 <6> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
 <7> Obviously, this is not for production: we drop and recreate the index every time we start the application.
-<8> We consider the `yellow` status is sufficient to proceed after an index is created.
-This is for testing purposes with the Elasticsearch Docker container.
-It should not be used in production.
-<9> This means that we wait for the entities to be searchable before considering a write complete.
+<8> This means that we wait for the entities to be searchable before considering a write complete.
 On a production setup, the `write-sync` default will provide better performance.
 Using `sync` is especially important when testing as you need the entities to be searchable immediately.
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -367,7 +367,7 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          * The minimal cluster status required.
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "green")
+        @ConfigItem(defaultValueDocumentation = "yellow")
         Optional<IndexStatus> requiredStatus;
 
         /**

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
@@ -11,6 +11,5 @@ quarkus.hibernate-search-orm.elasticsearch.version=7
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol}
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=io.quarkus.it.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
-quarkus.hibernate-search-orm.elasticsearch.schema-management.required-status=yellow
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync


### PR DESCRIPTION
Release announcement: https://in.relation.to/2020/11/24/hibernate-search-6-0-0-CR2/

To be added to the migration guide:

``````
## Hibernate Search ORM + Elasticsearch (Preview)

* The default required status for Elasticsearch indexes is now `yellow`. If you have specific requirements and need to wait for indexes to be `green` on startup, set `quarkus.hibernate-search.elasticsearch.schema-management.required-status` to `green`.
* [Queries](https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/#troubleshooting-logging-query)
and [requests](https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/#troubleshooting-logging-elasticsearch-request)
are now logged at the `TRACE` level instead of the `DEBUG` level.
``````