### PR TITLE
Provide M2Eclipse metadata to silence errors in Eclipse

### DIFF
--- a/devtools/maven/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/devtools/maven/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>generate-code</goal>
+                    <goal>generate-code-tests</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>false</runOnIncremental>
+                    <runOnConfiguration>true</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
When importing a project.

I don't run them on incremental as I think most people will use dev mode.

Let's see how it goes, we can adjust later.