### PR TITLE
Throw an exception when model classes and no datasource

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -688,7 +688,7 @@ public final class HibernateOrmProcessor {
                 && (!hibernateOrmConfig.defaultPersistenceUnit.datasource.isPresent()
                         || DataSourceUtil.isDefault(hibernateOrmConfig.defaultPersistenceUnit.datasource.get()))
                 && !defaultJdbcDataSource.isPresent()) {
-            LOG.warn(
+            throw new ConfigurationException(
                     "Model classes are defined for the default persistence unit but no default datasource found: the default EntityManagerFactory will not be created.");
         }
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/EntitiesWithoutDataSourceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/EntitiesWithoutDataSourceTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EntitiesWithoutDataSourceTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .assertException(t -> {
+                assertThat(t).isInstanceOf(ConfigurationException.class);
+                assertThat(t).hasMessageStartingWith(
+                        "Model classes are defined for the default persistence unit but no default datasource found");
+            })
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class));
+
+    @Test
+    public void testInvalidConfiguration() {
+        // deployment exception should happen first
+        Assertions.fail();
+    }
+}


### PR DESCRIPTION
A warn is not enough and it used to be an exception so let's go back to
the previous behavior.