### PR TITLE
Add GenericType to the signature of ServerMessageBodyWriter methods

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
@@ -65,12 +65,13 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(Object o, ServerRequestContext context) throws WebApplicationException, IOException {
+    public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
         context.serverResponse().setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         OutputStream stream = context.getOrCreateOutputStream();
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
@@ -42,12 +42,13 @@ public class JsonbMessageBodyWriter implements ServerMessageBodyWriter<Object> {
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(Object o, ServerRequestContext context) throws WebApplicationException, IOException {
+    public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
         context.serverResponse().setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         OutputStream originalStream = context.getOrCreateOutputStream();
         OutputStream stream = new NoopCloseAndFlushOutputStream(originalStream);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/BasicGenericTypesHandlingTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/BasicGenericTypesHandlingTest.java
@@ -1,0 +1,164 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class BasicGenericTypesHandlingTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+                    archive.addClasses(AbstractResource.class, TestResource.class, Input.class, Output.class,
+                            TestMessageBodyReader.class, TestMessageBodyWriter.class);
+                    return archive;
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.with().body("hello").contentType("text/test").post("/test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("out / hello"));
+    }
+
+    public static abstract class AbstractResource<I, O> {
+
+        protected abstract O convert(I i);
+
+        @POST
+        @Produces("text/test")
+        @Consumes("text/test")
+        public O handle(I i) {
+            return convert(i);
+        }
+    }
+
+    @Path("/test")
+    public static class TestResource extends AbstractResource<Input, Output> {
+
+        @Override
+        protected Output convert(Input input) {
+            return new Output("out / " + input.getInMessage());
+        }
+    }
+
+    public static class Input {
+
+        private final String inMessage;
+
+        public Input(String inMessage) {
+            this.inMessage = inMessage;
+        }
+
+        public String getInMessage() {
+            return inMessage;
+        }
+    }
+
+    public static class Output {
+
+        private final String outMessage;
+
+        public Output(String outMessage) {
+            this.outMessage = outMessage;
+        }
+
+        public String getOutMessage() {
+            return outMessage;
+        }
+    }
+
+    @Provider
+    @Consumes("text/test")
+    public static class TestMessageBodyReader implements ServerMessageBodyReader<Object> {
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod,
+                MediaType mediaType) {
+            return genericType.getTypeName().equals(Input.class.getName());
+        }
+
+        @Override
+        public Object readFrom(Class<Object> type, Type genericType, MediaType mediaType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            return new Input(MessageReaderUtil.readString(context.getInputStream(), mediaType));
+        }
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+                throws IOException, WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+    }
+
+    @Provider
+    @Produces("text/test")
+    public static class TestMessageBodyWriter implements ServerMessageBodyWriter<Object> {
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+            return genericType.getTypeName().equals(Output.class.getName());
+        }
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            if (genericType.getTypeName().equals(Output.class.getName())) {
+                context.getOrCreateOutputStream().write(((Output) o).getOutMessage().getBytes(StandardCharsets.UTF_8));
+            } else {
+                throw new IllegalStateException("Writer called with generic type: " + genericType.getTypeName());
+            }
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/GenericEntityTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/GenericEntityTest.java
@@ -17,8 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.GenericEntityDoubleWriter;
+import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.GenericEntityFloatWriter;
+import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.GenericEntityIntegerServerMessageBodyWriter;
 import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.GenericEntityResource;
-import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.GenericEntitytFloatWriter;
 import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -39,7 +40,7 @@ public class GenericEntityTest {
                 public JavaArchive get() {
                     JavaArchive war = ShrinkWrap.create(JavaArchive.class);
                     war.addClasses(PortProviderUtil.class, GenericEntityResource.class, GenericEntityDoubleWriter.class,
-                            GenericEntitytFloatWriter.class);
+                            GenericEntityFloatWriter.class, GenericEntityIntegerServerMessageBodyWriter.class);
                     return war;
                 }
             });
