### PR TITLE
Updates XStream due to published CVE

### DIFF
--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -48,7 +48,7 @@
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <!-- Avoid adding this to the BOM -->
-            <version>1.4.13</version>
+            <version>1.4.14</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See https://github.com/x-stream/xstream/security/advisories/GHSA-mw36-7c6c-q4q2

Not sure if Quarkus is impacted though as I'm not aware of the usage. Our build tools reported this one 😄 