### PR TITLE
Add AwsProxyRequestContext to quarkus context

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
@@ -176,6 +177,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
         }
         QuarkusHttpHeaders quarkusHeaders = new QuarkusHttpHeaders();
         quarkusHeaders.setContextObject(Context.class, context);
+        quarkusHeaders.setContextObject(AwsProxyRequestContext.class, request.getRequestContext());
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.valueOf(request.getHttpMethod()), path, quarkusHeaders);
         if (request.getMultiValueHeaders() != null) { //apparently this can be null if no headers are sent

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/model/ApiGatewayAuthorizerContext.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/model/ApiGatewayAuthorizerContext.java
@@ -43,6 +43,10 @@ public class ApiGatewayAuthorizerContext {
     //-------------------------------------------------------------
 
     @JsonAnyGetter
+    public Map<String, String> getContextProperties() {
+        return contextProperties;
+    }
+
     public String getContextValue(String key) {
         return contextProperties.get(key);
     }

--- a/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
@@ -8,6 +8,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+
 @Path("/hello")
 public class GreetingResource {
 
@@ -49,6 +51,14 @@ public class GreetingResource {
             throw new RuntimeException();
         if (ctx.getAwsRequestId() == null)
             throw new RuntimeException("aws context not set");
+    }
+
+    @GET
+    @Path("proxyRequestContext")
+    @Produces(MediaType.TEXT_PLAIN)
+    public void proxyRequestContext(@Context AwsProxyRequestContext ctx) {
+        if (ctx == null)
+            throw new RuntimeException();
     }
 
 }

--- a/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.amazon.lambda.test.LambdaClient;
@@ -103,6 +104,16 @@ public class AmazonLambdaSimpleTestCase {
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 204);
 
+    }
+
+    @Test
+    public void testProxyRequestContext() throws Exception {
+        AwsProxyRequest request = new AwsProxyRequest();
+        request.setRequestContext(new AwsProxyRequestContext());
+        request.setHttpMethod("GET");
+        request.setPath("/hello/proxyRequestContext");
+        AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 204);
     }
 
 }

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
@@ -8,6 +8,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+
 @Path("/hello")
 public class GreetingResource {
 
@@ -49,6 +51,14 @@ public class GreetingResource {
             throw new RuntimeException();
         if (ctx.getAwsRequestId() == null)
             throw new RuntimeException("aws context not set");
+    }
+
+    @GET
+    @Path("proxyRequestContext")
+    @Produces(MediaType.TEXT_PLAIN)
+    public void proxyRequestContext(@Context AwsProxyRequestContext ctx) {
+        if (ctx == null)
+            throw new RuntimeException();
     }
 
 }

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.amazon.lambda.test.LambdaClient;
@@ -137,6 +138,16 @@ public class AmazonLambdaSimpleTestCase {
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "\"Make it funqy Bill\"");
         Assertions.assertTrue(out.getMultiValueHeaders().getFirst("Content-Type").startsWith("application/json"));
+    }
+
+    @Test
+    public void testProxyRequestContext() throws Exception {
+        AwsProxyRequest request = new AwsProxyRequest();
+        request.setRequestContext(new AwsProxyRequestContext());
+        request.setHttpMethod("GET");
+        request.setPath("/hello/proxyRequestContext");
+        AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 204);
     }
 
 }


### PR DESCRIPTION
Issue #6376 
Addresses the inability to get any lambda authorization context in dispatched request.

Open to suggestions on how to implement a way to expose more AwsProxyRequestContext in the dispatched request in the lambda http extension.