### PR TITLE
Avoid ICC_ColorSpace instances in Apache Tika to support GraalVM 20.3

### DIFF
--- a/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
+++ b/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceDirectoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.tika.TikaParseException;
 import io.quarkus.tika.runtime.TikaConfiguration;
@@ -68,10 +69,17 @@ public class TikaProcessor {
         return new FeatureBuildItem(Feature.TIKA);
     }
 
-    @BuildStep
-    public void registerRuntimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> resource) {
-        //org.apache.tika.parser.pdf.PDFParser (https://issues.apache.org/jira/browse/PDFBOX-4548)
-        resource.produce(new RuntimeInitializedClassBuildItem("org.apache.pdfbox.pdmodel.font.PDType1Font"));
+    @BuildStep(onlyIf = NativeBuild.class)
+    List<RuntimeInitializedClassBuildItem> runtimeInitImageIOClasses() {
+        return Arrays.asList(
+                //org.apache.tika.parser.pdf.PDFParser (https://issues.apache.org/jira/browse/PDFBOX-4548)
+                new RuntimeInitializedClassBuildItem("org.apache.pdfbox.pdmodel.font.PDType1Font"),
+                // The following classes hold instances of java.awt.color.ICC_ColorSpace that are not allowed in the
+                // image heap as this class should be initialized at image runtime
+                // See https://github.com/quarkusio/quarkus/pull/13644
+                new RuntimeInitializedClassBuildItem("org.apache.pdfbox.rendering.SoftMask"),
+                new RuntimeInitializedClassBuildItem(
+                        "org.apache.pdfbox.pdmodel.graphics.color.PDCIEDictionaryBasedColorSpace"));
     }
 
     @BuildStep

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/graalvm/PDFBoxSubstitutions.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/graalvm/PDFBoxSubstitutions.java
@@ -1,0 +1,36 @@
+package io.quarkus.tika.graalvm;
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB")
+final class Target_org_apache_pdfbox_pdmodel_graphics_color_PDDeviceRGB {
+    @Substitute
+    private void init() {
+        // This method appears to be just a workaround for PDFBOX-2184
+    }
+
+    // awtColorSpace is not actually used in PDDeviceRGB
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private volatile ColorSpace awtColorSpace;
+}
+
+@TargetClass(className = "org.apache.pdfbox.pdmodel.graphics.color.PDICCBased")
+final class Target_org_apache_pdfbox_pdmodel_graphics_color_PDICCBased {
+    // This class provides alternative paths for when awtColorSpace is null, so it is safe to reset it
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private volatile ICC_ColorSpace awtColorSpace;
+}
+
+// Substitutions to prevent ICC_ColorSpace instances from appearing in the native image when using Apache Tika
+// See https://github.com/quarkusio/quarkus/pull/13644
+class PDFBoxSubstitutions {
+
+}


### PR DESCRIPTION
Fixes apache tika integration test.
Note however that users still need to avoid bringing instances of `ICC_ColorSpace` in the native image (this is a limitation of GraalVM 20.3 that I am afraid we can't work around in Quarkus. The good thing is that it won't be present in 21.0, since it's already fixed in graal `master`).
Another thing to keep in mind is that there are at least two more classes in pdfbox that hold instances of `ICC_ColorSpace`:
* PDJPXColorSpace
* PDDeviceCMYK
which, although not reachable from the existing test, if reachable through Apache Tika might also cause issues to users.