### PR TITLE
Use setters for Person in the example usage

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -341,9 +341,9 @@ Once you have written your repository, here are the most common operations you w
 ----
 // creating a person
 Person person = new Person();
-person.name = "Stef";
-person.birth = LocalDate.of(1910, Month.FEBRUARY, 1);
-person.status = Status.Alive;
+person.setName("Stef");
+person.setBirth(LocalDate.of(1910, Month.FEBRUARY, 1));
+person.setStatus(Status.Alive);
 
 // persist it
 personRepository.persist(person);


### PR DESCRIPTION
In the repository pattern example the fields of Person are private. Therefore, in the following usage example setters have to be used instead of direct field access.