### PR TITLE
Update DefaultTokenStateManager to remove all session cookies when tokens are split

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -484,10 +484,15 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             if (SESSION_COOKIE_NAME.equals(cookieName)) {
                 resolver.getTokenStateManager().deleteTokens(context, configContext.oidcConfig, cookie.getValue());
             }
+            removeCookie(cookie, configContext.oidcConfig);
+        }
+    }
 
+    static void removeCookie(ServerCookie cookie, OidcTenantConfig oidcConfig) {
+        if (cookie != null) {
             cookie.setValue("");
             cookie.setMaxAge(0);
-            Authentication auth = configContext.oidcConfig.getAuthentication();
+            Authentication auth = oidcConfig.getAuthentication();
             if (auth.cookiePath.isPresent()) {
                 cookie.setPath(auth.cookiePath.get());
             }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -619,6 +619,27 @@ public class CodeFlowTest {
             Cookie rtTokenCookie = getSessionRtCookie(page.getWebClient(), "tenant-split-tokens");
             checkSingleTokenCookie(rtTokenCookie, "Refresh");
 
+            // verify all the cookies are cleared after the session timeout
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.getCache().clear();
+
+            await().atLeast(6, TimeUnit.SECONDS)
+                    .pollDelay(Duration.ofSeconds(6))
+                    .until(new Callable<Boolean>() {
+                        @Override
+                        public Boolean call() throws Exception {
+                            WebResponse webResponse = webClient
+                                    .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/index.html").toURL()));
+                            assertEquals(302, webResponse.getStatusCode());
+                            assertNull(getSessionCookie(webClient, null));
+                            return true;
+                        }
+                    });
+
+            assertNull(getSessionCookie(page.getWebClient(), "tenant-split-tokens"));
+            assertNull(getSessionAtCookie(page.getWebClient(), "tenant-split-tokens"));
+            assertNull(getSessionRtCookie(page.getWebClient(), "tenant-split-tokens"));
+
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
A user reported that `DefaultTokenStateManager` does not clear the AT and RT session cookies when it is configured to keep all the tokens but split them (into individual cookies).
`CodeAuthenticationFlow` will always remove the main `q_session` cookie itself, specifically for the custom  `TokenStateManager` implementations not to worry about it.
But `DefaultTokenStateManager` needs to remove the AT and RT cookies itself in this case.