### PR TITLE
Interceptors - always skip bridge methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -41,6 +41,8 @@ final class Methods {
     public static final String CLINIT = "<clinit>";
     // copied from java.lang.reflect.Modifier.SYNTHETIC
     static final int SYNTHETIC = 0x00001000;
+    // copied from java.lang.reflect.Modifier.BRIDGE
+    static final int BRIDGE = 0x00000040;
     public static final String TO_STRING = "toString";
 
     private static final List<String> IGNORED_METHODS = initIgnoredMethods();
@@ -57,6 +59,10 @@ final class Methods {
 
     static boolean isSynthetic(MethodInfo method) {
         return (method.flags() & SYNTHETIC) != 0;
+    }
+
+    static boolean isBridge(MethodInfo method) {
+        return (method.flags() & BRIDGE) != 0;
     }
 
     static void addDelegatingMethods(IndexView index, ClassInfo classInfo, Map<MethodKey, MethodInfo> methods,
@@ -258,7 +264,7 @@ final class Methods {
     }
 
     private static boolean skipForSubclass(MethodInfo method) {
-        if (Modifier.isStatic(method.flags())) {
+        if (Modifier.isStatic(method.flags()) || isBridge(method)) {
             return true;
         }
         if (IGNORED_METHODS.contains(method.name())) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/Counter.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/Counter.java
@@ -8,15 +8,15 @@ public class Counter {
 
     private AtomicInteger counter = new AtomicInteger();
 
-    int incrementAndGet() {
+    public int incrementAndGet() {
         return counter.incrementAndGet();
     }
 
-    void reset() {
+    public void reset() {
         counter.set(0);
     }
 
-    int get() {
+    public int get() {
         return counter.get();
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/BridgeMethodInterceptionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/BridgeMethodInterceptionTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.interceptors.Counter;
+import io.quarkus.arc.test.interceptors.Simple;
+import io.quarkus.arc.test.interceptors.SimpleInterceptor;
+import javax.enterprise.context.ApplicationScoped;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class BridgeMethodInterceptionTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Base.class, Submarine.class, Counter.class, Simple.class,
+            SimpleInterceptor.class);
+
+    @Test
+    public void testInterception() {
+        ArcContainer container = Arc.container();
+
+        Submarine submarine = container.instance(Submarine.class).get();
+        Counter counter = container.instance(Counter.class).get();
+
+        assertEquals("0foo1", submarine.echo("foo"));
+        assertEquals(1, counter.get());
+
+        // Now let's invoke the bridge method...
+        Base<String> base = submarine;
+        assertEquals("1foo2", base.echo("foo"));
+        assertEquals(2, counter.get());
+    }
+
+    static class Base<T> {
+
+        String echo(T payload) {
+            return payload.toString().toUpperCase();
+        }
+
+    }
+
+    @ApplicationScoped
+    static class Submarine extends Base<String> {
+
+        @Simple
+        @Override
+        String echo(String payload) {
+            return payload.toString();
+        }
+
+    }
+
+}

--- a/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/Count.java
+++ b/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/Count.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.amazon.lambda;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Documented
+@Retention(RUNTIME)
+@Target({ METHOD, TYPE })
+public @interface Count {
+}

--- a/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/CounterInterceptor.java
+++ b/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/CounterInterceptor.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.amazon.lambda;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Priority(1)
+@Count
+@Interceptor
+public class CounterInterceptor {
+
+    static final AtomicInteger COUNTER = new AtomicInteger();
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext context) throws Exception {
+        COUNTER.incrementAndGet();
+        return context.proceed();
+    }
+
+}

--- a/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/TestLambda.java
+++ b/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/TestLambda.java
@@ -12,6 +12,7 @@ public class TestLambda implements RequestHandler<InputObject, OutputObject> {
     @Inject
     ProcessingService service;
 
+    @Count
     @Override
     public OutputObject handleRequest(InputObject input, Context context) {
         return service.proces(input).setRequestId(context.getAwsRequestId());

--- a/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.amazon.lambda;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.amazon.lambda.test.LambdaClient;
@@ -11,27 +14,46 @@ public class AmazonLambdaSimpleTestCase {
 
     @Test
     public void testSimpleLambdaSuccess() throws Exception {
+        resetCounter();
         InputObject in = new InputObject();
         in.setGreeting("Hello");
         in.setName("Stu");
         OutputObject out = LambdaClient.invoke(OutputObject.class, in);
-        Assertions.assertEquals("Hello Stu", out.getResult());
-        Assertions.assertTrue(out.getRequestId().matches("aws-request-\\d"), "Expected requestId as 'aws-request-<number>'");
+        assertEquals("Hello Stu", out.getResult());
+        assertCounter(1);
+        assertTrue(out.getRequestId().matches("aws-request-\\d"), "Expected requestId as 'aws-request-<number>'");
     }
 
     @Test
     public void testSimpleLambdaFailure() throws Exception {
+        resetCounter();
         InputObject in = new InputObject();
         in.setGreeting("Hello");
         in.setName("Stuart");
         try {
             OutputObject out = LambdaClient.invoke(OutputObject.class, in);
             out.getResult();
-            Assertions.fail();
+            fail();
         } catch (Exception e) {
-            Assertions.assertEquals(ProcessingService.CAN_ONLY_GREET_NICKNAMES, e.getMessage());
+            assertEquals(ProcessingService.CAN_ONLY_GREET_NICKNAMES, e.getMessage());
             //Assertions.assertEquals(IllegalArgumentException.class.getName(), e.getType());
         }
+        assertCounter(1);
+    }
 
+    private void resetCounter() {
+        if (!isNativeImageTest()) {
+            CounterInterceptor.COUNTER.set(0);
+        }
+    }
+
+    private void assertCounter(int expected) {
+        if (!isNativeImageTest()) {
+            assertEquals(expected, CounterInterceptor.COUNTER.get());
+        }
+    }
+
+    private boolean isNativeImageTest() {
+        return System.getProperty("native.image.path") != null;
     }
 }


### PR DESCRIPTION
- annotations may be copied to the generated bridge methods (javac does
copy them since jdk8b94) and so an invocation of a bridge method may
result in multiple interceptor invocations