### PR TITLE
Amazon Lambda HTTP native image failure archetype fix

### DIFF
--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -73,9 +73,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>\${quarkus-plugin.version}</version>
-                <configuration>
-                    <uberJar>true</uberJar>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Fix #13692 

Native image failure to build archetype

Reproduce:
```
mvn archetype:generate \
       -DarchetypeGroupId=io.quarkus \
       -DarchetypeArtifactId=quarkus-amazon-lambda-http-archetype \
       -DarchetypeVersion=1.10.3.Final

mvn package -Pnative
```

Removing fat jar resolves:
```
  <plugin>
     <groupId>io.quarkus</groupId>
      <artifactId>quarkus-maven-plugin</artifactId>
       <version>${quarkus-plugin.version}</version>

        <configuration>
             <uberJar>true</uberJar>
         </configuration>

    </plugin>
```
