### PR TITLE
Remove microprofile-context-propagation-api runtime cache dependency

### DIFF
--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -23,10 +23,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-caffeine</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.context-propagation</groupId>
-            <artifactId>microprofile-context-propagation-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Context propagation was removed from the cache extension a while ago so this shouldn't be there.