### PR TITLE
Use X-FORWARDED-PREFIX in the final OIDC redirect uri and fix the restore path calculation when queries are used

### DIFF
--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -2,15 +2,22 @@ package io.quarkus.it.keycloak;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 import io.quarkus.security.Authenticated;
 
 @Path("/tenant-https")
+@Authenticated
 public class TenantHttps {
 
-    @Authenticated
     @GET
     public String getTenant() {
         return "tenant-https";
+    }
+
+    @GET
+    @Path("query")
+    public String getTenantWithQuery(@QueryParam("a") String value) {
+        return "tenant-https?a=" + value;
     }
 }


### PR DESCRIPTION
Fixes #13973
Fixes #13062

This PR makes sure all the code where the redirect URIs are built uses the same base `buildUri` function thus taking care of the X-Forwarded-Prefix header and fixes an issue related to the path segment being lost in a very specific case where the redirect uri is the same as current request URI and a query component is present. Tests have been added too