### PR TITLE
IDE dev mode: add only reloadable local dependencies to the devmode context

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -125,6 +125,7 @@
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-core</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-development-mode-spi</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-app-model</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus:quarkus-bootstrap-maven-resolver</parentFirstArtifact>
                         <parentFirstArtifact>org.slf4j:slf4j-api</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.slf4j:slf4j-jboss-logmanager</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager-embedded</parentFirstArtifact>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -203,6 +203,12 @@ public class BootstrapAppModelFactory {
         if (mvnContext != null) {
             return mvnContext;
         }
+        if (mavenArtifactResolver != null) {
+            mvnContext = mavenArtifactResolver.getMavenContext();
+            if (mvnContext != null) {
+                return mvnContext;
+            }
+        }
         final BootstrapMavenContextConfig<?> config = BootstrapMavenContext.config();
         if (offline != null) {
             config.setOffline(offline);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/devmode/DependenciesFilter.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/devmode/DependenciesFilter.java
@@ -1,0 +1,150 @@
+package io.quarkus.bootstrap.devmode;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.DependencyVisitor;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
+import org.jboss.logging.Logger;
+
+public class DependenciesFilter {
+
+    private static final Logger log = Logger.getLogger(DependenciesFilter.class);
+
+    public static List<LocalProject> filterNotReloadableDependencies(LocalProject localProject,
+            MavenArtifactResolver mvnResolver) throws BootstrapMavenException {
+        final AppArtifact appArtifact = localProject.getAppArtifact("jar");
+        final List<Artifact> projectDeps = new ArrayList<>();
+        mvnResolver
+                .resolveDependencies(
+                        new DefaultArtifact(appArtifact.getGroupId(), appArtifact.getArtifactId(),
+                                appArtifact.getClassifier(), appArtifact.getType(), appArtifact.getVersion()),
+                        Collections.emptyList())
+                .getRoot().accept(new TreeDependencyVisitor(new DependencyVisitor() {
+                    @Override
+                    public boolean visitEnter(DependencyNode node) {
+                        final Dependency dep = node.getDependency();
+                        if (dep != null && dep.getArtifact().getFile().isDirectory()) {
+                            org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
+                            final org.apache.maven.artifact.DefaultArtifact mvnArtifact = new org.apache.maven.artifact.DefaultArtifact(
+                                    a.getGroupId(), a.getArtifactId(), a.getVersion(), dep.getScope(), a.getExtension(),
+                                    a.getClassifier(), new DefaultArtifactHandler("jar"));
+                            mvnArtifact.setFile(a.getFile());
+                            projectDeps.add(mvnArtifact);
+                        }
+                        return true;
+                    }
+
+                    @Override
+                    public boolean visitLeave(DependencyNode node) {
+                        return true;
+                    }
+                }));
+        return filterNotReloadableDependencies(localProject, projectDeps, mvnResolver.getSystem(),
+                mvnResolver.getSession(), mvnResolver.getRepositories());
+    }
+
+    public static List<LocalProject> filterNotReloadableDependencies(LocalProject localProject,
+            Iterable<Artifact> projectDeps,
+            RepositorySystem repoSystem,
+            RepositorySystemSession repoSession,
+            List<RemoteRepository> repos) {
+        final LocalWorkspace workspace = localProject.getWorkspace();
+        if (workspace == null) {
+            return Collections.singletonList(localProject);
+        }
+
+        List<LocalProject> ret = new ArrayList<>();
+        Set<AppArtifactKey> extensionsAndDeps = new HashSet<>();
+
+        ret.add(localProject);
+        for (Artifact a : projectDeps) {
+            final AppArtifactKey depKey = new AppArtifactKey(a.getGroupId(), a.getArtifactId());
+            final LocalProject project = workspace.getProject(depKey);
+            if (project == null) {
+                continue;
+            }
+            if (!project.getVersion().equals(a.getVersion())) {
+                log.warn(depKey + " is excluded from live coding since the application depends on version "
+                        + a.getVersion() + " while the version present in the workspace is " + project.getVersion());
+                continue;
+            }
+
+            if (project.getClassesDir() != null &&
+            //if this project also contains Quarkus extensions we do no want to include these in the discovery
+            //a bit of an edge case, but if you try and include a sample project with your extension you will
+            //run into problems without this
+                    (Files.exists(project.getClassesDir().resolve("META-INF/quarkus-extension.properties")) ||
+                            Files.exists(project.getClassesDir().resolve("META-INF/quarkus-build-steps.list")))) {
+                // TODO add the deployment deps
+                extensionDepWarning(depKey);
+                try {
+                    final DependencyNode depRoot = repoSystem.collectDependencies(repoSession, new CollectRequest()
+                            .setRoot(new org.eclipse.aether.graph.Dependency(
+                                    new DefaultArtifact(a.getGroupId(), a.getArtifactId(),
+                                            a.getClassifier(), a.getArtifactHandler().getExtension(), a.getVersion()),
+                                    JavaScopes.RUNTIME))
+                            .setRepositories(repos)).getRoot();
+                    depRoot.accept(new DependencyVisitor() {
+                        @Override
+                        public boolean visitEnter(DependencyNode node) {
+                            final org.eclipse.aether.artifact.Artifact artifact = node.getArtifact();
+                            if ("jar".equals(artifact.getExtension())) {
+                                extensionsAndDeps.add(new AppArtifactKey(artifact.getGroupId(), artifact.getArtifactId()));
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public boolean visitLeave(DependencyNode node) {
+                            return true;
+                        }
+                    });
+                } catch (DependencyCollectionException e) {
+                    throw new RuntimeException("Failed to collect dependencies for " + a, e);
+                }
+            } else {
+                ret.add(project);
+            }
+        }
+
+        if (extensionsAndDeps.isEmpty()) {
+            return ret;
+        }
+
+        Iterator<LocalProject> iterator = ret.iterator();
+        while (iterator.hasNext()) {
+            final LocalProject localDep = iterator.next();
+            if (extensionsAndDeps.contains(localDep.getKey())) {
+                extensionDepWarning(localDep.getKey());
+                iterator.remove();
+            }
+        }
+        return ret;
+    }
+
+    private static void extensionDepWarning(AppArtifactKey key) {
+        log.warn("Local Quarkus extension dependency " + key + " will not be hot-reloadable");
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -93,6 +93,7 @@ public class MavenArtifactResolver {
         return new Builder();
     }
 
+    protected final BootstrapMavenContext context;
     protected final RepositorySystem repoSystem;
     protected final RepositorySystemSession repoSession;
     protected final List<RemoteRepository> remoteRepos;
@@ -100,30 +101,35 @@ public class MavenArtifactResolver {
     protected final RemoteRepositoryManager remoteRepoManager;
 
     private MavenArtifactResolver(Builder builder) throws BootstrapMavenException {
-        final BootstrapMavenContext mvnSettings = new BootstrapMavenContext(builder);
-        this.repoSystem = mvnSettings.getRepositorySystem();
+        this.context = new BootstrapMavenContext(builder);
+        this.repoSystem = context.getRepositorySystem();
 
-        final RepositorySystemSession session = mvnSettings.getRepositorySystemSession();
+        final RepositorySystemSession session = context.getRepositorySystemSession();
         if (builder.localRepo != null && builder.reTryFailedResolutionsAgainstDefaultLocalRepo) {
             localRepoManager = new MavenLocalRepositoryManager(
                     repoSystem.newLocalRepositoryManager(session, new LocalRepository(builder.localRepo)),
-                    Paths.get(mvnSettings.getLocalRepo()));
+                    Paths.get(context.getLocalRepo()));
             this.repoSession = new DefaultRepositorySystemSession(session).setLocalRepositoryManager(localRepoManager);
         } else {
             this.repoSession = session;
             localRepoManager = null;
         }
 
-        this.remoteRepos = mvnSettings.getRemoteRepositories();
-        this.remoteRepoManager = mvnSettings.getRemoteRepositoryManager();
+        this.remoteRepos = context.getRemoteRepositories();
+        this.remoteRepoManager = context.getRemoteRepositoryManager();
     }
 
     public MavenArtifactResolver(BootstrapMavenContext mvnSettings) throws BootstrapMavenException {
+        this.context = mvnSettings;
         this.repoSystem = mvnSettings.getRepositorySystem();
         this.repoSession = mvnSettings.getRepositorySystemSession();
         localRepoManager = null;
         this.remoteRepos = mvnSettings.getRemoteRepositories();
         this.remoteRepoManager = mvnSettings.getRemoteRepositoryManager();
+    }
+
+    public BootstrapMavenContext getMavenContext() {
+        return context;
     }
 
     public RemoteRepositoryManager getRemoteRepositoryManager() {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -307,14 +307,18 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         runAndCheck();
 
         final List<String> extDepWarnings = Files.readAllLines(testDir.toPath().resolve("build-project-with-extension.log"))
-                .stream().filter(s -> s.startsWith("[WARNING] Local Quarkus extension dependency "))
+                .stream()
+                .filter(s -> s.startsWith(
+                        "[WARNING] [io.quarkus.bootstrap.devmode.DependenciesFilter] Local Quarkus extension dependency "))
                 .collect(Collectors.toList());
         assertTrue(extDepWarnings
-                .contains("[WARNING] Local Quarkus extension dependency org.acme:acme-quarkus-ext will not be hot-reloadable"));
+                .contains(
+                        "[WARNING] [io.quarkus.bootstrap.devmode.DependenciesFilter] Local Quarkus extension dependency org.acme:acme-quarkus-ext will not be hot-reloadable"));
         assertTrue(extDepWarnings
-                .contains("[WARNING] Local Quarkus extension dependency org.acme:acme-common will not be hot-reloadable"));
+                .contains(
+                        "[WARNING] [io.quarkus.bootstrap.devmode.DependenciesFilter] Local Quarkus extension dependency org.acme:acme-common will not be hot-reloadable"));
         assertTrue(extDepWarnings.contains(
-                "[WARNING] Local Quarkus extension dependency org.acme:acme-common-transitive will not be hot-reloadable"));
+                "[WARNING] [io.quarkus.bootstrap.devmode.DependenciesFilter] Local Quarkus extension dependency org.acme:acme-common-transitive will not be hot-reloadable"));
         assertEquals(3, extDepWarnings.size());
     }
 


### PR DESCRIPTION
This PR is based on the investigations performed by @famod. Thanks a lot for your great efforts, @famod!

The IDE dev mode should be using only the re-loadable local dependencies of the app module instead of adding all the workspace modules as re-loadable.
The extension dependency filtering is extracted to a common utility class and applied to the IDE dev mode setup as well.
The logger in the DevMojo is now properly initialized.