### PR TITLE
Create quarkus-smallrye-jwt-build extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -973,6 +973,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-smallrye-jwt-build</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-context-propagation</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -2950,6 +2960,14 @@
                     <exclusion>
                         <groupId>javax</groupId>
                         <artifactId>javaee-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-jwt-build</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -34,7 +34,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=security-jwt-quickstart \
     -DclassName="org.acme.security.jwt.TokenSecuredResource" \
     -Dpath="/secured" \
-    -Dextensions="resteasy-jackson, jwt"
+    -Dextensions="resteasy-jackson, smallrye-jwt, smallrye-jwt-build"
 cd security-jwt-quickstart
 ----
 
@@ -45,7 +45,7 @@ to your project by running the following command in your project base directory:
 
 [source,bash]
 ----
-./mvnw quarkus:add-extension -Dextensions="smallrye-jwt"
+./mvnw quarkus:add-extension -Dextensions="smallrye-jwt, smallrye-jwt-build"
 ----
 
 This will add the following to your `pom.xml`:
@@ -55,6 +55,10 @@ This will add the following to your `pom.xml`:
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-smallrye-jwt</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-jwt-build</artifactId>
 </dependency>
 ----
 
@@ -812,8 +816,8 @@ SmallRye JWT provides an API for securing the JWT claims using all of these opti
 [source,xml]
 ----
 <dependency>
-  <groupId>io.smallrye</groupId>
-  <artifactId>smallrye-jwt-build</artifactId>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-jwt-build</artifactId>
 </dependency>
 ----
 

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -41,7 +41,6 @@ import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
 import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
-import io.smallrye.jwt.build.impl.JwtProviderImpl;
 
 public class OidcBuildStep {
     public static final DotName DOTNAME_SECURITY_EVENT = DotName.createSimple(SecurityEvent.class.getName());
@@ -79,8 +78,6 @@ public class OidcBuildStep {
                 .addBeanClass(DefaultTenantConfigResolver.class)
                 .addBeanClass(DefaultTokenStateManager.class);
         additionalBeans.produce(builder.build());
-
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, JwtProviderImpl.class));
     }
 
     @BuildStep(onlyIf = IsEnabled.class)

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -34,14 +34,12 @@
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   guide: "https://quarkus.io/guides/security-openid-connect"
   categories:
   - "security"
-  status: "preview"
+  status: "stable"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -129,6 +129,7 @@
         <module>elytron-security-ldap</module>
         <module>elytron-security-properties-file</module>
         <module>elytron-security-oauth2</module>
+        <module>smallrye-jwt-build</module>
         <module>smallrye-jwt</module>
         <module>oidc</module>
         <module>keycloak-authorization</module>

--- a/extensions/smallrye-jwt-build/deployment/pom.xml
+++ b/extensions/smallrye-jwt-build/deployment/pom.xml
@@ -3,57 +3,40 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-smallrye-jwt-parent</artifactId>
+        <artifactId>quarkus-smallrye-jwt-build-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-smallrye-jwt</artifactId>
-    <name>Quarkus - SmallRye JWT - Runtime</name>
-    <description>Secure your applications with JSON Web Token</description>
+    <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+    <name>Quarkus - SmallRye JWT Build - Deployment</name>
 
     <dependencies>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-smallrye-jwt-build</artifactId>
         </dependency>
+
+        <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-json-p-provider</artifactId>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/builder/deployment/SmallRyeJwtBuildProcessor.java
+++ b/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/builder/deployment/SmallRyeJwtBuildProcessor.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.jwt.builder.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.build.impl.JwtProviderImpl;
+
+class SmallRyeJwtBuildProcessor {
+
+    @BuildStep
+    void addClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, SignatureAlgorithm.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, JwtProviderImpl.class));
+    }
+}

--- a/extensions/smallrye-jwt-build/pom.xml
+++ b/extensions/smallrye-jwt-build/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-smallrye-jwt-build-parent</artifactId>
+    <name>Quarkus - SmallRye JWT Token Build</name>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/smallrye-jwt-build/runtime/pom.xml
+++ b/extensions/smallrye-jwt-build/runtime/pom.xml
@@ -3,48 +3,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-smallrye-jwt-parent</artifactId>
+        <artifactId>quarkus-smallrye-jwt-build-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-smallrye-jwt</artifactId>
-    <name>Quarkus - SmallRye JWT - Runtime</name>
-    <description>Secure your applications with JSON Web Token</description>
+    <artifactId>quarkus-smallrye-jwt-build</artifactId>
+    <name>Quarkus - SmallRye JWT Token Build - Runtime</name>
+    <description>Create JSON Web Token with SmallRye JWT Build API</description>
 
     <dependencies>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
+            <artifactId>smallrye-jwt-build</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-json-p-provider</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-jwt-build/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-jwt-build/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "SmallRye JWT Build"
+metadata:
+  keywords:
+  - "smallrye-jwt"
+  - "smallrye-jwt-build"
+  - "jwt"
+  - "json-web-token"
+  guide: "https://quarkus.io/guides/security-jwt"
+  categories:
+  - "security"
+  status: "stable"

--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -38,6 +38,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -35,14 +35,12 @@ import io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism;
 import io.quarkus.smallrye.jwt.runtime.auth.JwtPrincipalProducer;
 import io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator;
 import io.quarkus.smallrye.jwt.runtime.auth.RawOptionalClaimCreator;
-import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JWTCallerPrincipalFactoryProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
 import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
 import io.smallrye.jwt.auth.principal.DefaultJWTParser;
-import io.smallrye.jwt.build.impl.JwtProviderImpl;
 import io.smallrye.jwt.config.JWTAuthContextInfoProvider;
 
 /**
@@ -87,9 +85,6 @@ class SmallRyeJwtProcessor {
         removable.addBeanClass(JWTCallerPrincipalFactoryProducer.class);
         removable.addBeanClass(Claim.class);
         additionalBeans.produce(removable.build());
-
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, SignatureAlgorithm.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, JwtProviderImpl.class));
     }
 
     /**

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
@@ -71,6 +75,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
@@ -58,6 +62,19 @@
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-deployment</artifactId>


### PR DESCRIPTION
Fixes #13499

This PR adds a light-weight `quarkus-smallrye-jwt-build` extension which will help users create JWT tokens with the smallrye-jwt build API in the native mode.

I've excluded `smallrye-jwt-build` from the `smallrye-jwt` dependency as none of the latter's code depends on it - it just has been there before it was moved into its own module - many smallrye-jwt users should benefit; I'll also update the migration notes for `11.0.0.Final` that those `quarkus-smallrye-jwt` users who also require creating JWT tokens will need to add a `quarkus-smallrye-jwt-build` dependency if this specific change is approved;

Also updated `quarkus-smallrye-jwt` and `quarkus-oidc` deployment code and removed  `smallrye-jwt-build` related code and the docs - quickstarts PR to match it will also be opened shortly.

I'll update the soon to be PR-ed `quarkus-oidc-client` with the `quarkus-smallrye-jwt-build` dependency asap after the merge as well - as I'll need to support the client credentials JWT authentication there (similarly to how `quarkus-oidc` does it).

Tests which depend on this API are run in `quarkus-smallrye-jwt/deployment`, `integration-test/oidc-code-flow`, `integration-test/oidc-tenancy` and in the `quickstarts/security-jwt-quickstart` 