### PR TITLE
Escaping JSON strings in QuarkusErrorHandler

### DIFF
--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -103,9 +103,13 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         String accept = event.request().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             event.response().headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json; charset=utf-8");
-            String escapedStack = stack.replace(System.lineSeparator(), "\\n").replace("\"", "\\\"");
-            StringBuilder jsonPayload = new StringBuilder("{\"details\":\"").append(details).append("\",\"stack\":\"")
-                    .append(escapedStack).append("\"}");
+            String escapedDetails = escapeJsonString(details);
+            String escapedStack = escapeJsonString(stack);
+            StringBuilder jsonPayload = new StringBuilder("{\"details\":\"")
+                    .append(escapedDetails)
+                    .append("\",\"stack\":\"")
+                    .append(escapedStack)
+                    .append("\"}");
             event.response().end(jsonPayload.toString());
         } else {
             //We default to HTML representation
@@ -122,12 +126,12 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         StringWriter stringWriter = new StringWriter();
         exception.printStackTrace(new PrintWriter(stringWriter));
 
-        return escapeHtml(stringWriter.toString().trim());
+        return stringWriter.toString().trim();
     }
 
     private static String generateHeaderMessage(final Throwable exception, String uuid) {
-        return escapeHtml(String.format("Error handling %s, %s: %s", uuid, exception.getClass().getName(),
-                extractFirstLine(exception.getMessage())));
+        return String.format("Error handling %s, %s: %s", uuid, exception.getClass().getName(),
+                extractFirstLine(exception.getMessage()));
     }
 
     private static String extractFirstLine(final String message) {
@@ -139,15 +143,37 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         return lines[0].trim();
     }
 
-    private static String escapeHtml(final String bodyText) {
-        if (bodyText == null) {
-            return "null";
+    static String escapeJsonString(final String text) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            switch (ch) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    sb.append(ch);
+            }
         }
-
-        return bodyText
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
+        return sb.toString();
     }
 
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+
+class QuarkusErrorHandlerTest {
+
+    @Test
+    public void string_with_tab_should_be_correctly_escaped() {
+        String initial = "String with a tab\tcharacter";
+        String json = QuarkusErrorHandler.escapeJsonString(initial);
+        String parsed = Json.decodeValue('"' + json + '"', String.class);
+        assertEquals(initial, parsed);
+    }
+
+    @Test
+    public void string_with_backslash_should_be_correctly_escaped() {
+        String initial = "String with a backslash \\ character";
+        String json = QuarkusErrorHandler.escapeJsonString(initial);
+        String parsed = Json.decodeValue('"' + json + '"', String.class);
+        assertEquals(initial, parsed);
+    }
+
+    @Test
+    public void string_with_quotes_should_be_correctly_escaped() {
+        String initial = "String with \"quoted text\"";
+        String json = QuarkusErrorHandler.escapeJsonString(initial);
+        String parsed = Json.decodeValue('"' + json + '"', String.class);
+        assertEquals(initial, parsed);
+    }
+
+}


### PR DESCRIPTION
Fixes #13681 

As Vert.x QuarkusErrorHandler implementation is very close to Undertow QuarkusErrorServlet, I just reported the equivalent fix from Undertow ([see PR](https://github.com/quarkusio/quarkus/pull/9484))

I also added basic unit tests, but I finally disabled tests that check unescaped special characters are invalid in a Json string (as it is not related to testing the code). Tell me if you want me to just remove those tests...