### PR TITLE
Make it possible for integration tests to observe Classloading events

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -344,7 +344,8 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                 }
                             }).produces(ApplicationClassPredicateBuildItem.class).build();
                         }
-                    }));
+                    }),
+                    Collections.emptyList());
             List<CodeGenData> codeGens = new ArrayList<>();
             QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
 

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -25,6 +25,7 @@ import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.ClassChangeInformation;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildChain;
 import io.quarkus.builder.BuildChainBuilder;
@@ -66,6 +67,7 @@ public class AugmentActionImpl implements AugmentAction {
     private final CuratedApplication curatedApplication;
     private final LaunchMode launchMode;
     private final List<Consumer<BuildChainBuilder>> chainCustomizers;
+    private final List<ClassLoaderEventListener> classLoadListeners;
 
     /**
      * A map that is shared between all re-runs of the same augment instance. This is
@@ -75,13 +77,25 @@ public class AugmentActionImpl implements AugmentAction {
     private final Map<Class<?>, Object> reloadContext = new ConcurrentHashMap<>();
 
     public AugmentActionImpl(CuratedApplication curatedApplication) {
-        this(curatedApplication, Collections.emptyList());
+        this(curatedApplication, Collections.emptyList(), Collections.emptyList());
     }
 
+    /**
+     * Leaving this here for backwards compatibility, even though this is only internal.
+     * 
+     * @Deprecated use one of the other constructors
+     */
+    @Deprecated
     public AugmentActionImpl(CuratedApplication curatedApplication, List<Consumer<BuildChainBuilder>> chainCustomizers) {
+        this(curatedApplication, chainCustomizers, Collections.emptyList());
+    }
+
+    public AugmentActionImpl(CuratedApplication curatedApplication, List<Consumer<BuildChainBuilder>> chainCustomizers,
+            List<ClassLoaderEventListener> classLoadListeners) {
         this.quarkusBootstrap = curatedApplication.getQuarkusBootstrap();
         this.curatedApplication = curatedApplication;
         this.chainCustomizers = chainCustomizers;
+        this.classLoadListeners = classLoadListeners;
         this.launchMode = quarkusBootstrap.getMode() == QuarkusBootstrap.Mode.PROD ? LaunchMode.NORMAL
                 : quarkusBootstrap.getMode() == QuarkusBootstrap.Mode.TEST ? LaunchMode.TEST : LaunchMode.DEVELOPMENT;
     }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/GenerateConfigTask.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/GenerateConfigTask.java
@@ -41,7 +41,7 @@ public class GenerateConfigTask implements BiConsumer<CuratedApplication, Map<St
         try {
             Path temp = Files.createTempDirectory("empty");
             try {
-                AugmentActionImpl augmentAction = new AugmentActionImpl(application, Collections.emptyList());
+                AugmentActionImpl augmentAction = new AugmentActionImpl(application);
                 BuildResult buildResult = augmentAction.runCustomAction(new Consumer<BuildChainBuilder>() {
                     @Override
                     public void accept(BuildChainBuilder chainBuilder) {

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversFastBootingTest.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversFastBootingTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.orm.envers;
+
+import javax.inject.Inject;
+
+import org.hibernate.Session;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.bootstrap.classloading.ClassLoaderLimiter;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Let's run some checks to verify that the optimisations we have
+ * to actually boot efficiently are going to survive other patches.
+ */
+public class EnversFastBootingTest {
+
+    private static final ClassLoaderLimiter limitsChecker = ClassLoaderLimiter.builder()
+            .neverLoadedResource("org/hibernate/jpa/orm_2_1.xsd")
+            .neverLoadedResource("org/hibernate/jpa/orm_2_2.xsd")
+            .build();
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyAuditedEntity.class))
+            .withConfigurationResource("application.properties")
+            .addClassLoaderEventListener(limitsChecker);
+
+    @Inject
+    Session session;
+
+    @Test
+    public void testInjection() {
+        //Check that Hibernate actually started:
+        Assert.assertNotNull(session);
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JPAFastBootingTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JPAFastBootingTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.orm;
+
+import javax.inject.Inject;
+
+import org.hibernate.Session;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.bootstrap.classloading.ClassLoaderLimiter;
+import io.quarkus.hibernate.orm.enhancer.Address;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Let's run some checks to verify that the optimisations we have
+ * to actually boot efficiently are going to survive other patches.
+ */
+public class JPAFastBootingTest {
+
+    private static final ClassLoaderLimiter limitsChecker = ClassLoaderLimiter.builder()
+            .neverLoadedResource("org/hibernate/jpa/orm_2_1.xsd")
+            .neverLoadedResource("org/hibernate/jpa/orm_2_2.xsd")
+            .neverLoadedClassName("org.hibernate.boot.jaxb.internal.MappingBinder")
+            .build();
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(Address.class))
+            .withConfigurationResource("application.properties")
+            .addClassLoaderEventListener(limitsChecker);
+
+    @Inject
+    Session session;
+
+    @Test
+    public void testInjection() {
+        //Check that Hibernate actually started:
+        Assert.assertNotNull(session);
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -174,6 +174,7 @@ public class CuratedApplication implements Serializable, Closeable {
             //first run, we need to build all the class loaders
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder("Augmentation Class Loader",
                     quarkusBootstrap.getBaseClassLoader(), !quarkusBootstrap.isIsolateDeployment());
+            builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
             //we want a class loader that can load the deployment artifacts and all their dependencies, but not
             //any of the runtime artifacts, or user classes
             //this will load any deployment artifacts from the parent CL if they are present
@@ -202,6 +203,7 @@ public class CuratedApplication implements Serializable, Closeable {
         if (baseRuntimeClassLoader == null) {
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder("Quarkus Base Runtime ClassLoader",
                     quarkusBootstrap.getBaseClassLoader(), false);
+            builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
             if (quarkusBootstrap.getMode() == QuarkusBootstrap.Mode.TEST) {
                 //in test mode we have everything in the base class loader
                 //there is no need to restart so there is no need for an additional CL
@@ -250,6 +252,7 @@ public class CuratedApplication implements Serializable, Closeable {
         //first run, we need to build all the class loaders
         QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder("Deployment Class Loader",
                 getAugmentClassLoader(), false)
+                .addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners())
                 .setAggregateParentResources(true);
 
         for (Path root : quarkusBootstrap.getApplicationRoot()) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -2,6 +2,7 @@ package io.quarkus.bootstrap.app;
 
 import io.quarkus.bootstrap.BootstrapAppModelFactory;
 import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.model.AppDependency;
@@ -85,6 +86,7 @@ public class QuarkusBootstrap implements Serializable {
     private final AppModel existingModel;
     private final boolean rebuild;
     private final Set<AppArtifactKey> localArtifacts;
+    private final List<ClassLoaderEventListener> classLoadListeners;
 
     private QuarkusBootstrap(Builder builder) {
         this.applicationRoot = builder.applicationRoot;
@@ -113,6 +115,7 @@ public class QuarkusBootstrap implements Serializable {
         this.existingModel = builder.existingModel;
         this.rebuild = builder.rebuild;
         this.localArtifacts = new HashSet<>(builder.localArtifacts);
+        this.classLoadListeners = builder.classLoadListeners;
     }
 
     public CuratedApplication bootstrap() throws BootstrapException {
@@ -219,7 +222,12 @@ public class QuarkusBootstrap implements Serializable {
         return rebuild;
     }
 
+    public List<ClassLoaderEventListener> getClassLoaderEventListeners() {
+        return this.classLoadListeners;
+    }
+
     public static class Builder {
+        public List<ClassLoaderEventListener> classLoadListeners = new ArrayList<>();
         boolean rebuild;
         PathsCollection applicationRoot;
         String baseName;
@@ -431,6 +439,11 @@ public class QuarkusBootstrap implements Serializable {
 
         public Builder setRebuild(boolean value) {
             this.rebuild = value;
+            return this;
+        }
+
+        public Builder addClassLoaderEventListeners(List<ClassLoaderEventListener> classLoadListeners) {
+            this.classLoadListeners.addAll(classLoadListeners);
             return this;
         }
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderEventListener.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderEventListener.java
@@ -1,0 +1,26 @@
+package io.quarkus.bootstrap.classloading;
+
+/**
+ * You can register classloader event listeners during our integration tests
+ * to verify / count certain events.
+ * This is useful, for example, to verify that certain classes or resources
+ * are not being loaded; which in turn allows us to write regression tests
+ * for certain optimisations.
+ * Limitations: we don't intercept the system classloader, and the same operation
+ * might be observed multiple times when multiple classloaders are chained.
+ */
+public interface ClassLoaderEventListener {
+
+    default void enumeratingResourceURLs(String resourceName, String classLoaderName) {
+    }
+
+    default void gettingURLFromResource(String resourceName, String classLoaderName) {
+    }
+
+    default void openResourceStream(String resourceName, String classLoaderName) {
+    }
+
+    default void loadClass(String className, String classLoaderName) {
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderLimiter.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderLimiter.java
@@ -1,0 +1,207 @@
+package io.quarkus.bootstrap.classloading;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public final class ClassLoaderLimiter implements ClassLoaderEventListener {
+
+    //Store which classloader (by name) has loaded each resource as it helps diagnostics
+    private final ConcurrentMap<String, String> atMostOnceResourcesLoaded = new ConcurrentHashMap();
+    private final ConcurrentMap<String, String> allResourcesLoaded = new ConcurrentHashMap();
+
+    private final Set<String> vetoedResources;
+    private final Set<String> vetoedClasses;
+    private final Set<String> atMostOnceResources;
+    private final Set<String> onHitPrintStacktrace;
+    private final boolean traceAllResourceLoad;
+
+    private ClassLoaderLimiter(Builder builder) {
+        vetoedClasses = builder.vetoedClasses;
+        vetoedResources = builder.vetoedResources;
+        atMostOnceResources = builder.atMostOnceResources;
+        onHitPrintStacktrace = builder.onHitPrintStacktrace;
+        traceAllResourceLoad = builder.traceAllResourceLoad;
+    }
+
+    @Override
+    public void openResourceStream(String resourceName, String classLoaderName) {
+        Objects.requireNonNull(resourceName);
+        Objects.requireNonNull(classLoaderName);
+        if (traceAllResourceLoad) {
+            System.out.println("Opening resource: " + resourceName);
+        }
+        if (onHitPrintStacktrace.contains(resourceName)) {
+            final RuntimeException e = new RuntimeException("Tracing load of resource: " + resourceName);
+            e.printStackTrace();
+        }
+        if (vetoedResources.contains(resourceName)) {
+            throw new IllegalStateException(
+                    "Attempted to load vetoed resource '" + resourceName + "' from classloader " + classLoaderName);
+        }
+        if (atMostOnceResources.contains(resourceName)) {
+            final String previousLoadEvent = atMostOnceResourcesLoaded.put(resourceName, classLoaderName);
+            if (previousLoadEvent != null) {
+                throw new IllegalStateException("Resource being loaded more than once: " + resourceName + ".\n" +
+                        "Attempted load by " + classLoaderName + ", recorded previous load by " + previousLoadEvent);
+            }
+        }
+        if (resourceName.endsWith(".class")) {
+            //Skip further tracking on classes as it would create unnecessary noise
+            return;
+        }
+        final String previousLoad = allResourcesLoaded.put(resourceName, classLoaderName);
+        if (previousLoad != null) {
+            //This diagnostic has no flag, as it's generally useful, doesn't throw exceptions, and should
+            //generally not log much at all.
+            System.out.println(
+                    "Resource loaded multiple times: " + resourceName + ". Currently being loaded by " + classLoaderName +
+                            ", previous loaded by " + previousLoad);
+        }
+    }
+
+    @Override
+    public void loadClass(String className, String classLoaderName) {
+        if (vetoedClasses.contains(className)) {
+            throw new IllegalStateException(
+                    "Attempted to load vetoed class '" + className + "' from classloader " + classLoaderName);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Set<String> vetoedResources = new TreeSet<>();
+        private final Set<String> vetoedClasses = new TreeSet<>();
+        private final Set<String> atMostOnceResources = new TreeSet<>();
+        private final Set<String> onHitPrintStacktrace = new TreeSet<>();
+        private boolean traceAllResourceLoad = false;
+
+        private Builder() {
+            //private constructor to encourage using the builder() method.
+        }
+
+        /**
+         * List a resource name as one that you don't expect to be loaded ever.
+         * If there is an attempt of loading the matched resource, a runtime exception will be thrown instead:
+         * useful for running integration tests to verify your assumptions.
+         *
+         * Limitations: if the resource is being loaded using the bootstrap classloader we
+         * can't check it; some frameworks explicitly request using the base classloader
+         * for resource loading (or even use the Filesystem API), so they can't be tested via this method.
+         *
+         * @param resourceFullName the resource name
+         * @return this, for method chaining.
+         */
+        public Builder neverLoadedResource(String resourceFullName) {
+            Objects.requireNonNull(resourceFullName);
+            final boolean add = vetoedResources.add(resourceFullName);
+            if (!add) {
+                throw new ClassLoaderLimiterConsistencyException(
+                        "resource listed multiple times as never loaded: " + resourceFullName);
+            }
+            if (atMostOnceResources.contains(resourceFullName)) {
+                throw new ClassLoaderLimiterConsistencyException(
+                        resourceFullName + " is being listed both as never loaded and as at most once");
+            }
+            return this;
+        }
+
+        /**
+         * List a fully qualified class name as one that you don't expect to be loaded ever.
+         * If there is an attempt of loading the matched class, a runtime exception will be thrown instead:
+         * useful for running integration tests to verify your assumptions.
+         *
+         * DO NOT list the name by doing using <code>literal.class.getName()</code> as this will implicitly get you
+         * to load the class during the test, and produce a failure.
+         *
+         * Limitations: if the class is being loaded using the bootstrap classloader we
+         * can't check it. Most Quarkus extensions and frameworks will not use the bootstrap classloader,
+         * but some code could make use of it explicitly.
+         *
+         * @param vetoedClassName the fully qualified class name
+         * @return this, for method chaining.
+         */
+        public Builder neverLoadedClassName(String vetoedClassName) {
+            Objects.requireNonNull(vetoedClassName);
+            final boolean add = vetoedClasses.add(vetoedClassName);
+            if (!add)
+                throw new ClassLoaderLimiterConsistencyException(
+                        "never loaded class listed multiple times: " + vetoedClassName);
+            return this;
+        }
+
+        /**
+         * Useful to check that a resource is being loaded only once, or never.
+         * If there is an attempt of loading the matched resource more than once, a runtime exception will be thrown instead:
+         * useful for running integration tests to verify your assumptions.
+         *
+         * Limitations: if the resource is being loaded using the bootstrap classloader we
+         * can't check it; some frameworks explicitly request using the base classloader
+         * for resource loading (or even use the Filesystem API), so they can't be tested via this method.
+         * Additionally, some frameworks will load the same resource but in different Quarkus build
+         * phases (which map to different classloaders); such cases will count as multiple times
+         * so it might not be suited to test this way.
+         *
+         * @param resourceFullName the resource name
+         * @return this, for method chaining.
+         */
+        public Builder loadedAtMostOnceResource(String resourceFullName) {
+            Objects.requireNonNull(resourceFullName);
+            final boolean add = atMostOnceResources.add(resourceFullName);
+            if (!add)
+                throw new ClassLoaderLimiterConsistencyException(
+                        "resource listed multiple times as loaded at most once: " + resourceFullName);
+            if (vetoedResources.contains(resourceFullName)) {
+                throw new ClassLoaderLimiterConsistencyException(
+                        resourceFullName + " is being listed both as never loaded and as at most once");
+            }
+            return this;
+        }
+
+        /**
+         * When the specified resource is loaded, print a full stack trace on System out.
+         * This is not useful for testing, but handy to trace were a certain load is coming from,
+         * should you need to diagnose a failing expectation.
+         *
+         * @param resourceFullName
+         * @return this, for method chaining.
+         */
+        public Builder produceStackTraceOnLoad(String resourceFullName) {
+            Objects.requireNonNull(resourceFullName);
+            final boolean add = onHitPrintStacktrace.add(resourceFullName);
+            if (!add)
+                throw new ClassLoaderLimiterConsistencyException(
+                        "resource listed multiple times to produce a stacktrace: " + resourceFullName);
+            return this;
+        }
+
+        /**
+         * Simply log all resource loading events. Useful to get an idea of which resources are being loaded;
+         * Note it includes resources being used to load classes.
+         *
+         * @param enable
+         * @return this, for method chaining.
+         */
+        public Builder traceAllResourceLoad(boolean enable) {
+            traceAllResourceLoad = enable;
+            return this;
+        }
+
+        public ClassLoaderLimiter build() {
+            return new ClassLoaderLimiter(this);
+        }
+
+    }
+
+    public static class ClassLoaderLimiterConsistencyException extends IllegalArgumentException {
+        public ClassLoaderLimiterConsistencyException(String detail) {
+            super("ClassLoaderLimiter definition inconsistency: " + detail);
+        }
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -140,7 +140,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public Enumeration<URL> getResources(String unsanitisedName) throws IOException {
-        classLoaderEventListeners.forEach(l -> l.enumeratingResourceURLs(unsanitisedName, this.name));
+        for (ClassLoaderEventListener l : classLoaderEventListeners) {
+            l.enumeratingResourceURLs(unsanitisedName, this.name);
+        }
         boolean endsWithTrailingSlash = unsanitisedName.endsWith("/");
         ClassLoaderState state = getState();
         String name = sanitizeName(unsanitisedName);
@@ -271,7 +273,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public URL getResource(String unsanitisedName) {
-        classLoaderEventListeners.forEach(l -> l.gettingURLFromResource(unsanitisedName, this.name));
+        for (ClassLoaderEventListener l : classLoaderEventListeners) {
+            l.gettingURLFromResource(unsanitisedName, this.name);
+        }
         boolean endsWithTrailingSlash = unsanitisedName.endsWith("/");
         String name = sanitizeName(unsanitisedName);
         ClassLoaderState state = getState();
@@ -312,7 +316,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public InputStream getResourceAsStream(String unsanitisedName) {
-        classLoaderEventListeners.forEach(l -> l.openResourceStream(unsanitisedName, this.name));
+        for (ClassLoaderEventListener l : classLoaderEventListeners) {
+            l.openResourceStream(unsanitisedName, this.name);
+        }
         String name = sanitizeName(unsanitisedName);
         ClassLoaderState state = getState();
         if (state.bannedResources.contains(name)) {
@@ -365,13 +371,17 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
-        classLoaderEventListeners.forEach(l -> l.loadClass(name, this.name));
+        for (ClassLoaderEventListener l : classLoaderEventListeners) {
+            l.loadClass(name, this.name);
+        }
         return loadClass(name, false);
     }
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        classLoaderEventListeners.forEach(l -> l.loadClass(name, this.name));
+        for (ClassLoaderEventListener l : classLoaderEventListeners) {
+            l.loadClass(name, this.name);
+        }
         if (name.startsWith(JAVA)) {
             return parent.loadClass(name);
         }


### PR DESCRIPTION
This introduces a `ClassLoaderListener` interface, which is applied on all but our production ClassLoaders, and then modifies our test helpers to easily allow registering a listeners.

Then, I introduce an implementation of such a listener which I use to verify certain classes are _not_ being loaded, and the same for some resources.

Couple tests added to verify optimisations of the Hibernate ORM bootstrap process.