### PR TITLE
Mutiny / Vertx Mutiny and SmallRye Reactive Messaging update

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,8 +48,8 @@
         <smallrye-jwt.version>2.4.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.19</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.2.2</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.6.1</smallrye-reactive-messaging.version>
+        <smallrye-converter-api.version>1.3.0</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>2.7.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
@@ -135,9 +135,9 @@
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
-        <mutiny.version>0.11.0</mutiny.version>
-        <axle-client.version>1.2.2</axle-client.version>
-        <mutiny-client.version>1.2.2</mutiny-client.version>
+        <mutiny.version>0.12.5</mutiny.version>
+        <axle-client.version>1.3.0</axle-client.version>
+        <mutiny-client.version>1.3.0</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -40,7 +40,7 @@
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>0.11.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>0.12.5</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -49,7 +49,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>
-        <mutiny.version>0.10.1</mutiny.version>
+        <mutiny.version>0.12.5</mutiny.version>
         <smallrye-common-annotation.version>1.5.0</smallrye-common-annotation.version>
         <vertx.version>3.9.5</vertx.version>
         <rest-assured.version>4.3.3</rest-assured.version>


### PR DESCRIPTION
* Update Mutiny to version 0.12.5 
* Update Mutiny Vert.x clients to version 1.3.0 
* Update SmallRye Reactive Messaging to version 2.7.0

Also, update the mutiny version used in Qute and Resteasy Reactive.

* Fix https://github.com/quarkusio/quarkus/issues/12820
* Fix https://github.com/quarkusio/quarkus/issues/9947
* Fix https://github.com/quarkusio/quarkus/issues/13632
* Fix https://github.com/quarkusio/quarkus/issues/11801

