### PR TITLE
Change name of RESTEasy Reactive CI step

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -484,7 +484,7 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Run Quarkus REST TCK
+      - name: Run RESTEasy Reactive TCK
         run: mvn -B --settings ../tcks/.github/mvn-settings.xml install
         working-directory: ./quarkus-rest-testsuite
       - name: Verify with Maven

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -463,11 +463,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: tcks
-      - name: Download Quarkus REST Testsuite
+      - name: Download RESTEasy Reactive Testsuite
         uses: actions/checkout@v2
         with:
-          repository: quarkusio/quarkus-rest-testsuite
-          path: quarkus-rest-testsuite
+          repository: quarkusio/resteasy-reactive-testsuite
+          path: resteasy-reactive-testsuite
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
         working-directory: ./tcks
@@ -486,7 +486,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Run RESTEasy Reactive TCK
         run: mvn -B --settings ../tcks/.github/mvn-settings.xml install
-        working-directory: ./quarkus-rest-testsuite
+        working-directory: ./resteasy-reactive-testsuite
       - name: Verify with Maven
         run: mvn -B --settings .github/mvn-settings.xml -f tcks/pom.xml install
         working-directory: ./tcks


### PR DESCRIPTION
I think we will still find some remaining ones in a year or two :].

I also think we should rename this repository: https://github.com/quarkusio/quarkus-rest-testsuite ?

Can I safely do it? I see it's used in the workflow so I would fix it there too.