### PR TITLE
Fix 'ClassNotFoundException: org.jboss.logmanager.LogManager' in some tests

### DIFF
--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -55,6 +55,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId> 
+            <artifactId>jboss-logmanager-embedded</artifactId> 
+            <scope>test</scope> 
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/datasource/common/pom.xml
+++ b/extensions/datasource/common/pom.xml
@@ -17,5 +17,10 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId> 
+            <artifactId>jboss-logmanager-embedded</artifactId> 
+            <scope>test</scope> 
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/panache/panacheql/pom.xml
+++ b/extensions/panache/panacheql/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId> 
+            <artifactId>jboss-logmanager-embedded</artifactId> 
+            <scope>test</scope> 
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Removes three of those scary looking exceptions from the build log:
```
2020-12-18T17:02:13.0750996Z [INFO] --- maven-surefire-plugin:3.0.0-M5:test (default-test) @ quarkus-panacheql ---
2020-12-18T17:02:13.0776773Z [INFO] Surefire report directory: /home/runner/work/quarkus/quarkus/extensions/panache/panacheql/target/surefire-reports
2020-12-18T17:02:13.0931633Z [INFO] 
2020-12-18T17:02:13.0933338Z [INFO] -------------------------------------------------------
2020-12-18T17:02:13.0934087Z [INFO]  T E S T S
2020-12-18T17:02:13.0935372Z [INFO] -------------------------------------------------------
2020-12-18T17:02:13.2831763Z [ERROR] Could not load Logmanager "org.jboss.logmanager.LogManager"
2020-12-18T17:02:13.2836431Z [ERROR] java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager
2020-12-18T17:02:13.2841731Z [ERROR] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
2020-12-18T17:02:13.2844148Z [ERROR] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
2020-12-18T17:02:13.2846799Z [ERROR] 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
2020-12-18T17:02:13.2849259Z [ERROR] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
2020-12-18T17:02:13.2851790Z [ERROR] 	at java.util.logging.LogManager$1.run(LogManager.java:195)
2020-12-18T17:02:13.2854370Z [ERROR] 	at java.util.logging.LogManager$1.run(LogManager.java:181)
2020-12-18T17:02:13.2857116Z [ERROR] 	at java.security.AccessController.doPrivileged(Native Method)
2020-12-18T17:02:13.2859539Z [ERROR] 	at java.util.logging.LogManager.<clinit>(LogManager.java:181)
2020-12-18T17:02:13.2862105Z [ERROR] 	at java.util.logging.Logger.demandLogger(Logger.java:448)
2020-12-18T17:02:13.2865770Z [ERROR] 	at java.util.logging.Logger.getLogger(Logger.java:502)
2020-12-18T17:02:13.2869428Z [ERROR] 	at org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger.<init>(LoggerFactory.java:80)
2020-12-18T17:02:13.2872213Z [ERROR] 	at org.junit.platform.commons.logging.LoggerFactory.getLogger(LoggerFactory.java:51)
2020-12-18T17:02:13.2876094Z [ERROR] 	at org.junit.platform.launcher.core.ServiceLoaderTestEngineRegistry.<clinit>(ServiceLoaderTestEngineRegistry.java:32)
2020-12-18T17:02:13.2878561Z [ERROR] 	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:95)
2020-12-18T17:02:13.2880491Z [ERROR] 	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:75)
2020-12-18T17:02:13.2883451Z [ERROR] 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.<init>(JUnitPlatformProvider.java:90)
2020-12-18T17:02:13.2886084Z [ERROR] 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2020-12-18T17:02:13.2890327Z [ERROR] 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2020-12-18T17:02:13.2902104Z [ERROR] 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2020-12-18T17:02:13.2903861Z [ERROR] 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
2020-12-18T17:02:13.2905534Z [ERROR] 	at org.apache.maven.surefire.api.util.ReflectionUtils.instantiateOneArg(ReflectionUtils.java:123)
2020-12-18T17:02:13.2910955Z [ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.createProviderInCurrentClassloader(ForkedBooter.java:491)
2020-12-18T17:02:13.2913342Z [ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
2020-12-18T17:02:13.2915084Z [ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
2020-12-18T17:02:13.2916619Z [ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
2020-12-18T17:02:13.2918006Z [ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
2020-12-18T17:02:13.7660307Z [INFO] Running io.quarkus.panacheql.LexerTest
2020-12-18T17:02:14.0880963Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.319 s - in io.quarkus.panacheql.LexerTest
2020-12-18T17:02:14.1016172Z [INFO] 
2020-12-18T17:02:14.1017037Z [INFO] Results:
2020-12-18T17:02:14.1017586Z [INFO] 
2020-12-18T17:02:14.1018223Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```