### PR TITLE
Improve logging and documentation about objcopy dependency

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -300,6 +300,9 @@ public class NativeImageBuildStep {
                 }
                 // Strip debug symbols regardless, because the underlying JDK might contain them
                 objcopy("--strip-debug", finalPath.toString());
+            } else {
+                log.warn("objcopy executable not found in PATH. Debug symbols will not be separated from executable.");
+                log.warn("That will result in a larger native image with debug symbols embedded in it.");
             }
 
             return new NativeImageBuildItem(finalPath);
@@ -657,7 +660,6 @@ public class NativeImageBuildStep {
             }
         }
 
-        log.debug("Cannot find executable (objcopy) to separate symbols from executable.");
         return false;
     }
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -578,6 +578,25 @@ To generate debug symbols,
 add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
 You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
 
+[NOTE]
+====
+The generation of the `.debug` file depends on `objcopy`.
+On common Linux distributions and macOS you will need to install the `binutils` package:
+
+[source,bash]
+----
+# dnf (rpm-based)
+sudo dnf install binutils
+# Debian-based distributions
+sudo apt-get install binutils
+# macOS
+brew install binutils
+export PATH=/usr/local/opt/binutils/bin:$PATH
+----
+
+When `objcopy` is not available debug symbols are embedded in the executable.
+====
+
 Aside from debug symbols,
 setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
 for any JDK runtime classes, GraalVM classes and application classes resolved during native executable generation.


### PR DESCRIPTION
Improves documentation and logging about `objcopy` as suggested in #13517 