### PR TITLE
Deactivate logs from SqlExceptionHelper

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -603,6 +603,8 @@ public final class HibernateOrmProcessor {
         if (hibernateOrmConfig.log.bindParam || hibernateOrmConfig.log.bindParameters) {
             categories.produce(new LogCategoryBuildItem("org.hibernate.type.descriptor.sql.BasicBinder", Level.TRACE));
         }
+
+        categories.produce(new LogCategoryBuildItem("org.hibernate.engine.jdbc.spi.SqlExceptionHelper", Level.OFF));
     }
 
     @BuildStep(onlyIf = NativeBuild.class)


### PR DESCRIPTION
This is done to prevent duplicate logs.
SqlExceptionHelper logs the cause and sql state from the given, and all underlying, SQLExceptions. These already appear as part of the original exceptions getMessage().
Related to #13776.