### PR TITLE
Use builder image's objcopy when building with quarkus.native.container-build=true and quarkus.native.debug.enabled=true

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -166,8 +166,8 @@ public class NativeConfig {
     public boolean dumpProxies;
 
     /**
-     * If this build should be done using a container runtime. If this is set docker will be used by default,
-     * unless container-runtime is also set.
+     * If this build should be done using a container runtime. Unless container-runtime is also set, docker will be
+     * used by default. If docker is not available or is an alias to podman, podman will be used instead as the default.
      */
     @ConfigItem
     public boolean containerBuild;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -30,7 +30,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         containerRuntime = nativeConfig.containerRuntime.orElseGet(NativeImageBuildContainerRunner::detectContainerRuntime);
         log.infof("Using %s to run the native image builder", containerRuntime.getExecutableName());
 
-        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C" };
+        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C", "--rm" };
 
         outputPath = outputDir == null ? null : outputDir.toAbsolutePath().toString();
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -70,6 +70,17 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         return buildCommand("run", getContainerRuntimeBuildArgs(), args);
     }
 
+    @Override
+    protected void objcopy(String... args) {
+        final List<String> containerRuntimeBuildArgs = getContainerRuntimeBuildArgs();
+        Collections.addAll(containerRuntimeBuildArgs, "--entrypoint", "/bin/bash");
+        final ArrayList<String> objcopyCommand = new ArrayList<>(2);
+        objcopyCommand.add("-c");
+        objcopyCommand.add("objcopy " + String.join(" ", args));
+        final String[] command = buildCommand("run", containerRuntimeBuildArgs, objcopyCommand);
+        runCommand(command, null, null);
+    }
+
     protected List<String> getContainerRuntimeBuildArgs() {
         List<String> containerRuntimeArgs = new ArrayList<>();
         nativeConfig.containerRuntimeOptions.ifPresent(containerRuntimeArgs::addAll);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -35,7 +35,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
             }
         }
 
