### PR TITLE
Improve error message for missing wrong/named parameters

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/CustomQueryMissingNamedParamTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/CustomQueryMissingNamedParamTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.spring.data.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomQueryMissingNamedParamTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("import_books.sql", "import.sql")
+                    .addClasses(Book.class, BookRepositoryNamedParameterWrongName.class))
+            .withConfigurationResource("application.properties")
+            .assertException(e -> assertThat(e).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("BookRepositoryNamedParameterWrongName is missing the named parameters [name], "
+                            + "provided are [wrong]"));
+
+    @Test
+    public void testNamedParameters() {
+        // an exception should be thrown
+    }
+
+    public interface BookRepositoryNamedParameterWrongName extends Repository<Book, Integer> {
+        // wrong @Param annotation
+        @Query(value = "FROM Book b WHERE b.name = :name")
+        List<Book> queryBookByNameWrongAnnotation(@Param("wrong") String name);
+    }
+}


### PR DESCRIPTION
* If a named parameter is not specified you currently get a runtime error message: "Could not locate ordinal parameter [1], expecting one of []". With this PR you will get a compile time error message instead: "`myMethod` of Repository `MyRepo` is missing the named parameters [myParam], provided are [otherParam]. Ensure that the parameters are correctly annotated with `@Param`".
* The error messages of MethodNameParser did not include the Repository name which can make it hard to identify the source if you have many Repositories declaring the same method.