### PR TITLE
Funqy generics improvement

### DIFF
--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
@@ -48,7 +48,7 @@ public class FunqyLambdaBindingRecorder {
         ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper;
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputType());
                 ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
             }

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import org.jboss.logging.Logger;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -47,11 +48,13 @@ public class FunqyLambdaBindingRecorder {
         ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper;
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                ObjectReader reader = objectMapper.readerFor(invoker.getInputType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
             }
             if (invoker.hasOutput()) {
-                ObjectWriter writer = objectMapper.writerFor(invoker.getOutputType());
+                JavaType javaOutputType = objectMapper.constructType(invoker.getOutputType());
+                ObjectWriter writer = objectMapper.writerFor(javaOutputType);
                 invoker.getBindingContext().put(ObjectWriter.class.getName(), writer);
             }
         }

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.funqy.gcp.functions;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -34,11 +35,13 @@ public class FunqyCloudFunctionsBindingRecorder {
 
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                ObjectReader reader = objectMapper.readerFor(invoker.getInputType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
             }
             if (invoker.hasOutput()) {
-                ObjectWriter writer = objectMapper.writerFor(invoker.getOutputType());
+                JavaType javaOutputType = objectMapper.constructType(invoker.getOutputType());
+                ObjectWriter writer = objectMapper.writerFor(javaOutputType);
                 invoker.getBindingContext().put(ObjectWriter.class.getName(), writer);
             }
         }

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
@@ -35,7 +35,7 @@ public class FunqyCloudFunctionsBindingRecorder {
 
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputType());
                 ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
             }

--- a/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
+++ b/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
@@ -4,6 +4,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -38,13 +39,15 @@ public class FunqyHttpBindingRecorder {
         queryMapper = new QueryObjectMapper();
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                ObjectReader reader = objectMapper.readerFor(invoker.getInputType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                ObjectReader reader = objectMapper.readerFor(javaInputType);
                 QueryReader queryReader = queryMapper.readerFor(invoker.getInputType(), invoker.getInputGenericType());
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
                 invoker.getBindingContext().put(QueryReader.class.getName(), queryReader);
             }
             if (invoker.hasOutput()) {
-                ObjectWriter writer = objectMapper.writerFor(invoker.getOutputType());
+                JavaType javaOutputType = objectMapper.constructType(invoker.getOutputType());
+                ObjectWriter writer = objectMapper.writerFor(javaOutputType);
                 invoker.getBindingContext().put(ObjectWriter.class.getName(), writer);
             }
         }

--- a/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
+++ b/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
@@ -39,9 +39,9 @@ public class FunqyHttpBindingRecorder {
         queryMapper = new QueryObjectMapper();
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
-                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputType());
                 ObjectReader reader = objectMapper.readerFor(javaInputType);
