### PR TITLE
Detect superfluous minimal deployment dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,38 @@ We try to make it easy, and all contributions, even the smaller ones, are more t
 This includes bug reports, fixes, documentation, examples... 
 But first, read this page (including the small print at the end).
 
+* [Legal](#legal)
+* [Reporting an issue](#reporting-an-issue)
+* [Checking an issue is fixed in master](#checking-an-issue-is-fixed-in-master)
+  + [Using snapshots](#using-snapshots)
+  + [Building master](#building-master)
+  + [Updating the version](#updating-the-version)
+* [Before you contribute](#before-you-contribute)
+  + [Code reviews](#code-reviews)
+  + [Coding Guidelines](#coding-guidelines)
+  + [Continuous Integration](#continuous-integration)
+  + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
+* [Setup](#setup)
+  + [IDE Config and Code Style](#ide-config-and-code-style)
+    - [Eclipse Setup](#eclipse-setup)
+    - [IDEA Setup](#idea-setup)
+* [Build](#build)
+  + [Workflow tips](#workflow-tips)
+    - [Building all modules of an extension](#building-all-modules-of-an-extension)
+    - [Building a single module of an extension](#building-a-single-module-of-an-extension)
+    - [Running a single test](#running-a-single-test)
+* [Usage](#usage)
+    - [With Maven](#with-maven)
+    - [With Gradle](#with-gradle)
+  + [MicroProfile TCK's](#microprofile-tck-s)
+  + [Test Coverage](#test-coverage)
+* [Extensions](#extensions)
+  + [Descriptions](#descriptions)
+* [The small print](#the-small-print)
+* [Frequently Asked Questions](#frequently-asked-questions)
+
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
+
 ## Legal
 
 All original contributions to Quarkus are licensed under the
@@ -340,29 +372,43 @@ This project is an open source project, please act responsibly, be nice, polite 
 
 * The Maven build fails with `OutOfMemoryException`
 
-Set Maven options to use 1.5GB of heap: `export MAVEN_OPTS="-Xmx1563m"`.
+  Set Maven options to use 1.5GB of heap: `export MAVEN_OPTS="-Xmx1563m"`.
 
 * IntelliJ fails to import Quarkus Maven project with `java.lang.OutOfMemoryError: GC overhead limit exceeded` 
 
-In IntelliJ IDEA (version older than `2019.2`) if you see problems in the Maven view claiming `java.lang.OutOfMemoryError: GC overhead limit exceeded` that means the project import failed.
-  
-To fix the issue, you need to update the Maven importing settings:  
-`Build, Execution, Deployment` > `Build Tools`> `Maven` > `Importing` > `VM options for importer`
-To import Quarkus you need to define the JVM Max Heap Size (E.g. `-Xmx1g`)
+  In IntelliJ IDEA (version older than `2019.2`) if you see problems in the Maven view claiming `java.lang.OutOfMemoryError: GC overhead limit exceeded` that means the project import failed.
 
-**Note** As for now, we can't provide a unique Max Heap Size value. We have been reported to require from 768M to more than 3G to import Quarkus properly.
+  To fix the issue, you need to update the Maven importing settings:
+  `Build, Execution, Deployment` > `Build Tools`> `Maven` > `Importing` > `VM options for importer`
+  To import Quarkus you need to define the JVM Max Heap Size (E.g. `-Xmx1g`)
 
-* Build hangs with DevMojoIT running infinitely 
-```
-./mvnw clean install
-# Wait...
-[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.192 s - in io.quarkus.maven.it.GenerateConfigIT
-[INFO] Running io.quarkus.maven.it.DevMojoIT
+  **Note** As for now, we can't provide a unique Max Heap Size value. We have been reported to require from 768M to more than 3G to import Quarkus properly.
 
-```
-DevMojoIT require a few minutes to run but anything more than that is not expected. Make sure that nothing is running on 8080.
+* Build hangs with DevMojoIT running infinitely
+  ```
+  ./mvnw clean install
+  # Wait...
+  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.192 s - in io.quarkus.maven.it.GenerateConfigIT
+  [INFO] Running io.quarkus.maven.it.DevMojoIT
+  ```
+  DevMojoIT require a few minutes to run but anything more than that is not expected. Make sure that nothing is running on 8080.
 
 * The native integration test for my extension didn't run in the CI
 
-In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which are run in parallel. 
-This means that each new extension needs to be configured explicitly in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
+  In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which are run in parallel.
+  This means that each new extension needs to be configured explicitly in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
+
+* Build aborts complaining about missing (or superfluous) `minimal *-deployment dependencies` or `illegal runtime dependencies`
+
+  To ensure a consistent build order, even when building in parallel (`./mvnw -T...`) or building incrementally/partially (`./mvnw -pl...`), the build enforces the presence of certain dependencies.
+  If those dependencies are not present, your local build will most likely use possibly outdated artifacts from you local repo and CI build might even fail not finding certain artifacts.
+
+  Just do what the failing enforcer rule is telling you and you should be fine.
+
+* Build fails with multiple `This project has been banned from the build due to previous failures` messages
+
+  Just scroll up, there should be an error or warning somewhere. Failing enforcer rules are known to cause such effects and in this case there'll be something like:
+  ```
+  [WARNING] Rule 0: ... failed with message:
+  ...
+  ```

--- a/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/ext1/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/ext1/pom.xml
@@ -17,7 +17,7 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- "Symbolic" test dependencies to *-deployment artifacts for consistent build order -->
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-enforcer-rules-smoketest-ext1-deployment</artifactId>
@@ -32,5 +32,26 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>SuperfluousDeploymentDep</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-enforcer-rules-smoketest-ext2-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/independent-projects/enforcer-rules/src/it/smoketest/invoker.properties
+++ b/independent-projects/enforcer-rules/src/it/smoketest/invoker.properties
@@ -1,8 +1,15 @@
+invoker.name.1 = Test build ok without enforcer
 invoker.goals.1 = package -Denforcer.skip
 invoker.buildResult.1 = success
 
+invoker.name.2 = Test BansRuntimeDependency failure
 invoker.goals.2 = package -PBansRuntimeDependency
 invoker.buildResult.2 = failure
 
+invoker.name.3 = Test RequiresMinimalDeploymentDependency failure: missing dependency
 invoker.goals.3 = package
 invoker.buildResult.3 = failure
+
+invoker.name.4 = Test RequiresMinimalDeploymentDependency failure: superfluous dependency
+invoker.goals.4 = package -PSuperfluousDeploymentDep
+invoker.buildResult.4 = failure

--- a/independent-projects/enforcer-rules/src/it/smoketest/verify.groovy
+++ b/independent-projects/enforcer-rules/src/it/smoketest/verify.groovy
@@ -1,10 +1,19 @@
 File buildLog = new File( basedir, 'build.log' )
 
+// Test BansRuntimeDependency failure
 assert buildLog.text.contains( 'quarkus-enforcer-rules-smoketest-ext2-deployment ... SUCCESS' )
 assert buildLog.text.contains( 'quarkus-enforcer-rules-smoketest-ext3-deployment ... FAILURE' )
 assert buildLog.text.contains( 'BansRuntimeDependency failed with message' )
 
+// Test RequiresMinimalDeploymentDependency failure: missing dependency
 assert buildLog.text.contains( 'quarkus-enforcer-rules-smoketest-integration-tests-ext1 SUCCESS' )
 assert buildLog.text.contains( 'quarkus-enforcer-rules-smoketest-integration-tests-ext2 FAILURE' )
 assert buildLog.text.contains( 'RequiresMinimalDeploymentDependency failed with message' )
+assert buildLog.text.contains( '1 minimal *-deployment dependencies are missing' )
 assert buildLog.text.contains( '<artifactId>quarkus-enforcer-rules-smoketest-ext2-deployment</artifactId>' )
+
+// Test RequiresMinimalDeploymentDependency failure: superfluous dependency
+assert buildLog.text.contains( 'quarkus-enforcer-rules-smoketest-integration-tests-ext1 FAILURE' )
+assert buildLog.text.contains( 'RequiresMinimalDeploymentDependency failed with message' )
+assert buildLog.text.contains( '1 minimal *-deployment dependencies are superfluous' )
+assert buildLog.text.contains( '    io.quarkus:quarkus-enforcer-rules-smoketest-ext2-deployment:1.0-SNAPSHOT' )

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -256,19 +256,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-logging-json-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>


### PR DESCRIPTION
To aid with the "verbosity" of those minimal deployment depencies (pom type test deps with wildcard exclusions), enforcer rule `RequiresMinimalDeploymentDependency` now detects superfluous dependency entries, e.g.:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-deployment-deps) @ quarkus-integration-test-main ---
[WARNING] Rule 0: io.quarkus.enforcer.RequiresMinimalDeploymentDependency failed with message:
1 minimal *-deployment dependencies are superfluous and must be removed from pom.xml:
    io.quarkus:quarkus-logging-json-deployment:999-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```
Of course, this only works where the rule runs, that is currently `integration-tests/*` and `tcks/*`.
Those few other places where minimal deployment dependencies were added have to be managed manually.

Some notes about the changes to `CONTRIBUTING.md`:
- I thought it might be helpful to explain why those dependencies and enforcer rules are required, e.g.: https://github.com/quarkusio/quarkus/pull/13899#issuecomment-746461258 (/cc @FroMage)
- The file is rather large, so I added a generated TOC (http://ecotrust-canada.github.io/markdown-toc/)
- I found the FAQ a bit hard to read because the text blocks were not aligned to the bullet points
- Not sure we want to mention parallel builds (`-T...`) before #13218 is merged 🤔 