### PR TITLE
Revert "Use temporary branch for RESTEast Reactive TCK"

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -468,7 +468,6 @@ jobs:
         with:
           repository: quarkusio/quarkus-rest-testsuite
           path: quarkus-rest-testsuite
-          ref: resteasy-reactive
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
         working-directory: ./tcks


### PR DESCRIPTION
This reverts commit 4a8151aa

The was being used to support the renaming. It is no longer needed