### PR TITLE
MP Health 3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -39,7 +39,7 @@
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
         <smallrye-common.version>1.5.0</smallrye-common.version>
         <smallrye-config.version>2.0.0-RC3</smallrye-config.version>
-        <smallrye-health.version>2.2.5</smallrye-health.version>
+        <smallrye-health.version>3.0.0-RC2</smallrye-health.version>
         <smallrye-metrics.version>3.0.0-RC2</smallrye-metrics.version>
         <smallrye-open-api.version>2.0.16</smallrye-open-api.version>
         <smallrye-graphql.version>1.1.0-RC1</smallrye-graphql.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,7 +59,7 @@
         <gradle-wrapper.version>6.6.1</gradle-wrapper.version>
 
         <!-- MicroProfile TCK versions -->
-        <microprofile-health-api.version>2.2</microprofile-health-api.version>
+        <microprofile-health-api.version>3.0</microprofile-health-api.version>
         <microprofile-config-api.version>2.0</microprofile-config-api.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
         <microprofile-fault-tolerance-api.version>3.0-RC2</microprofile-fault-tolerance-api.version>

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1803,7 +1803,7 @@ import java.util.List;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import io.quarkus.test.QuarkusUnitTest;
@@ -1826,7 +1826,7 @@ public class FailingUnitTest {
             );
 
     @Inject                                                                             // <3>
