### PR TITLE
Add support for injection of HttpSession

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/Counter.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/Counter.java
@@ -1,0 +1,21 @@
+package io.quarkus.undertow.test.builtinbeans;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
+
+@SessionScoped
+class Counter {
+
+    AtomicInteger counter;
+
+    @PostConstruct
+    void init() {
+        counter = new AtomicInteger();
+    }
+
+    int incrementAndGet() {
+        return counter.incrementAndGet();
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/ServletBuiltinBeanInjectingBean.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/ServletBuiltinBeanInjectingBean.java
@@ -1,0 +1,40 @@
+package io.quarkus.undertow.test.builtinbeans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+@Dependent
+class ServletBuiltinBeanInjectingBean {
+
+    @Inject
+    HttpServletRequest request;
+
+    @Inject
+    HttpSession session;
+
+    @Inject
+    ServletContext context;
+
+    public void verifyRequest() {
+        assertEquals(true, request.getRequestURI().contains("/request"));
+        assertEquals(request.getParameter("foo"), "bar");
+    }
+
+    public void verifySession(boolean isNew) {
+        assertEquals(isNew, session.isNew());
+        assertEquals(session.getAttribute("foo"), "bar");
+        session.setMaxInactiveInterval(60);
+    }
+
+    public void verifyServletContext() {
+        assertEquals(context.getAttribute("foo"), "bar");
+        assertNotNull(context.getServletRegistration("testServlet"));
+        assertEquals(context.getServletRegistration("testServlet").getClassName(), TestServlet.class.getName());
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/ServletBuiltinBeanTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/ServletBuiltinBeanTestCase.java
@@ -1,0 +1,75 @@
+package io.quarkus.undertow.test.builtinbeans;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.Response;
+
+public class ServletBuiltinBeanTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestServlet.class,
+                    ServletBuiltinBeanInjectingBean.class, Counter.class));
+
+    @Test
+    public void testHttpServletRequest() {
+        String uri = "/foo/request";
+        given().param("foo", "bar")
+                .when().get(uri)
+                .then()
+                .statusCode(200)
+                .body(is("foo=bar"));
+    }
+
+    @Test
+    public void testHttpSession() {
+        String uri = "/foo/session";
+
+        Response response = when().get(uri);
+        response.then()
+                .statusCode(200)
+                .body(is("foo=bar"))
+                .header("counter", "1");
+        String sessionId = response.sessionId();
+
+        // another request reusing sessionId
+        given().sessionId(sessionId)
+                .when().get(uri)
+                .then()
+                .statusCode(200)
+                .body(is("foo=bar"))
+                .header("counter", "2");
+
+        // Destroy session
+        given().sessionId(sessionId).param("destroy", "true")
+                .when().get(uri)
+                .then()
+                .statusCode(200);
+
+        // New session
+        response = when().get(uri);
+        response.then()
+                .statusCode(200)
+                .body(is("foo=bar"))
+                .header("counter", "1");
+        assertNotEquals(sessionId, response.sessionId());
+    }
+
+    @Test
+    public void testServletContext() {
+        String uri = "/foo/context";
+        when().get(uri)
+                .then()
+                .statusCode(200)
+                .body(is("foo=bar"));
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/TestServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/builtinbeans/TestServlet.java
@@ -1,0 +1,48 @@
+package io.quarkus.undertow.test.builtinbeans;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/foo/*", name = "testServlet")
+public class TestServlet extends HttpServlet {
+
+    @Inject
+    ServletBuiltinBeanInjectingBean bean;
+
+    @Inject
+    Counter counter;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (req.getRequestURI().contains("/request")) {
+            bean.verifyRequest();
+            resp.getWriter().write("foo=bar");
+        }
+        if (req.getRequestURI().endsWith("/session")) {
+            if (req.getParameter("destroy") != null) {
+                req.getSession().invalidate();
+            } else {
+                HttpSession session = req.getSession();
+                if (session.isNew()) {
+                    session.setAttribute("foo", "bar");
+                }
+                bean.verifySession(session.isNew());
+                resp.setIntHeader("counter", counter.incrementAndGet());
+                resp.getWriter().write("foo=bar");
+            }
+        }
+        if (req.getRequestURI().endsWith("/context")) {
+            req.getSession().getServletContext().setAttribute("foo", "bar");
+            bean.verifyServletContext();
+            resp.getWriter().write("foo=bar");
+        }
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletProducer.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletProducer.java
@@ -5,6 +5,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import io.undertow.servlet.handlers.ServletRequestContext;
 
@@ -21,5 +22,11 @@ public class ServletProducer {
     @RequestScoped
     HttpServletResponse response() {
         return (HttpServletResponse) ServletRequestContext.requireCurrent().getServletResponse();
+    }
+
+    @Produces
+    @RequestScoped
+    HttpSession session() {
+        return request().getSession();
     }
 }


### PR DESCRIPTION
CDI 2.0 specification[1] defines HttpSession as one of supported additional built-in beans, but an injection of HttpSession does not work in Quarkus. Quarkus throws UnsatisfiedResolutionException[2] during the build phase of an application that uses `@Inject HttpSession`. An injection of HttpServletRequest, HttpServletResponse, or ServletContext works fine, so it appears that only support for injection of HttpSession is currently missing.

[1] https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#additional_builtin_beans
```
A servlet container must provide the following built-in beans, all of which have qualifier @Default:
 - a bean with bean type javax.servlet.http.HttpServletRequest, allowing injection of a reference to the HttpServletRequest
 - a bean with bean type javax.servlet.http.HttpSession, allowing injection of a reference to the HttpSession,
 - a bean with bean type javax.servlet.ServletContext, allowing injection of a reference to the ServletContext,
```

[2] UnsatisfiedResolutionException happens when building an application that has `@Inject HttpSession`
```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:1.10.5.Final:build (default) on project getting-started: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR] 	[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate threw an exception: javax.enterprise.inject.spi.DeploymentException: javax.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type javax.servlet.http.HttpSession and qualifiers [@Default]
[ERROR] 	- java member: org.acme.quickstart.GreetingResource#session
[ERROR] 	- declared on CLASS bean [types=[org.acme.quickstart.GreetingResource, java.lang.Object], qualifiers=[@Default, @Any], target=org.acme.quickstart.GreetingResource]
[ERROR] 	at io.quarkus.arc.processor.BeanDeployment.processErrors(BeanDeployment.java:1021)
[ERROR] 	at io.quarkus.arc.processor.BeanDeployment.init(BeanDeployment.java:241)
[ERROR] 	at io.quarkus.arc.processor.BeanProcessor.initialize(BeanProcessor.java:127)
[ERROR] 	at io.quarkus.arc.deployment.ArcProcessor.validate(ArcProcessor.java:411)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[ERROR] 	at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:972)
[ERROR] 	at io.quarkus.builder.BuildContext.run(BuildContext.java:277)
[ERROR] 	at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2046)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1578)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)
[ERROR] 	at java.base/java.lang.Thread.run(Thread.java:834)
[ERROR] 	at org.jboss.threads.JBossThread.run(JBossThread.java:479)
[ERROR] Caused by: javax.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type javax.servlet.http.HttpSession and qualifiers [@Default]
[ERROR] 	- java member: org.acme.quickstart.GreetingResource#session
[ERROR] 	- declared on CLASS bean [types=[org.acme.quickstart.GreetingResource, java.lang.Object], qualifiers=[@Default, @Any], target=org.acme.quickstart.GreetingResource]
[ERROR] 	at io.quarkus.arc.processor.Beans.resolveInjectionPoint(Beans.java:504)
[ERROR] 	at io.quarkus.arc.processor.BeanInfo.init(BeanInfo.java:363)
[ERROR] 	at io.quarkus.arc.processor.BeanDeployment.init(BeanDeployment.java:233)
[ERROR] 	... 14 more
```
