### PR TITLE
Replace resteasy usage with resteasy reactive in hibernate-reactive integration tests

### DIFF
--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/JAXBEntity.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/JAXBEntity.java
@@ -1,8 +1,7 @@
-package io.quarkus.it.panache.reactive;
+package io.quarkus.hibernate.reactive.panache.test;
 
 import javax.persistence.Entity;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import javax.persistence.Transient;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
@@ -13,7 +12,6 @@ import io.quarkus.hibernate.reactive.panache.PanacheEntity;
 
 @Entity
 @XmlRootElement(name = "JAXBEntity")
-@XmlAccessorType(XmlAccessType.NONE)
 public class JAXBEntity extends PanacheEntity {
 
     @XmlAttribute(name = "Named")
@@ -32,4 +30,22 @@ public class JAXBEntity extends PanacheEntity {
     public String arrayAnnotatedProp;
 
     public String unAnnotatedProp;
+
+    // note that this annotation is automatically added for mapped fields, which is not the case here
+    // so we do it manually to emulate a mapped field situation
+    @XmlTransient
+    @Transient
+    public int serialisationTrick;
+
+    public String name;
+
+    // For JAXB: both getter and setter are required
+    // Here we make sure the field is not used by Hibernate, but the accessor is used by jaxb, jsonb and jackson
+    public int getSerialisationTrick() {
+        return ++serialisationTrick;
+    }
+
+    public void setSerialisationTrick(int serialisationTrick) {
+        this.serialisationTrick = serialisationTrick;
+    }
 }

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/JAXBTestResource.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/JAXBTestResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Assertions;
+
+@Path("test")
+public class JAXBTestResource {
+
+    @Produces(MediaType.APPLICATION_XML)
+    @GET
+    @Path("ignored-properties")
+    public JAXBEntity ignoredProperties() throws NoSuchMethodException, SecurityException {
+        JAXBEntity.class.getMethod("$$_hibernate_read_id");
+        JAXBEntity.class.getMethod("$$_hibernate_read_name");
+        try {
+            JAXBEntity.class.getMethod("$$_hibernate_read_persistent");
+            Assertions.fail();
+        } catch (NoSuchMethodException e) {
+        }
+
+        // no need to persist it, we can fake it
+        JAXBEntity entity = new JAXBEntity();
+        entity.id = 666l;
+        entity.name = "Eddie";
+        return entity;
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/PanacheJAXBTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/PanacheJAXBTest.java
@@ -1,0 +1,107 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlTransient;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class PanacheJAXBTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(JAXBEntity.class, JAXBTestResource.class)
+                    .addAsResource("application.properties"));
+
+    @Test
+    public void testJaxbAnnotationTransfer() throws Exception {
+        // Test for fix to this bug: https://github.com/quarkusio/quarkus/issues/6021
+
+        // Ensure that any JAX-B annotations are properly moved to generated getters
+        Method m = JAXBEntity.class.getMethod("getNamedAnnotatedProp");
+        XmlAttribute anno = m.getAnnotation(XmlAttribute.class);
+        assertNotNull(anno);
+        assertEquals("Named", anno.name());
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getDefaultAnnotatedProp");
+        anno = m.getAnnotation(XmlAttribute.class);
+        assertNotNull(anno);
+        assertEquals("##default", anno.name());
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getUnAnnotatedProp");
+        assertNull(m.getAnnotation(XmlAttribute.class));
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getTransientProp");
+        assertNull(m.getAnnotation(XmlAttribute.class));
+        assertNotNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getArrayAnnotatedProp");
+        assertNull(m.getAnnotation(XmlTransient.class));
+        XmlElements elementsAnno = m.getAnnotation(XmlElements.class);
+        assertNotNull(elementsAnno);
+        assertNotNull(elementsAnno.value());
+        assertEquals(2, elementsAnno.value().length);
+        assertEquals("array1", elementsAnno.value()[0].name());
+        assertEquals("array2", elementsAnno.value()[1].name());
+
+        // Ensure that all original fields were labeled @XmlTransient and had their original JAX-B annotations removed
+        ensureFieldSanitized("namedAnnotatedProp");
+        ensureFieldSanitized("transientProp");
+        ensureFieldSanitized("defaultAnnotatedProp");
+        ensureFieldSanitized("unAnnotatedProp");
+        ensureFieldSanitized("arrayAnnotatedProp");
+    }
+
+    private void ensureFieldSanitized(String fieldName) throws Exception {
+        Field f = JAXBEntity.class.getDeclaredField(fieldName);
+        assertNull(f.getAnnotation(XmlAttribute.class));
+        assertNotNull(f.getAnnotation(XmlTransient.class));
+    }
+
+    @Test
+    public void testPanacheSerialisation() {
+        RestAssured.given().accept(ContentType.XML)
+                .when().get("/test/ignored-properties")
+                .then().body(is(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><JAXBEntity><id>666</id><name>Eddie</name><serialisationTrick>1</serialisationTrick></JAXBEntity>"));
+    }
+
+    @Test
+    public void jaxbDeserializationHasAllFields() throws JAXBException {
+        // set Up
+        JAXBEntity person = new JAXBEntity();
+        person.name = "max";
+        // do
+        JAXBContext jaxbContext = JAXBContext.newInstance(JAXBEntity.class);
+
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(person, sw);
+        assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><JAXBEntity><name>max</name><serialisationTrick>1</serialisationTrick></JAXBEntity>",
+                sw.toString());
+    }
+}

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -28,11 +28,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -76,20 +72,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -29,11 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -77,20 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -29,27 +29,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-reactive</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jaxb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-jackson</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
@@ -109,11 +93,6 @@
             </exclusions>
         </dependency>
         <dependency>
-          <groupId>com.fasterxml.jackson.module</groupId>
-          <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -127,19 +106,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -191,7 +157,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -202,58 +168,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
     </dependencies>
 
     <build>

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -3,14 +3,9 @@ package io.quarkus.it.panache.reactive;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.StringWriter;
-
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.transaction.Transactional;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -56,10 +51,6 @@ public class PanacheFunctionalityTest {
                 .when().get("/test/ignored-properties")
                 .then()
                 .body(is("{\"id\":666,\"dogs\":[],\"name\":\"Eddie\",\"serialisationTrick\":1,\"status\":\"DECEASED\"}"));
-        RestAssured.given().accept(ContentType.XML)
-                .when().get("/test/ignored-properties")
-                .then().body(is(
-                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><person><id>666</id><name>Eddie</name><serialisationTrick>1</serialisationTrick><status>DECEASED</status></person>"));
     }
 
     @DisabledOnNativeImage
@@ -78,18 +69,10 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/5885").then().body(is("OK"));
     }
 
-    @Test
-    public void testJaxbAnnotationTransfer() {
-        RestAssured.when()
-                .get("/test/testJaxbAnnotationTransfer")
-                .then()
-                .body(is("OK"));
-    }
-
     /**
      * _PanacheEntityBase_ has the method _isPersistent_. This method is used by Jackson to serialize the attribute *peristent*
      * in the JSON which is not intended. This test ensures that the attribute *persistent* is not generated when using Jackson.
-     * 
+     *
      * This test does not interact with the Quarkus application itself. It is just using the Jackson ObjectMapper with a
      * PanacheEntity. Thus this test is disabled in native mode. The test code runs the JVM and not native.
      */
@@ -109,26 +92,6 @@ public class PanacheFunctionalityTest {
         assertEquals(
                 "{\"id\":null,\"name\":\"max\",\"uniqueName\":null,\"address\":null,\"status\":null,\"dogs\":[],\"serialisationTrick\":1}",
                 personAsString);
-    }
-
-    /**
-     * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
-     */
-    @DisabledOnNativeImage
-    @Test
-    public void jaxbDeserializationHasAllFields() throws JsonProcessingException, JAXBException {
-        // set Up
-        Person person = new Person();
-        person.name = "max";
-        // do
-        JAXBContext jaxbContext = JAXBContext.newInstance(Person.class);
-
-        Marshaller marshaller = jaxbContext.createMarshaller();
-        StringWriter sw = new StringWriter();
-        marshaller.marshal(person, sw);
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
-                + "<person><name>max</name><serialisationTrick>1</serialisationTrick></person>",
-                sw.toString());
     }
 
     /**

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -29,11 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -77,20 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Need to wait for jaxb support in resteasy-reactive.
hibernate-reactive-panache depends on it.

This is also why this pr is still a draft


Fixes #13944 