### PR TITLE
Register generated output dir for kotlin gradle plugin

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -191,6 +191,18 @@ public class QuarkusPlugin implements Plugin<Project> {
         project.getPlugins().withId("org.jetbrains.kotlin.jvm", plugin -> {
             tasks.getByName("compileKotlin").dependsOn(quarkusGenerateCode);
             tasks.getByName("compileTestKotlin").dependsOn(quarkusGenerateCodeTests);
+
+            // Register the quarkus-generated-code
+            SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class)
+                    .getSourceSets();
+            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+            SourceSet testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
+            SourceSet generatedSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
+            SourceSet generatedTestSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
+            for (String provider : QuarkusGenerateCode.CODE_GENERATION_PROVIDER) {
+                mainSourceSet.getJava().srcDir(new File(generatedSourceSet.getJava().getOutputDir(), provider));
+                testSourceSet.getJava().srcDir(new File(generatedTestSourceSet.getJava().getOutputDir(), provider));
+            }
         });
     }
 

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -29,6 +29,8 @@ public class QuarkusGenerateCode extends QuarkusTask {
 
     public static final String QUARKUS_GENERATED_SOURCES = "quarkus-generated-sources";
     public static final String QUARKUS_TEST_GENERATED_SOURCES = "quarkus-test-generated-sources";
+    // TODO dynamically load generation provider, or make them write code directly in quarkus-generated-sources
+    public static final String[] CODE_GENERATION_PROVIDER = new String[] { "grpc" };
 
     public static final String INIT_AND_RUN = "initAndRun";
     private Set<Path> sourcesDirectories;

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinGRPCProjectBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinGRPCProjectBuildTest.java
@@ -4,13 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class KotlinGRPCProjectBuildTest extends QuarkusGradleWrapperTestBase {
 
     @Test
-    @Disabled
     public void testBasicMultiModuleBuild() throws Exception {
         final File projectDir = getProjectDir("kotlin-grpc-project");
         final BuildResult build = runGradleWrapper(projectDir, "clean", "build");

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/main/kotlin/org/acme/ExampleResource.kt
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/main/kotlin/org/acme/ExampleResource.kt
@@ -5,10 +5,12 @@ import javax.ws.rs.Path
 import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
+import io.quarkus.example.HelloMsg
+
 @Path("/hello")
 class ExampleResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    fun hello() = "hello"
+    fun hello() = "hello" + HelloMsg.Status.TEST_ONE.getNumber()
 }

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/main/proto/hello.proto
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/main/proto/hello.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package io.quarkus.example;
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+
+import "google/protobuf/timestamp.proto";
+
+
+message HelloMsg {
+  enum Status {
+    UNKNOWN = 0;
+    NOT_SERVING = 1;
+    TEST_ONE = 2;
+  }
+  string message = 1;
+  google.protobuf.Timestamp date_time = 2;
+  Status status = 3;
+}
+
+service DevModeService {
+  rpc Check(HelloMsg) returns (HelloMsg);
+}

--- a/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/test/kotlin/org/acme/ExampleResourceTest.kt
+++ b/integration-tests/gradle/src/test/resources/kotlin-grpc-project/src/test/kotlin/org/acme/ExampleResourceTest.kt
@@ -14,7 +14,7 @@ class ExampleResourceTest {
           .`when`().get("/hello")
           .then()
              .statusCode(200)
-             .body(`is`("hello"))
+             .body(`is`("hello2"))
     }
 
 }


### PR DESCRIPTION
It looks like when no `src/main/java` is present, the kotlin task does not trigger the `compileJava`. 

This register the `build/classes/java/quarkus-generated-sources/grpc` directory in the main sourceset (it does the same thing for tests). 

The only thing that I don't like, is that I cannot load the provider name (e.g. grpc) dynamically has done in the extension. 

Also, I re enabled the `KotlinGRPCProjectBuildTest`, it pass on my machine and on the Release build Test job on my fork. 

close #12874 