### PR TITLE
Issue with the SecurityIdentity on the IO Thread

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -110,6 +110,18 @@ credential then that request will always be authenticated (even if the target pa
 This means that requests with an invalid credential will always be rejected, even for public pages. You can change
 this behavior and only authenticate when required by setting `quarkus.http.auth.proactive=false`.
 
+If you disable proactive authentication then the authentication process will only be run when an identity is requested,
+either because there are security rules that requires the user to be authenticated, or due to programatic access to the
+current identity.
+
+Note that if proactive authentication is in use accessing the `SecurityIdentity` is a blocking operation. This is because
+authentication may not have happened yet, and accessing it may require calls to external systems such as databases that
+may block. For blocking applications this is no problem, however if you are have disabled authentication in a reactive
+application this will fail (as you cannot do blocking operations on the IO thread). To work around this you need to
+`@Inject` an instance of `io.quarkus.security.identity.CurrentIdentityAssociation`, and call the
+`Uni<SecurityIdentity> getDeferredIdentity();` method. You can then subscribe to the resulting `Uni` and will be notified
+when authentication is complete and the identity is available.
+
 == References
 
 * link:security[Quarkus Security]

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
@@ -34,7 +33,6 @@ import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
-import io.smallrye.mutiny.Uni;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -350,7 +348,13 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         ManagedContext requestContext = beanContainer.requestContext();
         requestContext.activate();
         if (association != null) {
-            ((Consumer<Uni<SecurityIdentity>>) association).accept(QuarkusHttpUser.getSecurityIdentity(routingContext, null));
+            QuarkusHttpUser existing = (QuarkusHttpUser) routingContext.user();
+            if (existing != null) {
+                SecurityIdentity identity = existing.getSecurityIdentity();
+                association.setIdentity(identity);
+            } else {
+                association.setIdentity(QuarkusHttpUser.getSecurityIdentity(routingContext, null));
+            }
         }
         currentVertxRequest.setCurrent(routingContext);
         try {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -1,7 +1,5 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
-import java.util.function.Supplier;
-
 import javax.enterprise.event.Event;
 import javax.ws.rs.core.SecurityContext;
 
@@ -12,41 +10,33 @@ import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestCont
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.impl.LazyValue;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.ext.web.RoutingContext;
 
 public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactiveRequestContext {
 
-    private static final LazyValue<Event<SecurityIdentity>> SECURITY_IDENTITY_EVENT = new LazyValue<>(
-            new Supplier<Event<SecurityIdentity>>() {
-                @Override
-                public Event<SecurityIdentity> get() {
-                    return QuarkusResteasyReactiveRequestContext.createEvent();
-                }
-            });
+    final CurrentIdentityAssociation association;
 
     public QuarkusResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
             RoutingContext context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
-            ServerRestHandler[] abortHandlerChain) {
+            ServerRestHandler[] abortHandlerChain, CurrentIdentityAssociation currentIdentityAssociation) {
         super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain);
+        this.association = currentIdentityAssociation;
     }
 
     protected void handleRequestScopeActivation() {
         super.handleRequestScopeActivation();
-        QuarkusHttpUser user = (QuarkusHttpUser) context.user();
-        if (user != null) {
-            fireSecurityIdentity(user.getSecurityIdentity());
+        if (association != null) {
+            QuarkusHttpUser existing = (QuarkusHttpUser) context.user();
+            if (existing != null) {
+                SecurityIdentity identity = existing.getSecurityIdentity();
+                association.setIdentity(identity);
+            } else {
+                association.setIdentity(QuarkusHttpUser.getSecurityIdentity(context, null));
+            }
         }
-    }
-
-    static void fireSecurityIdentity(SecurityIdentity identity) {
-        SECURITY_IDENTITY_EVENT.get().fire(identity);
-    }
-
-    static void clear() {
-        SECURITY_IDENTITY_EVENT.clear();
     }
 
     private static Event<SecurityIdentity> createEvent() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -32,6 +32,7 @@ import org.jboss.resteasy.reactive.server.vertx.ResteasyReactiveVertxHandler;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.resteasy.reactive.common.runtime.ArcBeanFactory;
 import io.quarkus.resteasy.reactive.common.runtime.ArcThreadSetupAction;
@@ -42,6 +43,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.vertx.core.Handler;
@@ -85,6 +87,8 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder {
                 shutdownContext.addShutdownTask(new ShutdownContext.CloseRunnable(closeable));
             }
         };
+        CurrentIdentityAssociation currentIdentityAssociation = Arc.container().instance(CurrentIdentityAssociation.class)
+                .get();
         if (contextFactory == null) {
             contextFactory = new RequestContextFactory() {
                 @Override
@@ -94,7 +98,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder {
                     return new QuarkusResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
                             requestContext,
                             handlerChain,
-                            abortHandlerChain);
+                            abortHandlerChain, currentIdentityAssociation);
                 }
             };
         }

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -24,6 +24,7 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.resteasy.runtime.ContextUtil;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.VertxInputStream;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
@@ -104,7 +105,13 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         requestContext.activate();
         routingContext.remove(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
         if (association != null) {
-            association.setIdentity(QuarkusHttpUser.getSecurityIdentity(routingContext, null));
+            QuarkusHttpUser existing = (QuarkusHttpUser) routingContext.user();
+            if (existing != null) {
+                SecurityIdentity identity = existing.getSecurityIdentity();
+                association.setIdentity(identity);
+            } else {
+                association.setIdentity(QuarkusHttpUser.getSecurityIdentity(routingContext, null));
+            }
         }
         currentVertxRequest.setCurrent(routingContext);
         try {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityAssociation.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityAssociation.java
@@ -3,10 +3,10 @@ package io.quarkus.security.runtime;
 import java.security.Principal;
 
 import javax.enterprise.context.RequestScoped;
-import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
+import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -36,7 +36,7 @@ public class SecurityIdentityAssociation implements CurrentIdentityAssociation {
     }
 
     @Override
-    public void setIdentity(@Observes SecurityIdentity identity) {
+    public void setIdentity(SecurityIdentity identity) {
         this.identity = identity;
         this.deferredIdentity = null;
     }
@@ -55,7 +55,14 @@ public class SecurityIdentityAssociation implements CurrentIdentityAssociation {
     public SecurityIdentity getIdentity() {
         if (identity == null) {
             if (deferredIdentity != null) {
-                identity = deferredIdentity.await().indefinitely();
+                if (BlockingOperationControl.isBlockingAllowed()) {
+                    identity = deferredIdentity.await().indefinitely();
+                } else {
+                    throw new RuntimeException("Cannot call getIdentity() from the IO thread when lazy authentication " +
+                            "is in use, as resolving the identity may block the thread. Instead you should inject the " +
+                            "CurrentIdentityAssociation, call CurrentIdentityAssociation#getDeferredIdentity() and " +
+                            "subscribe to the Uni.");
+                }
             }
             if (identity == null) {
                 identity = identityProviderManager.authenticate(AnonymousAuthenticationRequest.INSTANCE).await().indefinitely();

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -20,6 +20,7 @@ import javax.json.JsonWriterFactory;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.graphql.execution.ExecutionService;
@@ -69,7 +70,13 @@ public class SmallRyeGraphQLExecutionHandler implements Handler<RoutingContext> 
 
     private void doHandle(final RoutingContext ctx) {
         if (currentIdentityAssociation != null) {
-            currentIdentityAssociation.setIdentity(QuarkusHttpUser.getSecurityIdentity(ctx, null));
+            QuarkusHttpUser existing = (QuarkusHttpUser) ctx.user();
+            if (existing != null) {
+                SecurityIdentity identity = existing.getSecurityIdentity();
+                currentIdentityAssociation.setIdentity(identity);
+            } else {
+                currentIdentityAssociation.setIdentity(QuarkusHttpUser.getSecurityIdentity(ctx, null));
+            }
         }
         currentVertxRequest.setCurrent(ctx);
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -46,6 +46,7 @@ import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
@@ -557,8 +558,13 @@ public class UndertowDeploymentRecorder {
                                 currentVertxRequest.setCurrent(rc);
 
                                 if (association != null) {
-                                    association
-                                            .setIdentity(QuarkusHttpUser.getSecurityIdentity(rc, null));
+                                    QuarkusHttpUser existing = (QuarkusHttpUser) rc.user();
+                                    if (existing != null) {
+                                        SecurityIdentity identity = existing.getSecurityIdentity();
+                                        association.setIdentity(identity);
+                                    } else {
+                                        association.setIdentity(QuarkusHttpUser.getSecurityIdentity(rc, null));
+                                    }
                                 }
 
                                 return action.call(exchange, context);


### PR DESCRIPTION
This will no longer wrap the Identity in a Uni if
proactive auth is in use.

This also resolves a problem with setting the current
SecurityIdentity via a CDI event, which is not
compatible with lazy authentication.

Note that the problem can still occur if using lazy
auth from the IO thread, which is expected. To get
the identity in this situation you need to use
CurrentIdentityAssociation#getDeferredIdentity
and subscribe to the result.

Fixes #13835