### PR TITLE
Implement missing JpaRepository method deleteAllInBatch()

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
@@ -110,6 +110,8 @@ public class StockMethodsAdder {
         generateDelete(classCreator, generatedClassName, entityTypeStr, allMethodsToBeImplementedToResult);
         generateDeleteAllWithIterable(classCreator, generatedClassName, entityTypeStr, allMethodsToBeImplementedToResult);
         generateDeleteAll(classCreator, entityClassFieldDescriptor, generatedClassName, allMethodsToBeImplementedToResult);
+        generateDeleteAllInBatch(classCreator, entityClassFieldDescriptor, generatedClassName,
+                allMethodsToBeImplementedToResult);
 
         handleUnimplementedMethods(classCreator, allMethodsToBeImplementedToResult);
     }
@@ -919,6 +921,27 @@ public class StockMethodsAdder {
                 }
             }
             allMethodsToBeImplementedToResult.put(deleteAllDescriptor, true);
+        }
+    }
+
+    private void generateDeleteAllInBatch(ClassCreator classCreator, FieldDescriptor entityClassFieldDescriptor,
+            String generatedClassName, Map<MethodDescriptor, Boolean> allMethodsToBeImplementedToResult) {
+
+        MethodDescriptor deleteAllInBatchDescriptor = MethodDescriptor.ofMethod(generatedClassName, "deleteAllInBatch",
+                void.class);
+
+        if (allMethodsToBeImplementedToResult.containsKey(deleteAllInBatchDescriptor)) {
+            if (!classCreator.getExistingMethods().contains(deleteAllInBatchDescriptor)) {
+                try (MethodCreator deleteAll = classCreator.getMethodCreator(deleteAllInBatchDescriptor)) {
+                    deleteAll.addAnnotation(Transactional.class);
+                    ResultHandle result = deleteAll.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(AbstractJpaOperations.class, "deleteAll", long.class, Class.class),
+                            deleteAll.readStaticField(operationsField),
+                            deleteAll.readInstanceField(entityClassFieldDescriptor, deleteAll.getThis()));
+                    deleteAll.returnValue(result);
+                }
+            }
+            allMethodsToBeImplementedToResult.put(deleteAllInBatchDescriptor, true);
         }
     }
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CountryResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CountryResource.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.persistence.NoResultException;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -72,5 +73,11 @@ public class CountryResource {
     @Produces("application/json")
     public Country getOne(@PathParam("id") Long id) {
         return countryRepository.getOne(id);
+    }
+
+    @DELETE
+    @Path("/")
+    public void deleteAllInBatch() {
+        this.countryRepository.deleteAllInBatch();
     }
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CountryResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CountryResourceTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -15,17 +16,22 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CountryResourceTest {
 
     private static final Set<String> NOT_ADDED_OR_REMOVED = new HashSet<>(
             Arrays.asList("Greece", "France", "Czechia"));
 
     @Test
+    @Order(1)
     void testAll() {
         List<Country> countries = when().get("/country/all").then()
                 .statusCode(200)
@@ -37,6 +43,7 @@ public class CountryResourceTest {
     }
 
     @Test
+    @Order(2)
     void testPage() {
         when().get("/country/page/1/0").then()
                 .statusCode(200)
@@ -56,6 +63,7 @@ public class CountryResourceTest {
     }
 
     @Test
+    @Order(3)
     void testPageSorted() {
         String response = when().get("/country/page-sorted/2/0").then()
                 .statusCode(200)
@@ -65,6 +73,7 @@ public class CountryResourceTest {
     }
 
     @Test
+    @Order(4)
     void testGetOne() {
         when().get("/country/getOne/1").then()
                 .statusCode(200)
@@ -75,6 +84,7 @@ public class CountryResourceTest {
     }
 
     @Test
+    @Order(5)
     void testNewAndEditIso() {
         when().get("/country/all").then()
                 .statusCode(200)
@@ -101,5 +111,16 @@ public class CountryResourceTest {
 
         when().get("/country/editIso3/100/ZZZ").then()
                 .statusCode(500);
+    }
+
+    @Test
+    @Order(6)
+    void testDeleteAllInBatch() {
+        when().delete("/country").then()
+                .statusCode(204);
+
+        when().get("/country/all").then()
+                .statusCode(200)
+                .body("size()", equalTo(0));
     }
 }


### PR DESCRIPTION
This pull request implements the method JpaRepository.deleteAllInBatch() which currently throws a FunctionalityNotImplemented exception. I have to migrate a lot of test code which called this method and I thought it makes sense to implement it.