### PR TITLE
Move non application endpoints to separate URL path

### DIFF
--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -548,7 +548,7 @@ You can now interact with your reactive REST service:
 If you are using the `quarkus-smallrye-health` extension, `cassandra-quarkus` will automatically
 add a readiness health check to validate the connection to the cluster.
 
-So when you access the `/health/ready` endpoint of your application you will have information about
+So when you access the `/q/health/ready` endpoint of your application you will have information about
 the connection validation status.
 
 TIP: This behavior can be disabled by setting the `quarkus.cassandra.health.enabled` property to
@@ -583,7 +583,7 @@ For the full list of available metrics, please refer to the
 link:https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/[driver settings reference]
 and the `advanced.metrics` section.
 
-When metrics are properly enabled and when you access the `/metrics` endpoint of your application,
+When metrics are properly enabled and when you access the `/q/metrics` endpoint of your application,
 you will see metric reports for all enabled metrics.
 
 == Building a native executable

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -583,7 +583,7 @@ For the full list of available metrics, please refer to the
 link:https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/[driver settings reference]
 and the `advanced.metrics` section.
 
-When metrics are properly enabled and when you access the `/q/metrics` endpoint of your application,
+When metrics are enabled and you access the `/q/metrics` endpoint of your application,
 you will see metric reports for all enabled metrics.
 
 == Building a native executable

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -406,7 +406,7 @@ AgroalDataSource inventoryDataSource;
 If you are using the `quarkus-smallrye-health` extension, the `quarkus-agroal` and reactive client extensions will automatically add a readiness health check
 to validate the datasource.
 
-So when you access the `/health/ready` endpoint of your application you will have information about the datasource validation status.
+So when you access the `/q/health/ready` endpoint of your application you will have information about the datasource validation status.
 If you have multiple datasources, all datasources will be checked and the status will be `DOWN` as soon as there is one datasource validation failure.
 
 This behavior can be disabled via the property `quarkus.datasource.health.enabled`.
@@ -414,13 +414,13 @@ This behavior can be disabled via the property `quarkus.datasource.health.enable
 == Datasource Metrics
 
 If you are using the `quarkus-micrometer` or `quarkus-smallrye-metrics` extension, `quarkus-agroal` can expose some data source metrics on the
-`/metrics` endpoint. This can be turned on by setting the property `quarkus.datasource.metrics.enabled` to true.
+`/q/metrics` endpoint. This can be turned on by setting the property `quarkus.datasource.metrics.enabled` to true.
 
 For the exposed metrics to contain any actual values, it is necessary that metric collection is enabled internally
 by Agroal mechanisms. By default, this metric collection mechanism gets turned on for all data sources if a metrics extension
 is present and metrics for the Agroal extension are enabled. If you want to disable metrics for a particular data source,
 this can be done by setting `quarkus.datasource.jdbc.enable-metrics` to `false` (or `quarkus.datasource.<datasource name>.jdbc.enable-metrics` for a named datasource).
-This disables collecting the metrics as well as exposing them in the `/metrics` endpoint,
+This disables collecting the metrics as well as exposing them in the `/q/metrics` endpoint,
 because it does not make sense to expose metrics if the mechanism to collect them is disabled.
 
 Conversely, setting `quarkus.datasource.jdbc.enable-metrics` to `true` (or `quarkus.datasource.<datasource name>.jdbc.enable-metrics` for a named datasource) explicitly can be used to enable collection of metrics even if

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -406,7 +406,7 @@ AgroalDataSource inventoryDataSource;
 If you are using the `quarkus-smallrye-health` extension, the `quarkus-agroal` and reactive client extensions will automatically add a readiness health check
 to validate the datasource.
 
-So when you access the `/q/health/ready` endpoint of your application you will have information about the datasource validation status.
+When you access the `/q/health/ready` endpoint of your application you will have information about the datasource validation status.
 If you have multiple datasources, all datasources will be checked and the status will be `DOWN` as soon as there is one datasource validation failure.
 
 This behavior can be disabled via the property `quarkus.datasource.health.enabled`.

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -391,7 +391,7 @@ If you're interested in it, you can read the link:hibernate-search-orm-elasticse
 If you are using the `quarkus-smallrye-health` extension, both the extension will automatically add a readiness health check
 to validate the health of the cluster.
 
-So when you access the `/health/ready` endpoint of your application you will have information about the cluster status.
+So when you access the `/q/health/ready` endpoint of your application you will have information about the cluster status.
 It uses the cluster health endpoint, the check will be down if the status of the cluster is **red**, or the cluster is not available.
 
 This behavior can be disabled by setting the `quarkus.elasticsearch.health.enabled` property to `false` in your `application.properties`.

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -184,7 +184,7 @@ For more details, check out the
 https://github.com/grpc/grpc/blob/v1.28.1/doc/health-checking.md[gRPC documentation]
 
 Additionally, if Quarkus SmallRye Health is added to the application, a readiness check for
-the state of the gRPC services will be added to the MicroProfile Health endpoint response, that is `/health`.
+the state of the gRPC services will be added to the MicroProfile Health endpoint response, that is `/q/health`.
 
 == Reflection Service
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -659,7 +659,7 @@ For more information about Hibernate Envers, see link:https://hibernate.org/orm/
 == Metrics
 Either link:micrometer[Micrometer] or link:microprofile-metrics[SmallRye Metrics] are
 capable of exposing metrics that Hibernate ORM collects at runtime. To enable exposure of Hibernate metrics
-on the `/metrics` endpoint, make sure your project depends on a metrics extension and set the configuration property `quarkus.hibernate-orm.metrics.enabled` to `true`.
+on the `/q/metrics` endpoint, make sure your project depends on a metrics extension and set the configuration property `quarkus.hibernate-orm.metrics.enabled` to `true`.
 When using link:microprofile-metrics[SmallRye Metrics], metrics will be available under the `vendor` scope.
 
 == Limitations and other things you should know

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1146,12 +1146,12 @@ If you are using the `quarkus-smallrye-health` extension, `quarkus-kafka-streams
 * a readiness health check to validate that all topics declared in the `quarkus.kafka-streams.topics` property are created,
 * a liveness health check based on the Kafka Streams state.
 
-So when you access the `/health` endpoint of your application you will have information about the state of the Kafka Streams and the available and/or missing topics.
+So when you access the `/q/health` endpoint of your application you will have information about the state of the Kafka Streams and the available and/or missing topics.
 
 This is an example of when the status is `DOWN`:
 [source, subs=attributes+]
 ----
-curl -i http://aggregator:8080/health
+curl -i http://aggregator:8080/q/health
 
 HTTP/1.1 503 Service Unavailable
 content-type: application/json; charset=UTF-8
@@ -1178,8 +1178,8 @@ content-length: 454
     ]
 }
 ----
-<1> Liveness health check. Also available at `/health/live` endpoint.
-<2> Readiness health check. Also available at `/health/ready` endpoint.
+<1> Liveness health check. Also available at `/q/health/live` endpoint.
+<2> Readiness health check. Also available at `/q/health/ready` endpoint.
 
 So as you can see, the status is `DOWN` as soon as one of the `quarkus.kafka-streams.topics` is missing or the Kafka Streams `state` is not `RUNNING`.
 
@@ -1188,7 +1188,7 @@ As well as if no topics are missing, the `missing_topics` key will not be presen
 
 You can of course disable the health check of the `quarkus-kafka-streams` extension by setting the `quarkus.kafka-streams.health.enabled` property to `false` in your `application.properties`.
 
-Obviously you can create your liveness and readiness probes based on the respective endpoints `/health/live` and `/health/ready`.
+Obviously you can create your liveness and readiness probes based on the respective endpoints `/q/health/live` and `/q/health/ready`.
 
 === Liveness health check
 
@@ -1196,7 +1196,7 @@ Here is an example of the liveness check:
 
 [source]
 ----
-curl -i http://aggregator:8080/health/live
+curl -i http://aggregator:8080/q/health/live
 
 HTTP/1.1 503 Service Unavailable
 content-type: application/json; charset=UTF-8
@@ -1223,7 +1223,7 @@ Here is an example of the readiness check:
 
 [source]
 ----
-curl -i http://aggregator:8080/health/ready
+curl -i http://aggregator:8080/q/health/ready
 
 HTTP/1.1 503 Service Unavailable
 content-type: application/json; charset=UTF-8

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -384,7 +384,7 @@ The new `Emitter.send` method returns a `CompletionStage` completed when the pro
 If you are using the `quarkus-smallrye-health` extension, `quarkus-kafka` can add a readiness health check
 to validate the connection to the broker. This is disabled by default.
 
-If enabled, when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
+If enabled, when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be enabled by setting the `quarkus.kafka.health.enabled` property to `true` in your `application.properties`.
 

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -190,7 +190,7 @@ If you want, try some more calls with numbers of your choice.
 
 === Review the generated metrics
 
-To view the metrics, execute `curl localhost:8080/metrics/`
+To view the metrics, execute `curl localhost:8080/q/metrics/`
 
 Prometheus-formatted metrics will be returned in plain text in no particular order.
 

--- a/docs/src/main/asciidoc/microprofile-health.adoc
+++ b/docs/src/main/asciidoc/microprofile-health.adoc
@@ -27,7 +27,7 @@ To complete this guide, you need:
 == Architecture
 
 In this guide, we build a simple REST application that exposes MicroProfile Health 
-functionalities at the `/health/live` and `/health/ready` endpoints according to the 
+functionalities at the `/q/health/live` and `/q/health/ready` endpoints according to the
 specification.
 
 == Solution
@@ -79,15 +79,15 @@ This will add the following to your `pom.xml`:
 
 Importing the `smallrye-health` extension directly exposes three REST endpoints:
 
-- `/health/live` - The application is up and running.
-- `/health/ready` - The application is ready to serve requests.
-- `/health` - Accumulating all health check procedures in the application.
+- `/q/health/live` - The application is up and running.
+- `/q/health/ready` - The application is ready to serve requests.
+- `/q/health` - Accumulating all health check procedures in the application.
  
 To check that the `smallrye-health` extension is working as expected:
 
 * start your Quarkus application with `./mvnw compile quarkus:dev`
-* access the `http://localhost:8080/health/live` endpoint using your browser or 
-`curl http://localhost:8080/health/live`
+* access the `http://localhost:8080/q/health/live` endpoint using your browser or
+`curl http://localhost:8080/q/health/live`
 
 All of the health REST endpoints return a simple JSON object with two fields:
 
