### PR TITLE
Fix quarkus-jackson build warning in hibernate-reactive-panache IT module

### DIFF
--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -33,16 +33,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
@@ -74,11 +64,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,19 +104,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Fixes:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-integration-test-hibernate-reactive-panache:jar:999-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.quarkus:quarkus-jackson:jar -> duplicate declaration of version (?) @ line 79, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
I guess this is a side effect of this commit: https://github.com/quarkusio/quarkus/commit/8645fa0e669b6d2eeb117503e938f0b0cbc5d3e2#diff-6ed62e3af0f07f41ecd42d6042c65810e3675eb6e49282966b951b188ea11eae (/cc @Postremus)

Seems `quarkus-jackson` is not required at all (anymore) in that module? Tests are passing locally without it.

/cc @FroMage @Sanne 