### PR TITLE
The build directory should only exist in the Gradle plugin's .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ graph-output.dot
 *.swo
 ObjectStore
 .gradle
-build
 docker/distroless/bazel-*
 /.apt_generated_tests/
 quarkus.log

--- a/devtools/gradle/.gitignore
+++ b/devtools/gradle/.gitignore
@@ -1,0 +1,20 @@
+# Created by https://www.toptal.com/developers/gitignore/api/gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+### Gradle Patch ###
+**/build/
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle

--- a/integration-tests/gradle/.gitignore
+++ b/integration-tests/gradle/.gitignore
@@ -1,0 +1,20 @@
+# Created by https://www.toptal.com/developers/gitignore/api/gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+### Gradle Patch ###
+**/build/
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle


### PR DESCRIPTION
This change allows `build` directories to exist outside Gradle projects