### PR TITLE
Added org.bouncycastle:bcpkix-jdk15on to bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2273,6 +2273,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bctls-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>            
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
We have seen an issue, created by the bom not also including org.bouncycastle:bcpkix-jdk15on. This is resulting in a version conflict.