### PR TITLE
Fixes around default JSON handling

### DIFF
--- a/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/jackson/QuarkusJacksonSerializer.java
+++ b/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/jackson/QuarkusJacksonSerializer.java
@@ -59,6 +59,7 @@ public class QuarkusJacksonSerializer extends ResteasyJackson2Provider {
             return false;
         }
         return mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                || mediaType.isWildcardType()
                 || super.isWriteable(type, genericType, annotations, mediaType);
     }
 

--- a/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/jsonb/QuarkusJsonbSerializer.java
+++ b/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/jsonb/QuarkusJsonbSerializer.java
@@ -58,7 +58,8 @@ public class QuarkusJsonbSerializer extends JsonBindingProvider {
         if (BUILTIN_DEFAULTS.contains(type)) {
             return false;
         }
-        return isSupportedMediaType(mediaType) || mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+        return isSupportedMediaType(mediaType) || mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                || mediaType.isWildcardType();
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -46,6 +47,7 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
             entityStream.write(((String) o).getBytes());
         } else {
@@ -60,6 +62,7 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
 
     @Override
     public void writeResponse(Object o, ServerRequestContext context) throws WebApplicationException, IOException {
+        context.serverResponse().setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         OutputStream stream = context.getOrCreateOutputStream();
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
             stream.write(((String) o).getBytes());

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -32,6 +33,7 @@ public class JsonbMessageBodyWriter implements ServerMessageBodyWriter<Object> {
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
             entityStream.write(((String) o).getBytes());
         } else {
@@ -46,6 +48,7 @@ public class JsonbMessageBodyWriter implements ServerMessageBodyWriter<Object> {
 
     @Override
     public void writeResponse(Object o, ServerRequestContext context) throws WebApplicationException, IOException {
+        context.serverResponse().setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         OutputStream originalStream = context.getOrCreateOutputStream();
         OutputStream stream = new NoopCloseAndFlushOutputStream(originalStream);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...


### PR DESCRIPTION
This makes sure that the correct writer is selected
for RESTEasy, and that the correct content type is
set for RESTEasy Reactive.