### PR TITLE
Amazon Services - Make native work even if nothing configured 

### DIFF
--- a/extensions/amazon-services/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AmazonServicesClientsProcessor.java
+++ b/extensions/amazon-services/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AmazonServicesClientsProcessor.java
@@ -95,39 +95,74 @@ public class AmazonServicesClientsProcessor {
         final Predicate<AmazonClientBuildItem> isSyncApache = client -> client
                 .getBuildTimeSyncConfig().type == SyncClientType.APACHE;
 
-        //Register only clients that are used
+        // Register what's needed depending on the clients in the classpath and the configuration.
+        // We use the configuration to guide us but if we don't have any clients configured,
+        // we still register what's needed depending on what is in the classpath.
+        boolean isSyncApacheInClasspath = isInClasspath(APACHE_HTTP_SERVICE);
+        boolean isSyncUrlConnectionInClasspath = isInClasspath(URL_HTTP_SERVICE);
+        boolean isAsyncInClasspath = isInClasspath(NETTY_HTTP_SERVICE);
+
+        // Check that the clients required by the configuration are available
         if (syncTransportNeeded) {
             if (amazonClients.stream().filter(isSyncApache).findAny().isPresent()) {
-                checkClasspath(APACHE_HTTP_SERVICE, "apache-client");
-                //Register Apache client as sync client
-                proxyDefinition
-                        .produce(new NativeImageProxyDefinitionBuildItem("org.apache.http.conn.HttpClientConnectionManager",
-                                "org.apache.http.pool.ConnPoolControl",
-                                "software.amazon.awssdk.http.apache.internal.conn.Wrapped"));
-
-                serviceProvider.produce(
-                        new ServiceProviderBuildItem(SdkHttpService.class.getName(), APACHE_HTTP_SERVICE));
+                if (isSyncApacheInClasspath) {
+                    registerSyncApacheClient(proxyDefinition, serviceProvider);
+                } else {
+                    throw missingDependencyException("apache-client");
+                }
+            } else if (isSyncUrlConnectionInClasspath) {
+                registerSyncUrlConnectionClient(serviceProvider);
             } else {
-                checkClasspath(URL_HTTP_SERVICE, "url-connection-client");
-                serviceProvider.produce(new ServiceProviderBuildItem(SdkHttpService.class.getName(), URL_HTTP_SERVICE));
+                throw missingDependencyException("url-connection-client");
+            }
+        } else {
+            // even if we don't register any clients via configuration, we still register the clients
+            // but this time only based on the classpath.
+            if (isSyncApacheInClasspath) {
+                registerSyncApacheClient(proxyDefinition, serviceProvider);
+            } else if (isSyncUrlConnectionInClasspath) {
+                registerSyncUrlConnectionClient(serviceProvider);
             }
         }
 
-        if (asyncTransportNeeded) {
-            checkClasspath(NETTY_HTTP_SERVICE, "netty-nio-client");
-            //Register netty as async client
-            serviceProvider.produce(
-                    new ServiceProviderBuildItem(SdkAsyncHttpService.class.getName(),
-                            NETTY_HTTP_SERVICE));
+        if (isAsyncInClasspath) {
+            registerAsyncNettyClient(serviceProvider);
+        } else if (asyncTransportNeeded) {
+            throw missingDependencyException("netty-nio-client");
         }
     }
 
-    private void checkClasspath(String className, String dependencyName) {
+    private static void registerSyncApacheClient(BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinition,
+            BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        proxyDefinition
+                .produce(new NativeImageProxyDefinitionBuildItem("org.apache.http.conn.HttpClientConnectionManager",
+                        "org.apache.http.pool.ConnPoolControl",
+                        "software.amazon.awssdk.http.apache.internal.conn.Wrapped"));
+
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(SdkHttpService.class.getName(), APACHE_HTTP_SERVICE));
+    }
+
+    private static void registerSyncUrlConnectionClient(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(new ServiceProviderBuildItem(SdkHttpService.class.getName(), URL_HTTP_SERVICE));
+    }
+
+    private static void registerAsyncNettyClient(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(SdkAsyncHttpService.class.getName(),
+                        NETTY_HTTP_SERVICE));
+    }
+
+    private static boolean isInClasspath(String className) {
         try {
             Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+            return true;
         } catch (ClassNotFoundException e) {
-            throw new DeploymentException(
-                    "Missing 'software.amazon.awssdk:" + dependencyName + "' dependency on the classpath");
+            return false;
         }
+    }
+
+    private DeploymentException missingDependencyException(String dependencyName) {
+        return new DeploymentException("Missing 'software.amazon.awssdk:" + dependencyName + "' dependency on the classpath");
     }
 }

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -337,7 +337,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                             expectedExtensionDeps.put(currentNode.gact, currentNode);
                             extDepsTotal.incrementAndGet();
                         }
-                    } catch (IOException e) {
+                    } catch (Throwable e) {
                         throw new IllegalStateException("Failed to read " + f, e);
                     }
                 }


### PR DESCRIPTION
We had several users who want to use Amazon Services but without our
configuration layer because they need dynamic clients.
Before this commit, it didn't work in native.

@geoand @machi1990 interested in having other pairs of eyes checking this patch as it's not really testable without adding a major cost to CI.