### PR TITLE
Fix dev mode when the same file is marked multiple times for hot deploy

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/HotDeploymentConfigFileBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/HotDeploymentConfigFileBuildStep.java
@@ -17,7 +17,8 @@ public class HotDeploymentConfigFileBuildStep {
         if (processor != null) {
             Map<String, Boolean> watchedFilePaths = files.stream()
                     .collect(Collectors.toMap(HotDeploymentWatchedFileBuildItem::getLocation,
-                            HotDeploymentWatchedFileBuildItem::isRestartNeeded));
+                            HotDeploymentWatchedFileBuildItem::isRestartNeeded,
+                            (isRestartNeeded1, isRestartNeeded2) -> isRestartNeeded1 || isRestartNeeded2));
             processor.setWatchedFilePaths(watchedFilePaths);
         }
         return null;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsImportSqlHotReloadScriptTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsImportSqlHotReloadScriptTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Function;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.shared.SharedEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user.User;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user.subpackage.OtherUserInSubPackage;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * See https://github.com/quarkusio/quarkus/issues/13722
+ */
+public class MultiplePersistenceUnitsImportSqlHotReloadScriptTest {
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(Plane.class.getPackage().getName())
+                    .addPackage(SharedEntity.class.getPackage().getName())
+                    .addPackage(User.class.getPackage().getName())
+                    .addPackage(OtherUserInSubPackage.class.getPackage().getName())
+                    .addClass(MultiplePersistenceUnitsSqlLoadScriptTestResource.class)
+                    .addAsResource("application-multiple-persistence-units-annotations.properties", "application.properties")
+                    .addAsResource("import-sharedentity.sql", "import.sql"));
+
+    @Test
+    public void testImportSqlScriptHotReload() {
+        String expectedName = "import.sql load script entity";
+        assertBodyIs(expectedName);
+
+        String hotReloadExpectedName = "modified import.sql load script entity";
+        TEST.modifyResourceFile("import.sql", new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace(expectedName, hotReloadExpectedName);
+            }
+        });
+        assertBodyIs(hotReloadExpectedName);
+    }
+
+    private void assertBodyIs(String expectedBody) {
+        RestAssured.when().get("/multiple-persistence-units/orm-sql-load-script/2").then().body(is(expectedBody));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsSqlLoadScriptTestResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsSqlLoadScriptTestResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.shared.SharedEntity;
+
+@Path("/multiple-persistence-units/orm-sql-load-script")
+public class MultiplePersistenceUnitsSqlLoadScriptTestResource {
+
+    public static final String NO_ENTITY_MESSAGE = "no entity";
+
+    @Inject
+    EntityManager em;
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getName(@PathParam("id") long id) {
+        SharedEntity entity = em.find(SharedEntity.class, id);
+        if (entity != null) {
+            return entity.getName();
+        }
+
+        return NO_ENTITY_MESSAGE;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-sharedentity.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-sharedentity.sql
@@ -1,0 +1,2 @@
+INSERT INTO SharedEntity(id, name) VALUES(1, 'default sql load script entity');
+INSERT INTO SharedEntity(id, name) VALUES(2, 'import.sql load script entity');


### PR DESCRIPTION
Better reviewed commit per commit.

Fixes #13722 

Also changes the behavior for named persistence units (which is slightly related as we will then only produce the `import.sql` build item once).

/cc @Sanne I would need your blessing for the change of behavior in the second commit. My rationale is that there's a good chance you will not want to push the same `import.sql` for your additional named datasources.