### PR TITLE
Refactor CacheResultInterceptor exceptions handling and tests

### DIFF
--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -21,7 +21,7 @@ public class CacheResultInterceptor extends CacheInterceptor {
     private static final Logger LOGGER = Logger.getLogger(CacheResultInterceptor.class);
 
     @AroundInvoke
-    public Object intercept(InvocationContext context) throws Exception {
+    public Object intercept(InvocationContext context) throws Throwable {
         CacheResultInterceptorBinding binding = getInterceptorBinding(context, CacheResultInterceptorBinding.class);
 
         AbstractCache cache = (AbstractCache) cacheManager.getCache(binding.cacheName()).get();
@@ -65,24 +65,20 @@ public class CacheResultInterceptor extends CacheInterceptor {
              * thrown during a CompletionStage execution.
              */
             if (e.getCause() instanceof CacheException) {
-                // The ExecutionException was caused by a CacheException (most likely case).
-                CacheException cacheException = (CacheException) e.getCause();
-                // Let's see if we can throw the root cause of the exceptions chain.
-                if (cacheException.getCause() instanceof Exception) {
-                    // If it is an Exception, the root cause is thrown.
-                    throw (Exception) cacheException.getCause();
-                } else {
-                    // If it is an Error, the CacheException itself is thrown because interceptors have to throw exceptions.
-                    throw cacheException;
-                }
-            } else if (e.getCause() instanceof Exception) {
-                // The ExecutionException was caused by another type of Exception (very unlikely case). Let's throw that cause!
-                throw (Exception) e.getCause();
-            } else {
                 /*
-                 * The ExecutionException was caused by an Error which can't be thrown because interceptors have to throw
-                 * exceptions. The ExecutionException itself is thrown instead.
+                 * The ExecutionException was caused by a CacheException (most likely case).
+                 * Let's throw the CacheException cause if possible or the CacheException itself otherwise.
                  */
+                if (e.getCause().getCause() != null) {
+                    throw e.getCause().getCause();
+                } else {
+                    throw e.getCause();
+                }
+            } else if (e.getCause() != null) {
+                // The ExecutionException was caused by another type of Throwable (unlikely case).
+                throw e.getCause();
+            } else {
+                // The ExecutionException does not have a cause (very unlikely case).
                 throw e;
             }
         }


### PR DESCRIPTION
The code from `CacheResultInterceptor` was simplified with https://github.com/quarkusio/quarkus/commit/72ea4e8a441dff1db6ca300b3cab3f1f7996c1b0 but the corresponding tests were left behind at that time and are unnecessarily complicated today. I removed the deprecated part of the tests, added a new test for Errors and also simplified a bit the `CacheResultInterceptor` code related to exceptions handling.