-        Collections.addAll(containerRuntimeArgs, "--rm", "-v",
+        Collections.addAll(containerRuntimeArgs, "-v",
                 volumeOutputPath + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + ":z");
         return containerRuntimeArgs;
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
@@ -1,14 +1,17 @@
 package io.quarkus.deployment.pkg.steps;
 
+import java.io.File;
 import java.util.List;
 import java.util.stream.Stream;
 
 public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
 
     private final String nativeImageExecutable;
+    private final File workingDirectory;
 
-    public NativeImageBuildLocalRunner(String nativeImageExecutable) {
+    public NativeImageBuildLocalRunner(String nativeImageExecutable, File workingDirectory) {
         this.nativeImageExecutable = nativeImageExecutable;
+        this.workingDirectory = workingDirectory;
     }
 
     @Override
@@ -19,6 +22,34 @@ public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
     @Override
     protected String[] getBuildCommand(List<String> args) {
         return buildCommand(args);
+    }
+
+    @Override
+    protected void objcopy(String... args) {
+        final String[] command = new String[args.length + 1];
+        command[0] = "objcopy";
+        System.arraycopy(args, 0, command, 1, args.length);
+        runCommand(command, null, workingDirectory);
+    }
+
+    @Override
+    protected boolean objcopyExists() {
+        // System path
+        String systemPath = System.getenv("PATH");
+        if (systemPath != null) {
+            String[] pathDirs = systemPath.split(File.pathSeparator);
+            for (String pathDir : pathDirs) {
+                File dir = new File(pathDir);
+                if (dir.isDirectory()) {
+                    File file = new File(dir, "objcopy");
+                    if (file.exists()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private String[] buildCommand(List<String> args) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -17,11 +17,14 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
     private static final Logger log = Logger.getLogger(NativeImageBuildRemoteContainerRunner.class);
     private static final String CONTAINER_BUILD_VOLUME_NAME = "quarkus-native-builder-image-project-volume";
 
+    private final String nativeImageName;
     private final String resultingExecutableName;
     private String containerId;
 
-    public NativeImageBuildRemoteContainerRunner(NativeConfig nativeConfig, Path outputDir, String resultingExecutableName) {
+    public NativeImageBuildRemoteContainerRunner(NativeConfig nativeConfig, Path outputDir,
+            String nativeImageName, String resultingExecutableName) {
         super(nativeConfig, outputDir);
+        this.nativeImageName = nativeImageName;
         this.resultingExecutableName = resultingExecutableName;
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -15,6 +15,9 @@ import io.quarkus.deployment.pkg.NativeConfig;
 public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildContainerRunner {
 
     private static final Logger log = Logger.getLogger(NativeImageBuildRemoteContainerRunner.class);
+    // Use a predefined volume name and implicitly create the volume with `podman create`, instead of explicitly
+    // generating a unique volume with `podman volume create`, to work around Podman's 3.0.x
+    // issue https://github.com/containers/podman/issues/9608
     private static final String CONTAINER_BUILD_VOLUME_NAME = "quarkus-native-builder-image-project-volume";
 
     private final String nativeImageName;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -57,6 +57,8 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
         copyFromContainerVolume(resultingExecutableName, "Failed to copy native image from container volume back to the host.");
         if (nativeConfig.debug.enabled) {
             copyFromContainerVolume("sources", "Failed to copy sources from container volume back to the host.");
+            String symbols = String.format("%s.debug", nativeImageName);
+            copyFromContainerVolume(symbols, "Failed to copy debug symbols from container volume back to the host.");
         }
         // docker container rm <containerID>
         final String[] rmTempContainerCommand = new String[] { containerRuntime.getExecutableName(), "container", "rm",

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -42,8 +42,8 @@ public abstract class NativeImageBuildRunner {
     public void setup(boolean processInheritIODisabled) {
     }
 
-    public int build(List<String> args, String nativeImageName, Path outputDir, boolean debugEnabled,
-            boolean processInheritIODisabled)
+    public int build(List<String> args, String nativeImageName, String resultingExecutableName, Path outputDir,
+            boolean debugEnabled, boolean processInheritIODisabled)
             throws InterruptedException, IOException {
         preBuild(args);
         try {
@@ -65,10 +65,10 @@ public abstract class NativeImageBuildRunner {
 
             if (objcopyExists()) {
                 if (debugEnabled) {
-                    splitDebugSymbols(nativeImageName);
+                    splitDebugSymbols(nativeImageName, resultingExecutableName);
                 } else {
                     // Strip debug symbols regardless, because the underlying JDK might contain them
-                    objcopy("--strip-debug", nativeImageName);
+                    objcopy("--strip-debug", resultingExecutableName);
                 }
             } else {
                 log.warn("objcopy executable not found in PATH. Debug symbols will not be separated from executable.");
@@ -80,10 +80,10 @@ public abstract class NativeImageBuildRunner {
         }
     }
 
-    private void splitDebugSymbols(String executable) {
-        String symbols = String.format("%s.debug", executable);
-        objcopy("--only-keep-debug", executable, symbols);
-        objcopy(String.format("--add-gnu-debuglink=%s", symbols), executable);
+    private void splitDebugSymbols(String nativeImageName, String resultingExecutableName) {
+        String symbols = String.format("%s.debug", nativeImageName);
+        objcopy("--only-keep-debug", resultingExecutableName, symbols);
+        objcopy(String.format("--add-gnu-debuglink=%s", symbols), resultingExecutableName);
     }
 
     protected abstract String[] getGraalVMVersionCommand(List<String> args);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -42,7 +42,8 @@ public abstract class NativeImageBuildRunner {
     public void setup(boolean processInheritIODisabled) {
     }
 
-    public int build(List<String> args, Path outputDir, boolean processInheritIODisabled)
+    public int build(List<String> args, String nativeImageName, Path outputDir, boolean debugEnabled,
+            boolean processInheritIODisabled)
             throws InterruptedException, IOException {
         preBuild(args);
         try {
@@ -57,15 +58,43 @@ public abstract class NativeImageBuildRunner {
                     errorReportLatch));
             executor.shutdown();
             errorReportLatch.await();
-            return process.waitFor();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                return exitCode;
+            }
+
+            if (objcopyExists()) {
+                if (debugEnabled) {
+                    splitDebugSymbols(nativeImageName);
+                } else {
+                    // Strip debug symbols regardless, because the underlying JDK might contain them
+                    objcopy("--strip-debug", nativeImageName);
+                }
+            } else {
+                log.warn("objcopy executable not found in PATH. Debug symbols will not be separated from executable.");
+                log.warn("That will result in a larger native image with debug symbols embedded in it.");
+            }
+            return 0;
         } finally {
             postBuild();
         }
     }
 
+    private void splitDebugSymbols(String executable) {
+        String symbols = String.format("%s.debug", executable);
+        objcopy("--only-keep-debug", executable, symbols);
+        objcopy(String.format("--add-gnu-debuglink=%s", symbols), executable);
+    }
+
     protected abstract String[] getGraalVMVersionCommand(List<String> args);
 
     protected abstract String[] getBuildCommand(List<String> args);
+
+    protected boolean objcopyExists() {
+        return true;
+    }
+
+    protected abstract void objcopy(String... args);
 
     protected void preBuild(List<String> buildArgs) throws IOException, InterruptedException {
     }
@@ -81,7 +110,7 @@ public abstract class NativeImageBuildRunner {
      *        If {@code null} the failure is ignored, but logged.
      * @param workingDirectory The directory in which to run the command
      */
-    void runCommand(String[] command, String errorMsg, File workingDirectory) {
+    static void runCommand(String[] command, String errorMsg, File workingDirectory) {
         log.info(String.join(" ", command).replace("$", "\\$"));
         Process process = null;
         try {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -150,7 +150,8 @@ public class NativeImageBuildStep {
         String nativeImageName = getNativeImageName(outputTargetBuildItem, packageConfig);
         String resultingExecutableName = getResultingExecutableName(nativeImageName, isContainerBuild);
 
-        NativeImageBuildRunner buildRunner = getNativeImageBuildRunner(nativeConfig, outputDir, resultingExecutableName);
+        NativeImageBuildRunner buildRunner = getNativeImageBuildRunner(nativeConfig, outputDir,
+                nativeImageName, resultingExecutableName);
         buildRunner.setup(processInheritIODisabled.isPresent());
         final GraalVM.Version graalVMVersion = buildRunner.getGraalVMVersion();
 
@@ -183,8 +184,8 @@ public class NativeImageBuildStep {
 
             List<String> nativeImageArgs = commandAndExecutable.args;
 
-            int exitCode = buildRunner.build(nativeImageArgs, nativeImageName, outputDir, nativeConfig.debug.enabled,
-                    processInheritIODisabled.isPresent());
+            int exitCode = buildRunner.build(nativeImageArgs, nativeImageName, resultingExecutableName, outputDir,
+                    nativeConfig.debug.enabled, processInheritIODisabled.isPresent());
             if (exitCode != 0) {
                 throw imageGenerationFailed(exitCode, nativeImageArgs);
             }
@@ -238,7 +239,7 @@ public class NativeImageBuildStep {
     }
 
     private static NativeImageBuildRunner getNativeImageBuildRunner(NativeConfig nativeConfig, Path outputDir,
-            String resultingExecutableName) {
+            String nativeImageName, String resultingExecutableName) {
         if (!isContainerBuild(nativeConfig)) {
             NativeImageBuildLocalRunner localRunner = getNativeImageBuildLocalRunner(nativeConfig, outputDir.toFile());
             if (localRunner != null) {
@@ -253,7 +254,8 @@ public class NativeImageBuildStep {
             log.warn(errorMessage + " Attempting to fall back to container build.");
         }
         if (nativeConfig.remoteContainerBuild) {
-            return new NativeImageBuildRemoteContainerRunner(nativeConfig, outputDir, resultingExecutableName);
+            return new NativeImageBuildRemoteContainerRunner(nativeConfig, outputDir,
+                    nativeImageName, resultingExecutableName);
         }
         return new NativeImageBuildLocalContainerRunner(nativeConfig, outputDir);
     }


### PR DESCRIPTION
Closes #13754 
Closes #13856 