### PR TITLE
Bump to jGit 5.9.0.202009080501-r

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,7 @@ updates:
       - dependency-name: org.flywaydb:flyway-core
       - dependency-name: org.liquibase:liquibase-core
       - dependency-name: org.freemarker:freemarker
-      - dependency-name: org.eclipse.jgit:org.eclipse.jgit
-      - dependency-name: org.eclipse.jgit:org.eclipse.jgit.http.server
+      - dependency-name: org.eclipse.jgit:*
       - dependency-name: io.fabric8:kubernetes-client-bom
       - dependency-name: org.apache.httpcomponents:httpclient
       - dependency-name: org.apache.httpcomponents:httpasyncclient

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -159,7 +159,7 @@
         <awaitility.version>4.0.3</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
         <jboss-logmanager.version>1.0.6</jboss-logmanager.version>
-        <jgit.version>5.8.0.202006091008-r</jgit.version>
+        <jgit.version>5.9.0.202009080501-r</jgit.version>
         <flyway.version>7.3.1</flyway.version>
         <yasson.version>1.0.8</yasson.version>
         <liquibase.version>4.2.2</liquibase.version>


### PR DESCRIPTION
It also adds the missing GA in the dependabot descriptor