### PR TITLE
Update to smallrye-jwt 2.4.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-graphql.version>1.0.20</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>2.4.0</smallrye-jwt.version>
+        <smallrye-jwt.version>2.4.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.19</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.2.2</smallrye-converter-api.version>


### PR DESCRIPTION
This update is only about a few minor improvements in the JWT build API: 
- easier to set a custom expiry claim (using a relative/lifespan long or `Duration` value) as opposed to calculating an absolute value
- `jti` (token id) claim value which is automatically added to new tokens is now `UUID` (=> uses `SecureRandom`)
- easier to reuse the code loading all types of simple key stores (PEM, JWK - local file system, classpath or HTTPS) - something I'd like to reuse in `quarkus-oidc-client` for the client credentials JWT authentication

@radcortez has helped with stopping my panic attack after a failed release attempt and completed it calmly, thanks Roberto :-)