### PR TITLE
Bump jib-core to 0.16.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -191,7 +191,7 @@
         <jzlib.version>1.1.1</jzlib.version>
         <checker-qual.version>2.5.2</checker-qual.version>
         <error-prone-annotations.version>2.2.0</error-prone-annotations.version>
-        <jib-core.version>0.15.0</jib-core.version>
+        <jib-core.version>0.16.0</jib-core.version>
         <google-http-client.version>1.34.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->


### PR DESCRIPTION
This updates to the latest jib version available in maven central