@@ -90,6 +91,28 @@ public class GenericEntityTest {
             Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             String body = response.readEntity(String.class);
             Assertions.assertEquals("45.0F 50.0F ", body, "The response doesn't contain the expected entity");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testIntegers() {
+        doTestIntegers("/integers");
+    }
+
+    @Test
+    public void testIntegersNoResponse() {
+        doTestIntegers("/integers-no-response");
+    }
+
+    private void doTestIntegers(String path) {
+        WebTarget base = client.target(generateURL(path));
+        try {
+            Response response = base.request().get();
+            Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            String body = response.readEntity(String.class);
+            Assertions.assertEquals("45I 50I ", body, "The response doesn't contain the expected entity");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityDoubleWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityDoubleWriter.java
@@ -46,7 +46,7 @@ public class GenericEntityDoubleWriter implements MessageBodyWriter<List<Double>
     public void writeTo(List<Double> floats, Class<?> type, Type genericType, Annotation[] annotations,
             MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
             throws IOException, WebApplicationException {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (Double f : floats) {
             buf.append(f.toString()).append("D ");
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityFloatWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityFloatWriter.java
@@ -18,9 +18,9 @@ import org.jboss.logging.Logger;
 
 @Provider
 @Produces("*/*")
-public class GenericEntitytFloatWriter implements MessageBodyWriter<List<Float>> {
+public class GenericEntityFloatWriter implements MessageBodyWriter<List<Float>> {
 
-    private static final Logger LOG = Logger.getLogger(GenericEntitytFloatWriter.class);
+    private static final Logger LOG = Logger.getLogger(GenericEntityFloatWriter.class);
 
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         if (!List.class.isAssignableFrom(type)) {
@@ -43,7 +43,7 @@ public class GenericEntitytFloatWriter implements MessageBodyWriter<List<Float>>
     public void writeTo(List<Float> floats, Class<?> type, Type genericType, Annotation[] annotations,
             MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
             throws IOException, WebApplicationException {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (Float f : floats) {
             buf.append(f.toString()).append("F ");
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityIntegerServerMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityIntegerServerMessageBodyWriter.java
@@ -1,0 +1,67 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic.resource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+
+@Provider
+@Produces("*/*")
+public class GenericEntityIntegerServerMessageBodyWriter implements ServerMessageBodyWriter<List<Integer>> {
+
+    private static final Logger LOG = Logger.getLogger(GenericEntityIntegerServerMessageBodyWriter.class);
+
+    @Override
+    public long getSize(List<Integer> integers, Class<?> type, Type genericType, Annotation[] annotations,
+            MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        throw new IllegalStateException("Should never have been called");
+    }
+
+    @Override
+    public void writeTo(List<Integer> integers, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        throw new IllegalStateException("Should never have been called");
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+        if (!List.class.isAssignableFrom(type)) {
+            return false;
+        }
+        if (!(genericType instanceof ParameterizedType)) {
+            return false;
+        }
+        ParameterizedType pt = (ParameterizedType) genericType;
+        boolean result = pt.getActualTypeArguments()[0].equals(Integer.class);
+        LOG.debug("IntegerWriter result!!!: " + result);
+        return result;
+    }
+
+    @Override
+    public void writeResponse(List<Integer> integers, Type genericType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
+        StringBuilder buf = new StringBuilder();
+        for (Integer i : integers) {
+            buf.append(i.toString()).append("I ");
+        }
+        context.getOrCreateOutputStream().write(buf.toString().getBytes());
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/GenericEntityResource.java
@@ -31,4 +31,24 @@ public class GenericEntityResource {
         };
         return Response.ok(ge).build();
     }
+
+    @Path("integers")
+    @GET
+    public Response getIntegers() {
+        List<Integer> list = new ArrayList<>();
+        list.add(45);
+        list.add(50);
+        GenericEntity<List<Integer>> ge = new GenericEntity<List<Integer>>(list) {
+        };
+        return Response.ok(ge).build();
+    }
+
+    @Path("integers-no-response")
+    @GET
+    public List<Integer> getIntegersNoResponse() {
+        List<Integer> list = new ArrayList<>();
+        list.add(45);
+        list.add(50);
+        return list;
+    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerVertxBufferMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerVertxBufferMessageBodyWriter.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
+import java.lang.reflect.Type;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
@@ -16,12 +18,12 @@ public class ServerVertxBufferMessageBodyWriter extends VertxBufferMessageBodyWr
         implements ServerMessageBodyWriter<Buffer> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(Buffer buffer, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(Buffer buffer, Type genericType, ServerRequestContext context) throws WebApplicationException {
         context.serverResponse().end(buffer.getBytes());
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -569,6 +569,10 @@ public abstract class ResteasyReactiveRequestContext
         this.additionalAnnotations = additionalAnnotations;
     }
 
+    public boolean hasGenericReturnType() {
+        return this.genericReturnType != null;
+    }
+
     public Type getGenericReturnType() {
         if (genericReturnType == null) {
             if (target == null) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerByteArrayMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerByteArrayMessageBodyHandler.java
@@ -17,12 +17,12 @@ public class ServerByteArrayMessageBodyHandler extends ByteArrayMessageBodyHandl
         implements ServerMessageBodyWriter<byte[]>, ServerMessageBodyReader<byte[]> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(byte[] o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(byte[] o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         // FIXME: use response encoding
         context.serverResponse().end(o);
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharArrayMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharArrayMessageBodyHandler.java
@@ -17,12 +17,12 @@ public class ServerCharArrayMessageBodyHandler extends CharArrayMessageBodyHandl
         implements ServerMessageBodyWriter<char[]>, ServerMessageBodyReader<char[]> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(char[] o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(char[] o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         // FIXME: use response encoding
         context.serverResponse().end(new String(o));
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
@@ -29,12 +29,12 @@ public class ServerFileBodyHandler extends FileBodyHandler implements ServerMess
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return File.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(File o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(File o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         ServerHttpResponse vertxResponse = context.serverResponse();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFormUrlEncodedProvider.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFormUrlEncodedProvider.java
@@ -42,12 +42,12 @@ public class ServerFormUrlEncodedProvider extends FormUrlEncodedProvider
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return MultivaluedMap.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(MultivaluedMap o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(MultivaluedMap o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         try {
             // FIXME: use response encoding
             context.serverResponse().end(multiValuedMapToString(o, MessageReaderUtil.UTF8_CHARSET));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerStringMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerStringMessageBodyHandler.java
@@ -16,12 +16,12 @@ public class ServerStringMessageBodyHandler extends StringMessageBodyHandler
         implements ServerMessageBodyWriter<Object>, ServerMessageBodyReader<String> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return true;
     }
 
     @Override
-    public void writeResponse(Object o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(Object o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         // FIXME: use response encoding
         context.serverResponse().end(o.toString());
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonArrayHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonArrayHandler.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.providers.serialisers.jsonp;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
 import javax.json.JsonArray;
 import javax.json.JsonWriter;
 import javax.ws.rs.WebApplicationException;
@@ -14,12 +15,12 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 public class ServerJsonArrayHandler extends JsonArrayHandler implements ServerMessageBodyWriter<JsonArray> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return JsonArray.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(JsonArray o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(JsonArray o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonWriter writer = JsonpUtil.writer(out, context.getResponseContentType().getMediaType())) {
             writer.writeArray(o);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonObjectHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonObjectHandler.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.providers.serialisers.jsonp;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
 import javax.json.JsonObject;
 import javax.json.JsonWriter;
 import javax.ws.rs.WebApplicationException;
@@ -14,12 +15,12 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 public class ServerJsonObjectHandler extends JsonObjectHandler implements ServerMessageBodyWriter<JsonObject> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return JsonObject.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(JsonObject o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(JsonObject o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonWriter writer = JsonpUtil.writer(out, context.getResponseMediaType())) {
             writer.writeObject(o);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonStructureHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonStructureHandler.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.providers.serialisers.jsonp;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
 import javax.json.JsonObject;
 import javax.json.JsonStructure;
 import javax.json.JsonWriter;
@@ -16,12 +17,12 @@ public class ServerJsonStructureHandler extends JsonStructureHandler
         implements ServerMessageBodyWriter<JsonStructure> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return JsonStructure.class.isAssignableFrom(type) && !JsonObject.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(JsonStructure o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(JsonStructure o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonWriter writer = JsonpUtil.writer(out, context.getResponseMediaType())) {
             writer.write(o);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonValueHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/jsonp/ServerJsonValueHandler.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.providers.serialisers.jsonp;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
 import javax.json.JsonValue;
 import javax.json.JsonWriter;
 import javax.ws.rs.WebApplicationException;
@@ -14,12 +15,12 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 public class ServerJsonValueHandler extends JsonValueHandler implements ServerMessageBodyWriter<JsonValue> {
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
         return JsonValue.class.isAssignableFrom(type);
     }
 
     @Override
-    public void writeResponse(JsonValue o, ServerRequestContext context) throws WebApplicationException {
+    public void writeResponse(JsonValue o, Type genericType, ServerRequestContext context) throws WebApplicationException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonWriter writer = JsonpUtil.writer(out, context.getResponseMediaType())) {
             writer.write(o);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.spi;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.MessageBodyWriter;
@@ -8,11 +9,11 @@ import javax.ws.rs.ext.MessageBodyWriter;
 /**
  * Extension of MessageBodyWriter which can write directly to a Vert.x response
  */
-// FIXME: do we actually need to make it extend MessageBodyWriter?                                ``
+// FIXME: do we actually need to make it extend MessageBodyWriter?
 public interface ServerMessageBodyWriter<T> extends MessageBodyWriter<T> {
 
-    boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, MediaType mediaType);
+    boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType);
 
-    void writeResponse(T o, ServerRequestContext context) throws WebApplicationException, IOException;
+    void writeResponse(T o, Type genericType, ServerRequestContext context) throws WebApplicationException, IOException;
 
 }


### PR DESCRIPTION
This is done in a way that doesn't make us look up the types using generics

The instigator for this was that Qson needs this generic type