### PR TITLE
Register ServerFormUrlEncodedProvider manually

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -55,6 +55,7 @@ import io.quarkus.deployment.builditem.ProxyUnwrapperBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.resteasy.common.runtime.ResteasyInjectorFactoryRecorder;
+import io.quarkus.resteasy.common.runtime.providers.ServerFormUrlEncodedProvider;
 import io.quarkus.resteasy.common.spi.ResteasyConfigBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
@@ -169,8 +170,10 @@ public class ResteasyCommonProcessor {
             checkProperConstructorInProvider(i);
         }
 
-        Set<String> availableProviders = ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
-                "META-INF/services/" + Providers.class.getName());
+        Set<String> availableProviders = new HashSet<>(ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
+                "META-INF/services/" + Providers.class.getName()));
+        // this one is added manually in RESTEasy's ResteasyDeploymentImpl
+        availableProviders.add(ServerFormUrlEncodedProvider.class.getName());
 
         MediaTypeMap<String> categorizedReaders = new MediaTypeMap<>();
         MediaTypeMap<String> categorizedWriters = new MediaTypeMap<>();

--- a/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/providers/ServerFormUrlEncodedProvider.java
+++ b/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/providers/ServerFormUrlEncodedProvider.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.common.runtime.providers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.spi.HttpRequest;
+
+/**
+ * We maintain a stripped down version of RESTEasy's ServerFormUrlEncodedProvider here because we need a version compatible with
+ * our media types discovery i.e. we need a no-args constructor.
+ */
+@Produces("application/x-www-form-urlencoded")
+@Consumes("application/x-www-form-urlencoded")
+@ConstrainedTo(RuntimeType.SERVER)
+public class ServerFormUrlEncodedProvider extends FormUrlEncodedProvider {
+
+    @Context
+    HttpRequest request;
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public MultivaluedMap readFrom(Class<MultivaluedMap> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+        LogMessages.LOGGER.debugf("Provider : %s,  Method : readFrom", getClass().getName());
+
+        return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/multipart/MultipartResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/multipart/MultipartResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.test.multipart;
+
+import static java.util.stream.Collectors.toList;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+@Path("multipart/")
+public class MultipartResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String hello(MultivaluedMap<String, String> formData) {
+        return formData.entrySet().stream()
+                .map(e -> e.getKey() + ":" + String.join(",", e.getValue()))
+                .collect(toList())
+                .toString();
+    }
+
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/multipart/MultipartResourceTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/multipart/MultipartResourceTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.test.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.http.ContentType;
+
+public class MultipartResourceTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MultipartResource.class));
+
+    @Test
+    public void testHelloEndpoint() {
+        Map<String, String> map = new HashMap<>();
+        map.put("test", "value");
+
+        given()
+                .formParams(map)
+                .contentType(ContentType.URLENC)
+                .when().post("/multipart/")
+                .then()
+                .statusCode(200)
+                .body(is("[test:value]"));
+    }
+
+}


### PR DESCRIPTION
It's registered manually in RESTEasy so it totally defeats our
auto-detection mechanism.
Add a version with a no-args constructor and add it manually to Quarkus.

Fix #13667