### PR TITLE
Make sure that remote-dev mode listens on all interfaces instead of localhost

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
@@ -22,6 +22,10 @@ public enum LaunchMode {
         return this != NORMAL;
     }
 
+    public boolean isRemoteDev() {
+        return (current() == DEVELOPMENT) && "true".equals(System.getenv("QUARKUS_LAUNCH_DEVMODE"));
+    }
+
     private final String defaultProfile;
 
     LaunchMode(String defaultProfile) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpHostConfigSource.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpHostConfigSource.java
@@ -17,6 +17,7 @@ import io.quarkus.runtime.LaunchMode;
 public class HttpHostConfigSource implements ConfigSource, Serializable {
 
     public static final String QUARKUS_HTTP_HOST = "quarkus.http.host";
+    private static final String ALL_INTERFACES = "0.0.0.0";
 
     private final int priority;
 
@@ -37,7 +38,11 @@ public class HttpHostConfigSource implements ConfigSource, Serializable {
     @Override
     public String getValue(String propertyName) {
         if (propertyName.equals(QUARKUS_HTTP_HOST)) {
-            return LaunchMode.current().isDevOrTest() ? "localhost" : "0.0.0.0";
+            if (LaunchMode.current().isRemoteDev()) {
+                // in remote-dev mode we need to listen on all interfaces
+                return ALL_INTERFACES;
+            }
+            return LaunchMode.current().isDevOrTest() ? "localhost" : ALL_INTERFACES;
         }
         return null;
     }


### PR DESCRIPTION
Fixes: #13638

After this PR, when I launch `QUARKUS_LAUNCH_DEVMODE=true java -jar target/quarkus-app/quarkus-run.jar ` I get:

```
2020-12-04 17:40:14,136 INFO  [io.quarkus] (Quarkus Main Thread) getting-started 1.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 1.255s. Listening on: http://0.0.0.0:8080
2020-12-04 17:40:14,151 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
2020-12-04 17:40:14,151 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive]

```

