### PR TITLE
Test cache synchronous value loader execution

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ConcurrencyTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ConcurrencyTest.java
@@ -1,11 +1,13 @@
 package io.quarkus.cache.test.runtime;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -18,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.cache.CacheResult;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class LockTimeoutTest {
+public class ConcurrencyTest {
 
     private static final Object TIMEOUT_KEY = new Object();
     private static final Object NO_TIMEOUT_KEY = new Object();
@@ -35,7 +37,9 @@ public class LockTimeoutTest {
         // This is required to make sure the CompletableFuture from this test are executed concurrently.
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
+        AtomicReference<String> callingThreadName1 = new AtomicReference<>();
         CompletableFuture<Object> future1 = CompletableFuture.supplyAsync(() -> {
+            callingThreadName1.set(Thread.currentThread().getName());
             try {
                 return cachedService.cachedMethodWithLockTimeout(TIMEOUT_KEY);
             } catch (InterruptedException e) {
@@ -43,7 +47,9 @@ public class LockTimeoutTest {
             }
         }, executorService);
 
+        AtomicReference<String> callingThreadName2 = new AtomicReference<>();
         CompletableFuture<Object> future2 = CompletableFuture.supplyAsync(() -> {
+            callingThreadName2.set(Thread.currentThread().getName());
             try {
                 return cachedService.cachedMethodWithLockTimeout(TIMEOUT_KEY);
             } catch (InterruptedException e) {
@@ -51,11 +57,19 @@ public class LockTimeoutTest {
             }
         }, executorService);
 
+        // Let's wait for both futures to complete before running assertions.
         CompletableFuture.allOf(future1, future2).get();
 
-        // The following assertion checks that the objects references resulting from both futures executions are different,
-        // which means the method was invoked twice because the lock timeout was triggered.
-        assertTrue(future1.get() != future2.get());
+        /*
+         * A cache lock timeout should be triggered during the second cached method call, which means that both calls should
+         * result in an execution of the value loader function. Since the calls are done from different threads, the resulting
+         * values (threads names) should be different.
+         */
+        assertNotEquals(future1.get(), future2.get());
+
+        // All value loader executions should be done synchronously on the calling thread.
+        assertEquals(callingThreadName1.get(), future1.get());
+        assertEquals(callingThreadName2.get(), future2.get());
     }
 
     @Test
@@ -63,7 +77,9 @@ public class LockTimeoutTest {
         // This is required to make sure the CompletableFuture from this test are executed concurrently.
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
-        CompletableFuture<Object> future1 = CompletableFuture.supplyAsync(() -> {
+        AtomicReference<String> callingThreadName1 = new AtomicReference<>();
+        CompletableFuture<String> future1 = CompletableFuture.supplyAsync(() -> {
+            callingThreadName1.set(Thread.currentThread().getName());
             try {
                 return cachedService.cachedMethodWithoutLockTimeout(NO_TIMEOUT_KEY);
             } catch (InterruptedException e) {
@@ -71,7 +87,7 @@ public class LockTimeoutTest {
             }
         }, executorService);
 
-        CompletableFuture<Object> future2 = CompletableFuture.supplyAsync(() -> {
+        CompletableFuture<String> future2 = CompletableFuture.supplyAsync(() -> {
             try {
                 return cachedService.cachedMethodWithoutLockTimeout(NO_TIMEOUT_KEY);
             } catch (InterruptedException e) {
@@ -79,11 +95,17 @@ public class LockTimeoutTest {
             }
         }, executorService);
 
+        // Let's wait for both futures to complete before running assertions.
         CompletableFuture.allOf(future1, future2).get();
 
-        // The following assertion checks that the objects references resulting from both futures executions are the same,
-        // which means the method was invoked once and the lock timeout was NOT triggered.
-        assertTrue(future1.get() == future2.get());
+        /*
+         * This test should NOT trigger any cache lock timeout so there should only be one value loader execution and the
+         * resulting values from both cached methods calls should be the same.
+         */
+        assertEquals(future1.get(), future2.get());
+
+        // The value loader execution from `future1` should be done synchronously on the calling thread.
+        assertEquals(callingThreadName1.get(), future1.get());
     }
 
     @Singleton
@@ -92,19 +114,19 @@ public class LockTimeoutTest {
         private static final String CACHE_NAME = "test-cache";
 
         @CacheResult(cacheName = CACHE_NAME, lockTimeout = 500)
-        public Object cachedMethodWithLockTimeout(Object key) throws InterruptedException {
+        public String cachedMethodWithLockTimeout(Object key) throws InterruptedException {
             // The following sleep is longer than the @CacheResult lockTimeout parameter value, a timeout will be triggered if
             // two concurrent calls are made at the same time.
             Thread.sleep(1000);
-            return new Object();
+            return Thread.currentThread().getName();
         }
 
         @CacheResult(cacheName = CACHE_NAME, lockTimeout = 1000)
-        public Object cachedMethodWithoutLockTimeout(Object key) throws InterruptedException {
+        public String cachedMethodWithoutLockTimeout(Object key) throws InterruptedException {
             // The following sleep is shorter than the @CacheResult lockTimeout parameter value, two concurrent calls made at
             // the same time won't trigger a timeout.
             Thread.sleep(500);
-            return new Object();
+            return Thread.currentThread().getName();
         }
     }
 }


### PR DESCRIPTION
The cache [value loader function](https://github.com/quarkusio/quarkus/blob/master/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java#L65) is expected to be executed synchronously on the calling thread.

This was not checked in any test, this PR fixes that.