### PR TITLE
Handle null gradle resource directory in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -445,7 +445,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 outputPath = rootPath;
                 doCopy = false;
             }
-            if (rootPath == null) {
+            if (rootPath == null || outputPath == null) {
                 continue;
             }
             Path root = Paths.get(rootPath);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
@@ -12,10 +12,9 @@ import java.util.Map;
 
 /**
  * IDE entry point.
- *
+ * <p>
  * This is launched from the core/launcher module. To avoid any shading issues core/launcher unpacks all its dependencies
  * into the jar file, then uses a custom class loader load them.
- *
  */
 public class IDELauncherImpl {
 


### PR DESCRIPTION
In a gradle project, if the `src/main/resources` directory is empty, gradle does create the equivalent resource  directory in the output. 
This is causing a nullPointerException in dev mode when running with the IDE. 

close #13711