### PR TITLE
Fix context root handling based on the builder used.

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseJavaImage.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseJavaImage.java
@@ -8,25 +8,27 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 public enum OpenshiftBaseJavaImage {
 
     //We only compare `repositories` so registries and tags are stripped
-    FABRIC8("fabric8/s2i-java:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH", "JAVA_OPTIONS"),
-    OPENJDK_8_RHEL7("redhat-openjdk-18/openjdk18-openshift:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+    FABRIC8("fabric8/s2i-java:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
+            "JAVA_OPTIONS"),
+    OPENJDK_8_RHEL7("redhat-openjdk-18/openjdk18-openshift:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR",
+            "JAVA_LIB_DIR", "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJDK_8_RHEL8("openjdk/openjdk-8-rhel8:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
             "JAVA_CLASSPATH", "JAVA_OPTIONS"),
-    OPENJDK_8_RHEL8("openjdk/openjdk-8-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJDK_11_RHEL7("openjdk/openjdk-11-rhel7:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJDK_11_RHEL8("openjdk/openjdk-11-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJ9_8_RHEL7("openj9/openj9-8-rhel7:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJ9_8_RHEL8("openj9/openj9-8-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJ9_11_RHEL7("openj9/openj9-11-rhel7:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS"),
-    OPENJ9_11_RHEL8("openj9/openj9-11-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
-            "JAVA_OPTIONS");
+    OPENJDK_11_RHEL7("openjdk/openjdk-11-rhel7:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJDK_11_RHEL8("openjdk/openjdk-11-rhel8:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJ9_8_RHEL7("openj9/openj9-8-rhel7:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJ9_8_RHEL8("openj9/openj9-8-rhel8:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJ9_11_RHEL7("openj9/openj9-11-rhel7:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJ9_11_RHEL8("openj9/openj9-11-rhel8:latest", "/deployments", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS");
 
     private final String image;
+    private final String jarDirectory;
     private final String javaMainClassEnvVar;
     private final String jarEnvVar;
     private final String jarLibEnvVar;
@@ -42,9 +44,10 @@ public enum OpenshiftBaseJavaImage {
         return Optional.empty();
     }
 
-    private OpenshiftBaseJavaImage(String image, String javaMainClassEnvVar, String jarEnvVar, String jarLibEnvVar,
-            String classpathEnvVar, String jvmOptionsEnvVar) {
+    private OpenshiftBaseJavaImage(String image, String jarDirectory, String javaMainClassEnvVar, String jarEnvVar,
+            String jarLibEnvVar, String classpathEnvVar, String jvmOptionsEnvVar) {
         this.image = image;
+        this.jarDirectory = jarDirectory;
         this.javaMainClassEnvVar = javaMainClassEnvVar;
         this.jarEnvVar = jarEnvVar;
         this.jarLibEnvVar = jarLibEnvVar;
@@ -54,6 +57,10 @@ public enum OpenshiftBaseJavaImage {
 
     public String getImage() {
         return image;
+    }
+
+    public String getJarDirectory() {
+        return this.jarDirectory;
     }
 
     public String getJavaMainClassEnvVar() {

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseNativeImage.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseNativeImage.java
@@ -8,9 +8,10 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 public enum OpenshiftBaseNativeImage {
 
     //We only compare `repositories` so registries and tags are stripped
-    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
+    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "/home/quarkus/", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
 
     private final String image;
+    private final String nativeBinaryDirectory;
     private final String fixedNativeBinaryName;
     private final String homeDirEnvVar;
     private final String optsEnvVar;
@@ -24,8 +25,10 @@ public enum OpenshiftBaseNativeImage {
         return Optional.empty();
     }
 
-    private OpenshiftBaseNativeImage(String image, String fixedNativeBinaryName, String homeDirEnvVar, String optsEnvVar) {
+    private OpenshiftBaseNativeImage(String image, String nativeBinaryDirectory, String fixedNativeBinaryName,
+            String homeDirEnvVar, String optsEnvVar) {
         this.image = image;
+        this.nativeBinaryDirectory = nativeBinaryDirectory;
         this.fixedNativeBinaryName = fixedNativeBinaryName;
         this.homeDirEnvVar = homeDirEnvVar;
         this.optsEnvVar = optsEnvVar;
@@ -33,6 +36,10 @@ public enum OpenshiftBaseNativeImage {
 
     public String getImage() {
         return image;
+    }
+
+    public String getNativeBinaryDirectory() {
+        return nativeBinaryDirectory;
     }
 
     public String getFixedNativeNinaryName() {
@@ -46,4 +53,5 @@ public enum OpenshiftBaseNativeImage {
     public String getOptsEnvVar() {
         return optsEnvVar;
     }
+
 }

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
@@ -18,6 +18,9 @@ public class OpenshiftConfig {
     public static final String DEFAULT_JVM_DOCKERFILE = "src/main/docker/Dockerfile.jvm";
     public static final String DEFAULT_NATIVE_DOCKERFILE = "src/main/docker/Dockerfile.native";
 
+    public static final String FALLBACK_JAR_DIRECTORY = "/deployments/";
+    public static final String FALLBAC_NATIVE_BINARY_DIRECTORY = "/home/quarkus/";
+
     /**
      * The build config strategy to use.
      */
@@ -64,8 +67,8 @@ public class OpenshiftConfig {
      * The directory where the jar is added during the assemble phase.
      * This is dependent on the S2I image and should be supplied if a non default image is used.
      */
-    @ConfigItem(defaultValue = "/deployments/target/")
-    public String jarDirectory;
+    @ConfigItem
+    public Optional<String> jarDirectory;
 
     /**
      * The resulting filename of the jar in the S2I image.
@@ -78,8 +81,8 @@ public class OpenshiftConfig {
      * The directory where the native binary is added during the assemble phase.
      * This is dependent on the S2I image and should be supplied if a non-default image is used.
      */
-    @ConfigItem(defaultValue = "/home/quarkus/")
-    public String nativeBinaryDirectory;
+    @ConfigItem
+    public Optional<String> nativeBinaryDirectory;
 
     /**
      * The resulting filename of the native binary in the S2I image.

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -98,7 +98,9 @@ public class OpenshiftProcessor {
         if (config.buildStrategy == BuildStrategy.DOCKER) {
             decorator.produce(new DecoratorBuildItem(new ApplyDockerfileToBuildConfigDecorator(null,
                     findMainSourcesRoot(out.getOutputDirectory()).getValue().resolve(openshiftConfig.jvmDockerfile))));
+            //When using the docker build strategy, we can't possibly know these values, so it's the image responsibility to work without them.
             decorator.produce(new DecoratorBuildItem(new RemoveEnvVarDecorator(null, "JAVA_APP_JAR")));
+            decorator.produce(new DecoratorBuildItem(new RemoveEnvVarDecorator(null, "JAVA_APP_LIB")));
         }
     }
 
@@ -114,6 +116,7 @@ public class OpenshiftProcessor {
         }
         //Let's remove this for all kinds of native build
         decorator.produce(new DecoratorBuildItem(new RemoveEnvVarDecorator(null, "JAVA_APP_JAR")));
+        decorator.produce(new DecoratorBuildItem(new RemoveEnvVarDecorator(null, "JAVA_APP_LIB")));
     }
 
     @BuildStep(onlyIf = { IsNormal.class, OpenshiftBuild.class }, onlyIfNot = NativeBuild.class)
@@ -131,34 +134,38 @@ public class OpenshiftProcessor {
         OpenshiftConfig config = mergeConfig(openshiftConfig, s2iConfig);
         final List<AppDependency> appDeps = curateOutcomeBuildItem.getEffectiveModel().getUserDependencies();
         String outputJarFileName = jarBuildItem.getPath().getFileName().toString();
-        String classpath = appDeps.stream()
-                .map(d -> d.getArtifact().getGroupId() + "." + d.getArtifact().getPath().getFileName())
-                .map(s -> concatUnixPaths(config.jarDirectory, "lib", s))
-                .collect(Collectors.joining(":"));
-
         String jarFileName = config.jarFileName.orElse(outputJarFileName);
-        String jarDirectory = config.jarDirectory;
-        String pathToJar = concatUnixPaths(jarDirectory, jarFileName);
-
-        List<String> args = new ArrayList<>();
-        args.addAll(Arrays.asList("-jar", pathToJar, "-cp", classpath));
-        args.addAll(config.jvmArguments);
 
         builderImageProducer.produce(new BaseImageInfoBuildItem(config.baseJvmImage));
         Optional<OpenshiftBaseJavaImage> baseImage = OpenshiftBaseJavaImage.findMatching(config.baseJvmImage);
 
-        if (config.buildStrategy != BuildStrategy.DOCKER) {
+        if (config.buildStrategy == BuildStrategy.BINARY) {
+            // Jar directory priorities:
+            // 1. explictly specified by the user.
+            // 2. detected via OpenshiftBaseJavaImage
+            // 3. fallback value
+            String jarDirectory = config.jarDirectory
+                    .orElse(baseImage.map(i -> i.getJarDirectory()).orElse(config.FALLBACK_JAR_DIRECTORY));
+            String pathToJar = concatUnixPaths(jarDirectory, jarFileName);
+            String classpath = appDeps.stream()
+                    .map(d -> d.getArtifact().getGroupId() + "." + d.getArtifact().getPath().getFileName())
+                    .map(s -> concatUnixPaths(jarDirectory, "lib", s))
+                    .collect(Collectors.joining(":"));
+
+            // If the image is known, we can define env vars for classpath, jar, lib etc.
             baseImage.ifPresent(b -> {
                 envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJarEnvVar(), pathToJar, null));
-                envProducer.produce(
-                        KubernetesEnvBuildItem.createSimpleVar(b.getJarLibEnvVar(), concatUnixPaths(jarDirectory, "lib"),
-                                null));
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJarLibEnvVar(),
+                        concatUnixPaths(jarDirectory, "lib"), null));
                 envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getClasspathEnvVar(), classpath, null));
                 envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getJvmOptionsEnvVar(),
                         String.join(" ", config.jvmArguments), null));
             });
-
+            //In all other cases its the responsibility of the image to set those up correctly.
             if (!baseImage.isPresent()) {
+                List<String> args = new ArrayList<>();
+                args.addAll(Arrays.asList("-jar", pathToJar, "-cp", classpath));
+                args.addAll(config.jvmArguments);
                 envProducer.produce(KubernetesEnvBuildItem.createSimpleVar("JAVA_APP_JAR", pathToJar, null));
                 envProducer.produce(
                         KubernetesEnvBuildItem.createSimpleVar("JAVA_LIB_DIR", concatUnixPaths(jarDirectory, "lib"), null));
@@ -193,17 +200,22 @@ public class OpenshiftProcessor {
             nativeBinaryFileName = config.nativeBinaryFileName.orElse(outputNativeBinaryFileName);
         }
 
-        if (config.buildStrategy != BuildStrategy.DOCKER) {
-            String pathToNativeBinary = concatUnixPaths(config.nativeBinaryDirectory, nativeBinaryFileName);
+        if (config.buildStrategy == BuildStrategy.BINARY) {
             builderImageProducer.produce(new BaseImageInfoBuildItem(config.baseNativeImage));
             Optional<OpenshiftBaseNativeImage> baseImage = OpenshiftBaseNativeImage.findMatching(config.baseNativeImage);
+            // Native binary directory priorities:
+            // 1. explictly specified by the user.
+            // 2. detected via OpenshiftBaseNativeImage
+            // 3. fallback value
+            String nativeBinaryDirectory = config.nativeBinaryDirectory
+                    .orElse(baseImage.map(i -> i.getNativeBinaryDirectory()).orElse(config.FALLBAC_NATIVE_BINARY_DIRECTORY));
+            String pathToNativeBinary = concatUnixPaths(nativeBinaryDirectory, nativeBinaryFileName);
+
             baseImage.ifPresent(b -> {
                 envProducer.produce(
-                        KubernetesEnvBuildItem.createSimpleVar(b.getHomeDirEnvVar(), config.nativeBinaryDirectory,
-                                OPENSHIFT));
-                envProducer.produce(
-                        KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(), String.join(" ", config.nativeArguments),
-                                OPENSHIFT));
+                        KubernetesEnvBuildItem.createSimpleVar(b.getHomeDirEnvVar(), nativeBinaryDirectory, OPENSHIFT));
+                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(),
+                        String.join(" ", config.nativeArguments), OPENSHIFT));
             });
 
             if (!baseImage.isPresent()) {
@@ -253,9 +265,11 @@ public class OpenshiftProcessor {
         //For s2i kind of builds where jars are expected directly in the '/' we have to use null.
         String contextRoot = config.buildStrategy == BuildStrategy.DOCKER ? "target" : null;
         if (packageConfig.isFastJar()) {
-            createContainerImage(kubernetesClient, openshiftYml.get(), config, contextRoot, jar.getPath().getParent(), jar.getPath().getParent());
+            createContainerImage(kubernetesClient, openshiftYml.get(), config, contextRoot, jar.getPath().getParent(),
+                    jar.getPath().getParent());
         } else {
-            createContainerImage(kubernetesClient, openshiftYml.get(), config, contextRoot, jar.getPath().getParent(), jar.getPath(), jar.getLibraryDir());
+            createContainerImage(kubernetesClient, openshiftYml.get(), config, contextRoot, jar.getPath().getParent(),
+                    jar.getPath(), jar.getLibraryDir());
         }
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "jar-container", Collections.emptyMap()));
     }

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
@@ -3,6 +3,7 @@ package io.quarkus.container.image.openshift.deployment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -125,12 +126,12 @@ public class OpenshiftUtils {
                 : openshiftConfig.jvmArguments;
         result.nativeArguments = hasS2iNativeArguments && !hasOpenshiftNativeArguments ? s2iConfig.nativeArguments
                 : openshiftConfig.nativeArguments;
-        result.jarDirectory = hasS2iJarDirectory && !hasOpenshiftJarDirectory ? s2iConfig.jarDirectory
+        result.jarDirectory = hasS2iJarDirectory && !hasOpenshiftJarDirectory ? Optional.of(s2iConfig.jarDirectory)
                 : openshiftConfig.jarDirectory;
         result.jarFileName = hasS2iJarFileName && !hasOpenshiftJarFileName ? s2iConfig.jarFileName
                 : openshiftConfig.jarFileName;
         result.nativeBinaryDirectory = hasS2iNativeBinaryDirectory && !hasOpenshiftNativeBinaryDirectory
-                ? s2iConfig.nativeBinaryDirectory
+                ? Optional.of(s2iConfig.nativeBinaryDirectory)
                 : openshiftConfig.nativeBinaryDirectory;
         result.nativeBinaryFileName = hasS2iNativeBinaryFileName && !hasOpenshiftNativeBinaryFileName
                 ? s2iConfig.nativeBinaryFileName

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerBuildStrategyTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerBuildStrategyTest.java
@@ -48,6 +48,8 @@ public class OpenshiftWithDockerBuildStrategyTest {
                 assertThat(dc.getSpec().getTemplate().getSpec().getContainers()).singleElement().satisfies(c -> {
                     assertThat(c.getCommand()).isNullOrEmpty();
                     assertThat(c.getArgs()).isNullOrEmpty();
+                    //We explicitly remove them when using the `docker build strategy`.
+                    assertThat(c.getEnv()).extracting("name").doesNotContain("JAVA_APP_JAR", "JAVA_LIB_DIR");
                 });
             });
         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
@@ -74,11 +74,11 @@ public class OpenshiftWithS2iTest {
                             List<EnvVar> envVars = container.getEnv();
                             assertThat(envVars).anySatisfy(envVar -> {
                                 assertThat(envVar.getName()).isEqualTo("JAVA_APP_JAR");
-                                assertThat(envVar.getValue()).isEqualTo("/deployments/target/openshift-s2i-runner.jar");
+                                assertThat(envVar.getValue()).isEqualTo("/deployments/openshift-s2i-runner.jar");
                             });
                             assertThat(envVars).anySatisfy(envVar -> {
                                 assertThat(envVar.getName()).isEqualTo("JAVA_LIB_DIR");
-                                assertThat(envVar.getValue()).isEqualTo("/deployments/target/lib");
+                                assertThat(envVar.getValue()).isEqualTo("/deployments/lib");
                             });
                             assertThat(envVars).anySatisfy(envVar -> {
                                 assertThat(envVar.getName()).isEqualTo("JAVA_CLASSPATH");


### PR DESCRIPTION
This pull  request performs the following changes.

Change the way we create the container image context root, based on the following conditions:

- If docker is used assume build is executed from the module root (so context root is: `target`).
- If any sort of binary build is used, we use `/` as context root, and set the appropriate env vars supported by the builder image.
- Only use fallback values, when values have not been provided by the user nor detected by the builder image.

In simpler words: Only use `target` as the context root for docker strategy builds.