### PR TITLE
Fix scope for junit-jupiter-api in Panache artifacts - 1.10

### DIFF
--- a/extensions/panache/panache-common/runtime/pom.xml
+++ b/extensions/panache/panache-common/runtime/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/extensions/panache/panache-hibernate-common/runtime/pom.xml
+++ b/extensions/panache/panache-hibernate-common/runtime/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Already fixed in master but in a big commit mixing ton of things. We need a backport.