### PR TITLE
Introduce async exception mapping to RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
@@ -1,47 +1,25 @@
 package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
 
-import javax.enterprise.inject.spi.CDI;
+import static io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.ExceptionMapperUtil.responseFromAuthenticator;
+
 import javax.ws.rs.core.Response;
 
-import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveExceptionMapper;
-import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.resteasy.reactive.server.spi.AsyncExceptionMapperContext;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveAsyncExceptionMapper;
 
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext;
 import io.quarkus.security.AuthenticationFailedException;
-import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.quarkus.vertx.http.runtime.security.ChallengeData;
-import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
-import io.vertx.ext.web.RoutingContext;
 
-/**
- * TODO: We'll probably need to make ResteasyReactiveExceptionMapper work in an async manner as
- * this implementation blocks
- */
-public class AuthenticationFailedExceptionMapper implements ResteasyReactiveExceptionMapper<AuthenticationFailedException> {
+public class AuthenticationFailedExceptionMapper
+        implements ResteasyReactiveAsyncExceptionMapper<AuthenticationFailedException> {
 
     @Override
     public Response toResponse(AuthenticationFailedException exception) {
-        return doToResponse(CDI.current().select(CurrentVertxRequest.class).get().getCurrent());
+        throw new IllegalStateException("This should never have been called");
     }
 
     @Override
-    public Response toResponse(AuthenticationFailedException exception, ServerRequestContext ctx) {
-        return doToResponse(((QuarkusResteasyReactiveRequestContext) ctx).getContext());
-    }
-
-    private Response doToResponse(RoutingContext routingContext) {
-        if (routingContext != null) {
-            HttpAuthenticator authenticator = routingContext.get(HttpAuthenticator.class.getName());
-            if (authenticator != null) {
-                ChallengeData challengeData = authenticator.getChallenge(routingContext)
-                        .await().indefinitely();
-                Response.ResponseBuilder status = Response.status(challengeData.status);
-                if (challengeData.headerName != null) {
-                    status.header(challengeData.headerName.toString(), challengeData.headerContent);
-                }
-                return status.build();
-            }
-        }
-        return Response.status(Response.Status.UNAUTHORIZED).entity("Not Authenticated").build();
+    public void asyncResponse(AuthenticationFailedException exception, AsyncExceptionMapperContext ctx) {
+        responseFromAuthenticator((QuarkusResteasyReactiveRequestContext) ctx.serverRequestContext());
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/ExceptionMapperUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/ExceptionMapperUtil.java
@@ -1,0 +1,51 @@
+package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
+
+import java.util.function.Consumer;
+
+import javax.ws.rs.core.Response;
+
+import io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+final class ExceptionMapperUtil {
+
+    private static final Response DEFAULT_UNAUTHORIZED_RESPONSE = Response.status(Response.Status.UNAUTHORIZED)
+            .entity("Not Authenticated").build();
+
+    static void responseFromAuthenticator(QuarkusResteasyReactiveRequestContext context) {
+        RoutingContext routingContext = context.getContext();
+        HttpAuthenticator authenticator = routingContext.get(HttpAuthenticator.class.getName());
+        if (authenticator != null) {
+            Uni<ChallengeData> challenge = authenticator.getChallenge(routingContext);
+            context.suspend();
+            challenge.subscribe().with(new Consumer<ChallengeData>() {
+                @Override
+                public void accept(ChallengeData challengeData) {
+                    if (challengeData == null) {
+                        context.setResult(DEFAULT_UNAUTHORIZED_RESPONSE);
+                        context.resume();
+                        return;
+                    }
+                    Response.ResponseBuilder status = Response.status(challengeData.status);
+                    if (challengeData.headerName != null) {
+                        status.header(challengeData.headerName.toString(), challengeData.headerContent);
+                    }
+                    context.setResult(status.build());
+                    context.resume();
+                }
+            }, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable throwable) {
+                    context.setResult(DEFAULT_UNAUTHORIZED_RESPONSE);
+                    context.resume();
+                }
+            });
+        } else {
+            context.setResult(DEFAULT_UNAUTHORIZED_RESPONSE);
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/UnauthorizedExceptionMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/UnauthorizedExceptionMapper.java
@@ -1,54 +1,24 @@
 package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
 
-import javax.enterprise.inject.spi.CDI;
+import static io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.ExceptionMapperUtil.responseFromAuthenticator;
+
 import javax.ws.rs.core.Response;
 
-import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveExceptionMapper;
-import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.resteasy.reactive.server.spi.AsyncExceptionMapperContext;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveAsyncExceptionMapper;
 
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext;
 import io.quarkus.security.UnauthorizedException;
-import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.quarkus.vertx.http.runtime.security.ChallengeData;
-import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
-import io.vertx.ext.web.RoutingContext;
 
-/**
- * TODO: We'll probably need to make ResteasyReactiveExceptionMapper work in an async manner as
- * this implementation blocks
- */
-public class UnauthorizedExceptionMapper implements ResteasyReactiveExceptionMapper<UnauthorizedException> {
-
-    private static final Logger log = Logger.getLogger(UnauthorizedExceptionMapper.class.getName());
+public class UnauthorizedExceptionMapper implements ResteasyReactiveAsyncExceptionMapper<UnauthorizedException> {
 
     @Override
     public Response toResponse(UnauthorizedException exception) {
-        return doToResponse(CDI.current().select(CurrentVertxRequest.class).get().getCurrent());
+        throw new IllegalStateException("This should never have been called");
     }
 
     @Override
-    public Response toResponse(UnauthorizedException exception, ServerRequestContext ctx) {
-        return doToResponse(((QuarkusResteasyReactiveRequestContext) ctx).getContext());
-    }
-
-    private Response doToResponse(RoutingContext context) {
-        if (context != null) {
-            HttpAuthenticator authenticator = context.get(HttpAuthenticator.class.getName());
-            if (authenticator != null) {
-                ChallengeData challengeData = authenticator.getChallenge(context)
-                        .await().indefinitely();
-                if (challengeData != null) {
-                    Response.ResponseBuilder status = Response.status(challengeData.status);
-                    if (challengeData.headerName != null) {
-                        status.header(challengeData.headerName.toString(), challengeData.headerContent);
-                    }
-                    return status.build();
-                } else {
-                    return Response.status(Response.Status.UNAUTHORIZED).build();
-                }
-            }
-        }
-        return Response.status(Response.Status.UNAUTHORIZED).entity("Not authorized").build();
+    public void asyncResponse(UnauthorizedException exception, AsyncExceptionMapperContext ctx) {
+        responseFromAuthenticator((QuarkusResteasyReactiveRequestContext) ctx.serverRequestContext());
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/AsyncExceptionMapperContextImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/AsyncExceptionMapperContextImpl.java
@@ -1,0 +1,34 @@
+package org.jboss.resteasy.reactive.server.core;
+
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.server.spi.AsyncExceptionMapperContext;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+
+public class AsyncExceptionMapperContextImpl implements AsyncExceptionMapperContext {
+
+    private final ResteasyReactiveRequestContext context;
+
+    public AsyncExceptionMapperContextImpl(ResteasyReactiveRequestContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public ServerRequestContext serverRequestContext() {
+        return context;
+    }
+
+    @Override
+    public void suspend() {
+        context.suspend();
+    }
+
+    @Override
+    public void resume() {
+        context.resume();
+    }
+
+    @Override
+    public void setResponse(Response response) {
+        context.setResult(response);
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -296,7 +296,7 @@ public abstract class ResteasyReactiveRequestContext
         // we got an exception
         if (throwable != null) {
             this.responseContentType = null;
-            setResult(deployment.getExceptionMapping().mapException(throwable, this));
+            deployment.getExceptionMapping().mapException(throwable, this);
             // NOTE: keep the throwable around for close() AsyncResponse notification
         }
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/AsyncExceptionMapperContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/AsyncExceptionMapperContext.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.reactive.server.spi;
+
+import javax.ws.rs.core.Response;
+
+public interface AsyncExceptionMapperContext {
+
+    ServerRequestContext serverRequestContext();
+
+    void suspend();
+
+    void resume();
+
+    void setResponse(Response response);
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveAsyncExceptionMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveAsyncExceptionMapper.java
@@ -1,0 +1,22 @@
+package org.jboss.resteasy.reactive.server.spi;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Allow ExceptionMapper classes that can use resume and suspend when attempting to convert
+ * an exception into a response
+ */
+public interface ResteasyReactiveAsyncExceptionMapper<E extends Throwable> extends ExceptionMapper<E> {
+
+    /**
+     * If the handling of the exception involves async handling async results, the implementation can
+     * use {@link AsyncExceptionMapperContext#suspend()} and {@link AsyncExceptionMapperContext#resume()}.
+     *
+     * In all cases, tt is the responsibility of the implementation to call
+     * {@link AsyncExceptionMapperContext#setResponse(Response)}
+     * when the exception has been properly mapped.
+     *
+     */
+    void asyncResponse(E exception, AsyncExceptionMapperContext context);
+}


### PR DESCRIPTION
This is done in order to handle async types (for example when dealing with Quarkus Security)