### PR TITLE
Upgrade SmallRye OpenAPI to 2.0.16

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -40,7 +40,7 @@
         <smallrye-config.version>1.9.3</smallrye-config.version>
         <smallrye-health.version>2.2.5</smallrye-health.version>
         <smallrye-metrics.version>2.4.4</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.15</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.16</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.18</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -114,6 +114,11 @@ public class SmallRyeOpenApiProcessor {
     private static final String SPRING = "Spring";
     private static final String VERT_X = "Vert.x";
 
+    static {
+        System.setProperty(io.smallrye.openapi.api.constants.OpenApiConstants.DEFAULT_PRODUCES, "application/json");
+        System.setProperty(io.smallrye.openapi.api.constants.OpenApiConstants.DEFAULT_CONSUMES, "application/json");
+    }
+
     @BuildStep
     CapabilityBuildItem capability() {
         return new CapabilityBuildItem(Capability.SMALLRYE_OPENAPI);
@@ -485,7 +490,6 @@ public class SmallRyeOpenApiProcessor {
         }
         document.modelFromReader(readerModel);
         document.modelFromStaticFile(staticModel);
-        document.filter(filter(openApiConfig));
         for (AddToOpenAPIDefinitionBuildItem openAPIBuildItem : openAPIBuildItems) {
             OASFilter otherExtensionFilter = openAPIBuildItem.getOASFilter();
             document.filter(otherExtensionFilter);
@@ -499,10 +503,5 @@ public class SmallRyeOpenApiProcessor {
         document.reset();
         document.config(openApiConfig);
         return document;
-    }
-
-    private OASFilter filter(OpenApiConfig openApiConfig) {
-        return OpenApiProcessor.getFilter(openApiConfig,
-                Thread.currentThread().getContextClassLoader());
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeResource.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/greeting")
+public class DefaultContentTypeResource {
+
+    @GET
+    @Path("/hello")
+    public Greeting hello() {
+        return new Greeting("Hello there");
+    }
+
+    @POST
+    @Path("/hello")
+    public Greeting hello(Greeting greeting) {
+        return greeting;
+    }
+
+    @GET
+    @Path("/goodbye")
+    @Produces(MediaType.APPLICATION_XML)
+    public Greeting byebye() {
+        return new Greeting("Good Bye !");
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/DefaultContentTypeTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DefaultContentTypeTest {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DefaultContentTypeResource.class, Greeting.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.store-schema-directory=target"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths.'/greeting/goodbye'.get.responses.'200'.content.'application/xml'.schema.$ref",
+                        Matchers.containsString("#/components/schemas/Greeting"))
+                .body("paths.'/greeting/hello'.get.responses.'200'.content.'application/json'.schema.$ref",
+                        Matchers.containsString("#/components/schemas/Greeting"))
+                .body("paths.'/greeting/hello'.post.responses.'200'.content.'application/json'.schema.$ref",
+                        Matchers.containsString("#/components/schemas/Greeting"));
+
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/Greeting.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/Greeting.java
@@ -1,0 +1,14 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+public class Greeting {
+
+    private final String message;
+
+    public Greeting(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -41,7 +41,7 @@ public class OpenApiDocumentService {
                     OpenApiDocument document = OpenApiDocument.INSTANCE;
                     document.reset();
                     document.config(openApiConfig);
-                    document.modelFromStaticFile(io.smallrye.openapi.runtime.OpenApiProcessor.modelFromStaticFile(staticFile));
+                    document.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
                     document.filter(OpenApiProcessor.getFilter(openApiConfig, cl));
                     document.initialize();
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
@@ -17,11 +17,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-/**
- * @author Ken Finnigan
- */
 @QuarkusTest
 public class OpenApiTestCase {
+
+    private static final String DEFAULT_MEDIA_TYPE = "application/json";
 
     @TestHTTPResource("openapi")
     URL uri;
@@ -63,8 +62,10 @@ public class OpenApiTestCase {
         // test RESTEasy extensions
 
         JsonObject schemasObj = obj.getJsonObject("components").getJsonObject("schemas");
-        String testSchemaType = schemaType("200", "*/*", testObj.getJsonObject("get").getJsonObject("responses"), schemasObj);
-        String rxSchemaType = schemaType("200", "*/*", injectionObj.getJsonObject("get").getJsonObject("responses"),
+        String testSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE, testObj.getJsonObject("get").getJsonObject("responses"),
+                schemasObj);
+        String rxSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE,
+                injectionObj.getJsonObject("get").getJsonObject("responses"),
                 schemasObj);
         // make sure String, CompletionStage<String> and Single<String> are detected the same
         Assertions.assertEquals(testSchemaType,
@@ -72,7 +73,7 @@ public class OpenApiTestCase {
                 "Normal and RX/Single have same schema");
         JsonObject csObj = paths.getJsonObject("/test/cs");
         Assertions.assertEquals(testSchemaType,
-                schemaType("200", "*/*", csObj.getJsonObject("get").getJsonObject("responses"), schemasObj),
+                schemaType("200", DEFAULT_MEDIA_TYPE, csObj.getJsonObject("get").getJsonObject("responses"), schemasObj),
                 "Normal and RX/CS have same schema");
 
         JsonObject paramsObj = paths.getJsonObject("/test/params/{path}");
@@ -86,7 +87,7 @@ public class OpenApiTestCase {
         Assertions.assertEquals(1, keys.size());
         Assertions.assertEquals("get", keys.iterator().next());
 
-        String uniSchemaType = schemaType("200", "*/*", uniObj.getJsonObject("get").getJsonObject("responses"),
+        String uniSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE, uniObj.getJsonObject("get").getJsonObject("responses"),
                 schemasObj);
         // make sure String, CompletionStage<String> and Uni<String> are detected the same
         Assertions.assertEquals(testSchemaType,
@@ -99,11 +100,13 @@ public class OpenApiTestCase {
         Assertions.assertEquals(1, keys.size());
         Assertions.assertEquals("get", keys.iterator().next());
 
-        String uniTypedSchemaType = schemaType("200", "*/*", uniTypedObj.getJsonObject("get").getJsonObject("responses"),
+        String uniTypedSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE,
+                uniTypedObj.getJsonObject("get").getJsonObject("responses"),
                 schemasObj);
         // make sure ComponentType and Uni<ComponentType> are detected the same
         JsonObject ctObj = paths.getJsonObject("/test/compType");
-        String ctSchemaType = schemaType("200", "*/*", ctObj.getJsonObject("get").getJsonObject("responses"), schemasObj);
+        String ctSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE, ctObj.getJsonObject("get").getJsonObject("responses"),
+                schemasObj);
         Assertions.assertEquals(ctSchemaType,
                 uniTypedSchemaType,
                 "Normal and Mutiny Uni have same schema");
@@ -116,7 +119,7 @@ public class OpenApiTestCase {
 
         // make sure Multi<String> is detected as array
         JsonObject multiSchema = multiObj.getJsonObject("get").getJsonObject("responses")
-                .getJsonObject("200").getJsonObject("content").getJsonObject("*/*").getJsonObject("schema");
+                .getJsonObject("200").getJsonObject("content").getJsonObject(DEFAULT_MEDIA_TYPE).getJsonObject("schema");
         Assertions.assertEquals("array", multiSchema.getString("type"));
         Assertions.assertEquals("string", multiSchema.getJsonObject("items").getString("type"));
 
@@ -127,7 +130,7 @@ public class OpenApiTestCase {
         Assertions.assertEquals("get", keys.iterator().next());
 
         JsonObject multiTypedSchema = multiTypedObj.getJsonObject("get").getJsonObject("responses")
-                .getJsonObject("200").getJsonObject("content").getJsonObject("*/*").getJsonObject("schema");
+                .getJsonObject("200").getJsonObject("content").getJsonObject(DEFAULT_MEDIA_TYPE).getJsonObject("schema");
         // make sure Multi<ComponentType> is detected as array
         Assertions.assertEquals("array", multiTypedSchema.getString("type"));
         String mutliTypedObjectSchema = schemaTypeFromRef(multiTypedSchema.getJsonObject("items"), schemasObj);


### PR DESCRIPTION
This PR Updates SmallRye OpenAPI to version 2.0.16, that added a way to specify a default content type.
It also fix the filter that ran on build and deploy time.

See https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.16 for a full change log.

Fixes #13683
Fixes #13615

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>