-                QueryReader queryReader = queryMapper.readerFor(invoker.getInputType(), invoker.getInputGenericType());
+                QueryReader queryReader = queryMapper.readerFor(invoker.getInputType());
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
                 invoker.getBindingContext().put(QueryReader.class.getName(), queryReader);
             }

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithGenerics.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithGenerics.java
@@ -1,0 +1,29 @@
+package io.quarkus.funqy.test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+import io.smallrye.mutiny.Uni;
+
+public class WithGenerics {
+
+    @Funq
+    @CloudEventMapping(trigger = "listOfStrings")
+    public String toCommaSeparated(List<Identity> identityList) {
+        return identityList
+                .stream()
+                .map(Identity::getName)
+                .collect(Collectors.joining(","));
+    }
+
+    @Funq
+    @CloudEventMapping(trigger = "integer")
+    public Uni<List<Integer>> range(int n) {
+        return Uni.createFrom().item(() -> IntStream.range(0, n)
+                .boxed()
+                .collect(Collectors.toList()));
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithGenericsTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithGenericsTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.funqy.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WithGenericsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(WithGenerics.class, Identity.class));
+
+    @Test
+    public void testToCommaSeparated() {
+        RestAssured.given().contentType("application/json")
+                .body("[{\"name\": \"Bill\"}, {\"name\": \"Matej\"}]")
+                .header("ce-id", "42")
+                .header("ce-type", "listOfStrings")
+                .header("ce-source", "/ofTest")
+                .header("ce-specversion", "1.0")
+                .post("/")
+                .then().statusCode(200)
+                .body(equalTo("\"Bill,Matej\""));
+    }
+
+    @Test
+    public void testRange() {
+        RestAssured.given().contentType("application/json")
+                .body("3")
+                .header("ce-id", "42")
+                .header("ce-type", "integer")
+                .header("ce-source", "/ofTest")
+                .header("ce-specversion", "1.0")
+                .post("/")
+                .then().statusCode(200);
+    }
+}

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -60,13 +61,15 @@ public class KnativeEventsBindingRecorder {
             }
 
             if (invoker.hasInput()) {
-                ObjectReader reader = objectMapper.readerFor(invoker.getInputType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
                 QueryReader queryReader = queryMapper.readerFor(invoker.getInputType(), invoker.getInputGenericType());
                 invoker.getBindingContext().put(QueryReader.class.getName(), queryReader);
             }
             if (invoker.hasOutput()) {
-                ObjectWriter writer = objectMapper.writerFor(invoker.getOutputType());
+                JavaType outputJavaType = objectMapper.constructType(invoker.getOutputType());
+                ObjectWriter writer = objectMapper.writerFor(outputJavaType);
                 invoker.getBindingContext().put(ObjectWriter.class.getName(), writer);
 
                 String functionName = invoker.getName();

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
@@ -61,10 +61,10 @@ public class KnativeEventsBindingRecorder {
             }
 
             if (invoker.hasInput()) {
-                JavaType javaInputType = objectMapper.constructType(invoker.getInputGenericType());
+                JavaType javaInputType = objectMapper.constructType(invoker.getInputType());
                 ObjectReader reader = objectMapper.readerFor(javaInputType);
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
-                QueryReader queryReader = queryMapper.readerFor(invoker.getInputType(), invoker.getInputGenericType());
+                QueryReader queryReader = queryMapper.readerFor(invoker.getInputType());
                 invoker.getBindingContext().put(QueryReader.class.getName(), queryReader);
             }
             if (invoker.hasOutput()) {

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
@@ -16,7 +16,7 @@ public class FunctionInvoker {
     protected ArrayList<ValueInjector> parameterInjectors;
     protected Class<?> inputType;
     protected Type inputGenericType;
-    protected Class<?> outputType;
+    protected Type outputType;
     protected boolean isAsync;
 
     protected Map<String, Object> bindingContext = new ConcurrentHashMap<>();
@@ -48,8 +48,8 @@ public class FunctionInvoker {
                 Type genericReturnType = method.getGenericReturnType();
                 if (genericReturnType instanceof ParameterizedType) {
                     Type[] actualParams = ((ParameterizedType) genericReturnType).getActualTypeArguments();
-                    if (actualParams.length == 1 && actualParams[0] instanceof Class<?>) {
-                        outputType = (Class<?>) actualParams[0];
+                    if (actualParams.length == 1) {
+                        outputType = actualParams[0];
                     }
                 }
                 if (outputType == null) {
@@ -84,7 +84,7 @@ public class FunctionInvoker {
         return inputGenericType;
     }
 
-    public Class getOutputType() {
+    public Type getOutputType() {
         return outputType;
     }
 

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
@@ -14,8 +14,7 @@ public class FunctionInvoker {
     protected Method method;
     protected FunctionConstructor<?> constructor;
     protected ArrayList<ValueInjector> parameterInjectors;
-    protected Class<?> inputType;
-    protected Type inputGenericType;
+    protected Type inputType;
     protected Type outputType;
     protected boolean isAsync;
 
@@ -33,8 +32,7 @@ public class FunctionInvoker {
                 Annotation[] annotations = method.getParameterAnnotations()[i];
                 ValueInjector injector = ParameterInjector.createInjector(type, clz, annotations);
                 if (injector instanceof InputValueInjector) {
-                    inputType = clz;
-                    inputGenericType = method.getGenericParameterTypes()[i];
+                    inputType = type;
                 }
                 parameterInjectors.add(injector);
             }
@@ -76,12 +74,8 @@ public class FunctionInvoker {
         return inputType != null;
     }
 
-    public Class getInputType() {
+    public Type getInputType() {
         return inputType;
-    }
-
-    public Type getInputGenericType() {
-        return inputGenericType;
     }
 
     public Type getOutputType() {

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectMapper.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectMapper.java
@@ -1,5 +1,6 @@
 package io.quarkus.funqy.runtime.query;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -72,6 +73,18 @@ public class QueryObjectMapper {
 
     public <T> QueryReader<T> readerFor(Class<T> clz) {
         return readerFor(clz, null);
+    }
+
+    public QueryReader readerFor(Type type) {
+        Class<?> clazz = null;
+        if (type instanceof Class) {
+            clazz = (Class<?>) type;
+        } else if (type instanceof ParameterizedType) {
+            clazz = (Class<?>) ((ParameterizedType) type).getRawType();
+        } else {
+            throw new RuntimeException("Cannot get QueryReader for: " + type);
+        }
+        return readerFor(clazz, type);
     }
 
     public <T> QueryReader<T> readerFor(Class<T> clz, Type genericType) {


### PR DESCRIPTION
Fixes inability to use generic class as an input.
e.g. `void foo(List<Person> persons);`

Fixes inability to use generic class and an output with Uni<>.
e.g. `Uni<List<Person> bar();`