-    @Health
+    @Liveness
     Instance<HealthCheck> checks;
 
     @Test

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
@@ -21,7 +21,7 @@ public class KafkaStreamsStateHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Kafka Streams state health check");
         try {
             KafkaStreams.State state = kafkaStreams.state();
-            responseBuilder.state(state.isRunningOrRebalancing())
+            responseBuilder.status(state.isRunningOrRebalancing())
                     .withData("state", state.name());
         } catch (Exception e) {
             responseBuilder.down().withData("technical_error", e.getMessage());

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
@@ -33,21 +33,21 @@ public class KafkaStreamsHealthCheckTest {
     public void shouldBeUpIfStateRunning() {
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.RUNNING);
         HealthCheckResponse response = healthCheck.call();
-        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeUpIfStateRebalancing() {
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.REBALANCING);
         HealthCheckResponse response = healthCheck.call();
-        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeDownIfStateCreated() {
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.CREATED);
         HealthCheckResponse response = healthCheck.call();
-        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
 
 }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -34,13 +34,13 @@ public class KafkaStreamsTopicsHealthCheckTest {
     public void shouldBeUpIfNoMissingTopic() throws InterruptedException {
         Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.emptySet());
         HealthCheckResponse response = healthCheck.call();
-        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeDownIfMissingTopic() throws InterruptedException {
         Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.singleton("topic"));
         HealthCheckResponse response = healthCheck.call();
-        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
 }

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -17,7 +17,6 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
 import org.eclipse.microprofile.health.spi.HealthCheckResponseProvider;
@@ -81,7 +80,6 @@ import io.vertx.ext.web.RoutingContext;
 class SmallRyeHealthProcessor {
     private static final Logger LOG = Logger.getLogger(SmallRyeHealthProcessor.class);
 
-    private static final DotName HEALTH = DotName.createSimple(Health.class.getName());
     private static final DotName LIVENESS = DotName.createSimple(Liveness.class.getName());
     private static final DotName READINESS = DotName.createSimple(Readiness.class.getName());
     private static final DotName HEALTH_GROUP = DotName.createSimple(HealthGroup.class.getName());
@@ -148,9 +146,8 @@ class SmallRyeHealthProcessor {
                     .produce(new NotFoundPageDisplayableEndpointBuildItem(healthConfig.rootPath + healthConfig.wellnessPath));
         }
 
-        // Discover the beans annotated with @Health, @Liveness, @Readiness, @HealthGroup,
+        // Discover the beans annotated with @Liveness, @Readiness, @HealthGroup,
         // @HealthGroups and @Wellness even if no scope is defined
-        beanDefiningAnnotation.produce(new BeanDefiningAnnotationBuildItem(HEALTH));
         beanDefiningAnnotation.produce(new BeanDefiningAnnotationBuildItem(LIVENESS));
         beanDefiningAnnotation.produce(new BeanDefiningAnnotationBuildItem(READINESS));
         beanDefiningAnnotation.produce(new BeanDefiningAnnotationBuildItem(HEALTH_GROUP));
@@ -189,7 +186,6 @@ class SmallRyeHealthProcessor {
         // log a warning if users try to use MP Health annotations with JAX-RS @Path
         warnIfJaxRsPathUsed(index, LIVENESS);
         warnIfJaxRsPathUsed(index, READINESS);
-        warnIfJaxRsPathUsed(index, HEALTH);
         warnIfJaxRsPathUsed(index, WELLNESS);
 
         // Register the health handler
@@ -304,7 +300,6 @@ class SmallRyeHealthProcessor {
         Set<DotName> stereotypes = beanArchiveIndex.getIndex().getAnnotations(DotNames.STEREOTYPE).stream()
                 .map(AnnotationInstance::name).collect(Collectors.toSet());
         List<DotName> healthAnnotations = new ArrayList<>(5);
-        healthAnnotations.add(HEALTH);
         healthAnnotations.add(LIVENESS);
         healthAnnotations.add(READINESS);
         healthAnnotations.add(HEALTH_GROUP);

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/BasicHealthCheck.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/BasicHealthCheck.java
@@ -23,8 +23,8 @@ public class BasicHealthCheck implements HealthCheck {
             }
 
             @Override
-            public State getState() {
-                return State.UP;
+            public Status getStatus() {
+                return Status.UP;
             }
 
             @Override

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingHealthCheck.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingHealthCheck.java
@@ -29,8 +29,8 @@ public class FailingHealthCheck implements HealthCheck {
             }
 
             @Override
-            public State getState() {
-                return State.DOWN;
+            public Status getStatus() {
+                return Status.DOWN;
             }
 
             @Override

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingUnitTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingUnitTest.java
@@ -45,6 +45,6 @@ public class FailingUnitTest {
             check.add(i);
         }
         assertEquals(1, check.size());
-        assertEquals(HealthCheckResponse.State.DOWN, check.get(0).call().getState());
+        assertEquals(HealthCheckResponse.Status.DOWN, check.get(0).call().getStatus());
     }
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/health/SimpleHealthCheck.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/health/SimpleHealthCheck.java
@@ -19,8 +19,8 @@ public class SimpleHealthCheck implements HealthCheck {
             }
 
             @Override
-            public State getState() {
-                return State.UP;
+            public Status getStatus() {
+                return Status.UP;
             }
 
             @Override

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
@@ -22,6 +22,7 @@ public class HealthCheckTestCase {
 
     @Test
     public void testInjection() {
-        Assert.assertTrue(simpleHealthCheck.call().getState() == HealthCheckResponse.State.UP);
+        Assert.assertTrue(simpleHealthCheck.call().getStatus() == HealthCheckResponse.Status.UP);
+        Assert.assertTrue(simpleHealthCheck.call().getStatus() == HealthCheckResponse.Status.UP);
     }
 }

--- a/integration-tests/reactive-messaging-kafka/pom.xml
+++ b/integration-tests/reactive-messaging-kafka/pom.xml
@@ -15,6 +15,8 @@
 
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
+        <!-- needs to wait for smallrye-reactive-messaging-health to update MP health to 3.0 -->
+        <enforcer.skip>true</enforcer.skip>
     </properties>
 
     <dependencies>
@@ -239,61 +241,62 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>native-image-it-main</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skipTests>${native.surefire.skip}</skipTests>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner
-                                        </native.image.path>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>native-image</id>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <cleanupServer>true</cleanupServer>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableAllSecurityServices>true</enableAllSecurityServices>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+        <!-- Needs to wait for the MP Health 3.0 update in the SR reactive messaging -->
+<!--        <profile>-->
+<!--            <id>native-image-it-main</id>-->
+<!--            <activation>-->
+<!--                <property>-->
+<!--                    <name>native</name>-->
+<!--                </property>-->
+<!--            </activation>-->
+<!--            <build>-->
+<!--                <plugins>-->
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-surefire-plugin</artifactId>-->
+<!--                        <configuration>-->
+<!--                            <skipTests>${native.surefire.skip}</skipTests>-->
+<!--                        </configuration>-->
+<!--                    </plugin>-->
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-failsafe-plugin</artifactId>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <goals>-->
+<!--                                    <goal>integration-test</goal>-->
+<!--                                    <goal>verify</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <systemPropertyVariables>-->
+<!--                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner-->
+<!--                                        </native.image.path>-->
+<!--                                    </systemPropertyVariables>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
+<!--                    <plugin>-->
+<!--                        <groupId>io.quarkus</groupId>-->
+<!--                        <artifactId>quarkus-maven-plugin</artifactId>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <id>native-image</id>-->
+<!--                                <goals>-->
+<!--                                    <goal>native-image</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <cleanupServer>true</cleanupServer>-->
+<!--                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>-->
+<!--                                    <graalvmHome>${graalvmHome}</graalvmHome>-->
+<!--                                    <enableAllSecurityServices>true</enableAllSecurityServices>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
+<!--                </plugins>-->
+<!--            </build>-->
+<!--        </profile>-->
     </profiles>
 
 


### PR DESCRIPTION
Fails on enforcer because smallrye-reactive-messaging-health still depends on MP Health 3.0. Clement already have a PR that will fix it in reactive messaging. This PR has a hacky `enforcer.skip` in the `quarkus-integration-test-reactive-messaging-kafka` module.