### PR TITLE
Update jbang-maven-plugin to allow use of Maven 3.6.2, jbang version bump

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>dev.jbang</groupId>
                 <artifactId>jbang-maven-plugin</artifactId>
-                <version>0.0.5</version>
+                <version>0.0.6</version>
                 <executions>
                     <execution>
                         <id>generate-build-item-doc</id>
@@ -67,7 +67,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <jbangVersion>0.47.1</jbangVersion>
+                            <jbangVersion>0.56.0</jbangVersion>
                             <script>${project.basedir}/../.github/quarkusbuilditemdoc.java</script>
                             <args>
                                 <arg>--outputFile ${project.basedir}/../target/asciidoc/generated/config/quarkus-all-build-items.adoc</arg>


### PR DESCRIPTION
Update jbang-maven-plugin to allow use of Maven 3.6.2, jbang version bump

Updated jbang-maven-plugin contains https://github.com/jbangdev/jbang-maven-plugin/pull/2