### PR TITLE
Implement Various Reactive fixes

### DIFF
--- a/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/ClientEndpointIndexer.java
+++ b/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/ClientEndpointIndexer.java
@@ -79,9 +79,9 @@ public class ClientEndpointIndexer
 
     protected MethodParameter createMethodParameter(ClassInfo currentClassInfo, ClassInfo actualEndpointInfo, boolean encoded,
             Type paramType, ClientIndexedParam parameterResult, String name, String defaultValue, ParameterType type,
-            String elementType, boolean single) {
+            String elementType, boolean single, String signature) {
         return new MethodParameter(name,
-                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index), type, single,
+                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index), signature, type, single,
                 defaultValue, parameterResult.isObtainedAsCollection(), encoded);
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/SerializersUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/SerializersUtil.java
@@ -44,7 +44,7 @@ public class SerializersUtil {
         for (MessageBodyReaderBuildItem additionalReader : RuntimeTypeItem.filter(messageBodyReaderBuildItems,
                 runtimeType)) {
             ResourceReader reader = new ResourceReader();
-            reader.setBuiltin(false);
+            reader.setBuiltin(additionalReader.isBuiltin());
             String readerClassName = additionalReader.getClassName();
             reader.setFactory(FactoryUtils.factory(readerClassName,
                     applicationResultBuildItem.getResult().getSingletonClasses(), recorder,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyReaderBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyReaderBuildItem.java
@@ -15,7 +15,7 @@ public final class MessageBodyReaderBuildItem extends MultiBuildItem implements 
     private final boolean builtin;
 
     public MessageBodyReaderBuildItem(String className, String handledClassName, List<String> mediaTypeStrings) {
-        this(className, handledClassName, mediaTypeStrings, null, false);
+        this(className, handledClassName, mediaTypeStrings, null, true);
     }
 
     public MessageBodyReaderBuildItem(String className, String handledClassName, List<String> mediaTypeStrings,
@@ -42,5 +42,9 @@ public final class MessageBodyReaderBuildItem extends MultiBuildItem implements 
     @Override
     public RuntimeType getRuntimeType() {
         return runtimeType;
+    }
+
+    public boolean isBuiltin() {
+        return builtin;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.resteasy.reactive.jackson.deployment.processor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -46,6 +47,12 @@ public class ResteasyReactiveJacksonProcessor {
 
         additionalReaders
                 .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Object.class.getName(),
+                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+        additionalReaders
+                .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Collection.class.getName(),
+                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+        additionalReaders
+                .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Map.class.getName(),
                         Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(JacksonMessageBodyWriter.class.getName(), Object.class.getName(),

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -3,7 +3,6 @@ package io.quarkus.resteasy.reactive.jackson.deployment.processor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,12 +46,6 @@ public class ResteasyReactiveJacksonProcessor {
 
         additionalReaders
                 .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Object.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
-        additionalReaders
-                .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Collection.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
-        additionalReaders
-                .produce(new MessageBodyReaderBuildItem(JacksonMessageBodyReader.class.getName(), Map.class.getName(),
                         Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(JacksonMessageBodyWriter.class.getName(), Object.class.getName(),

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import io.quarkus.runtime.BlockingOperationControl;
 
 @Path("/simple")
-public class SimpleJsonResource {
+public class SimpleJsonResource extends SuperClass<Person> {
 
     @GET
     @Path("/person")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -36,6 +39,21 @@ public class SimpleJsonResource {
             throw new RuntimeException("should not have dispatched");
         }
         return person;
+    }
+
+    @POST
+    @Path("/people")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public List<Person> getPeople(List<Person> people) {
+        if (BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        List<Person> reversed = new ArrayList<>(people.size());
+        for (Person person : people) {
+            reversed.add(0, person);
+        }
+        return reversed;
     }
 
     @POST

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -57,6 +57,15 @@ public class SimpleJsonResource {
     }
 
     @POST
+    @Path("/strings")
+    public List<String> strings(List<String> strings) {
+        if (BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        return strings;
+    }
+
+    @POST
     @Path("/person-large")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -44,6 +44,19 @@ public class SimpleJsonTest {
                 .statusCode(200)
                 .contentType("application/json")
                 .body("first", Matchers.equalTo("Bob")).body("last", Matchers.equalTo("Builder"));
+
+        RestAssured
+                .with()
+                .body("[{\"first\": \"Bob\", \"last\": \"Builder\"}, {\"first\": \"Bob2\", \"last\": \"Builder2\"}]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/people")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[1].first", Matchers.equalTo("Bob"))
+                .body("[1].last", Matchers.equalTo("Builder"))
+                .body("[0].first", Matchers.equalTo("Bob2"))
+                .body("[0].last", Matchers.equalTo("Builder2"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -57,6 +57,16 @@ public class SimpleJsonTest {
                 .body("[1].last", Matchers.equalTo("Builder"))
                 .body("[0].first", Matchers.equalTo("Bob2"))
                 .body("[0].last", Matchers.equalTo("Builder2"));
+
+        RestAssured.with()
+                .body("[\"first\", \"second\"]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/strings")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0]", Matchers.equalTo("first"))
+                .body("[1]", Matchers.equalTo("second"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -22,7 +22,7 @@ public class SimpleJsonTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(Person.class, SimpleJsonResource.class, User.class, Views.class);
+                            .addClasses(Person.class, SimpleJsonResource.class, User.class, Views.class, SuperClass.class);
                 }
             });
 
@@ -67,6 +67,19 @@ public class SimpleJsonTest {
                 .contentType("application/json")
                 .body("[0]", Matchers.equalTo("first"))
                 .body("[1]", Matchers.equalTo("second"));
+
+        RestAssured
+                .with()
+                .body("[{\"first\": \"Bob\", \"last\": \"Builder\"}, {\"first\": \"Bob2\", \"last\": \"Builder2\"}]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/super")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[1].first", Matchers.equalTo("Bob"))
+                .body("[1].last", Matchers.equalTo("Builder"))
+                .body("[0].first", Matchers.equalTo("Bob2"))
+                .body("[0].last", Matchers.equalTo("Builder2"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SuperClass.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SuperClass.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+public class SuperClass<T> {
+
+    @POST
+    @Path("/super")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public List<T> reverseListFromSuper(List<T> list) {
+        List<T> reversed = new ArrayList<>(list.size());
+        for (T t : list) {
+            reversed.add(0, t);
+        }
+        return reversed;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyReader.java
@@ -11,14 +11,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
-import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
-import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.providers.serialisers.json.AbstractJsonMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
-public class JacksonMessageBodyReader implements ServerMessageBodyReader<Object> {
+public class JacksonMessageBodyReader extends AbstractJsonMessageBodyReader {
 
     private final ObjectReader reader;
 
@@ -28,19 +27,9 @@ public class JacksonMessageBodyReader implements ServerMessageBodyReader<Object>
     }
 
     @Override
-    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return true;
-    }
-
-    @Override
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         return doReadFrom(type, genericType, entityStream);
-    }
-
-    @Override
-    public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod, MediaType mediaType) {
-        return true;
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
@@ -49,6 +49,15 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
             entityStream.write(((String) o).getBytes());
         } else {
+            if (annotations != null) {
+                for (Annotation annotation : annotations) {
+                    if (JsonView.class.equals(annotation.annotationType())) {
+                        if (handleJsonView(((JsonView) annotation), o, entityStream)) {
+                            return;
+                        }
+                    }
+                }
+            }
             entityStream.write(writer.writeValueAsBytes(o));
         }
     }
@@ -68,9 +77,7 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
             // where JsonView is not used
             if (context.getResteasyReactiveResourceInfo().getMethodAnnotationNames().contains(JSON_VIEW_NAME)) {
                 Method method = context.getResteasyReactiveResourceInfo().getMethod();
-                JsonView jsonView = method.getAnnotation(JsonView.class);
-                if ((jsonView != null) && (jsonView.value().length > 0)) {
-                    writer.withView(jsonView.value()[0]).writeValue(stream, o);
+                if (handleJsonView(method.getAnnotation(JsonView.class), o, stream)) {
                     return;
                 }
             }
@@ -78,5 +85,13 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
         }
         // we don't use try-with-resources because that results in writing to the http output without the exception mapping coming into play
         stream.close();
+    }
+
+    private boolean handleJsonView(JsonView jsonView, Object o, OutputStream stream) throws IOException {
+        if ((jsonView != null) && (jsonView.value().length > 0)) {
+            writer.withView(jsonView.value()[0]).writeValue(stream, o);
+            return true;
+        }
+        return false;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
@@ -1,6 +1,8 @@
 package io.quarkus.resteasy.reactive.jsonb.deployment.processor;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 
@@ -32,6 +34,11 @@ public class ResteasyReactiveJsonbProcessor {
                 .setUnremovable().build());
 
         additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Object.class.getName(),
+                Collections.singletonList(MediaType.APPLICATION_JSON)));
+        additionalReaders
+                .produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Collection.class.getName(),
+                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+        additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Map.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters.produce(new MessageBodyWriterBuildItem(JsonbMessageBodyWriter.class.getName(), Object.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
@@ -1,8 +1,6 @@
 package io.quarkus.resteasy.reactive.jsonb.deployment.processor;
 
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 
@@ -34,11 +32,6 @@ public class ResteasyReactiveJsonbProcessor {
                 .setUnremovable().build());
 
         additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Object.class.getName(),
-                Collections.singletonList(MediaType.APPLICATION_JSON)));
-        additionalReaders
-                .produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Collection.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
-        additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Map.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters.produce(new MessageBodyWriterBuildItem(JsonbMessageBodyWriter.class.getName(), Object.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.jsonb.deployment.test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -34,6 +37,21 @@ public class SimpleJsonResource {
             throw new RuntimeException("should not have dispatched");
         }
         return person;
+    }
+
+    @POST
+    @Path("/people")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public List<Person> getPeople(List<Person> people) {
+        if (BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        List<Person> reversed = new ArrayList<>(people.size());
+        for (Person person : people) {
+            reversed.add(0, person);
+        }
+        return reversed;
     }
 
     @POST

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.MediaType;
 import io.quarkus.runtime.BlockingOperationControl;
 
 @Path("/simple")
-public class SimpleJsonResource {
+public class SimpleJsonResource extends SuperClass<Person> {
 
     @GET
     @Path("/person")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
@@ -55,6 +55,15 @@ public class SimpleJsonResource {
     }
 
     @POST
+    @Path("/strings")
+    public List<String> strings(List<String> strings) {
+        if (BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        return strings;
+    }
+
+    @POST
     @Path("/person-large")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
@@ -41,6 +41,19 @@ public class SimpleJsonTest {
                 .statusCode(200)
                 .contentType("application/json")
                 .body("first", Matchers.equalTo("Bob")).body("last", Matchers.equalTo("Builder"));
+
+        RestAssured
+                .with()
+                .body("[{\"first\": \"Bob\", \"last\": \"Builder\"}, {\"first\": \"Bob2\", \"last\": \"Builder2\"}]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/people")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[1].first", Matchers.equalTo("Bob"))
+                .body("[1].last", Matchers.equalTo("Builder"))
+                .body("[0].first", Matchers.equalTo("Bob2"))
+                .body("[0].last", Matchers.equalTo("Builder2"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
@@ -19,7 +19,7 @@ public class SimpleJsonTest {
                 @Override
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(Person.class, SimpleJsonResource.class);
+                            .addClasses(Person.class, SimpleJsonResource.class, SuperClass.class);
                 }
             });
 
@@ -64,6 +64,19 @@ public class SimpleJsonTest {
                 .contentType("application/json")
                 .body("[0]", Matchers.equalTo("first"))
                 .body("[1]", Matchers.equalTo("second"));
+
+        RestAssured
+                .with()
+                .body("[{\"first\": \"Bob\", \"last\": \"Builder\"}, {\"first\": \"Bob2\", \"last\": \"Builder2\"}]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/super")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[1].first", Matchers.equalTo("Bob"))
+                .body("[1].last", Matchers.equalTo("Builder"))
+                .body("[0].first", Matchers.equalTo("Bob2"))
+                .body("[0].last", Matchers.equalTo("Builder2"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
@@ -54,6 +54,16 @@ public class SimpleJsonTest {
                 .body("[1].last", Matchers.equalTo("Builder"))
                 .body("[0].first", Matchers.equalTo("Bob2"))
                 .body("[0].last", Matchers.equalTo("Builder2"));
+
+        RestAssured.with()
+                .body("[\"first\", \"second\"]")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/strings")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0]", Matchers.equalTo("first"))
+                .body("[1]", Matchers.equalTo("second"));
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SuperClass.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SuperClass.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jsonb.deployment.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+public class SuperClass<T> {
+
+    @POST
+    @Path("/super")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public List<T> reverseListFromSuper(List<T> list) {
+        List<T> reversed = new ArrayList<>(list.size());
+        for (T t : list) {
+            reversed.add(0, t);
+        }
+        return reversed;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyReader.java
@@ -12,11 +12,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
-import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
-import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.providers.serialisers.json.AbstractJsonMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-public class JsonbMessageBodyReader implements ServerMessageBodyReader<Object> {
+public class JsonbMessageBodyReader extends AbstractJsonMessageBodyReader {
 
     private final Jsonb json;
 
@@ -26,19 +25,9 @@ public class JsonbMessageBodyReader implements ServerMessageBodyReader<Object> {
     }
 
     @Override
-    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return true;
-    }
-
-    @Override
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         return doReadFrom(type, genericType, entityStream);
-    }
-
-    @Override
-    public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod, MediaType mediaType) {
-        return true;
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyReader.java
@@ -51,7 +51,6 @@ public class JsonbMessageBodyReader implements ServerMessageBodyReader<Object> {
         if (entityStream instanceof EmptyInputStream) {
             return null;
         }
-        Type runtimeType = genericType != null ? genericType : type;
-        return json.fromJson(entityStream, runtimeType);
+        return json.fromJson(entityStream, genericType != null ? genericType : type);
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
@@ -118,7 +118,11 @@ public class QuarkusServerEndpointIndexer
         String baseName;
         ParameterConverterSupplier delegate;
         if (stringCtor != null || valueOf != null || fromString != null) {
-            baseName = prefix + elementType + "$quarkusrestparamConverter$";
+            String effectivePrefix = prefix + elementType;
+            if (effectivePrefix.startsWith("java")) {
+                effectivePrefix = effectivePrefix.replace("java", "javaq"); // generated classes can't start with the java package
+            }
+            baseName = effectivePrefix + "$quarkusrestparamConverter$";
             try (ClassCreator classCreator = new ClassCreator(
                     new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true), baseName, null,
                     Object.class.getName(), ParameterConverter.class.getName())) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/MultipleHttpAnnotationsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/MultipleHttpAnnotationsTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleHttpAnnotationsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Resource.class);
+                }
+            }).setExpectedException(DeploymentException.class);
+
+    @Test
+    public void test() {
+        fail("Should never have been called");
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @Path("hello")
+        @GET
+        @POST
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceRequestFilterTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceRequestFilterTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SubResourceRequestFilterTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive war = ShrinkWrap.create(JavaArchive.class);
+                    war.addClasses(RestResource.class, RestSubResource.class, SingleExecutionFilter.class);
+                    return war;
+                }
+            });
+
+    @Test
+    public void testAbortingRequestFilter() {
+        RestAssured.get("/sub-resource/hello")
+                .then()
+                .header("single-filter", Matchers.equalTo("once"))
+                .statusCode(200);
+    }
+
+    @Path("/")
+    public static class RestResource {
+
+        @Inject
+        RestSubResource restSubResource;
+
+        @Path("sub-resource/hello")
+        public RestSubResource hello() {
+            return restSubResource;
+        }
+    }
+
+    @ApplicationScoped
+    public static class RestSubResource {
+
+        @GET
+        public Response hello(HttpHeaders headers) {
+            return Response.ok().header("single-filter", headers.getHeaderString("single-filter")).build();
+        }
+    }
+
+    @Provider
+    public static class SingleExecutionFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            if (requestContext.getProperty("been.here") != null) {
+                throw new IllegalStateException("Filter should not have been called twice");
+            }
+            requestContext.setProperty("been.here", Boolean.TRUE);
+            requestContext.getHeaders().putSingle("single-filter", "once");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceRequestFilterTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceRequestFilterTest.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -37,9 +38,10 @@ public class SubResourceRequestFilterTest {
 
     @Test
     public void testAbortingRequestFilter() {
-        RestAssured.get("/sub-resource/hello")
+        RestAssured.get("/sub-resource/geo")
                 .then()
                 .header("single-filter", Matchers.equalTo("once"))
+                .body(Matchers.equalTo("geo"))
                 .statusCode(200);
     }
 
@@ -49,8 +51,8 @@ public class SubResourceRequestFilterTest {
         @Inject
         RestSubResource restSubResource;
 
-        @Path("sub-resource/hello")
-        public RestSubResource hello() {
+        @Path("sub-resource/{name}")
+        public RestSubResource hello(String name) {
             return restSubResource;
         }
     }
@@ -59,8 +61,8 @@ public class SubResourceRequestFilterTest {
     public static class RestSubResource {
 
         @GET
-        public Response hello(HttpHeaders headers) {
-            return Response.ok().header("single-filter", headers.getHeaderString("single-filter")).build();
+        public Response hello(HttpHeaders headers, @RestPath String name) {
+            return Response.ok(name).header("single-filter", headers.getHeaderString("single-filter")).build();
         }
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -336,5 +337,12 @@ public class SimpleQuarkusRestResource {
     public String simplifiedResourceInfo(@Context SimpleResourceInfo simplifiedResourceInfo) {
         return simplifiedResourceInfo.getResourceClass().getName() + "#" + simplifiedResourceInfo.getMethodName() + "-"
                 + simplifiedResourceInfo.parameterTypes().length;
+    }
+
+    @GET
+    @Path("bigDecimal/{val}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String bigDecimalConverter(BigDecimal val) {
+        return val.toString();
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -294,6 +294,7 @@ public class SimpleQuarkusRestTestCase {
                 .formParam("f2", "v2")
                 .post("/simple/form-map")
                 .then()
+                .statusCode(200)
                 .contentType("application/x-www-form-urlencoded")
                 .body(Matchers.equalTo("f1=v1&f2=v2"));
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -395,4 +395,10 @@ public class SimpleQuarkusRestTestCase {
         RestAssured.get("/simple/simplifiedResourceInfo")
                 .then().statusCode(200).body(Matchers.containsString("SimpleQuarkusRestResource#simplifiedResourceInfo-1"));
     }
+
+    @Test
+    public void bigDecimal() {
+        RestAssured.get("/simple/bigDecimal/1.0")
+                .then().statusCode(200).body(Matchers.equalTo("1.0"));
+    }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
@@ -77,7 +77,11 @@ public abstract class Serialisers {
             }
             List<ResourceReader> goodTypeReaders = readers.get(klass);
             readerLookup(mediaType, runtimeType, mt, ret, goodTypeReaders);
-            klass = klass.getSuperclass();
+            if (klass.isInterface()) {
+                klass = Object.class;
+            } else {
+                klass = klass.getSuperclass();
+            }
         } while (klass != null);
 
         return ret;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
@@ -9,6 +9,7 @@ public class MethodParameter {
      * will be the collection type
      */
     public String declaredType;
+    public String signature;
     public ParameterType parameterType;
     public boolean encoded;
     private boolean single;
@@ -18,14 +19,16 @@ public class MethodParameter {
     public MethodParameter() {
     }
 
-    public MethodParameter(String name, String type, String declaredType, ParameterType parameterType, boolean single,
+    public MethodParameter(String name, String type, String declaredType, String signature, ParameterType parameterType,
+            boolean single,
             String defaultValue, boolean isObtainedAsCollection, boolean encoded) {
         this.name = name;
         this.type = type;
+        this.declaredType = declaredType;
+        this.signature = signature;
         this.parameterType = parameterType;
         this.single = single;
         this.defaultValue = defaultValue;
-        this.declaredType = declaredType;
         this.isObtainedAsCollection = isObtainedAsCollection;
         this.encoded = encoded;
     }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -8,6 +8,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_STRING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_STRUCTURE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_VALUE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI_VALUED_MAP;
 
 import io.quarkus.gizmo.MethodCreator;
 import java.util.Collections;
@@ -84,6 +85,9 @@ public class ServerEndpointIndexer
             additionalReaders.add(ServerJsonObjectHandler.class, APPLICATION_JSON, javax.json.JsonObject.class);
         } else if (dotName.equals(JSONP_JSON_STRUCTURE)) {
             additionalReaders.add(ServerJsonStructureHandler.class, APPLICATION_JSON, javax.json.JsonStructure.class);
+        } else if (dotName.equals(MULTI_VALUED_MAP)) {
+            additionalReaders.add(ServerFormUrlEncodedProvider.class, APPLICATION_FORM_URLENCODED,
+                    MultivaluedMap.class);
         }
     }
 
@@ -203,11 +207,6 @@ public class ServerEndpointIndexer
             ServerIndexedParameter builder, String elementType) {
         builder.setConverter(extractConverter(elementType, index,
                 existingConverters, errorLocation, hasRuntimeConverters));
-    }
-
-    protected void handleMultiMapParam(AdditionalReaders additionalReaders, ServerIndexedParameter builder) {
-        additionalReaders.add(ServerFormUrlEncodedProvider.class, APPLICATION_FORM_URLENCODED,
-                MultivaluedMap.class);
     }
 
     protected void handleSortedSetParam(Map<String, String> existingConverters, String errorLocation,

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -191,10 +191,11 @@ public class ServerEndpointIndexer
 
     protected MethodParameter createMethodParameter(ClassInfo currentClassInfo, ClassInfo actualEndpointInfo, boolean encoded,
             Type paramType, ServerIndexedParameter parameterResult, String name, String defaultValue, ParameterType type,
-            String elementType, boolean single) {
+            String elementType, boolean single, String signature) {
         ParameterConverterSupplier converter = parameterResult.getConverter();
         return new ServerMethodParameter(name,
-                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index), type, single,
+                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index),
+                type, single, signature,
                 converter, defaultValue, parameterResult.isObtainedAsCollection(), encoded);
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/LocatableResourcePathParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/LocatableResourcePathParamExtractor.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.reactive.server.core.parameters;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.mapping.URITemplate;
+
+public class LocatableResourcePathParamExtractor implements ParameterExtractor {
+
+    private final String name;
+
+    public LocatableResourcePathParamExtractor(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        int index = findPathParamIndex(context.getLocatorTarget().getClassPath(), context.getLocatorTarget().getPath());
+        if (index >= 0) {
+            return context.getLocatorPathParam(index);
+        }
+        return null;
+    }
+
+    private int findPathParamIndex(URITemplate classPathTemplate, URITemplate methodPathTemplate) {
+        int index = 0;
+        if (classPathTemplate != null) {
+            for (URITemplate.TemplateComponent component : classPathTemplate.components) {
+                if (component.name != null) {
+                    if (component.name.equals(this.name)) {
+                        return index;
+                    }
+                    index++;
+                } else if (component.names != null) {
+                    for (String nm : component.names) {
+                        if (nm.equals(this.name)) {
+                            return index;
+                        }
+                    }
+                    index++;
+                }
+            }
+        }
+        for (URITemplate.TemplateComponent component : methodPathTemplate.components) {
+            if (component.name != null) {
+                if (component.name.equals(this.name)) {
+                    return index;
+                }
+                index++;
+            } else if (component.names != null) {
+                for (String nm : component.names) {
+                    if (nm.equals(this.name)) {
+                        return index;
+                    }
+                }
+                index++;
+            }
+        }
+        return -1;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -136,7 +136,10 @@ public class RuntimeResourceDeployment {
         //which we also want in the abort handler chain
         abortHandlingChain.addAll(handlers);
 
-        handlers.addAll(interceptorDeployment.setupRequestFilterHandler());
+        //spec doesn't seem to test this, but RESTEeasy does not run request filters again for sub resources (which makes sense)
+        if (!locatableResource) {
+            handlers.addAll(interceptorDeployment.setupRequestFilterHandler());
+        }
 
         // some parameters need the body to be read
         MethodParameter[] parameters = method.getParameters();

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -39,6 +39,7 @@ import org.jboss.resteasy.reactive.server.core.parameters.ContextParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.CookieParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.FormParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.HeaderParamExtractor;
+import org.jboss.resteasy.reactive.server.core.parameters.LocatableResourcePathParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.MatrixParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.NullParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
@@ -198,7 +199,8 @@ public class RuntimeResourceDeployment {
         for (int i = 0; i < parameters.length; i++) {
             ServerMethodParameter param = (ServerMethodParameter) parameters[i];
             boolean single = param.isSingle();
-            ParameterExtractor extractor = parameterExtractor(pathParameterIndexes, param.parameterType, param.type, param.name,
+            ParameterExtractor extractor = parameterExtractor(pathParameterIndexes, locatableResource, param.parameterType,
+                    param.type, param.name,
                     single, param.encoded);
             ParameterConverter converter = null;
             ParamConverterProviders paramConverterProviders = info.getParamConverterProviders();
@@ -346,7 +348,8 @@ public class RuntimeResourceDeployment {
         return runtimeResource;
     }
 
-    public ParameterExtractor parameterExtractor(Map<String, Integer> pathParameterIndexes, ParameterType type, String javaType,
+    public ParameterExtractor parameterExtractor(Map<String, Integer> pathParameterIndexes, boolean locatableResource,
+            ParameterType type, String javaType,
             String name,
             boolean single, boolean encoded) {
         ParameterExtractor extractor;
@@ -360,7 +363,11 @@ public class RuntimeResourceDeployment {
             case PATH:
                 Integer index = pathParameterIndexes.get(name);
                 if (index == null) {
-                    extractor = new NullParamExtractor();
+                    if (locatableResource) {
+                        extractor = new LocatableResourcePathParamExtractor(name);
+                    } else {
+                        extractor = new NullParamExtractor();
+                    }
                 } else {
                     extractor = new PathParamExtractor(index, encoded);
                 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -161,9 +161,9 @@ public class RuntimeResourceDeployment {
         }
         // if we need the body, let's deserialise it
         if (bodyParameter != null) {
-            Class<Object> typeClass = loadClass(bodyParameter.type);
+            Class<Object> typeClass = loadClass(bodyParameter.declaredType);
             Type genericType = typeClass;
-            if ((bodyParameter.declaredType != null) && !bodyParameter.type.equals(bodyParameter.declaredType)) {
+            if (!bodyParameter.type.equals(bodyParameter.declaredType)) {
                 // we only need to parse the signature and create generic type when the declared type differs from the type
                 genericType = TypeSignatureParser.parse(bodyParameter.signature);
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.reactive.server.handlers;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.List;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotSupportedException;
@@ -25,12 +26,15 @@ public class RequestDeserializeHandler implements ServerRestHandler {
     private static final Logger log = Logger.getLogger(RequestDeserializeHandler.class);
 
     private final Class<?> type;
+    private final Type genericType;
     private final MediaType mediaType;
     private final ServerSerialisers serialisers;
     private final int parameterIndex;
 
-    public RequestDeserializeHandler(Class<?> type, MediaType mediaType, ServerSerialisers serialisers, int parameterIndex) {
+    public RequestDeserializeHandler(Class<?> type, Type genericType, MediaType mediaType, ServerSerialisers serialisers,
+            int parameterIndex) {
         this.type = type;
+        this.genericType = genericType;
         this.mediaType = mediaType;
         this.serialisers = serialisers;
         this.parameterIndex = parameterIndex;
@@ -86,20 +90,20 @@ public class RequestDeserializeHandler implements ServerRestHandler {
     private boolean isReadable(MessageBodyReader<?> reader, ResteasyReactiveRequestContext requestContext,
             MediaType requestType) {
         if (reader instanceof ServerMessageBodyReader) {
-            return ((ServerMessageBodyReader<?>) reader).isReadable(type, type,
+            return ((ServerMessageBodyReader<?>) reader).isReadable(type, genericType,
                     requestContext.getTarget().getLazyMethod(),
                     requestType);
         }
-        return reader.isReadable(type, type, getAnnotations(requestContext), requestType);
+        return reader.isReadable(type, genericType, getAnnotations(requestContext), requestType);
     }
 
     @SuppressWarnings("unchecked")
     public Object readFrom(MessageBodyReader<?> reader, ResteasyReactiveRequestContext requestContext, MediaType requestType)
             throws IOException {
         if (reader instanceof ServerMessageBodyReader) {
-            return ((ServerMessageBodyReader<?>) reader).readFrom((Class) type, type, requestType, requestContext);
+            return ((ServerMessageBodyReader<?>) reader).readFrom((Class) type, genericType, requestType, requestContext);
         }
-        return reader.readFrom((Class) type, type, getAnnotations(requestContext), requestType,
+        return reader.readFrom((Class) type, genericType, getAnnotations(requestContext), requestType,
                 requestContext.getHttpHeaders().getRequestHeaders(), requestContext.getInputStream());
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceLocatorHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceLocatorHandler.java
@@ -80,7 +80,7 @@ public class ResourceLocatorHandler implements ServerRestHandler {
         requestContext.setRemaining(res.remaining);
         requestContext.setEndpointInstance(locator);
         requestContext.setResult(null);
-        requestContext.restart(res.value);
+        requestContext.restart(res.value, true);
         requestContext.setMaxPathParams(res.pathParamValues.length);
         for (int i = 0; i < res.pathParamValues.length; ++i) {
             String pathParamValue = res.pathParamValues[i];

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
@@ -12,8 +12,9 @@ public class ServerMethodParameter extends MethodParameter {
     }
 
     public ServerMethodParameter(String name, String type, String declaredType, ParameterType parameterType, boolean single,
+            String signature,
             ParameterConverterSupplier converter, String defaultValue, boolean isObtainedAsCollection, boolean encoded) {
-        super(name, type, declaredType, parameterType, single, defaultValue, isObtainedAsCollection, encoded);
+        super(name, type, declaredType, signature, parameterType, single, defaultValue, isObtainedAsCollection, encoded);
         this.converter = converter;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/json/AbstractJsonMessageBodyReader.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/json/AbstractJsonMessageBodyReader.java
@@ -1,0 +1,33 @@
+package org.jboss.resteasy.reactive.server.providers.serialisers.json;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+
+public abstract class AbstractJsonMessageBodyReader implements ServerMessageBodyReader<Object> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return isReadable(mediaType, type);
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod, MediaType mediaType) {
+        return isReadable(mediaType, type);
+    }
+
+    private boolean isReadable(MediaType mediaType, Class<?> type) {
+        if (mediaType == null) {
+            return false;
+        }
+        if (String.class.equals(type)) { // don't attempt to read plain strings
+            return false;
+        }
+        String subtype = mediaType.getSubtype();
+        boolean isApplicationMediaType = "application".equals(mediaType.getType());
+        return (isApplicationMediaType && "json".equalsIgnoreCase(subtype) || subtype.endsWith("+json"))
+                || (mediaType.isWildcardSubtype() && (mediaType.isWildcardType() || isApplicationMediaType));
+    }
+}


### PR DESCRIPTION
The fixes are based on what was reported at #13852.

From that issue, the PR currently handles:

* 1
* 2
* 3
* 4
* 5 (currently we simply prevent multiple HTTP verbs - we can improve this later)
* 6
* 7 (not completely sure about this, the NPE is now not thrown, but I am not sure about the result of `requestContext.getUriInfo().getMatchedResources()`)