### PR TITLE
Allow to define system properties with @NativeImageTest

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeImageTest.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeImageTest.java
@@ -29,4 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith({ DisabledOnNativeImageCondition.class, QuarkusTestExtension.class, NativeTestExtension.class })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NativeImageTest {
+    /**
+     * Allow to define system properties that will be passed to the native image that will be started by the tests.
+     * Properties defined in this field will have precedence over the ones defined in profiles shipped with the image.
+     */
+    String[] systemProperties() default {};
 }


### PR DESCRIPTION
Currently it is only possible to pass system properties to the native image that is started using TestResources as test profiles are not allowed in native testing.

However TestResources are always started, no matter they are used with `@QuarkusTestResource` or not. By having multiple test classes annotated with `@NativeImageTest`, using test resources may lead to bad configuration depending on the order the resources are started.

There is currently no other way of passing system properties without rebuilding the native image until now. The idea of this PR is to be able to define system properties to use directly using the `@NativeImageTest` as an instance of the image is started by test class. This makes sense as it is possible to start a native image in production by passing system properties or environment variables. IMHO this respects the Quarkus philosophy as well as provides a way of testing configuration combinations for native images.