### PR TITLE
Extension registry: introduces 'compatible-quarkus-core' attribute

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/RepositoryIndexer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/RepositoryIndexer.java
@@ -38,6 +38,7 @@ public class RepositoryIndexer {
                 io.quarkus.dependencies.Extension ext = artifactResolver.resolveExtension(extension, release);
                 if (ext != null) {
                     visitor.visitExtension(ext, release.getQuarkusCore());
+                    visitor.visitExtensionRelease(ext.getGroupId(), ext.getArtifactId(), release);
                 }
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/RegistryBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/RegistryBuilder.java
@@ -119,4 +119,19 @@ public class RegistryBuilder implements IndexVisitor {
         String getQuarkusVersion();
     }
 
+    @Override
+    public void visitExtensionRelease(String groupId, String artifactId, Release release) {
+        ArtifactKey extensionKey = ImmutableArtifactKey.of(groupId, artifactId);
+        ArtifactCoords coords = ImmutableArtifactCoords.of(extensionKey, release.getVersion());
+        ArtifactCoordsTuple key = ImmutableArtifactCoordsTuple.builder().coords(coords)
+                .quarkusVersion(release.getQuarkusCore())
+                .build();
+        ModifiableExtensionRelease releaseBuilder = releases.computeIfAbsent(key,
+                appArtifactCoords -> ModifiableExtensionRelease.create()
+                        .setRelease(Release.builder()
+                                .version(appArtifactCoords.getCoords().getVersion())
+                                .quarkusCore(appArtifactCoords.getQuarkusVersion())
+                                .build()));
+        releaseBuilder.setRelease(release);
+    }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/catalog/spi/IndexVisitor.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/catalog/spi/IndexVisitor.java
@@ -2,10 +2,13 @@ package io.quarkus.registry.catalog.spi;
 
 import io.quarkus.dependencies.Extension;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.registry.model.Release;
 
 public interface IndexVisitor {
 
     void visitPlatform(QuarkusPlatformDescriptor platform);
 
     void visitExtension(Extension extension, String quarkusCore);
+
+    void visitExtensionRelease(String groupId, String artifactId, Release release);
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/model/Release.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/model/Release.java
@@ -2,6 +2,7 @@ package io.quarkus.registry.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.immutables.value.Value;
 
@@ -14,6 +15,9 @@ public interface Release extends Comparable<Release> {
     @Nullable
     @JsonProperty("quarkus-core")
     String getQuarkusCore();
+
+    @JsonProperty("compatible-quarkus-core")
+    List<String> getCompatibleQuarkusCore();
 
     @Nullable
     @JsonProperty("repository-url")


### PR DESCRIPTION
Which is a list of Quarkus core versions an extension release is compatible with in addition of the 'quarkus-core' version it was built with originally.