### PR TITLE
Fix NPE in BytecodeRecorderImpl

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1107,7 +1107,9 @@ public class BytecodeRecorderImpl implements RecorderContext {
         if (param instanceof Collection) {
             //if this is a collection we want to serialize every element
             for (Object i : (Collection) param) {
-                DeferredParameter val = loadObjectInstance(i, existing, i.getClass(), relaxedValidation);
+                DeferredParameter val = i != null
+                        ? loadObjectInstance(i, existing, i.getClass(), relaxedValidation)
+                        : loadObjectInstance(null, existing, Object.class, relaxedValidation);
                 setupSteps.add(new SerialzationStep() {
                     @Override
                     public void handle(MethodContext context, MethodCreator method, DeferredArrayStoreParameter out) {


### PR DESCRIPTION
It seems BytecodeRecorderImpl doesn't handle collections with null elements. While I agree collections with null values are not good practice, sometimes it's just simpler.

This fixes the problem.

Note that maps with null values work just fine.