### PR TITLE
Add OpenTracing Command Listener to MongoDB client

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -26,6 +26,7 @@
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
+        <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.0.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.0.1-alpha</opentelemetry-alpha.version>
         <jaeger.version>0.34.3</jaeger.version>
@@ -2829,6 +2830,11 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-kafka-client</artifactId>
                 <version>${opentracing-kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-mongo-common</artifactId>
+                <version>${opentracing-mongo.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -596,6 +596,12 @@ This behavior must first be enabled by setting the `quarkus.mongodb.metrics.enab
 So when you access the `/q/metrics` endpoint of your application you will have information about the connection pool status.
 When using link:microprofile-metrics[SmallRye Metrics], connection pool metrics will be available under the `vendor` scope.
 
+== Tracing
+
+If you are using the `quarkus-smallrye-opentracing` extension, `quarkus-mongodb-client` can register traces about the commands executed.
+This behavior must be enabled by setting the `quarkus.mongodb.tracing.enabled` property to `true` in your `application.properties` and adding the dependency `io.opentracing.contrib:opentracing-mongo-common` to your pom.xml (for more info read the link:opentracing#mongodb-client[OpenTracing - MongoDB client] section).
+
+Read the link:opentracing[OpenTracing] guide, for how to configure OpenTracing and how to use the Jaeger tracer.
 
 == The legacy client
 

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -258,6 +258,28 @@ mp.messaging.incoming.prices.interceptor.classes=io.opentracing.contrib.kafka.Tr
 
 NOTE: `interceptor.classes` accept a list of classes separated by a comma.
 
+
+=== MongoDB client
+
+The https://github.com/opentracing-contrib/java-mongo-driver[Mongo Driver instrumentation] will add a span for each command executed by your application. To enable it, add the following dependency to your pom.xml:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-mongo-common</artifactId>
+</dependency>
+----
+
+It contains the OpenTracing CommandListener that will be registered on the configuration of the mongo client.
+Following the link:mongodb[MongoDB guide], the command listener will be registered defining the config property as follows:
+
+[source, properties]
+----
+# Enable tracing commands in mongodb client 
+quarkus.mongodb.tracing.enabled=true
+----
+
 [[configuration-reference]]
 == Jaeger Configuration Reference
 

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -69,6 +69,27 @@
             <artifactId>quarkus-resteasy-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing.contrib</groupId>
+          <artifactId>opentracing-mongo-common</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
@@ -19,6 +19,12 @@ public class MongoClientBuildTimeConfig {
     public boolean metricsEnabled;
 
     /**
+     * Whether or not tracing spans of driver commands are sent in case the smallrye-opentracing extension is present.
+     */
+    @ConfigItem(name = "tracing.enabled")
+    public boolean tracingEnabled;
+
+    /**
      * If set to true, the default clients will always be created even if there are no injection points that use them
      */
     @ConfigItem(name = "force-default-clients")

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -36,6 +36,8 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -59,6 +61,7 @@ import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 public class MongoClientProcessor {
+    private static final String MONGODB_TRACING_COMMANDLISTENER_CLASSNAME = "io.quarkus.mongodb.tracing.MongoTracingCommandListener";
     private static final DotName LEGACY_MONGO_CLIENT_ANNOTATION = DotName
             .createSimple(io.quarkus.mongodb.runtime.MongoClientName.class.getName());
     private static final DotName MONGO_CLIENT_ANNOTATION = DotName.createSimple(MongoClientName.class.getName());
@@ -93,10 +96,16 @@ public class MongoClientProcessor {
     }
 
     @BuildStep
-    CommandListenerBuildItem collectCommandListeners(CombinedIndexBuildItem indexBuildItem) {
+    CommandListenerBuildItem collectCommandListeners(CombinedIndexBuildItem indexBuildItem,
+            MongoClientBuildTimeConfig buildTimeConfig, Capabilities capabilities) {
         Collection<ClassInfo> commandListenerClasses = indexBuildItem.getIndex()
                 .getAllKnownImplementors(DotName.createSimple(CommandListener.class.getName()));
-        List<String> names = commandListenerClasses.stream().map(ci -> ci.name().toString()).collect(Collectors.toList());
+        List<String> names = commandListenerClasses.stream()
+                .map(ci -> ci.name().toString())
+                .collect(Collectors.toList());
+        if (buildTimeConfig.tracingEnabled && capabilities.isPresent(Capability.OPENTRACING)) {
+            names.add(MONGODB_TRACING_COMMANDLISTENER_CLASSNAME);
+        }
         return new CommandListenerBuildItem(names);
     }
 

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingCommandListenerTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingCommandListenerTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
+import io.opentracing.util.GlobalTracerTestUtil;
+import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test the inclusion and config of the {@link MongoTracingCommandListener}.
+ * 
+ * @see io.quarkus.smallrye.opentracing.deployment.TracingTest
+ */
+public class MongoTracingCommandListenerTest extends MongoTestBase {
+
+    @Inject
+    MongoClient client;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(MongoTestBase.class))
+            .withConfigurationResource("application-tracing-mongo.properties");
+
+    static MockTracer mockTracer = new MockTracer();
+    static {
+        GlobalTracer.register(mockTracer);
+    }
+
+    @BeforeEach
+    public void before() {
+        mockTracer.reset();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        GlobalTracerTestUtil.resetGlobalTracer();
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testClientInitialization() {
+        assertThat(mockTracer.finishedSpans()).isEmpty();
+
+        assertThat(client.listDatabaseNames().first()).isNotEmpty();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+        MockSpan span = mockTracer.finishedSpans().get(0);
+        assertThat(span.operationName()).isEqualTo("listDatabases");
+    }
+
+}

--- a/extensions/mongodb-client/deployment/src/test/resources/application-tracing-mongo.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-tracing-mongo.properties
@@ -1,0 +1,8 @@
+quarkus.mongodb.connection-string=mongodb://localhost:27018
+quarkus.mongodb.tracing.enabled=true
+
+
+quarkus.jaeger.enabled=true
+quarkus.jaeger.service-name=tracing-test
+quarkus.jaeger.sampler-param=1
+quarkus.jaeger.sampler-type=const

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -64,6 +64,17 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-opentracing</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-mongo-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -1,0 +1,46 @@
+package io.quarkus.mongodb.tracing;
+
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+
+import io.opentracing.contrib.mongo.common.TracingCommandListener;
+import io.opentracing.util.GlobalTracer;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Command Listener for Mongo client delegated to {@link TracingCommandListener}.
+ * 
+ */
+public class MongoTracingCommandListener implements CommandListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoTracingCommandListener.class);
+
+    private TracingCommandListener delegate;
+
+    public MongoTracingCommandListener() {
+        this.delegate = new TracingCommandListener.Builder(GlobalTracer.get()).build();
+        LOGGER.debug("TracingCommandListener Delegate created");
+    }
+
+    @Override
+    public void commandStarted(CommandStartedEvent event) {
+        LOGGER.trace("commandStarted event " + event.getCommandName());
+        delegate.commandStarted(event);
+    }
+
+    @Override
+    public void commandFailed(CommandFailedEvent event) {
+        LOGGER.trace("commandFailed event " + event.getCommandName());
+        delegate.commandFailed(event);
+    }
+
+    @Override
+    public void commandSucceeded(CommandSucceededEvent event) {
+        LOGGER.trace("commandSucceded event " + event.getCommandName());
+        delegate.commandSucceeded(event);
+    }
+
+}


### PR DESCRIPTION
Following the instructions in the OpenTracing Mongo Driver Instrumentation there is a way to include the tracing information simply adding a CommandListener to the mongoclient settings.

After the work done on #12082, it is accomplished by adding the MongoTracingCommandListener to the list of CommandListeners to be set to the mongoclient settings.

Project sample https://github.com/juazugas/quarkus-mongodb-opentracing/

Discussion: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/possible.20new.20extension.20for.20mongodb.20client.20and.20opentracing