### PR TITLE
Uppercase long suffix for mongodb-panache and hibernate-orm-panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -785,11 +785,11 @@ public class PanacheFunctionalityTest {
         Assertions.assertEquals(0, Person.count());
 
         // Now let's specify the return value
-        Mockito.when(Person.count()).thenReturn(23l);
+        Mockito.when(Person.count()).thenReturn(23L);
         Assertions.assertEquals(23, Person.count());
 
         // Now let's change the return value
-        Mockito.when(Person.count()).thenReturn(42l);
+        Mockito.when(Person.count()).thenReturn(42L);
         Assertions.assertEquals(42, Person.count());
 
         // Now let's call the original method
@@ -801,13 +801,13 @@ public class PanacheFunctionalityTest {
 
         // Mock only with specific parameters
         Person p = new Person();
-        Mockito.when(Person.findById(12l)).thenReturn(p);
-        Assertions.assertSame(p, Person.findById(12l));
-        Assertions.assertNull(Person.findById(42l));
+        Mockito.when(Person.findById(12L)).thenReturn(p);
+        Assertions.assertSame(p, Person.findById(12L));
+        Assertions.assertNull(Person.findById(42L));
 
         // Mock throwing
-        Mockito.when(Person.findById(12l)).thenThrow(new WebApplicationException());
-        Assertions.assertThrows(WebApplicationException.class, () -> Person.findById(12l));
+        Mockito.when(Person.findById(12L)).thenThrow(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> Person.findById(12L));
 
         // We can even mock your custom methods
         Mockito.when(Person.findOrdered()).thenReturn(Collections.emptyList());
@@ -904,11 +904,11 @@ public class PanacheFunctionalityTest {
         Assertions.assertEquals(0, personRepository.count());
 
         // Now let's specify the return value
-        Mockito.when(personRepository.count()).thenReturn(23l);
+        Mockito.when(personRepository.count()).thenReturn(23L);
         Assertions.assertEquals(23, personRepository.count());
 
         // Now let's change the return value
-        Mockito.when(personRepository.count()).thenReturn(42l);
+        Mockito.when(personRepository.count()).thenReturn(42L);
         Assertions.assertEquals(42, personRepository.count());
 
         // Now let's call the original method
@@ -920,13 +920,13 @@ public class PanacheFunctionalityTest {
 
         // Mock only with specific parameters
         Person p = new Person();
-        Mockito.when(personRepository.findById(12l)).thenReturn(p);
-        Assertions.assertSame(p, personRepository.findById(12l));
-        Assertions.assertNull(personRepository.findById(42l));
+        Mockito.when(personRepository.findById(12L)).thenReturn(p);
+        Assertions.assertSame(p, personRepository.findById(12L));
+        Assertions.assertNull(personRepository.findById(42L));
 
         // Mock throwing
-        Mockito.when(personRepository.findById(12l)).thenThrow(new WebApplicationException());
-        Assertions.assertThrows(WebApplicationException.class, () -> personRepository.findById(12l));
+        Mockito.when(personRepository.findById(12L)).thenThrow(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> personRepository.findById(12L));
 
         Mockito.when(personRepository.findOrdered()).thenReturn(Collections.emptyList());
         Assertions.assertTrue(personRepository.findOrdered().isEmpty());

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -934,11 +934,11 @@ public class PanacheFunctionalityTest {
         Assertions.assertEquals(0, Person.count());
 
         // Now let's specify the return value
-        Mockito.when(Person.count()).thenReturn(23l);
+        Mockito.when(Person.count()).thenReturn(23L);
         Assertions.assertEquals(23, Person.count());
 
         // Now let's change the return value
-        Mockito.when(Person.count()).thenReturn(42l);
+        Mockito.when(Person.count()).thenReturn(42L);
         Assertions.assertEquals(42, Person.count());
 
         // Now let's call the original method
@@ -950,13 +950,13 @@ public class PanacheFunctionalityTest {
 
         // Mock only with specific parameters
         Person p = new Person();
-        Mockito.when(Person.findById(12l)).thenReturn(p);
-        Assertions.assertSame(p, Person.findById(12l));
-        Assertions.assertNull(Person.findById(42l));
+        Mockito.when(Person.findById(12L)).thenReturn(p);
+        Assertions.assertSame(p, Person.findById(12L));
+        Assertions.assertNull(Person.findById(42L));
 
         // Mock throwing
-        Mockito.when(Person.findById(12l)).thenThrow(new WebApplicationException());
-        Assertions.assertThrows(WebApplicationException.class, () -> Person.findById(12l));
+        Mockito.when(Person.findById(12L)).thenThrow(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> Person.findById(12L));
 
         // We can even mock your custom methods
         Mockito.when(Person.findOrdered()).thenReturn(Collections.emptyList());
@@ -1025,11 +1025,11 @@ public class PanacheFunctionalityTest {
         Assertions.assertEquals(0, personRepository.count());
 
         // Now let's specify the return value
-        Mockito.when(personRepository.count()).thenReturn(23l);
+        Mockito.when(personRepository.count()).thenReturn(23L);
         Assertions.assertEquals(23, personRepository.count());
 
         // Now let's change the return value
-        Mockito.when(personRepository.count()).thenReturn(42l);
+        Mockito.when(personRepository.count()).thenReturn(42L);
         Assertions.assertEquals(42, personRepository.count());
 
         // Now let's call the original method
@@ -1041,13 +1041,13 @@ public class PanacheFunctionalityTest {
 
         // Mock only with specific parameters
         Person p = new Person();
-        Mockito.when(personRepository.findById(12l)).thenReturn(p);
-        Assertions.assertSame(p, personRepository.findById(12l));
-        Assertions.assertNull(personRepository.findById(42l));
+        Mockito.when(personRepository.findById(12L)).thenReturn(p);
+        Assertions.assertSame(p, personRepository.findById(12L));
+        Assertions.assertNull(personRepository.findById(42L));
 
         // Mock throwing
-        Mockito.when(personRepository.findById(12l)).thenThrow(new WebApplicationException());
-        Assertions.assertThrows(WebApplicationException.class, () -> personRepository.findById(12l));
+        Mockito.when(personRepository.findById(12L)).thenThrow(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> personRepository.findById(12L));
 
         Mockito.when(personRepository.findOrdered()).thenReturn(Collections.emptyList());
         Assertions.assertTrue(personRepository.findOrdered().isEmpty());


### PR DESCRIPTION
Hello,

this is a proposal for replacing the log type suffix used into mongodb-panache and hibernate-orm-panache guide examples from 'l' to 'L'.

Currently, it is using the 'l' letter, and for removing the potential ambiguity it is preferred to use the upper case 'L' for declaring it; as the Java Language Spec mentions on their [Chapter 3. Lexical Structure](https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.10.1):

> The suffix L is preferred, because the letter l (ell) is often hard to distinguish from the digit 1 (one). 

Current look:

![imagen](https://user-images.githubusercontent.com/12197954/100674752-f29cae00-3365-11eb-9edb-526a6703025a.png)

Thanks.