### PR TITLE
Fix link to SameSite cookies on security guide

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -141,7 +141,7 @@ If you plan to make your Quarkus application accessible to another application r
 
 == SameSite cookies
 
-Please see link:vertx#same-site-cookie for information about adding a https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite] cookie property to any of the cookies set by a Quarkus endpoint.
+Please see link:vertx#same-site-cookie[SameSite cookies] for information about adding a https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite] cookie property to any of the cookies set by a Quarkus endpoint.
 
 == Testing
 


### PR DESCRIPTION
Asciidoc links to relative location needs explicit text decoration for correct generation.