### PR TITLE
Delegate final handling of un-mapped exceptions to Vert.x

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ExceptionInReaderTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FroMage.class, FroMageEndpoint.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.with().contentType("application/json").body("{\"name\": \"brie\"}").put("/fromage")
+                .then().statusCode(500).body(containsString("MismatchedInputException"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FroMage.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FroMage.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+public class FroMage {
+    public String name;
+
+    // required for Jackson
+    // public FroMage() {}
+    public FroMage(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "FroMage: " + name;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FroMageEndpoint.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FroMageEndpoint.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("fromage")
+public class FroMageEndpoint {
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @PUT
+    public FroMage putJson(FroMage fromage) {
+        return fromage;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -57,4 +57,18 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
         return new ResteasyReactiveSecurityContext(context);
     }
 
+    @Override
+    protected void handleUnrecoverableError(Throwable throwable) {
+        context.fail(throwable);
+        super.handleUnrecoverableError(throwable);
+    }
+
+    @Override
+    public void handleUnmappedException(Throwable throwable) {
+        throw sneakyThrow(throwable);
+    }
+
+    private <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
+        throw (E) e;
+    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AsyncExceptionMappingUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AsyncExceptionMappingUtil.java
@@ -8,7 +8,6 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.jboss.resteasy.reactive.server.spi.AsyncExceptionMapperContext;
 
-import io.quarkus.resteasy.reactive.server.runtime.NotFoundExceptionMapper;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -18,7 +17,7 @@ import io.smallrye.mutiny.Uni;
  */
 public final class AsyncExceptionMappingUtil {
 
-    private static final Logger log = Logger.getLogger(NotFoundExceptionMapper.class);
+    private static final Logger log = Logger.getLogger(AsyncExceptionMappingUtil.class);
 
     private static final Response DEFAULT_RESPONSE = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
             .entity("Internal Server Error").build();

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ExceptionMapping.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ExceptionMapping.java
@@ -58,8 +58,7 @@ public class ExceptionMapping {
         } else {
             log.error("Request failed ", throwable);
         }
-        // FIXME: configurable? stack trace?
-        context.setResult(Response.serverError().build());
+        context.handleUnmappedException(throwable);
     }
 
     /**

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -287,6 +287,10 @@ public abstract class ResteasyReactiveRequestContext
         return this;
     }
 
+    public void handleUnmappedException(Throwable throwable) {
+        setResult(Response.serverError().build());
+    }
+
     public RuntimeResource getTarget() {
         return target;
     }
@@ -581,7 +585,7 @@ public abstract class ResteasyReactiveRequestContext
     }
 
     protected void handleUnrecoverableError(Throwable throwable) {
-        ResteasyReactiveRequestContext.log.error("Request failed", throwable);
+        log.error("Request failed", throwable);
         if (serverResponse().headWritten()) {
             serverRequest().closeConnection();
         } else {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.NoContentException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.ReaderInterceptor;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
 import org.jboss.resteasy.reactive.server.jaxrs.ReaderInterceptorContextImpl;
@@ -20,6 +21,8 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 
 public class RequestDeserializeHandler implements ServerRestHandler {
+
+    private static final Logger log = Logger.getLogger(RequestDeserializeHandler.class);
 
     private final Class<?> type;
     private final MediaType mediaType;
@@ -68,6 +71,7 @@ public class RequestDeserializeHandler implements ServerRestHandler {
                         throw new BadRequestException(e);
                     }
                 } catch (Exception e) {
+                    log.debug("Error occurred during deserialization of input", e);
                     requestContext.resume(e);
                     return;
                 }


### PR DESCRIPTION
This is done in order to get the same behavior for `quarkus-resteasy-reactive` as we have from
`quarkus-resteasy`

Fixes: #13798