### PR TITLE
Dev mode: init timestamps for the added classes when they are detected

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -74,7 +74,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             boolean augmentDone = false;
             //ok, we have resolved all the deps
             try {
-                StartupActionImpl start = (StartupActionImpl) augmentAction.createInitialRuntimeApplication();
+                StartupAction start = (StartupActionImpl) augmentAction.createInitialRuntimeApplication();
                 //this is a bit yuck, but we need replace the default
                 //exit handler in the runtime class loader
                 //TODO: look at implementing a common core classloader, that removes the need for this sort of crappy hack

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -295,7 +295,6 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     }
 
     ClassScanResult checkForChangedClasses() throws IOException {
-        boolean hasChanges = false;
         ClassScanResult classScanResult = new ClassScanResult();
         boolean ignoreFirstScanChanges = !firstScanDone;
 
@@ -348,8 +347,6 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     private void checkForClassFilesChangesInModule(DevModeContext.ModuleInfo module, List<Path> moduleChangedSourceFiles,
             boolean isInitialRun, ClassScanResult classScanResult) {
-        boolean hasChanges = !moduleChangedSourceFiles.isEmpty();
-
         if (module.getClassesPath() == null) {
             return;
         }
@@ -545,6 +542,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     private boolean classFileWasAdded(final Path classFilePath, boolean ignoreFirstScanChanges) {
         final Long lastRecordedChange = classFileChangeTimeStamps.get(classFilePath);
+        if (lastRecordedChange == null) {
+            try {
+                classFileChangeTimeStamps.put(classFilePath, Files.getLastModifiedTime(classFilePath).toMillis());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
         return lastRecordedChange == null && !ignoreFirstScanChanges;
     }
 


### PR DESCRIPTION
This should fix a regression in dev mode following the merge of https://github.com/quarkusio/quarkus/pull/12563
The issue was found in the Kogito testsuite reported in https://github.com/quarkusio/quarkus/issues/12486#issuecomment-740388743