### PR TITLE
Enforce test dependencies scope

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -131,6 +131,8 @@
 
         <script.extension>sh</script.extension>
         <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>
+
+        <enforce-test-deps-scope.skip>${enforcer.skip}</enforce-test-deps-scope.skip>
     </properties>
 
     <dependencyManagement>
@@ -443,6 +445,34 @@
                                         </includes>
                                     </bannedDependencies>
                                 </rules>
+                            </configuration>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>enforce-test-deps-scope</id>
+                            <configuration>
+                                <rules>
+                                    <bannedDependencies>
+                                        <excludes>
+                                            <exclude>io.quarkus:quarkus-test-*</exclude>
+                                            <exclude>io.rest-assured:*</exclude>
+                                            <exclude>org.assertj:*</exclude>
+                                            <exclude>org.junit.jupiter:*</exclude>
+                                            <exclude>org.testcontainers:*</exclude>
+                                        </excludes>
+                                        <includes>
+                                            <include>io.quarkus:quarkus-test-*:*:*:test</include>
+                                            <include>io.rest-assured:*:*:*:test</include>
+                                            <include>org.assertj:*:*:*:test</include>
+                                            <include>org.junit.jupiter:*:*:*:test</include>
+                                            <include>org.testcontainers:*:*:*:test</include>
+                                        </includes>
+                                        <message>Found test dependencies with wrong scope:</message>
+                                    </bannedDependencies>
+                                </rules>
+                                <skip>${enforce-test-deps-scope.skip}</skip>
                             </configuration>
                             <goals>
                                 <goal>enforce</goal>

--- a/core/test-extension/pom.xml
+++ b/core/test-extension/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
     </properties>
 
     <modules>

--- a/extensions/panache/panache-mock/pom.xml
+++ b/extensions/panache/panache-mock/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>quarkus-panache-mock</artifactId>
     <name>Quarkus - Panache - Mock</name>
     <description>Mocking with Panache</description>
+
+    <properties>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/security/test-utils/pom.xml
+++ b/extensions/security/test-utils/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-security-test-utils</artifactId>
     <name>Quarkus - Security - Test Utilities</name>
 
+    <properties>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,6 +20,7 @@
         <gpg.skip>true</gpg.skip>
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <native.surefire.skip>${skipTests}</native.surefire.skip>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
     </properties>
     <modules>
         <module>bouncycastle</module>

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
     </properties>
 
     <build>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>quarkus-test-framework</artifactId>
     <name>Quarkus - Test Framework</name>
     <packaging>pom</packaging>
+
+    <properties>
+        <enforce-test-deps-scope.skip>true</enforce-test-deps-scope.skip>
+    </properties>
+
     <modules>
         <module>artemis</module>
         <module>common</module>


### PR DESCRIPTION
https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Litle.20error.20on.20quarkus-panache.20poms.201.2E9.2E2-Final

Avoids manual cleanups like #13916.

Example:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-test-deps-scope) @ quarkus-panache-common ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found test dependencies with wrong scope:
Found Banned Dependency: org.junit.jupiter:junit-jupiter-api:jar:5.7.0
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```

Note: `independent-projects` are not covered because they don't inherit from `build-parent`. _Edit: Should be ok since those projects are used by other modules that do inherit from `build-parent`, so we can rely on the transitive check._

- [x] check `quarkus-junit-*` as discussed via chat