### PR TITLE
Openshift docker build strategy fixes

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -152,7 +152,7 @@
         <aws-alexa-sdk.version>2.37.1</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.4.20</kotlin.version>
-        <dekorate.version>0.13.6</dekorate.version>
+        <dekorate.version>0.14.0</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -141,20 +141,23 @@ public class OpenshiftProcessor {
         builderImageProducer.produce(new BaseImageInfoBuildItem(config.baseJvmImage));
         Optional<OpenshiftBaseJavaImage> baseImage = OpenshiftBaseJavaImage.findMatching(config.baseJvmImage);
 
-        baseImage.ifPresent(b -> {
-            envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJarEnvVar(), pathToJar, null));
-            envProducer.produce(
-                    KubernetesEnvBuildItem.createSimpleVar(b.getJarLibEnvVar(), concatUnixPaths(jarDirectory, "lib"), null));
-            envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getClasspathEnvVar(), classpath, null));
-            envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJvmOptionsEnvVar(),
-                    String.join(" ", config.jvmArguments), null));
-        });
+        if (config.buildStrategy != BuildStrategy.DOCKER) {
+            baseImage.ifPresent(b -> {
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJarEnvVar(), pathToJar, null));
+                envProducer.produce(
+                        KubernetesEnvBuildItem.createSimpleVar(b.getJarLibEnvVar(), concatUnixPaths(jarDirectory, "lib"),
+                                null));
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getClasspathEnvVar(), classpath, null));
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJvmOptionsEnvVar(),
+                        String.join(" ", config.jvmArguments), null));
+            });
 
-        if (!baseImage.isPresent()) {
-            envProducer.produce(KubernetesEnvBuildItem.createSimpleVar("JAVA_APP_JAR", pathToJar, null));
-            envProducer.produce(
-                    KubernetesEnvBuildItem.createSimpleVar("JAVA_LIB_DIR", concatUnixPaths(jarDirectory, "lib"), null));
-            commandProducer.produce(new KubernetesCommandBuildItem("java", args.toArray(new String[args.size()])));
+            if (!baseImage.isPresent()) {
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar("JAVA_APP_JAR", pathToJar, null));
+                envProducer.produce(
+                        KubernetesEnvBuildItem.createSimpleVar("JAVA_LIB_DIR", concatUnixPaths(jarDirectory, "lib"), null));
+                commandProducer.produce(new KubernetesCommandBuildItem("java", args.toArray(new String[args.size()])));
+            }
         }
     }
 
@@ -184,22 +187,23 @@ public class OpenshiftProcessor {
             nativeBinaryFileName = config.nativeBinaryFileName.orElse(outputNativeBinaryFileName);
         }
 
-        String pathToNativeBinary = concatUnixPaths(config.nativeBinaryDirectory, nativeBinaryFileName);
+        if (config.buildStrategy != BuildStrategy.DOCKER) {
+            String pathToNativeBinary = concatUnixPaths(config.nativeBinaryDirectory, nativeBinaryFileName);
+            builderImageProducer.produce(new BaseImageInfoBuildItem(config.baseNativeImage));
+            Optional<OpenshiftBaseNativeImage> baseImage = OpenshiftBaseNativeImage.findMatching(config.baseNativeImage);
+            baseImage.ifPresent(b -> {
+                envProducer.produce(
+                        KubernetesEnvBuildItem.createSimpleVar(b.getHomeDirEnvVar(), config.nativeBinaryDirectory,
+                                OPENSHIFT));
+                envProducer.produce(
+                        KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(), String.join(" ", config.nativeArguments),
+                                OPENSHIFT));
+            });
 
-        builderImageProducer.produce(new BaseImageInfoBuildItem(config.baseNativeImage));
-        Optional<OpenshiftBaseNativeImage> baseImage = OpenshiftBaseNativeImage.findMatching(config.baseNativeImage);
-        baseImage.ifPresent(b -> {
-            envProducer.produce(
-                    KubernetesEnvBuildItem.createSimpleVar(b.getHomeDirEnvVar(), config.nativeBinaryDirectory,
-                            OPENSHIFT));
-            envProducer.produce(
-                    KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(), String.join(" ", config.nativeArguments),
-                            OPENSHIFT));
-        });
-
-        if (!baseImage.isPresent()) {
-            commandProducer.produce(new KubernetesCommandBuildItem(pathToNativeBinary,
-                    config.nativeArguments.toArray(new String[config.nativeArguments.size()])));
+            if (!baseImage.isPresent()) {
+                commandProducer.produce(new KubernetesCommandBuildItem(pathToNativeBinary,
+                        config.nativeArguments.toArray(new String[config.nativeArguments.size()])));
+            }
         }
     }
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -277,7 +277,7 @@ public class OpenshiftProcessor {
             return;
         }
 
-        createContainerImage(kubernetesClient, openshiftYml.get(), config, null, out.getOutputDirectory(),
+        createContainerImage(kubernetesClient, openshiftYml.get(), config, "target", out.getOutputDirectory(),
                 nativeImage.getPath());
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container", Collections.emptyMap()));
     }


### PR DESCRIPTION
This pull request fixes the following:

1. Wrong permissions of native binary in the tarball entry (fixed by bumping dekorate to 0.14.0)
2. Context for native docker build is now created under `target` (as is the case for jvm)
3. Skip command & args when using the docker build strategy (and use the image entrypoint), as there is no reliable way to figure those out for custom dockerfiles.