@@ -129,16 +129,16 @@ public class SimpleHealthCheck implements HealthCheck {
 
 As you can see, the health check procedures are defined as CDI beans that implement the `HealthCheck` interface and are annotated with one of the health check qualifiers, such as: 
 
-- `@Liveness` - the liveness check accessible at `/health/live`
-- `@Readiness` - the readiness check accessible at `/health/ready`
+- `@Liveness` - the liveness check accessible at `/q/health/live`
+- `@Readiness` - the readiness check accessible at `/q/health/ready`
 
 `HealthCheck` is a functional interface whose single method `call` returns a 
 `HealthCheckResponse` object which can be easily constructed by the fluent builder 
 API shown in the example.
 
 As we have started our Quarkus application in dev mode simply repeat the request 
-to `http://localhost:8080/health/live` by refreshing your browser window or by 
-using `curl http://localhost:8080/health/live`. Because we defined our health check 
+to `http://localhost:8080/q/health/live` by refreshing your browser window or by
+using `curl http://localhost:8080/q/health/live`. Because we defined our health check
 to be a liveness procedure (with `@Liveness` qualifier) the new health check procedure 
 is now present in the `checks` array.
 
@@ -180,15 +180,15 @@ public class DatabaseConnectionHealthCheck implements HealthCheck {
 
 ----
 
-If you now rerun the health check at `http://localhost:8080/health/live` the `checks` 
+If you now rerun the health check at `http://localhost:8080/q/health/live` the `checks`
 array will contain only the previously defined `SimpleHealthCheck` as it is the only 
 check defined with the `@Liveness` qualifier. However, if you access 
-`http://localhost:8080/health/ready` (in the browser or with 
-`curl http://localhost:8080/health/ready`) you will see only the 
+`http://localhost:8080/q/health/ready` (in the browser or with
+`curl http://localhost:8080/q/health/ready`) you will see only the
 `Database connection health check` as it is the only health check defined with the 
 `@Readiness` qualifier as the readiness health check procedure.
 
-NOTE: If you access `http://localhost:8080/health` you will get back both checks.
+NOTE: If you access `http://localhost:8080/q/health` you will get back both checks.
 
 More information about which health check procedures should be used in which situation 
 is detailed in the MicroProfile Health specification. Generally, the liveness 
@@ -253,9 +253,9 @@ through the `HealthCheckResponse#up(String)` (there is also
 From now on, we utilize the full builder capabilities provided by the
 `HealthCheckResponseBuilder` class.
 
-If you now rerun the readiness health check (at `http://localhost:8080/health/ready`) 
+If you now rerun the readiness health check (at `http://localhost:8080/q/health/ready`)
 the overall `status` should be DOWN. You can also check the liveness check at 
-`http://localhost:8080/health/live` which will return the overall `status` UP because 
+`http://localhost:8080/q/health/live` which will return the overall `status` UP because
 it isn't influenced by the readiness checks.
 
 As we shouldn't leave this application with a readiness check in a DOWN state and 
@@ -300,7 +300,7 @@ public class DataHealthCheck implements HealthCheck {
 }
 ----
 
-If you rerun the liveness health check procedure by accessing the `/health/live` 
+If you rerun the liveness health check procedure by accessing the `/q/health/live`
 endpoint you can see that the new health check `Health check with data` is present 
 in the `checks` array. This check contains a new attribute called `data` which is a 
 JSON object consisting of the properties we have defined in our health check procedure.
@@ -338,7 +338,7 @@ NOTE: Experimental - not included in the MicroProfile specification
 
 The Quarkus `smallrye-health` extension ships with `health-ui` and enables it by default in dev and test modes, but it can also be explicitly configured for production mode as well.
 
-`health-ui` can be accessed from http://localhost:8080/health-ui/ .
+`health-ui` can be accessed from http://localhost:8080/q/health-ui/ .
 
 image:health-ui-screenshot01.png[alt=Health UI]
 

--- a/docs/src/main/asciidoc/microprofile-metrics.adoc
+++ b/docs/src/main/asciidoc/microprofile-metrics.adoc
@@ -176,7 +176,7 @@ The application will respond that 629521085409773 is a prime number.
 If you want, try some more calls with numbers of your choice.
 
 === Review the generated metrics
-To view the metrics, execute `curl -H"Accept: application/json" localhost:8080/metrics/application`
+To view the metrics, execute `curl -H"Accept: application/json" localhost:8080/q/metrics/application`
 You will receive a response such as:
 
 [source,json]

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -584,7 +584,7 @@ The link:mongodb-panache[MongoDB with Panache] extension facilitates the usage o
 If you are using the `quarkus-smallrye-health` extension, `quarkus-mongodb-client` will automatically add a readiness health check
 to validate the connection to the cluster.
 
-So when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
+So when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be disabled by setting the `quarkus.mongodb.health.enabled` property to `false` in your `application.properties`.
 
@@ -593,7 +593,7 @@ This behavior can be disabled by setting the `quarkus.mongodb.health.enabled` pr
 If you are using the `quarkus-micrometer` or `quarkus-smallrye-metrics` extension, `quarkus-mongodb-client` can provide metrics about the connection pools.
 This behavior must first be enabled by setting the `quarkus.mongodb.metrics.enabled` property to `true` in your `application.properties`.
 
-So when you access the `/metrics` endpoint of your application you will have information about the connection pool status.
+So when you access the `/q/metrics` endpoint of your application you will have information about the connection pool status.
 When using link:microprofile-metrics[SmallRye Metrics], connection pool metrics will be available under the `vendor` scope.
 
 

--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -395,7 +395,7 @@ Depending on your system, that will take some time.
 If you are using the `quarkus-smallrye-health` extension, `quarkus-neo4j` will automatically add a readiness health check
 to validate the connection to Neo4j.
 
-So when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
+So when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be disabled by setting the `quarkus.neo4j.health.enabled` property to `false` in your `application.properties`.
 

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -200,11 +200,11 @@ Now, we are ready to run our application:
 ./mvnw compile quarkus:dev
 ----
 
-Once your application is started, you can make a request to the default `/openapi` endpoint:
+Once your application is started, you can make a request to the default `/q/openapi` endpoint:
 
 [source,shell]
 ----
-$ curl http://localhost:8080/openapi
+$ curl http://localhost:8080/q/openapi
 openapi: 3.0.3
 info:
   title: Generated API
@@ -251,7 +251,7 @@ components:
 
 [NOTE]
 ====
-If you do not like the default endpoint location `/openapi`, you can change it by adding the following configuration to your `application.properties`:
+If you do not like the default endpoint location `/q/openapi`, you can change it by adding the following configuration to your `application.properties`:
 [source, properties]
 ----
 quarkus.smallrye-openapi.path=/swagger
@@ -337,7 +337,7 @@ info:
   version: "1.0"
 
 servers:
-  - url: http://localhost:8080/openapi
+  - url: http://localhost:8080/q/openapi
     description: Optional dev mode server description
 
 paths:
@@ -379,10 +379,10 @@ components:
         name:
           type: string
 ----
-By default, a request to `/openapi` will serve the combined OpenAPI document from the static file and the model generated from application endpoints code.
+By default, a request to `/q/openapi` will serve the combined OpenAPI document from the static file and the model generated from application endpoints code.
 We can however change this to only serve the static OpenAPI document by adding `mp.openapi.scan.disable=true` configuration into `application.properties`.
 
-Now, a request to `/openapi` endpoint will serve the static OpenAPI document instead of the generated one.
+Now, a request to `/q/openapi` endpoint will serve the static OpenAPI document instead of the generated one.
 
 [[open-document-paths]]
 [TIP]
@@ -461,9 +461,9 @@ This is a build time property, it cannot be changed at runtime after your applic
 
 ====
 
-By default, Swagger UI is accessible at `/swagger-ui`.
+By default, Swagger UI is accessible at `/q/swagger-ui`.
 
-You can update this path by setting the `quarkus.swagger-ui.path` property in your `application.properties`:
+You can update the `/swagger-ui` sub path by setting the `quarkus.swagger-ui.path` property in your `application.properties`:
 
 [source, properties]
 ----
@@ -486,10 +486,10 @@ You can check the Swagger UI path in your application's log:
 
 [source]
 ----
-00:00:00,000 INFO  [io.qua.swa.run.SwaggerUiServletExtension] Swagger UI available at /swagger-ui
+00:00:00,000 INFO  [io.qua.swa.run.SwaggerUiServletExtension] Swagger UI available at /q/swagger-ui
 ----
 
-Once your application is started, you can go to http://localhost:8080/swagger-ui and play with your API.
+Once your application is started, you can go to http://localhost:8080/q/swagger-ui and play with your API.
 
 You can visualize your API's operations and schemas.
 image:openapi-swaggerui-guide-screenshot01.png[alt=Visualize your API]

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -610,7 +610,7 @@ This is enough to generate a basic OpenAPI schema document from your Vert.x Rout
 
 [source,bash]
 ----
-curl http://localhost:8080/openapi
+curl http://localhost:8080/q/openapi
 ----
 
 You will see the generated OpenAPI schema document:
@@ -746,7 +746,7 @@ paths:
 Swagger UI is included by default when running in `dev` or `test` mode, and can optionally added to `prod` mode.
 See <<openapi-swaggerui.adoc#use-swagger-ui-for-development,the Swagger UI>> Guide for more details.
 
-Navigate to link:http://localhost:8080/swagger-ui/[localhost:8080/swagger-ui/] and you will see the Swagger UI screen:
+Navigate to link:http://localhost:8080/q/swagger-ui/[localhost:8080/q/swagger-ui/] and you will see the Swagger UI screen:
 
 image:reactive-routes-guide-screenshot01.png[alt=Swagger UI]
 

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -536,7 +536,7 @@ Once the build is finished, you can run the executable with:
 If you are using the `quarkus-smallrye-health` extension, `quarkus-vertx-redis` will automatically add a readiness health check
 to validate the connection to the Redis server.
 
-So when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
+So when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be disabled by setting the `quarkus.redis.health.enabled` property to `false` in your `application.properties`.
 

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -388,7 +388,7 @@ I.e. if you wanted to add the `smallrye-openapi` and `swagger-ui` extensions and
 //Q:CONFIG quarkus.swagger-ui.always-include=true
 ----
 
-Now during build the `quarkus.swagger-ui.always-include` will be generated into the resulting jar and `http://0.0.0.0:8080/swagger-ui` will be available when run.
+Now during build the `quarkus.swagger-ui.always-include` will be generated into the resulting jar and `http://0.0.0.0:8080/q/swagger-ui` will be available when run.
 
 == Running as a native application
 

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -221,7 +221,7 @@ This is enough to generate a basic OpenAPI schema document from your REST Endpoi
 
 [source,bash]
 ----
-curl http://localhost:8080/openapi
+curl http://localhost:8080/q/openapi
 ----
 
 You will see the generated OpenAPI schema document:
@@ -371,7 +371,7 @@ components:
 Swagger UI is included by default when running in `Dev` or `Test` mode, and can optionally added to `Prod` mode.
 See link:https://quarkus.io/guides/openapi-swaggerui#use-swagger-ui-for-development[the Swagger UI] Guide for more details.
 
-Navigate to link:http://localhost:8080/swagger-ui/[localhost:8080/swagger-ui/] and you will see the Swagger UI screen:
+Navigate to link:http://localhost:8080/q/swagger-ui/[localhost:8080/q/swagger-ui/] and you will see the Swagger UI screen:
 
 image:spring-web-guide-screenshot01.png[alt=Swagger UI]
 

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -408,7 +408,7 @@ boolean valid = vaultTOTPSecretEngine.validateCode("my_key_2", keyCode); // <4>
 If you are using the `quarkus-smallrye-health` extension, `quarkus-vault` can add a readiness health check
 to validate the connection to the Vault server. This is disabled by default.
 
-If enabled, when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
+If enabled, when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be enabled by setting the `quarkus.vault.health.enabled` property to `true` in your `application.properties`.
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1831,7 +1831,7 @@ public class FailingUnitTest {
 
     @Test
     public void testHealthServlet() {
-        RestAssured.when().get("/health").then().statusCode(503);                       // <4>
+        RestAssured.when().get("/q/health").then().statusCode(503);                       // <4>
     }
 
     @Test

--- a/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/PolicyEnforcerTest.java
+++ b/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/PolicyEnforcerTest.java
@@ -108,7 +108,7 @@ public class PolicyEnforcerTest {
     @Test
     public void testHealthCheck() {
         RestAssured.given()
-                .when().get("/health/live")
+                .when().get("/q/health/live")
                 .then()
                 .statusCode(200);
     }

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
@@ -41,7 +41,11 @@ public class JsonRegistryProcessor {
                 .addBeanClass(JsonMeterRegistryProvider.class)
                 .setUnremovable().build());
         registryProviders.produce(new MicrometerRegistryProviderBuildItem(JsonMeterRegistry.class));
-        routes.produce(new RouteBuildItem(recorder.route(config.export.json.path), recorder.getHandler()));
+        routes.produce(new RouteBuildItem.Builder()
+                .routeFunction(recorder.route(config.export.json.path))
+                .handler(recorder.getHandler())
+                .nonApplicationRoute()
+                .build());
         reflectiveClasses.produce(ReflectiveClassBuildItem
                 .builder("org.HdrHistogram.Histogram",
                         "org.HdrHistogram.DoubleHistogram",

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -59,10 +59,18 @@ public class PrometheusRegistryProcessor {
         log.debug("PROMETHEUS CONFIG: " + pConfig);
 
         // Exact match for resources matched to the root path
-        routes.produce(new RouteBuildItem(recorder.route(pConfig.path), recorder.getHandler()));
+        routes.produce(new RouteBuildItem.Builder()
+                .routeFunction(recorder.route(pConfig.path))
+                .handler(recorder.getHandler())
+                .nonApplicationRoute()
+                .build());
 
         // Match paths that begin with the deployment path
         String matchPath = pConfig.path + (pConfig.path.endsWith("/") ? "*" : "/*");
-        routes.produce(new RouteBuildItem(recorder.route(matchPath), recorder.getHandler()));
+        routes.produce(new RouteBuildItem.Builder()
+                .routeFunction(recorder.route(matchPath))
+                .handler(recorder.getHandler())
+                .nonApplicationRoute()
+                .build());
     }
 }

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -66,8 +66,8 @@ import io.quarkus.smallrye.health.runtime.SmallRyeLivenessHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeReadinessHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeWellnessHandler;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
-import io.quarkus.vertx.http.deployment.FrameworkRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.smallrye.health.SmallRyeHealthReporter;
@@ -294,7 +294,7 @@ class SmallRyeHealthProcessor {
     }
 
     @BuildStep
-    public void kubernetes(FrameworkRootPathBuildItem frameworkRootPath,
+    public void kubernetes(NonApplicationRootPathBuildItem frameworkRootPath,
             SmallRyeHealthConfig healthConfig,
             BuildProducer<KubernetesHealthLivenessPathBuildItem> livenessPathItemProducer,
             BuildProducer<KubernetesHealthReadinessPathBuildItem> readinessPathItemProducer) {

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DispatchedThreadTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DispatchedThreadTest.java
@@ -31,7 +31,7 @@ public class DispatchedThreadTest {
 
     @Test
     public void check() {
-        RestAssured.when().get("/health/live").then()
+        RestAssured.when().get("/q/health/live").then()
                 .body("status", is("UP"),
                         "checks.status", contains("UP"),
                         "checks.name", contains("my-liveness-check"),
@@ -39,7 +39,7 @@ public class DispatchedThreadTest {
                         "checks.data.thread[0]", not(stringContainsInOrder("loop")),
                         "checks.data.request[0]", is(true));
 
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.status", contains("UP"),
                         "checks.name", contains("my-readiness-check"),

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingUnitTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingUnitTest.java
@@ -33,9 +33,9 @@ public class FailingUnitTest {
 
     @Test
     public void testHealthServlet() {
-        RestAssured.when().get("/health/live").then().statusCode(503);
-        RestAssured.when().get("/health/ready").then().statusCode(503);
-        RestAssured.when().get("/health").then().statusCode(503);
+        RestAssured.when().get("/q/health/live").then().statusCode(503);
+        RestAssured.when().get("/q/health/ready").then().statusCode(503);
+        RestAssured.when().get("/q/health").then().statusCode(503);
     }
 
     @Test

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckDefaultScopeTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckDefaultScopeTest.java
@@ -28,11 +28,11 @@ public class HealthCheckDefaultScopeTest {
         // the health check does not set a content type so we need to force the parser
         try {
             RestAssured.defaultParser = Parser.JSON;
-            when().get("/health/live").then()
+            when().get("/q/health/live").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP"),
                             "checks.name", contains("noScope"));
-            when().get("/health/live").then()
+            when().get("/q/health/live").then()
                     .body("status", is("DOWN"),
                             "checks.status", contains("DOWN"),
                             "checks.name", contains("noScope"));

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckProducerDefaultScopeTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckProducerDefaultScopeTest.java
@@ -33,11 +33,11 @@ public class HealthCheckProducerDefaultScopeTest {
         // the health check does not set a content type so we need to force the parser
         try {
             RestAssured.defaultParser = Parser.JSON;
-            when().get("/health/ready").then()
+            when().get("/q/health/ready").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP", "UP"),
                             "checks.name", containsInAnyOrder("alpha1", "bravo1"));
-            when().get("/health/ready").then()
+            when().get("/q/health/ready").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP", "UP"),
                             "checks.name", containsInAnyOrder("alpha1", "bravo2"));

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthOpenAPITest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthOpenAPITest.java
@@ -13,7 +13,7 @@ import io.restassured.RestAssured;
 
 public class HealthOpenAPITest {
 
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthUnitTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthUnitTest.java
@@ -26,7 +26,7 @@ public class HealthUnitTest {
         // the health check does not set a content type so we need to force the parser
         try {
             RestAssured.defaultParser = Parser.JSON;
-            RestAssured.when().get("/health/live").then()
+            RestAssured.when().get("/q/health/live").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP"),
                             "checks.name", contains("basic"));

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/WellnessHealthCheckTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/WellnessHealthCheckTest.java
@@ -27,7 +27,7 @@ public class WellnessHealthCheckTest {
     public void testWellness() {
         try {
             RestAssured.defaultParser = Parser.JSON;
-            when().get("/health/well").then()
+            when().get("/q/health/well").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP"),
                             "checks.name", contains(WellnessHC.class.getName()));

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ui/CustomConfigTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ui/CustomConfigTest.java
@@ -20,7 +20,7 @@ public class CustomConfigTest {
 
     @Test
     public void shouldUseCustomConfig() {
-        RestAssured.when().get("/custom").then().statusCode(200).body(containsString("SmallRye Health"));
-        RestAssured.when().get("/custom/index.html").then().statusCode(200).body(containsString("SmallRye Health"));
+        RestAssured.when().get("/q/custom").then().statusCode(200).body(containsString("SmallRye Health"));
+        RestAssured.when().get("/q/custom/index.html").then().statusCode(200).body(containsString("SmallRye Health"));
     }
 }

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ui/DisabledTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ui/DisabledTest.java
@@ -18,6 +18,6 @@ public class DisabledTest {
 
     @Test
     public void shouldUseDefaultConfig() {
-        RestAssured.when().get("/health-ui").then().statusCode(404);
+        RestAssured.when().get("/q/health-ui").then().statusCode(404);
     }
 }

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -77,10 +77,9 @@ import io.quarkus.smallrye.metrics.deployment.spi.MetricsConfigurationBuildItem;
 import io.quarkus.smallrye.metrics.runtime.MetadataHolder;
 import io.quarkus.smallrye.metrics.runtime.SmallRyeMetricsRecorder;
 import io.quarkus.smallrye.metrics.runtime.TagHolder;
-import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.FrameworkRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
-import io.quarkus.vertx.http.runtime.HandlerType;
 import io.smallrye.metrics.MetricProducer;
 import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.MetricsRequestHandler;
@@ -154,7 +153,7 @@ public class SmallRyeMetricsProcessor {
     @Record(STATIC_INIT)
     void createRoute(BuildProducer<RouteBuildItem> routes,
             SmallRyeMetricsRecorder recorder,
-            HttpRootPathBuildItem httpRoot,
+            FrameworkRootPathBuildItem frameworkRoot,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             LaunchModeBuildItem launchModeBuildItem) {
         Function<Router, Route> route = recorder.route(metrics.path + (metrics.path.endsWith("/") ? "*" : "/*"));
@@ -164,8 +163,18 @@ public class SmallRyeMetricsProcessor {
         if (launchModeBuildItem.getLaunchMode().isDevOrTest()) {
             displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(metrics.path));
         }
-        routes.produce(new RouteBuildItem(route, recorder.handler(httpRoot.adjustPath(metrics.path)), HandlerType.BLOCKING));
-        routes.produce(new RouteBuildItem(slash, recorder.handler(httpRoot.adjustPath(metrics.path)), HandlerType.BLOCKING));
+        routes.produce(new RouteBuildItem.Builder()
+                .routeFunction(route)
+                .handler(recorder.handler(frameworkRoot.adjustPath(metrics.path)))
+                .blockingRoute()
+                .nonApplicationRoute()
+                .build());
+        routes.produce(new RouteBuildItem.Builder()
+                .routeFunction(slash)
+                .handler(recorder.handler(frameworkRoot.adjustPath(metrics.path)))
+                .blockingRoute()
+                .nonApplicationRoute()
+                .build());
     }
 
     @BuildStep

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -77,7 +77,7 @@ import io.quarkus.smallrye.metrics.deployment.spi.MetricsConfigurationBuildItem;
 import io.quarkus.smallrye.metrics.runtime.MetadataHolder;
 import io.quarkus.smallrye.metrics.runtime.SmallRyeMetricsRecorder;
 import io.quarkus.smallrye.metrics.runtime.TagHolder;
-import io.quarkus.vertx.http.deployment.FrameworkRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.smallrye.metrics.MetricProducer;
@@ -153,7 +153,7 @@ public class SmallRyeMetricsProcessor {
     @Record(STATIC_INIT)
     void createRoute(BuildProducer<RouteBuildItem> routes,
             SmallRyeMetricsRecorder recorder,
-            FrameworkRootPathBuildItem frameworkRoot,
+            NonApplicationRootPathBuildItem frameworkRoot,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             LaunchModeBuildItem launchModeBuildItem) {
         Function<Router, Route> route = recorder.route(metrics.path + (metrics.path.endsWith("/") ? "*" : "/*"));

--- a/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/deployment/DevModeMetricsTest.java
+++ b/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/deployment/DevModeMetricsTest.java
@@ -70,7 +70,7 @@ public class DevModeMetricsTest {
         when().get("/getvalue/mycounter").then().body(equalTo("2"));
 
         // jax-rs metrics are disabled
-        when().get("/metrics").then()
+        when().get("/q/metrics").then()
                 .body(not(containsString("io.quarkus.smallrye.metrics.deployment.DevModeMetricsTest$MetricsResource")));
 
         // trigger a reload by adding a new metric (mycounter2)
@@ -95,7 +95,7 @@ public class DevModeMetricsTest {
         when().get("/getvalue/mycounter2").then().body(equalTo("1"));
 
         // jax-rs metrics are enabled
-        when().get("/metrics").then()
+        when().get("/q/metrics").then()
                 .body(containsString("io.quarkus.smallrye.metrics.deployment.DevModeMetricsTest$MetricsResource"));
 
         // disable jax-rs metrics via quarkus.resteasy.metrics.enabled
@@ -111,7 +111,7 @@ public class DevModeMetricsTest {
                 .statusCode(204);
 
         // jax-rs metrics are disabled
-        when().get("/metrics").then()
+        when().get("/q/metrics").then()
                 .body(not(containsString("io.quarkus.smallrye.metrics.deployment.DevModeMetricsTest$MetricsResource")));
 
         // enable jax-rs metrics via quarkus.resteasy.metrics.enabled
@@ -123,7 +123,7 @@ public class DevModeMetricsTest {
                 .statusCode(204);
 
         // jax-rs metrics are enabled
-        when().get("/metrics").then()
+        when().get("/q/metrics").then()
                 .body(containsString("io.quarkus.smallrye.metrics.deployment.DevModeMetricsTest$MetricsResource"));
 
     }

--- a/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/test/MicrometerMetricsCompatibilityModeTest.java
+++ b/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/test/MicrometerMetricsCompatibilityModeTest.java
@@ -25,7 +25,7 @@ public class MicrometerMetricsCompatibilityModeTest {
 
     @Test
     public void verifyOpenMetricsExport() {
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .body(containsString("jvm_memory_max_bytes{"),
                         containsString("jvm_memory_used_bytes{"),
                         containsString("jvm_memory_committed_bytes{"),

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -69,7 +69,6 @@ import io.quarkus.smallrye.openapi.runtime.OpenApiRuntimeConfig;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
-import io.quarkus.vertx.http.runtime.HandlerType;
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.OpenApiDocument;
@@ -169,7 +168,12 @@ public class SmallRyeOpenApiProcessor {
         }
 
         Handler<RoutingContext> handler = recorder.handler(openApiRuntimeConfig);
-        return new RouteBuildItem(openApiConfig.path, handler, HandlerType.BLOCKING);
+        return new RouteBuildItem.Builder()
+                .route(openApiConfig.path)
+                .handler(handler)
+                .blockingRoute()
+                .nonApplicationRoute()
+                .build();
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/OpenApiHotReloadTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/OpenApiHotReloadTest.java
@@ -20,7 +20,7 @@ public class OpenApiHotReloadTest {
 
     @Test
     public void testAddingAndDeletingEndpoint() {
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"));
 
@@ -30,14 +30,14 @@ public class OpenApiHotReloadTest {
                         + " return \"bonjour\"; "
                         + "}"));
 
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"))
                 .body(containsString("/api/foo"));
 
         TEST.modifySourceFile("MyResource.java", s -> s.replace("foo", "bar"));
 
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"))
                 .body(not(containsString("/api/foo")))
@@ -45,7 +45,7 @@ public class OpenApiHotReloadTest {
 
         TEST.modifySourceFile("MyResource.java", s -> s.replace("@GET @Path(\"bar\")", ""));
 
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"))
                 .body(not(containsString("/api/foo")))
@@ -54,20 +54,20 @@ public class OpenApiHotReloadTest {
 
     @Test
     public void testAddingAndUpdatingResource() {
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"));
 
         TEST.addSourceFile(MySecondResource.class);
 
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"))
                 .body(containsString("/my-second-api"));
 
         TEST.modifySourceFile("MySecondResource.java", s -> s.replace("my-second-api", "/foo"));
 
-        RestAssured.get("/openapi").then()
+        RestAssured.get("/q/openapi").then()
                 .statusCode(200)
                 .body(containsString("/api"))
                 .body(not(containsString("/my-second-api")))

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeTest.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class DefaultContentTypeTest {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiHttpRootDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithoutSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRuntimeFilterTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRuntimeFilterTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiRuntimeFilterTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiWithConfigTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiWithResteasyPathHttpRootDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiWithResteasyPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -24,7 +24,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
 
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/swagger"));
         RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -25,7 +25,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
         RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
-        RestAssured.when().get("/swagger").then().statusCode(200)
+        RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiDefaultPathTestCase.java
@@ -10,7 +10,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiHttpRootDefaultPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiHttpRootDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithoutSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithoutSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiWithConfigTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiWithConfigTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -24,7 +24,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
 
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/swagger"));
         RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -25,7 +25,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
         RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
-        RestAssured.when().get("/swagger").then().statusCode(200)
+        RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
@@ -10,7 +10,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiHttpRootDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithoutSegmentsTestCase.java
@@ -22,16 +22,16 @@ public class OpenApiPathWithoutSegmentsTestCase {
     @Test
     public void testOpenApiPathAccessResource() {
         RestAssured.given().header("Accept", "application/yaml")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().queryParam("format", "YAML")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/yaml;charset=UTF-8");
         RestAssured.given().header("Accept", "application/json")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
-                .when().get(OPEN_API_PATH)
+                .when().get("/q" + OPEN_API_PATH)
                 .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
@@ -11,7 +11,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
 public class OpenApiWithConfigTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+    private static final String OPEN_API_PATH = "/q/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -24,7 +24,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
 
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/swagger"));
         RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -25,7 +25,7 @@ public class SwaggerAndOpenAPIWithCommonPrefixTest {
     @Test
     public void shouldWorkEvenWithCommonPrefix() {
         RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
-        RestAssured.when().get("/swagger").then().statusCode(200)
+        RestAssured.when().get("/q/swagger").then().statusCode(200)
                 .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
     }
 }

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -22,8 +22,8 @@ import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
-import io.quarkus.vertx.http.deployment.FrameworkRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.smallrye.openapi.ui.IndexCreator;
@@ -53,7 +53,7 @@ public class SwaggerUiProcessor {
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
             BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
-            FrameworkRootPathBuildItem frameworkRootPathBuildItem,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
@@ -67,7 +67,7 @@ public class SwaggerUiProcessor {
                         "quarkus.swagger-ui.path was set to \"/\", this is not allowed as it blocks the application from serving anything else.");
             }
 
-            String openApiPath = frameworkRootPathBuildItem.adjustPath(openapi.path);
+            String openApiPath = nonApplicationRootPathBuildItem.adjustPath(openapi.path);
             AppArtifact artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, SWAGGER_UI_WEBJAR_GROUP_ID,
                     SWAGGER_UI_WEBJAR_ARTIFACT_ID);
 
@@ -121,11 +121,13 @@ public class SwaggerUiProcessor {
                     new RouteBuildItem.Builder()
                             .route(swaggerUiConfig.path)
                             .handler(handler)
+                            .nonApplicationRoute()
                             .build());
             routes.produce(
                     new RouteBuildItem.Builder()
                             .route(swaggerUiConfig.path + "/*")
                             .handler(handler)
+                            .nonApplicationRoute()
                             .build());
         }
     }

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
-import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
@@ -54,7 +53,6 @@ public class SwaggerUiProcessor {
             BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
             BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchMode,
@@ -77,7 +75,7 @@ public class SwaggerUiProcessor {
                 WebJarUtil.updateFile(tempPath.resolve("index.html"), generateIndexHtml(openApiPath, swaggerUiConfig));
 
                 swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(tempPath.toAbsolutePath().toString(),
-                        httpRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
+                        nonApplicationRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
                 displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(swaggerUiConfig.path + "/"));
             } else {
                 Map<String, byte[]> files = WebJarUtil.production(curateOutcomeBuildItem, artifact, SWAGGER_UI_WEBJAR_PREFIX);
@@ -98,7 +96,7 @@ public class SwaggerUiProcessor {
                     }
                 }
                 swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(SWAGGER_UI_FINAL_DESTINATION,
-                        httpRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
+                        nonApplicationRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
             }
         }
     }

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
+import io.quarkus.vertx.http.deployment.FrameworkRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
@@ -52,6 +53,7 @@ public class SwaggerUiProcessor {
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
             BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
+            FrameworkRootPathBuildItem frameworkRootPathBuildItem,
             HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
@@ -65,7 +67,7 @@ public class SwaggerUiProcessor {
                         "quarkus.swagger-ui.path was set to \"/\", this is not allowed as it blocks the application from serving anything else.");
             }
 
-            String openApiPath = httpRootPathBuildItem.adjustPath(openapi.path);
+            String openApiPath = frameworkRootPathBuildItem.adjustPath(openapi.path);
             AppArtifact artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, SWAGGER_UI_WEBJAR_GROUP_ID,
                     SWAGGER_UI_WEBJAR_ARTIFACT_ID);
 
@@ -115,8 +117,16 @@ public class SwaggerUiProcessor {
                     finalDestinationBuildItem.getSwaggerUiPath(),
                     runtimeConfig);
 
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path, handler));
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*", handler));
+            routes.produce(
+                    new RouteBuildItem.Builder()
+                            .route(swaggerUiConfig.path)
+                            .handler(handler)
+                            .build());
+            routes.produce(
+                    new RouteBuildItem.Builder()
+                            .route(swaggerUiConfig.path + "/*")
+                            .handler(handler)
+                            .build());
         }
     }
 

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomConfigTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomConfigTest.java
@@ -20,7 +20,7 @@ public class CustomConfigTest {
 
     @Test
     public void shouldUseCustomConfig() {
-        RestAssured.when().get("/custom").then().statusCode(200).body(containsString("/openapi"));
-        RestAssured.when().get("/custom/index.html").then().statusCode(200).body(containsString("/openapi"));
+        RestAssured.when().get("/q/custom").then().statusCode(200).body(containsString("/openapi"));
+        RestAssured.when().get("/q/custom/index.html").then().statusCode(200).body(containsString("/openapi"));
     }
 }

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomHttpRootTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomHttpRootTest.java
@@ -20,7 +20,7 @@ public class CustomHttpRootTest {
 
     @Test
     public void shouldUseCustomConfig() {
-        RestAssured.when().get("/swagger-ui").then().statusCode(200).body(containsString("/foo/openapi"));
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/foo/openapi"));
+        RestAssured.when().get("/swagger-ui").then().statusCode(200).body(containsString("/q/openapi"));
+        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/openapi"));
     }
 }

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomHttpRootTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/CustomHttpRootTest.java
@@ -20,7 +20,7 @@ public class CustomHttpRootTest {
 
     @Test
     public void shouldUseCustomConfig() {
-        RestAssured.when().get("/swagger-ui").then().statusCode(200).body(containsString("/q/openapi"));
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/openapi"));
+        RestAssured.when().get("/q/swagger-ui").then().statusCode(200).body(containsString("/q/openapi"));
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(200).body(containsString("/q/openapi"));
     }
 }

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/DisabledTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/DisabledTest.java
@@ -18,7 +18,7 @@ public class DisabledTest {
 
     @Test
     public void shouldUseDefaultConfig() {
-        RestAssured.when().get("/swagger-ui").then().statusCode(404);
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(404);
+        RestAssured.when().get("/q/swagger-ui").then().statusCode(404);
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(404);
     }
 }

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/NoConfigTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/NoConfigTest.java
@@ -18,8 +18,8 @@ public class NoConfigTest {
 
     @Test
     public void shouldUseDefaultConfig() {
-        RestAssured.when().get("/swagger-ui").then().statusCode(200).body(containsString("/openapi"));
-        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/openapi"));
+        RestAssured.when().get("/q/swagger-ui").then().statusCode(200).body(containsString("/openapi"));
+        RestAssured.when().get("/q/swagger-ui/index.html").then().statusCode(200).body(containsString("/openapi"));
 
     }
 }

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
@@ -24,7 +24,7 @@ public class SwaggerOptionsTest {
 
     @Test
     public void customOptions() {
-        RestAssured.when().get("/swagger-ui").then().statusCode(200)
+        RestAssured.when().get("/q/swagger-ui").then().statusCode(200)
                 .body(
                         containsString("Testing title"),
                         containsString("/openapi"),

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FrameworkRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FrameworkRootPathBuildItem.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class FrameworkRootPathBuildItem extends SimpleBuildItem {
+    private final String frameworkRootPath;
+    private final boolean separateRoot;
+
+    public FrameworkRootPathBuildItem(String frameworkRootPath) {
+        this.frameworkRootPath = frameworkRootPath;
+        this.separateRoot = frameworkRootPath != null
+                && !frameworkRootPath.equals("")
+                && !frameworkRootPath.equals("/");
+    }
+
+    public String getFrameworkRootPath() {
+        return frameworkRootPath;
+    }
+
+    public boolean isSeparateRoot() {
+        return separateRoot;
+    }
+
+    public String adjustPath(String path) {
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException("Path must start with /");
+        }
+        if (frameworkRootPath.equals("/")) {
+            return path;
+        }
+        return frameworkRootPath + path;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -2,11 +2,11 @@ package io.quarkus.vertx.http.deployment;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
-public final class FrameworkRootPathBuildItem extends SimpleBuildItem {
+public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
     private final String frameworkRootPath;
     private final boolean separateRoot;
 
-    public FrameworkRootPathBuildItem(String frameworkRootPath) {
+    public NonApplicationRootPathBuildItem(String frameworkRootPath) {
         this.frameworkRootPath = frameworkRootPath;
         this.separateRoot = frameworkRootPath != null
                 && !frameworkRootPath.equals("")

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -15,37 +15,62 @@ public final class RouteBuildItem extends MultiBuildItem {
     private final Function<Router, Route> routeFunction;
     private final Handler<RoutingContext> handler;
     private final HandlerType type;
+    private final boolean frameworkRoute;
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
     @Deprecated
-    public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type,
-            boolean resume) {
-        this.routeFunction = routeFunction;
-        this.handler = handler;
-        this.type = type;
-    }
-
     public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type) {
-        this(routeFunction, handler, type, true);
+        this(routeFunction, handler, type, false);
     }
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
+    @Deprecated
     public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler) {
         this(routeFunction, handler, HandlerType.NORMAL);
     }
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
+    @Deprecated
     public RouteBuildItem(String route, Handler<RoutingContext> handler, HandlerType type, boolean resume) {
-        this(new BasicRoute(route), handler, type, resume);
+        this(new BasicRoute(route), handler, type);
     }
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
+    @Deprecated
     public RouteBuildItem(String route, Handler<RoutingContext> handler, HandlerType type) {
         this(new BasicRoute(route), handler, type);
     }
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
+    @Deprecated
     public RouteBuildItem(String route, Handler<RoutingContext> handler, boolean resume) {
-        this(new BasicRoute(route), handler, HandlerType.NORMAL, resume);
+        this(new BasicRoute(route), handler, HandlerType.NORMAL);
     }
 
+    /**
+     * @deprecated Use the Builder instead.
+     */
+    @Deprecated
     public RouteBuildItem(String route, Handler<RoutingContext> handler) {
         this(new BasicRoute(route), handler);
+    }
+
+    private RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type,
+            boolean frameworkRoute) {
+        this.routeFunction = routeFunction;
+        this.handler = handler;
+        this.type = type;
+        this.frameworkRoute = frameworkRoute;
     }
 
     public Handler<RoutingContext> getHandler() {
@@ -58,5 +83,55 @@ public final class RouteBuildItem extends MultiBuildItem {
 
     public Function<Router, Route> getRouteFunction() {
         return routeFunction;
+    }
+
+    public boolean isFrameworkRoute() {
+        return frameworkRoute;
+    }
+
+    public static class Builder {
+        private Function<Router, Route> routeFunction;
+        private Handler<RoutingContext> handler;
+        private HandlerType type = HandlerType.NORMAL;
+        private boolean frameworkRoute = false;
+
+        public Builder routeFunction(Function<Router, Route> routeFunction) {
+            this.routeFunction = routeFunction;
+            return this;
+        }
+
+        public Builder route(String route) {
+            this.routeFunction = new BasicRoute(route);
+            return this;
+        }
+
+        public Builder handler(Handler<RoutingContext> handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        public Builder handlerType(HandlerType handlerType) {
+            this.type = handlerType;
+            return this;
+        }
+
+        public Builder blockingRoute() {
+            this.type = HandlerType.BLOCKING;
+            return this;
+        }
+
+        public Builder failureRoute() {
+            this.type = HandlerType.FAILURE;
+            return this;
+        }
+
+        public Builder nonApplicationRoute() {
+            this.frameworkRoute = true;
+            return this;
+        }
+
+        public RouteBuildItem build() {
+            return new RouteBuildItem(routeFunction, handler, type, frameworkRoute);
+        }
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxFrameworkRouterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxFrameworkRouterBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+import io.vertx.ext.web.Router;
+
+public final class VertxFrameworkRouterBuildItem extends SimpleBuildItem {
+
+    private RuntimeValue<Router> router;
+
+    VertxFrameworkRouterBuildItem(RuntimeValue<Router> router) {
+        this.router = router;
+    }
+
+    public RuntimeValue<Router> getRouter() {
+        return router;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -122,7 +122,7 @@ class VertxHttpProcessor {
     VertxWebRouterBuildItem initializeRouter(VertxHttpRecorder recorder,
             CoreVertxBuildItem vertx,
             List<RouteBuildItem> routes,
-            NonApplicationRootPathBuildItem frameworkRootPath,
+            NonApplicationRootPathBuildItem nonApplicationRootPath,
             BuildProducer<VertxNonApplicationRouterBuildItem> frameworkRouterBuildProducer,
             ShutdownContextBuildItem shutdown) {
 
@@ -131,7 +131,7 @@ class VertxHttpProcessor {
         boolean frameworkRouterFound = false;
 
         for (RouteBuildItem route : routes) {
-            if (frameworkRootPath.isSeparateRoot() && route.isFrameworkRoute()) {
+            if (nonApplicationRootPath.isSeparateRoot() && route.isFrameworkRoute()) {
                 frameworkRouterFound = true;
                 recorder.addRoute(frameworkRouter, route.getRouteFunction(), route.getHandler(), route.getType());
             } else {
@@ -139,7 +139,10 @@ class VertxHttpProcessor {
             }
         }
 
-        if (frameworkRouterFound) {
+        if (frameworkRouterFound && nonApplicationRootPath.isSeparateRoot()) {
+            // Handle redirects from old paths to new non application endpoint root
+            recorder.addNonApplicationPathRedirect(router, frameworkRouter, nonApplicationRootPath.getFrameworkRootPath());
+
             frameworkRouterBuildProducer.produce(new VertxNonApplicationRouterBuildItem(frameworkRouter));
         }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -79,6 +79,11 @@ class VertxHttpProcessor {
     }
 
     @BuildStep
+    FrameworkRootPathBuildItem frameworkRoot(HttpBuildTimeConfig httpBuildTimeConfig) {
+        return new FrameworkRootPathBuildItem(httpBuildTimeConfig.frameworkRootPath);
+    }
+
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     FilterBuildItem cors(CORSRecorder recorder, HttpConfiguration configuration) {
         return new FilterBuildItem(recorder.corsHandler(configuration), FilterBuildItem.CORS);
@@ -117,11 +122,25 @@ class VertxHttpProcessor {
     VertxWebRouterBuildItem initializeRouter(VertxHttpRecorder recorder,
             CoreVertxBuildItem vertx,
             List<RouteBuildItem> routes,
+            FrameworkRootPathBuildItem frameworkRootPath,
+            BuildProducer<VertxFrameworkRouterBuildItem> frameworkRouterBuildProducer,
             ShutdownContextBuildItem shutdown) {
 
         RuntimeValue<Router> router = recorder.initializeRouter(vertx.getVertx());
+        RuntimeValue<Router> frameworkRouter = recorder.initializeRouter(vertx.getVertx());
+        boolean frameworkRouterFound = false;
+
         for (RouteBuildItem route : routes) {
-            recorder.addRoute(router, route.getRouteFunction(), route.getHandler(), route.getType());
+            if (frameworkRootPath.isSeparateRoot() && route.isFrameworkRoute()) {
+                frameworkRouterFound = true;
+                recorder.addRoute(frameworkRouter, route.getRouteFunction(), route.getHandler(), route.getType());
+            } else {
+                recorder.addRoute(router, route.getRouteFunction(), route.getHandler(), route.getType());
+            }
+        }
+
+        if (frameworkRouterFound) {
+            frameworkRouterBuildProducer.produce(new VertxFrameworkRouterBuildItem(frameworkRouter));
         }
 
         return new VertxWebRouterBuildItem(router);
@@ -140,6 +159,8 @@ class VertxHttpProcessor {
             LaunchModeBuildItem launchMode,
             List<DefaultRouteBuildItem> defaultRoutes, List<FilterBuildItem> filters,
             VertxWebRouterBuildItem router,
+            Optional<VertxFrameworkRouterBuildItem> frameworkRouter,
+            FrameworkRootPathBuildItem frameworkRootPathBuildItem,
             HttpBuildTimeConfig httpBuildTimeConfig, HttpConfiguration httpConfiguration,
             List<RequireBodyHandlerBuildItem> requireBodyHandlerBuildItems,
             BodyHandlerBuildItem bodyHandlerBuildItem,
@@ -173,6 +194,12 @@ class VertxHttpProcessor {
         //if the body handler is required then we know it is installed for all routes, so we don't need to register it here
         Handler<RoutingContext> bodyHandler = !requireBodyHandlerBuildItems.isEmpty() ? bodyHandlerBuildItem.getHandler()
                 : null;
+
+        if (frameworkRouter.isPresent()) {
+            recorder.mountFrameworkRouter(router.getRouter(),
+                    frameworkRouter.get().getRouter(),
+                    frameworkRootPathBuildItem.getFrameworkRootPath());
+        }
 
         recorder.finalizeRouter(beanContainer.getValue(),
                 defaultRoute.map(DefaultRouteBuildItem::getRoute).orElse(null),

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -79,8 +79,8 @@ class VertxHttpProcessor {
     }
 
     @BuildStep
-    FrameworkRootPathBuildItem frameworkRoot(HttpBuildTimeConfig httpBuildTimeConfig) {
-        return new FrameworkRootPathBuildItem(httpBuildTimeConfig.frameworkRootPath);
+    NonApplicationRootPathBuildItem frameworkRoot(HttpBuildTimeConfig httpBuildTimeConfig) {
+        return new NonApplicationRootPathBuildItem(httpBuildTimeConfig.frameworkRootPath);
     }
 
     @BuildStep
@@ -122,8 +122,8 @@ class VertxHttpProcessor {
     VertxWebRouterBuildItem initializeRouter(VertxHttpRecorder recorder,
             CoreVertxBuildItem vertx,
             List<RouteBuildItem> routes,
-            FrameworkRootPathBuildItem frameworkRootPath,
-            BuildProducer<VertxFrameworkRouterBuildItem> frameworkRouterBuildProducer,
+            NonApplicationRootPathBuildItem frameworkRootPath,
+            BuildProducer<VertxNonApplicationRouterBuildItem> frameworkRouterBuildProducer,
             ShutdownContextBuildItem shutdown) {
 
         RuntimeValue<Router> router = recorder.initializeRouter(vertx.getVertx());
@@ -140,7 +140,7 @@ class VertxHttpProcessor {
         }
 
         if (frameworkRouterFound) {
-            frameworkRouterBuildProducer.produce(new VertxFrameworkRouterBuildItem(frameworkRouter));
+            frameworkRouterBuildProducer.produce(new VertxNonApplicationRouterBuildItem(frameworkRouter));
         }
 
         return new VertxWebRouterBuildItem(router);
@@ -159,8 +159,8 @@ class VertxHttpProcessor {
             LaunchModeBuildItem launchMode,
             List<DefaultRouteBuildItem> defaultRoutes, List<FilterBuildItem> filters,
             VertxWebRouterBuildItem router,
-            Optional<VertxFrameworkRouterBuildItem> frameworkRouter,
-            FrameworkRootPathBuildItem frameworkRootPathBuildItem,
+            Optional<VertxNonApplicationRouterBuildItem> frameworkRouter,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             HttpBuildTimeConfig httpBuildTimeConfig, HttpConfiguration httpConfiguration,
             List<RequireBodyHandlerBuildItem> requireBodyHandlerBuildItems,
             BodyHandlerBuildItem bodyHandlerBuildItem,
@@ -198,7 +198,7 @@ class VertxHttpProcessor {
         if (frameworkRouter.isPresent()) {
             recorder.mountFrameworkRouter(router.getRouter(),
                     frameworkRouter.get().getRouter(),
-                    frameworkRootPathBuildItem.getFrameworkRootPath());
+                    nonApplicationRootPathBuildItem.getFrameworkRootPath());
         }
 
         recorder.finalizeRouter(beanContainer.getValue(),

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -80,7 +80,7 @@ class VertxHttpProcessor {
 
     @BuildStep
     NonApplicationRootPathBuildItem frameworkRoot(HttpBuildTimeConfig httpBuildTimeConfig) {
-        return new NonApplicationRootPathBuildItem(httpBuildTimeConfig.frameworkRootPath);
+        return new NonApplicationRootPathBuildItem(httpBuildTimeConfig.nonApplicationRootPath);
     }
 
     @BuildStep
@@ -122,6 +122,7 @@ class VertxHttpProcessor {
     VertxWebRouterBuildItem initializeRouter(VertxHttpRecorder recorder,
             CoreVertxBuildItem vertx,
             List<RouteBuildItem> routes,
+            HttpBuildTimeConfig httpBuildTimeConfig,
             NonApplicationRootPathBuildItem nonApplicationRootPath,
             BuildProducer<VertxNonApplicationRouterBuildItem> frameworkRouterBuildProducer,
             ShutdownContextBuildItem shutdown) {
@@ -141,7 +142,9 @@ class VertxHttpProcessor {
 
         if (frameworkRouterFound && nonApplicationRootPath.isSeparateRoot()) {
             // Handle redirects from old paths to new non application endpoint root
-            recorder.addNonApplicationPathRedirect(router, frameworkRouter, nonApplicationRootPath.getFrameworkRootPath());
+            if (httpBuildTimeConfig.redirectToNonApplicationRootPath) {
+                recorder.addNonApplicationPathRedirect(router, frameworkRouter, nonApplicationRootPath.getFrameworkRootPath());
+            }
 
             frameworkRouterBuildProducer.produce(new VertxNonApplicationRouterBuildItem(frameworkRouter));
         }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxNonApplicationRouterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxNonApplicationRouterBuildItem.java
@@ -4,11 +4,11 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.runtime.RuntimeValue;
 import io.vertx.ext.web.Router;
 
-public final class VertxFrameworkRouterBuildItem extends SimpleBuildItem {
+public final class VertxNonApplicationRouterBuildItem extends SimpleBuildItem {
 
     private RuntimeValue<Router> router;
 
-    VertxFrameworkRouterBuildItem(RuntimeValue<Router> router) {
+    VertxNonApplicationRouterBuildItem(RuntimeValue<Router> router) {
         this.router = router;
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -37,11 +37,19 @@ public class HttpBuildTimeConfig {
     public String consolePath;
 
     /**
-     * The HTTP root path for framework endpoints. Various endpoints such as metrics, health,
+     * The HTTP root path for non application endpoints. Various endpoints such as metrics, health,
      * and open api are deployed under this path.
-     * Setting the value to "/" disables the separate framework root,
-     * resulting in all framework endpoints being served from "/" along with the application.
+     * Setting the value to "/" disables the separate non application root,
+     * resulting in all non application endpoints being served from "/" along with the application.
      */
     @ConfigItem(defaultValue = "/q")
-    public String frameworkRootPath;
+    public String nonApplicationRootPath;
+
+    /**
+     * Whether to redirect non application endpoints from previous location off the root to the
+     * new non application root path.
+     * Enabled by default.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean redirectToNonApplicationRootPath;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -35,4 +35,13 @@ public class HttpBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "/quarkus")
     public String consolePath;
+
+    /**
+     * The HTTP root path for framework endpoints. Various endpoints such as metrics, health,
+     * and open api are deployed under this path.
+     * Setting the value to "/" disables the separate framework root,
+     * resulting in all framework endpoints being served from "/" along with the application.
+     */
+    @ConfigItem(defaultValue = "/q")
+    public String frameworkRootPath;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -250,6 +250,11 @@ public class VertxHttpRecorder {
         }
     }
 
+    public void mountFrameworkRouter(RuntimeValue<Router> mainRouter, RuntimeValue<Router> frameworkRouter,
+            String frameworkPath) {
+        mainRouter.getValue().mountSubRouter(frameworkPath, frameworkRouter.getValue());
+    }
+
     public void finalizeRouter(BeanContainer container, Consumer<Route> defaultRouteHandler,
             List<Filter> filterList, Supplier<Vertx> vertx,
             LiveReloadConfig liveReloadConfig,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -807,7 +807,7 @@ public class VertxHttpRecorder {
             public void handle(RoutingContext context) {
                 String absoluteURI = context.request().absoluteURI();
                 int pathStart = absoluteURI.indexOf(context.request().path());
-                String redirectTo = absoluteURI.substring(0, pathStart - 1) + nonApplicationPath
+                String redirectTo = absoluteURI.substring(0, pathStart) + nonApplicationPath
                         + absoluteURI.substring(pathStart);
 
                 context.response()

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -37,7 +37,7 @@ public class AmazonLambdaSimpleTestCase {
     @Test
     public void testSwaggerUi() throws Exception {
         // this tests the FileRegion support in the handler
-        AwsProxyRequest request = request("/swagger-ui/");
+        AwsProxyRequest request = request("/q/swagger-ui/");
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertTrue(body(out).contains("Swagger UI"));

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
@@ -21,7 +21,7 @@ public class ArtemisHealthCheckTest {
 
     @Test
     public void test() {
-        Response response = RestAssured.with().get("/health/ready");
+        Response response = RestAssured.with().get("/q/health/ready");
         Assertions.assertEquals(Status.OK.getStatusCode(), response.statusCode());
 
         Map<String, Object> body = response.as(new TypeRef<Map<String, Object>>() {

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
@@ -21,7 +21,7 @@ public class ArtemisHealthCheckTest {
 
     @Test
     public void test() {
-        Response response = RestAssured.with().get("/health/ready");
+        Response response = RestAssured.with().get("/q/health/ready");
         Assertions.assertEquals(Status.OK.getStatusCode(), response.statusCode());
 
         Map<String, Object> body = response.as(new TypeRef<Map<String, Object>>() {

--- a/integration-tests/elasticsearch-rest-client/src/test/java/io/quarkus/it/elasticsearch/FruitResourceTest.java
+++ b/integration-tests/elasticsearch-rest-client/src/test/java/io/quarkus/it/elasticsearch/FruitResourceTest.java
@@ -60,7 +60,7 @@ public class FruitResourceTest {
 
     @Test
     public void testHealth() {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.status", containsInAnyOrder("UP"),
                         "checks.name", containsInAnyOrder("Elasticsearch cluster health check"));

--- a/integration-tests/elasticsearch-rest-high-level-client/src/test/java/io/quarkus/it/elasticsearch/FruitResourceTest.java
+++ b/integration-tests/elasticsearch-rest-high-level-client/src/test/java/io/quarkus/it/elasticsearch/FruitResourceTest.java
@@ -61,7 +61,7 @@ public class FruitResourceTest {
 
     @Test
     public void testHealth() {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.status", containsInAnyOrder("UP"),
                         "checks.name", containsInAnyOrder("Elasticsearch cluster health check"));

--- a/integration-tests/grpc-health/src/test/java/io/quarkus/grpc/health/MicroProfileHealthDisabledTest.java
+++ b/integration-tests/grpc-health/src/test/java/io/quarkus/grpc/health/MicroProfileHealthDisabledTest.java
@@ -23,7 +23,7 @@ public class MicroProfileHealthDisabledTest {
     public void shouldNotGetMpHealthInfoWhenDisabled() {
         // @formatter:off
         when()
-                .get("/health")
+                .get("/q/health")
         .then()
                 .statusCode(200)
                 .body("checks.size()", Matchers.equalTo(0));

--- a/integration-tests/grpc-health/src/test/java/io/quarkus/grpc/health/MicroProfileHealthEnabledTest.java
+++ b/integration-tests/grpc-health/src/test/java/io/quarkus/grpc/health/MicroProfileHealthEnabledTest.java
@@ -68,7 +68,7 @@ public class MicroProfileHealthEnabledTest {
     private void checkHealthOk() {
         // @formatter:off
         when()
-                .get("/health")
+                .get("/q/health")
         .then()
                 .statusCode(200)
                 .body("checks[0].name", Matchers.equalTo("gRPC Server"))

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -181,7 +181,7 @@ public class PanacheFunctionalityTest {
     @Test
     public void testMetrics() {
         RestAssured.when()
-                .get("/metrics")
+                .get("/q/metrics")
                 .then()
                 .body(containsString("vendor_hibernate_cache_update_timestamps_requests_total{entityManagerFactory=\""
                         + PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME + "\",result=\"miss\"}"));

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
@@ -38,7 +38,7 @@ public class KafkaStreamsStartupFailureTest {
     @Timeout(5)
     public void testShutdownBeforeKStreamsStarted() throws Exception {
         assertEquals(State.CREATED, kafkaStreams.state());
-        RestAssured.get("/health/ready").then()
+        RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
                 .body("checks[0].status", CoreMatchers.is("DOWN"))

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -147,42 +147,42 @@ public class KafkaStreamsTest {
 
     private void testMetricsPresent() {
         // Look for kafka consumer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
                 .body(containsString("kafka_stream_"));
     }
 
     public void testKafkaStreamsNotAliveAndNotReady() throws Exception {
-        RestAssured.get("/health/ready").then()
+        RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
                 .body("checks[0].status", CoreMatchers.is("DOWN"))
                 .body("checks[0].data.missing_topics", CoreMatchers.is("streams-test-customers,streams-test-categories"));
 
-        RestAssured.when().get("/health/live").then()
+        RestAssured.when().get("/q/health/live").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams state health check"))
                 .body("checks[0].status", CoreMatchers.is("DOWN"))
                 .body("checks[0].data.state", CoreMatchers.is("CREATED"));
 
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
     }
 
     public void testKafkaStreamsAliveAndReady() throws Exception {
-        RestAssured.get("/health/ready").then()
+        RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
                 .body("checks[0].status", CoreMatchers.is("UP"))
                 .body("checks[0].data.available_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
 
-        RestAssured.when().get("/health/live").then()
+        RestAssured.when().get("/q/health/live").then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams state health check"))
                 .body("checks[0].status", CoreMatchers.is("UP"))
                 .body("checks[0].data.state", CoreMatchers.is("RUNNING"));
 
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .statusCode(HttpStatus.SC_OK);
     }
 

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
@@ -40,7 +40,7 @@ public class KafkaConsumerTest {
     @Test
     public void metrics() throws Exception {
         // Look for kafka consumer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
                 .body(containsString("kafka_consumer_"));
     }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
@@ -44,7 +44,7 @@ public class KafkaProducerTest {
 
     @Test
     public void health() throws Exception {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.status", containsInAnyOrder("UP"),
                         "checks.name", containsInAnyOrder("Kafka connection health check"));
@@ -53,7 +53,7 @@ public class KafkaProducerTest {
     @Test
     public void metrics() throws Exception {
         // Look for kafka producer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
                 .body(containsString("kafka_producer_"));
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
@@ -64,14 +64,14 @@ public class KnativeWithHealthTest {
                                 });
                                 assertThat(c.getReadinessProbe()).isNotNull().satisfies(p -> {
                                     assertThat(p.getInitialDelaySeconds()).isEqualTo(0);
-                                    assertProbePath(p, "/health/ready");
+                                    assertProbePath(p, "/q/health/ready");
 
                                     assertNotNull(p.getHttpGet());
                                     assertNull(p.getHttpGet().getPort());
                                 });
                                 assertThat(c.getLivenessProbe()).isNotNull().satisfies(p -> {
                                     assertThat(p.getInitialDelaySeconds()).isEqualTo(20);
-                                    assertProbePath(p, "/health/live");
+                                    assertProbePath(p, "/q/health/live");
 
                                     assertNotNull(p.getHttpGet());
                                     assertNull(p.getHttpGet().getPort());

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
@@ -57,10 +57,10 @@ public class KubernetesWithHealthAndJibTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
-                                assertProbePath(p, "/health/ready");
+                                assertProbePath(p, "/q/health/ready");
                             });
                             assertThat(container.getLivenessProbe()).isNotNull().satisfies(p -> {
-                                assertProbePath(p, "/health/live");
+                                assertProbePath(p, "/q/health/live");
                             });
                             assertThat(container.getImagePullPolicy()).isEqualTo("Always");
                         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
@@ -77,14 +77,14 @@ public class KubernetesWithHealthTest {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
                                 assertThat(p.getInitialDelaySeconds()).isEqualTo(0);
-                                assertProbePath(p, "/health/ready");
+                                assertProbePath(p, "/q/health/ready");
 
                                 assertNotNull(p.getHttpGet());
                                 assertEquals(p.getHttpGet().getPort().getIntVal(), 9090);
                             });
                             assertThat(container.getLivenessProbe()).isNotNull().satisfies(p -> {
                                 assertThat(p.getInitialDelaySeconds()).isEqualTo(20);
-                                assertProbePath(p, "/health/live");
+                                assertProbePath(p, "/q/health/live");
 
                                 assertNotNull(p.getHttpGet());
                                 assertEquals(p.getHttpGet().getPort().getIntVal(), 9090);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
@@ -54,10 +54,10 @@ public class KubernetesWithRootAndHealthTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).satisfies(p -> {
-                                assertProbePath(p, "/api/health/ready");
+                                assertProbePath(p, "/q/health/ready");
                             });
                             assertThat(container.getLivenessProbe()).satisfies(p -> {
-                                assertProbePath(p, "/api/health/liveness");
+                                assertProbePath(p, "/q/health/liveness");
                             });
                         });
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
@@ -74,7 +74,7 @@ public class OpenshiftWithHealthTest {
                             assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
                                 assertThat(p.getPeriodSeconds()).isEqualTo(10);
                                 assertThat(p.getHttpGet()).satisfies(h1 -> {
-                                    assertThat(h1.getPath()).isEqualTo("/health/ready");
+                                    assertThat(h1.getPath()).isEqualTo("/q/health/ready");
                                 });
                             });
                             assertThat(container.getLivenessProbe()).isNotNull().satisfies(p -> {

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
@@ -54,4 +54,46 @@ public class HealthTestCase {
             RestAssured.reset();
         }
     }
+
+    @Test
+    public void testHealthCheckRedirect() {
+        try {
+            RestAssured.when().get("/health/live").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP", "UP"),
+                            "checks.name", containsInAnyOrder("basic", "basic-with-builder"));
+
+            RestAssured.when().get("/health/ready").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP"),
+                            "checks.name", containsInAnyOrder("Database connections health check"));
+
+            RestAssured.when().get("/health/group/group1").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP", "UP"),
+                            "checks.name", containsInAnyOrder("single", "combined"));
+
+            RestAssured.when().get("/health/group/group2").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP"),
+                            "checks.name", containsInAnyOrder("combined"));
+
+            RestAssured.when().get("/health/group").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP", "UP"),
+                            "checks.name", containsInAnyOrder("single", "combined"));
+        } finally {
+            RestAssured.reset();
+        }
+    }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
@@ -16,35 +16,35 @@ public class HealthTestCase {
     @Test
     public void testHealthCheck() {
         try {
-            RestAssured.when().get("/health/live").then()
+            RestAssured.when().get("/q/health/live").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),
                             "checks.status", containsInAnyOrder("UP", "UP"),
                             "checks.name", containsInAnyOrder("basic", "basic-with-builder"));
 
-            RestAssured.when().get("/health/ready").then()
+            RestAssured.when().get("/q/health/ready").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),
                             "checks.status", containsInAnyOrder("UP"),
                             "checks.name", containsInAnyOrder("Database connections health check"));
 
-            RestAssured.when().get("/health/group/group1").then()
+            RestAssured.when().get("/q/health/group/group1").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),
                             "checks.status", containsInAnyOrder("UP", "UP"),
                             "checks.name", containsInAnyOrder("single", "combined"));
 
-            RestAssured.when().get("/health/group/group2").then()
+            RestAssured.when().get("/q/health/group/group2").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),
                             "checks.status", containsInAnyOrder("UP"),
                             "checks.name", containsInAnyOrder("combined"));
 
-            RestAssured.when().get("/health/group").then()
+            RestAssured.when().get("/q/health/group").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
@@ -22,7 +22,7 @@ public class OpenApiTestCase {
 
     private static final String DEFAULT_MEDIA_TYPE = "application/json";
 
-    @TestHTTPResource("openapi")
+    @TestHTTPResource("q/openapi")
     URL uri;
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUITestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUITestCase.java
@@ -17,4 +17,11 @@ public class SwaggerUITestCase {
                 .body(containsString("/openapi"));
     }
 
+    @Test
+    public void testSwaggerUiRedirect() {
+        RestAssured.when().get("/swagger-ui").then()
+                .body(containsString("#swagger-ui"))
+                .body(containsString("/openapi"));
+    }
+
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUITestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUITestCase.java
@@ -12,7 +12,7 @@ public class SwaggerUITestCase {
 
     @Test
     public void testSwaggerUi() {
-        RestAssured.when().get("/swagger-ui").then()
+        RestAssured.when().get("/q/swagger-ui").then()
                 .body(containsString("#swagger-ui"))
                 .body(containsString("/openapi"));
     }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -298,7 +298,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> DevModeTestUtils.getHttpResponse("/openapi").contains("hello"));
+                .atMost(1, TimeUnit.MINUTES).until(() -> DevModeTestUtils.getHttpResponse("/q/openapi").contains("hello"));
     }
 
     @Test

--- a/integration-tests/micrometer-mp-metrics/src/test/java/io/quarkus/it/micrometer/mpmetrics/MPMetricsTest.java
+++ b/integration-tests/micrometer-mp-metrics/src/test/java/io/quarkus/it/micrometer/mpmetrics/MPMetricsTest.java
@@ -47,7 +47,7 @@ class MPMetricsTest {
     @Order(4)
     void validateMetricsOutput_1() {
         given()
-                .when().get("/metrics")
+                .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
 
@@ -84,7 +84,7 @@ class MPMetricsTest {
     @Order(6)
     void validateMetricsOutput_2() {
         given()
-                .when().get("/metrics")
+                .when().get("/q/metrics")
                 .then()
                 .log().body()
                 .statusCode(200)
@@ -103,7 +103,7 @@ class MPMetricsTest {
     void validateJsonOutput() {
         given()
                 .header("Accept", "application/json")
-                .when().get("/metrics")
+                .when().get("/q/metrics")
                 .then()
                 .log().body()
                 .statusCode(200)

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -95,7 +95,7 @@ class PrometheusMetricsRegistryTest {
     @Order(10)
     void testPrometheusScrapeEndpoint() {
         given()
-                .when().get("/metrics")
+                .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
 

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -43,7 +43,7 @@ public class BookResourceTest {
 
     @Test
     public void health() throws Exception {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.data", containsInAnyOrder(hasKey(MongoHealthCheck.CLIENT_DEFAULT)),
                         "checks.data", containsInAnyOrder(hasKey(MongoHealthCheck.CLIENT_DEFAULT_REACTIVE)),

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -314,7 +314,7 @@ class MongodbPanacheResourceTest {
 
         // Test prometheus metrics gathered using micrometer metrics
         RestAssured.given()
-                .when().get("/metrics")
+                .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
                 .body(CoreMatchers.containsString("mongodb_driver_pool_checkedout"))

--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -47,7 +47,7 @@ public class Neo4jFunctionalityTest {
 
     @Test
     public void health() {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .log().all()
                 .body("status", is("UP"),
                         "checks.status", containsInAnyOrder("UP"),
@@ -68,7 +68,7 @@ public class Neo4jFunctionalityTest {
     private void assertMetricValue(String name, Matcher<Integer> valueMatcher) {
         RestAssured
                 .given().accept(ContentType.JSON)
-                .when().get("/metrics/vendor/" + name)
+                .when().get("/q/metrics/vendor/" + name)
                 .then()
                 .body("'" + name + "'", valueMatcher);
     }

--- a/integration-tests/reactive-db2-client/src/test/java/io/quarkus/it/reactive/db2/client/HealthCheckTest.java
+++ b/integration-tests/reactive-db2-client/src/test/java/io/quarkus/it/reactive/db2/client/HealthCheckTest.java
@@ -14,7 +14,7 @@ import io.restassured.http.ContentType;
 public class HealthCheckTest {
     @Test
     public void testHealthCheck() {
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .contentType(ContentType.JSON)
                 .header("Content-Type", containsString("charset=UTF-8"))
                 .body("status", is("UP"),

--- a/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckTest.java
+++ b/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckTest.java
@@ -14,7 +14,7 @@ import io.restassured.http.ContentType;
 public class HealthCheckTest {
     @Test
     public void testHealthCheck() {
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .contentType(ContentType.JSON)
                 .header("Content-Type", containsString("charset=UTF-8"))
                 .body("status", is("UP"),

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckTest.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckTest.java
@@ -14,7 +14,7 @@ import io.restassured.http.ContentType;
 public class HealthCheckTest {
     @Test
     public void testHealthCheck() {
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .contentType(ContentType.JSON)
                 .header("Content-Type", containsString("charset=UTF-8"))
                 .body("status", is("UP"),

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/HealthCheckTest.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/HealthCheckTest.java
@@ -15,7 +15,7 @@ import io.restassured.http.ContentType;
 public class HealthCheckTest {
     @Test
     public void testHealthCheck() {
-        RestAssured.when().get("/health").then()
+        RestAssured.when().get("/q/health").then()
                 .contentType(ContentType.JSON)
                 .header("Content-Type", containsString("charset=UTF-8"))
                 .body("status", is("UP"),

--- a/integration-tests/smallrye-metrics/src/test/java/io/quarkus/it/metrics/MetricsOnClassTestCase.java
+++ b/integration-tests/smallrye-metrics/src/test/java/io/quarkus/it/metrics/MetricsOnClassTestCase.java
@@ -23,12 +23,12 @@ public class MetricsOnClassTestCase {
     }
 
     private void assertMetricExactValue(String scope, String name, String expectedNameInOutput, String val) {
-        RestAssured.when().get("/metrics/" + scope + "/" + name).then()
+        RestAssured.when().get("/q/metrics/" + scope + "/" + name).then()
                 .body(containsString(expectedNameInOutput + " " + val));
     }
 
     private void assertMetricExists(String scope, String name, String expectedNameInOutput) {
-        RestAssured.when().get("/metrics/" + scope + "/" + name).then()
+        RestAssured.when().get("/q/metrics/" + scope + "/" + name).then()
                 .body(containsString(expectedNameInOutput + " "));
     }
 

--- a/integration-tests/smallrye-metrics/src/test/java/io/quarkus/it/metrics/MetricsTestCase.java
+++ b/integration-tests/smallrye-metrics/src/test/java/io/quarkus/it/metrics/MetricsTestCase.java
@@ -96,9 +96,9 @@ public class MetricsTestCase {
 
     @Test
     public void testScopes() {
-        RestAssured.when().get("/metrics/base").then().statusCode(200);
-        RestAssured.when().get("/metrics/vendor").then().statusCode(200);
-        RestAssured.when().get("/metrics/application").then().statusCode(200);
+        RestAssured.when().get("/q/metrics/base").then().statusCode(200);
+        RestAssured.when().get("/q/metrics/vendor").then().statusCode(200);
+        RestAssured.when().get("/q/metrics/application").then().statusCode(200);
     }
 
     @Test
@@ -115,15 +115,15 @@ public class MetricsTestCase {
 
     @Test
     public void testInvalidScopes() {
-        RestAssured.when().get("/metrics/foo").then().statusCode(404)
+        RestAssured.when().get("/q/metrics/foo").then().statusCode(404)
                 .body(containsString("Scope foo not found"));
-        RestAssured.when().get("/metrics/vendor/foo").then().statusCode(404)
+        RestAssured.when().get("/q/metrics/vendor/foo").then().statusCode(404)
                 .body(containsString("Metric vendor/foo not found"));
     }
 
     @Test
     public void testBaseMetrics() {
-        RestAssured.when().get("/metrics/base").then().statusCode(200)
+        RestAssured.when().get("/q/metrics/base").then().statusCode(200)
                 // the spaces at the end are there on purpose to make sure the metrics are named exactly this way
                 .body(containsString("base_classloader_loadedClasses_total "))
                 .body(containsString("base_cpu_systemLoadAverage "))
@@ -141,7 +141,7 @@ public class MetricsTestCase {
 
     @Test
     public void testVendorMetrics() {
-        RestAssured.when().get("/metrics/vendor").then().statusCode(200)
+        RestAssured.when().get("/q/metrics/vendor").then().statusCode(200)
                 // the spaces at the end are there on purpose to make sure the metrics are named exactly this way
                 .body(containsString("vendor_memory_committedNonHeap_bytes "))
                 .body(containsString("vendor_memory_usedNonHeap_bytes "))
@@ -164,7 +164,7 @@ public class MetricsTestCase {
      */
     @Test
     public void testNoMetricsFromSmallRyeInternalClasses() {
-        RestAssured.when().get("/metrics/application").then()
+        RestAssured.when().get("/q/metrics/application").then()
                 .body(not(containsString("io_smallrye_metrics")));
     }
 
@@ -186,12 +186,12 @@ public class MetricsTestCase {
     }
 
     private void assertMetricExactValue(String name, String val) {
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .body(containsString(name + " " + val));
     }
 
     private void assertMetricExists(String name) {
-        RestAssured.when().get("/metrics").then()
+        RestAssured.when().get("/q/metrics").then()
                 .body(containsString(name));
     }
 

--- a/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultTest.java
+++ b/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultTest.java
@@ -24,7 +24,7 @@ public class VaultTest {
 
     @Test
     public void testHealthCheck() {
-        RestAssured.when().get("/health/ready").then()
+        RestAssured.when().get("/q/health/ready").then()
                 .assertThat()
                 .body("status", equalTo("UP"))
                 .body("checks.size()", is(2));

--- a/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
+++ b/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
@@ -29,7 +29,7 @@ public class FunctionTest {
     @Test
     public void testSwagger() {
         final HttpRequestMessageMock req = new HttpRequestMessageMock();
-        req.setUri(URI.create("https://foo.com/swagger-ui/"));
+        req.setUri(URI.create("https://foo.com/q/swagger-ui/"));
         req.setHttpMethod(HttpMethod.GET);
 
         // Invoke

--- a/tcks/microprofile-health/pom.xml
+++ b/tcks/microprofile-health/pom.xml
@@ -20,7 +20,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <!-- Change metrics endpoint to be /metrics -->
-                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
+                        <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                     </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>

--- a/tcks/microprofile-health/pom.xml
+++ b/tcks/microprofile-health/pom.xml
@@ -18,6 +18,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <systemPropertyVariables>
+                        <!-- Change metrics endpoint to be /metrics -->
+                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
+                    </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/tcks/microprofile-metrics/optional/pom.xml
+++ b/tcks/microprofile-metrics/optional/pom.xml
@@ -23,7 +23,7 @@
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <quarkus.resteasy.metrics.enabled>true</quarkus.resteasy.metrics.enabled>
                         <!-- Change metrics endpoint to be /metrics -->
-                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
+                        <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                         <context.root/>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using

--- a/tcks/microprofile-metrics/optional/pom.xml
+++ b/tcks/microprofile-metrics/optional/pom.xml
@@ -22,6 +22,8 @@
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <quarkus.resteasy.metrics.enabled>true</quarkus.resteasy.metrics.enabled>
+                        <!-- Change metrics endpoint to be /metrics -->
+                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
                         <context.root/>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using

--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -22,7 +22,7 @@
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <!-- Change metrics endpoint to be /metrics -->
-                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
+                        <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -21,6 +21,8 @@
                     <systemPropertyVariables>
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
+                        <!-- Change metrics endpoint to be /metrics -->
+                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -23,6 +23,8 @@
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <test.url>http://localhost:8081</test.url>
+                        <!-- Change metrics endpoint to be /metrics -->
+                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -24,7 +24,7 @@
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <test.url>http://localhost:8081</test.url>
                         <!-- Change metrics endpoint to be /metrics -->
-                        <quarkus.http.framework-root-path>/</quarkus.http.framework-root-path>
+                        <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->


### PR DESCRIPTION
- Fixes #13144
- OpenAPI, Metrics, Micrometer, Health, Health UI endpoints are all now served under /q by default
- Previous behavior can be attained by setting `quarkus.http.non-application-root-path` to `/`

Subsequent issue will be created for handling port and binding changes for non application endpoints