### PR TITLE
CI: replace netstat with ss for upcoming Ubuntu 20

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Stop mysql
         shell: bash
         run: |
-          netstat -ln
+          ss -ln
           sudo service mysql stop || true
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Motivated by this warning annotation:
![grafik](https://user-images.githubusercontent.com/22860528/102009704-92c8de80-3d39-11eb-9592-ddbb56693803.png)
(https://github.com/actions/virtual-environments/issues/1816)
I gave `ubuntu-20.04` [a try in my fork](https://github.com/famod/quarkus/actions/runs/418030814) and the only error that popped up was:
![grafik](https://user-images.githubusercontent.com/22860528/102009745-d28fc600-3d39-11eb-94dd-d1bc475ee76c.png)

Turns out that, even with current Ubuntu 18, `netstat` should not be used anymore. The replacement is `ss` ("show sockets").

So with this change the Quarkus CI should be safe for the upcoming migration (whenever that will be).