### PR TITLE
Ensure lib directory exists when building debug-enabled native-images

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -447,6 +447,10 @@ public class NativeImageBuildStep {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
         Path libDir = targetDirectory.resolve(JarResultBuildStep.LIB);
+        File libDirFile = libDir.toFile();
+        if (!libDirFile.exists()) {
+            libDirFile.mkdirs();
+        }
 
         final List<AppDependency> appDeps = curateOutcomeBuildItem.getEffectiveModel().getUserDependencies();
         for (AppDependency appDep : appDeps) {


### PR DESCRIPTION
Fixes #13848 