### PR TITLE
Add META-INF/panache-archive.marker to the jar ignore list

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -120,7 +120,8 @@ public class JarResultBuildStep {
             "META-INF/quarkus-extension.yaml",
             "META-INF/quarkus-deployment-dependency.graph",
             "META-INF/jandex.idx",
-            "META-INF/build.metadata", //present in the red hat build of Quarkus
+            "META-INF/panache-archive.marker",
+            "META-INF/build.metadata", // present in the Red Hat Build of Quarkus
             "LICENSE");
 
     private static final Logger log = Logger.getLogger(JarResultBuildStep.class);


### PR DESCRIPTION
When building an uberjar, you can have several of them around.

Per gripe from a user.