### PR TITLE
Add framework for integrating with RESTEasy Reactive Methods

### DIFF
--- a/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/ClientEndpointIndexer.java
+++ b/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/ClientEndpointIndexer.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.resteasy.reactive.common.model.InjectableBean;
 import org.jboss.resteasy.reactive.common.model.MethodParameter;
@@ -63,7 +64,7 @@ public class ClientEndpointIndexer
     }
 
     @Override
-    protected ResourceMethod createResourceMethod() {
+    protected ResourceMethod createResourceMethod(MethodInfo info, Map<String, Object> methodContext) {
         return new ResourceMethod();
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MethodScannerBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MethodScannerBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class MethodScannerBuildItem extends MultiBuildItem {
+
+    private final MethodScanner methodScanner;
+
+    public MethodScannerBuildItem(MethodScanner methodScanner) {
+        this.methodScanner = methodScanner;
+    }
+
+    public MethodScanner getMethodScanner() {
+        return methodScanner;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
@@ -27,7 +27,6 @@ import org.jboss.resteasy.reactive.server.core.parameters.converters.NoopParamet
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ParameterConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ParameterConverterSupplier;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.RuntimeResolvedConverter;
-import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
 import org.jboss.resteasy.reactive.server.processor.ServerEndpointIndexer;
 import org.jboss.resteasy.reactive.server.processor.ServerIndexedParameter;
 
@@ -186,11 +185,6 @@ public class QuarkusServerEndpointIndexer
         if (delegate == null)
             throw new RuntimeException("Failed to find converter for " + elementType);
         return delegate;
-    }
-
-    @Override
-    protected ServerResourceMethod createResourceMethod() {
-        return new ServerResourceMethod();
     }
 
     protected void handleFieldExtractors(String currentTypeName, Map<FieldInfo, ServerIndexedParameter> fieldExtractors,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.ws.rs.Priorities;
@@ -224,7 +225,8 @@ public class ResteasyReactiveProcessor {
             ResourceInterceptorsBuildItem resourceInterceptorsBuildItem,
             ExceptionMappersBuildItem exceptionMappersBuildItem,
             ParamConverterProvidersBuildItem paramConverterProvidersBuildItem,
-            ContextResolversBuildItem contextResolversBuildItem) throws NoSuchMethodException {
+            ContextResolversBuildItem contextResolversBuildItem,
+            List<MethodScannerBuildItem> methodScanners) throws NoSuchMethodException {
 
         if (!resourceScanningResultBuildItem.isPresent()) {
             // no detected @Path, bail out
@@ -281,6 +283,8 @@ public class ResteasyReactiveProcessor {
                 MethodCreator initConverters = c.getMethodCreator("init", void.class, Deployment.class)) {
 
             QuarkusServerEndpointIndexer.Builder serverEndpointIndexerBuilder = new QuarkusServerEndpointIndexer.Builder()
+                    .addMethodScanners(
+                            methodScanners.stream().map(MethodScannerBuildItem::getMethodScanner).collect(Collectors.toList()))
                     .setIndex(index)
                     .setFactoryCreator(new QuarkusFactoryCreator(recorder, beanContainerBuildItem.getValue()))
                     .setEndpointInvokerFactory(new QuarkusInvokerFactory(generatedClassBuildItemBuildProducer, recorder))

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -34,6 +34,7 @@ import org.jboss.resteasy.reactive.common.processor.scanning.ResteasyReactiveInt
 import org.jboss.resteasy.reactive.server.core.ExceptionMapping;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+import org.jboss.resteasy.reactive.server.processor.scanning.AsyncReturnTypeScanner;
 import org.jboss.resteasy.reactive.server.processor.scanning.ResteasyReactiveContextResolverScanner;
 import org.jboss.resteasy.reactive.server.processor.scanning.ResteasyReactiveExceptionMappingScanner;
 import org.jboss.resteasy.reactive.server.processor.scanning.ResteasyReactiveFeatureScanner;
@@ -65,6 +66,11 @@ import io.quarkus.resteasy.reactive.spi.ParamConverterBuildItem;
  * Processor that handles scanning for types and turning them into build items
  */
 public class ResteasyReactiveScanningProcessor {
+
+    @BuildStep
+    public MethodScannerBuildItem asyncSupport() {
+        return new MethodScannerBuildItem(new AsyncReturnTypeScanner());
+    }
 
     @BuildStep
     public ResourceInterceptorsContributorBuildItem scanForInterceptors(CombinedIndexBuildItem combinedIndexBuildItem,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveVertxWebSocketIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveVertxWebSocketIntegrationProcessor.java
@@ -1,0 +1,47 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.resteasy.reactive.server.runtime.websocket.VertxWebSocketParamExtractor;
+import io.quarkus.resteasy.reactive.server.runtime.websocket.VertxWebSocketRestHandler;
+import io.vertx.core.http.ServerWebSocket;
+
+public class ResteasyReactiveVertxWebSocketIntegrationProcessor {
+
+    static final DotName SERVER_WEB_SOCKET = DotName.createSimple(ServerWebSocket.class.getName());
+    public static final String NAME = ResteasyReactiveVertxWebSocketIntegrationProcessor.class.getName();
+
+    @BuildStep
+    MethodScannerBuildItem scanner() {
+        return new MethodScannerBuildItem(new MethodScanner() {
+            @Override
+            public List<HandlerChainCustomizer> scan(MethodInfo method, Map<String, Object> methodContext) {
+                if (methodContext.containsKey(NAME)) {
+                    return Collections.singletonList(new VertxWebSocketRestHandler());
+                }
+                return Collections.emptyList();
+            }
+
+            @Override
+            public ParameterExtractor handleCustomParameter(Type paramType, Map<DotName, AnnotationInstance> annotations,
+                    boolean field, Map<String, Object> methodContext) {
+                if (paramType.name().equals(SERVER_WEB_SOCKET)) {
+                    methodContext.put(NAME, true);
+                    return new VertxWebSocketParamExtractor();
+                }
+                return null;
+            }
+        });
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/websocket/WebSocketResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/websocket/WebSocketResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.reactive.server.test.websocket;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.ServerWebSocket;
+
+@Path("ws")
+public class WebSocketResource {
+
+    @GET
+    public void echoWebSocket(ServerWebSocket serverWebSocket) {
+        serverWebSocket.textMessageHandler(new Handler<String>() {
+            @Override
+            public void handle(String event) {
+                serverWebSocket.writeTextMessage(event);
+            }
+        });
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/websocket/WebSocketTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/websocket/WebSocketTestCase.java
@@ -1,0 +1,64 @@
+package io.quarkus.resteasy.reactive.server.test.websocket;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.WebSocket;
+
+public class WebSocketTestCase {
+
+    @TestHTTPResource("/ws")
+    URI uri;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(WebSocketResource.class));
+
+    @Test
+    public void testWebSocket() throws Exception {
+        HttpClient httpClient = VertxCoreRecorder.getVertx().get().createHttpClient();
+        try {
+            final CompletableFuture<String> result = new CompletableFuture<>();
+            httpClient.webSocket(uri.getPort(), uri.getHost(), uri.getPath(), new Handler<AsyncResult<WebSocket>>() {
+                @Override
+                public void handle(AsyncResult<WebSocket> event) {
+                    if (event.failed()) {
+                        result.completeExceptionally(event.cause());
+                    } else {
+                        event.result().exceptionHandler(new Handler<Throwable>() {
+                            @Override
+                            public void handle(Throwable event) {
+                                result.completeExceptionally(event);
+                            }
+                        });
+                        event.result().textMessageHandler(new Handler<String>() {
+                            @Override
+                            public void handle(String event) {
+                                result.complete(event);
+                            }
+                        });
+                        event.result().writeTextMessage("Hello World");
+                    }
+                }
+            });
+            Assertions.assertEquals("Hello World", result.get());
+        } finally {
+            httpClient.close();
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketParamExtractor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketParamExtractor.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.server.runtime.websocket;
+
+import javax.ws.rs.container.CompletionCallback;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+import io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.ServerWebSocket;
+
+//TODO: do we actually want vert.x websockets?
+//they are not our primary API but they are easy to support
+public class VertxWebSocketParamExtractor implements ParameterExtractor {
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        QuarkusResteasyReactiveRequestContext qrs = (QuarkusResteasyReactiveRequestContext) context;
+        HttpServerRequest req = qrs.vertxServerRequest();
+        ParameterCallback parameterCallback = new ParameterCallback();
+        req.toWebSocket(new Handler<AsyncResult<ServerWebSocket>>() {
+            @Override
+            public void handle(AsyncResult<ServerWebSocket> event) {
+                if (event.succeeded()) {
+                    ServerWebSocket result = event.result();
+                    result.closeHandler(new Handler<Void>() {
+                        @Override
+                        public void handle(Void event) {
+                            context.close();
+                        }
+                    });
+                    parameterCallback.setResult(result);
+                    //the completion callback is generally invoked by the websocket close
+                    //so the close will be a no-op
+                    //if there is an exception somewhere else in processing though
+                    //we want to close the websocket
+                    context.registerCompletionCallback(new CompletionCallback() {
+                        @Override
+                        public void onComplete(Throwable throwable) {
+                            result.close();
+                        }
+                    });
+                } else {
+                    parameterCallback.setFailure(event.cause());
+                }
+
+            }
+        });
+        return parameterCallback;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.server.runtime.websocket;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public class VertxWebSocketRestHandler implements HandlerChainCustomizer {
+
+    private static final ServerRestHandler[] AWOL = new ServerRestHandler[] {
+            new ServerRestHandler() {
+
+                @Override
+                public void handle(ResteasyReactiveRequestContext requestContext)
+                        throws Exception {
+                    throw new IllegalStateException("FAILURE: should never be restarted");
+                }
+            }
+    };
+
+    @Override
+    public List<ServerRestHandler> handlers(Phase phase) {
+        if (phase == Phase.AFTER_METHOD_INVOKE) {
+            return Collections.singletonList(new ServerRestHandler() {
+                @Override
+                public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+                    //make sure that we are never restarted
+                    requestContext.restart(AWOL, true);
+                    requestContext.suspend(); //we never resume
+                }
+            });
+        }
+        return Collections.emptyList();
+
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
@@ -11,5 +11,6 @@ public enum ParameterType {
     CONTEXT,
     ASYNC_RESPONSE,
     COOKIE,
-    BEAN
+    BEAN,
+    CUSTOM
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerIndexedParameter.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerIndexedParameter.java
@@ -1,10 +1,12 @@
 package org.jboss.resteasy.reactive.server.processor;
 
 import org.jboss.resteasy.reactive.common.processor.IndexedParameter;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ParameterConverterSupplier;
 
 public class ServerIndexedParameter extends IndexedParameter<ServerIndexedParameter> {
     protected ParameterConverterSupplier converter;
+    private ParameterExtractor customerParameterExtractor;
 
     public ParameterConverterSupplier getConverter() {
         return converter;
@@ -12,6 +14,15 @@ public class ServerIndexedParameter extends IndexedParameter<ServerIndexedParame
 
     public ServerIndexedParameter setConverter(ParameterConverterSupplier converter) {
         this.converter = converter;
+        return this;
+    }
+
+    public ParameterExtractor getCustomerParameterExtractor() {
+        return customerParameterExtractor;
+    }
+
+    public ServerIndexedParameter setCustomerParameterExtractor(ParameterExtractor customerParameterExtractor) {
+        this.customerParameterExtractor = customerParameterExtractor;
         return this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/AsyncReturnTypeScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/AsyncReturnTypeScanner.java
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.reactive.server.processor.scanning;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.server.handlers.CompletionStageResponseHandler;
+import org.jboss.resteasy.reactive.server.handlers.MultiResponseHandler;
+import org.jboss.resteasy.reactive.server.handlers.UniResponseHandler;
+import org.jboss.resteasy.reactive.server.model.FixedHandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+
+public class AsyncReturnTypeScanner implements MethodScanner {
+    private static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    private static final DotName UNI = DotName.createSimple(Uni.class.getName());
+    private static final DotName MULTI = DotName.createSimple(Multi.class.getName());
+
+    @Override
+    public List<HandlerChainCustomizer> scan(MethodInfo method, Map<String, Object> methodContext) {
+        if (method.returnType().name().equals(COMPLETION_STAGE)) {
+            return Collections.singletonList(new FixedHandlerChainCustomizer(new CompletionStageResponseHandler(),
+                    HandlerChainCustomizer.Phase.AFTER_METHOD_INVOKE));
+        } else if (method.returnType().name().equals(UNI)) {
+            return Collections.singletonList(new FixedHandlerChainCustomizer(new UniResponseHandler(),
+                    HandlerChainCustomizer.Phase.AFTER_METHOD_INVOKE));
+        }
+        if (method.returnType().name().equals(MULTI)) {
+            return Collections.singletonList(new FixedHandlerChainCustomizer(new MultiResponseHandler(),
+                    HandlerChainCustomizer.Phase.AFTER_METHOD_INVOKE));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/MethodScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/MethodScanner.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.reactive.server.processor.scanning;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+
+public interface MethodScanner {
+
+    default List<HandlerChainCustomizer> scan(MethodInfo method, Map<String, Object> methodContext) {
+        return Collections.emptyList();
+    }
+
+    default ParameterExtractor handleCustomParameter(Type paramType, Map<DotName, AnnotationInstance> annotations,
+            boolean field, Map<String, Object> methodContext) {
+        return null;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -16,7 +16,6 @@ import org.jboss.resteasy.reactive.common.util.types.Types;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ParameterConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.RuntimeParameterConverter;
 import org.jboss.resteasy.reactive.server.core.serialization.EntityWriter;
-import org.jboss.resteasy.reactive.server.handlers.ResourceRequestFilterHandler;
 import org.jboss.resteasy.reactive.server.handlers.RestInitialHandler;
 import org.jboss.resteasy.reactive.server.mapping.RequestMapper;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
@@ -37,7 +36,7 @@ public class Deployment {
     private final Supplier<Application> applicationSupplier;
     private final ThreadSetupAction threadSetupAction;
     private final RequestContextFactory requestContextFactory;
-    private final List<ResourceRequestFilterHandler> preMatchHandlers;
+    private final List<ServerRestHandler> preMatchHandlers;
     private final List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
 
     public Deployment(ExceptionMapping exceptionMapping, ContextResolvers contextResolvers,
@@ -46,7 +45,7 @@ public class Deployment {
             EntityWriter dynamicEntityWriter, String prefix, ParamConverterProviders paramConverterProviders,
             ConfigurationImpl configuration, Supplier<Application> applicationSupplier,
             ThreadSetupAction threadSetupAction, RequestContextFactory requestContextFactory,
-            List<ResourceRequestFilterHandler> preMatchHandlers,
+            List<ServerRestHandler> preMatchHandlers,
             List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers) {
         this.exceptionMapping = exceptionMapping;
         this.contextResolvers = contextResolvers;
@@ -104,7 +103,7 @@ public class Deployment {
         return paramConverterProviders;
     }
 
-    public List<ResourceRequestFilterHandler> getPreMatchHandlers() {
+    public List<ServerRestHandler> getPreMatchHandlers() {
         return preMatchHandlers;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.server.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -10,6 +11,7 @@ import org.jboss.resteasy.reactive.common.model.ResourceInterceptors;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.DynamicFeatures;
 import org.jboss.resteasy.reactive.server.model.Features;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
@@ -29,6 +31,7 @@ public class DeploymentInfo {
     private ResteasyReactiveConfig config;
     private Function<Object, Object> clientProxyUnwrapper;
     private String applicationPath;
+    private List<HandlerChainCustomizer> globalHandlerCustomers = Collections.emptyList();
 
     public ResourceInterceptors getInterceptors() {
         return interceptors;
@@ -153,6 +156,15 @@ public class DeploymentInfo {
 
     public DeploymentInfo setApplicationPath(String applicationPath) {
         this.applicationPath = applicationPath;
+        return this;
+    }
+
+    public List<HandlerChainCustomizer> getGlobalHandlerCustomers() {
+        return globalHandlerCustomers;
+    }
+
+    public DeploymentInfo setGlobalHandlerCustomers(List<HandlerChainCustomizer> globalHandlerCustomers) {
+        this.globalHandlerCustomers = globalHandlerCustomers;
         return this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/ParameterExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/ParameterExtractor.java
@@ -21,12 +21,12 @@ public interface ParameterExtractor {
     public class ParameterCallback {
 
         private Object result;
-        private Exception failure;
-        private BiConsumer<Object, Exception> listener;
+        private Throwable failure;
+        private BiConsumer<Object, Throwable> listener;
 
-        public void setListener(BiConsumer<Object, Exception> listener) {
+        public void setListener(BiConsumer<Object, Throwable> listener) {
             Object result;
-            Exception failure;
+            Throwable failure;
             synchronized (this) {
                 if (this.listener != null) {
                     throw new RuntimeException("Listener already set");
@@ -41,7 +41,7 @@ public interface ParameterExtractor {
         }
 
         public void setResult(Object result) {
-            BiConsumer<Object, Exception> listener;
+            BiConsumer<Object, Throwable> listener;
             synchronized (this) {
                 if (this.result != null || this.failure != null) {
                     throw new RuntimeException("Callback already completed result:" + result + " failure:" + failure);
@@ -54,8 +54,8 @@ public interface ParameterExtractor {
             }
         }
 
-        public void setFailure(Exception failure) {
-            BiConsumer<Object, Exception> listener;
+        public void setFailure(Throwable failure) {
+            BiConsumer<Object, Throwable> listener;
             synchronized (this) {
                 if (this.result != null || this.failure != null) {
                     throw new RuntimeException("Callback already completed result:" + result + " failure:" + failure);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
@@ -36,9 +36,9 @@ public class ParameterHandler implements ServerRestHandler {
             Object result = extractor.extractParameter(requestContext);
             if (result instanceof ParameterExtractor.ParameterCallback) {
                 requestContext.suspend();
-                ((ParameterExtractor.ParameterCallback) result).setListener(new BiConsumer<Object, Exception>() {
+                ((ParameterExtractor.ParameterCallback) result).setListener(new BiConsumer<Object, Throwable>() {
                     @Override
-                    public void accept(Object o, Exception throwable) {
+                    public void accept(Object o, Throwable throwable) {
                         if (throwable != null) {
                             requestContext.resume(throwable);
                         } else {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
@@ -15,7 +15,7 @@ public class RestInitialHandler implements ServerRestHandler {
     final RequestMapper<InitialMatch> mappers;
     final Deployment deployment;
     final ProvidersImpl providers;
-    final List<ResourceRequestFilterHandler> preMappingHandlers;
+    final List<ServerRestHandler> preMappingHandlers;
     final ServerRestHandler[] initialChain;
 
     final ThreadSetupAction requestContext;
@@ -26,7 +26,7 @@ public class RestInitialHandler implements ServerRestHandler {
         this.deployment = deployment;
         this.providers = new ProvidersImpl(deployment);
         this.preMappingHandlers = deployment.getPreMatchHandlers();
-        if (preMappingHandlers == null) {
+        if (preMappingHandlers.isEmpty()) {
             initialChain = new ServerRestHandler[] { new MatrixParamHandler(), this };
         } else {
             initialChain = new ServerRestHandler[preMappingHandlers.size() + 2];

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/FixedHandlerChainCustomizer.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/FixedHandlerChainCustomizer.java
@@ -1,0 +1,45 @@
+package org.jboss.resteasy.reactive.server.model;
+
+import java.util.Collections;
+import java.util.List;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public class FixedHandlerChainCustomizer implements HandlerChainCustomizer {
+
+    private ServerRestHandler handler;
+    private Phase phase;
+
+    public FixedHandlerChainCustomizer(ServerRestHandler handler, Phase phase) {
+        this.handler = handler;
+        this.phase = phase;
+    }
+
+    public FixedHandlerChainCustomizer() {
+    }
+
+    @Override
+    public List<ServerRestHandler> handlers(Phase phase) {
+        if (this.phase == phase) {
+            return Collections.singletonList(handler);
+        }
+        return Collections.emptyList();
+    }
+
+    public ServerRestHandler getHandler() {
+        return handler;
+    }
+
+    public FixedHandlerChainCustomizer setHandler(ServerRestHandler handler) {
+        this.handler = handler;
+        return this;
+    }
+
+    public Phase getPhase() {
+        return phase;
+    }
+
+    public FixedHandlerChainCustomizer setPhase(Phase phase) {
+        this.phase = phase;
+        return this;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/HandlerChainCustomizer.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/HandlerChainCustomizer.java
@@ -1,0 +1,40 @@
+package org.jboss.resteasy.reactive.server.model;
+
+import java.util.List;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public interface HandlerChainCustomizer {
+
+    List<ServerRestHandler> handlers(Phase phase);
+
+    enum Phase {
+        /**
+         * handlers are added right at the start of the pre match handler chain
+         * this can only be applied globally, not on a per method basis
+         */
+        BEFORE_PRE_MATCH,
+        /**
+         * handlers are added at the end of the pre match handler chain, before
+         * the next chain is determined and matched (i.e. after pre match filters)
+         * this can only be applied globally, not on a per method basis
+         */
+        AFTER_PRE_MATCH,
+        /**
+         * handlers are invoked as soon as the matched handler chain is being run
+         */
+        AFTER_MATCH,
+        /**
+         * handlers are invoked as part of resolving method parameters
+         */
+        RESOLVE_METHOD_PARAMETERS,
+        /**
+         * handlers are invoked just before the resource method is invoked
+         */
+        BEFORE_METHOD_INVOKE,
+        /**
+         * handlers are invoked just after the resource method is invoked
+         */
+        AFTER_METHOD_INVOKE,
+
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
@@ -2,19 +2,23 @@ package org.jboss.resteasy.reactive.server.model;
 
 import org.jboss.resteasy.reactive.common.model.MethodParameter;
 import org.jboss.resteasy.reactive.common.model.ParameterType;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ParameterConverterSupplier;
 
 public class ServerMethodParameter extends MethodParameter {
 
     public ParameterConverterSupplier converter;
+    public ParameterExtractor customerParameterExtractor;
 
     public ServerMethodParameter() {
     }
 
     public ServerMethodParameter(String name, String type, String declaredType, ParameterType parameterType, boolean single,
             String signature,
-            ParameterConverterSupplier converter, String defaultValue, boolean isObtainedAsCollection, boolean encoded) {
+            ParameterConverterSupplier converter, String defaultValue, boolean isObtainedAsCollection, boolean encoded,
+            ParameterExtractor customerParameterExtractor) {
         super(name, type, declaredType, signature, parameterType, single, defaultValue, isObtainedAsCollection, encoded);
         this.converter = converter;
+        this.customerParameterExtractor = customerParameterExtractor;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -1,8 +1,11 @@
 package org.jboss.resteasy.reactive.server.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
 
 public class ServerResourceMethod extends ResourceMethod {
@@ -10,6 +13,9 @@ public class ServerResourceMethod extends ResourceMethod {
     private Supplier<EndpointInvoker> invoker;
 
     private Set<String> methodAnnotationNames;
+
+    private List<HandlerChainCustomizer> handlerChainCustomizers = new ArrayList<>();
+    private ParameterExtractor customerParameterExtractor;
 
     public Supplier<EndpointInvoker> getInvoker() {
         return invoker;
@@ -26,5 +32,23 @@ public class ServerResourceMethod extends ResourceMethod {
 
     public void setMethodAnnotationNames(Set<String> methodAnnotationNames) {
         this.methodAnnotationNames = methodAnnotationNames;
+    }
+
+    public List<HandlerChainCustomizer> getHandlerChainCustomizers() {
+        return handlerChainCustomizers;
+    }
+
+    public ServerResourceMethod setHandlerChainCustomizers(List<HandlerChainCustomizer> handlerChainCustomizers) {
+        this.handlerChainCustomizers = handlerChainCustomizers;
+        return this;
+    }
+
+    public ParameterExtractor getCustomerParameterExtractor() {
+        return customerParameterExtractor;
+    }
+
+    public ServerResourceMethod setCustomerParameterExtractor(ParameterExtractor customerParameterExtractor) {
+        this.customerParameterExtractor = customerParameterExtractor;
+        return this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -351,6 +351,14 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
         }
     }
 
+    public HttpServerRequest vertxServerRequest() {
+        return request;
+    }
+
+    public HttpServerResponse vertxServerResponse() {
+        return response;
+    }
+
     enum ContinueState {
         NONE,
         REQUIRED,


### PR DESCRIPTION
This adds interfaces that allow external code to:
- Add Handlers at various points in the chain
- Provide custom ParamExtractors

This enables integration of more complex things like
WebSockets. As a test of the intergration Vert.x
websocket support is also provided.