### PR TITLE
Fix RESTEasy Reactive / OpenTracing memory leak

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -28,7 +28,7 @@ public enum Capability {
     RESTEASY,
     RESTEASY_JSON,
     RESTEASY_MUTINY,
-    QUARKUS_REST,
+    RESTEASY_REACTIVE,
     JWT,
     TIKA,
     MONGODB_PANACHE,

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -152,7 +152,7 @@ class HibernateValidatorProcessor {
                     .supplier(hibernateValidatorRecorder.resteasyConfigSupportSupplier(
                             resteasyConfigBuildItem.isPresent() ? resteasyConfigBuildItem.get().isJsonDefault() : false))
                     .done());
-        } else if (capabilities.isPresent(Capability.QUARKUS_REST)) {
+        } else if (capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
             // The CDI interceptor which will validate the methods annotated with @JaxrsEndPointValidated
             additionalBeans.produce(new AdditionalBeanBuildItem(
                     "io.quarkus.hibernate.validator.runtime.jaxrs.QuarkusRestEndPointValidationInterceptor"));

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
@@ -56,7 +56,7 @@ public class VertxBinderProcessor {
         if (capabilities.isPresent(Capability.RESTEASY)) {
             resteasyJaxrsProviders.produce(new ResteasyJaxrsProviderBuildItem(RESTEASY_CONTAINER_FILTER_CLASS_NAME));
             turnVertxBinderFilterIntoBean(additionalBeans, RESTEASY_CONTAINER_FILTER_CLASS_NAME);
-        } else if (capabilities.isPresent(Capability.QUARKUS_REST)) {
+        } else if (capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
             customContainerRequestFilter
                     .produce(new CustomContainerRequestFilterBuildItem(QUARKUS_REST_CONTAINER_FILTER_CLASS_NAME));
             turnVertxBinderFilterIntoBean(additionalBeans, QUARKUS_REST_CONTAINER_FILTER_CLASS_NAME);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -128,7 +128,7 @@ public class ResteasyReactiveProcessor {
 
     @BuildStep
     CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(Capability.QUARKUS_REST);
+        return new CapabilityBuildItem(Capability.RESTEASY_REACTIVE);
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BlockingWithFilterTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BlockingWithFilterTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+
+public class BlockingWithFilterTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestFilter.class, TestResource.class);
+                }
+            });
+
+    @Test
+    public void requestFilterTest() {
+        String response = RestAssured.get("/test/request")
+                .then().statusCode(200).contentType("text/plain").extract().body().asString();
+        String[] parts = response.split("/");
+        assertEquals(2, parts.length);
+        assertEquals(parts[0], parts[1]);
+        assertFalse(parts[0].contains("eventloop"));
+        assertTrue(parts[0].contains("executor"));
+    }
+
+    public static class TestFilter {
+
+        @ServerRequestFilter
+        public void filter(ContainerRequestContext requestContext) {
+            requestContext.getHeaders().add("filter-thread", Thread.currentThread().getName());
+        }
+
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @Blocking
+        @Path("/request")
+        @GET
+        public String get(@Context HttpHeaders headers) {
+            return headers.getHeaderString("filter-thread") + "/" + Thread.currentThread().getName();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/BlockingInputHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/BlockingInputHandler.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import javax.ws.rs.HttpMethod;
+
+import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestContext;
+
+import io.quarkus.vertx.http.runtime.VertxInputStream;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handler that reads data and sets up the input stream and blocks until the data has been read.
+ * This is meant to be used only when the request processing has already been offloaded to a worker thread.
+ */
+public class BlockingInputHandler implements ServerRestHandler {
+
+    private final long timeout;
+
+    public BlockingInputHandler(long timeout) {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext context) throws Exception {
+        // in some cases, with sub-resource locators or via request filters, 
+        // it's possible we've already read the entity
+        if (context.getInputStream() != EmptyInputStream.INSTANCE) {
+            // let's not set it twice
+            return;
+        }
+        if (context.serverRequest().getRequestMethod().equals(HttpMethod.GET) ||
+                context.serverRequest().getRequestMethod().equals(HttpMethod.HEAD)) {
+            return;
+        }
+
+        VertxResteasyReactiveRequestContext vertxContext = (VertxResteasyReactiveRequestContext) context;
+        RoutingContext routingContext = vertxContext.getContext();
+        vertxContext.setInputStream(new VertxInputStream(routingContext, timeout));
+    }
+
+}

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
@@ -65,7 +65,7 @@ public class JaxRsMetricsProcessor {
             } else if (capabilities.isPresent(Capability.RESTEASY)) {
                 jaxRsProviders.produce(
                         new ResteasyJaxrsProviderBuildItem(SMALLRYE_QUARKUS_RESTEASY_FILTER_CLASS_NAME));
-            } else if (capabilities.isPresent(Capability.QUARKUS_REST)) {
+            } else if (capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
                 customContainerResponseFilters
                         .produce(new CustomContainerResponseFilterBuildItem(SMALLRYE_QUARKUS_REST_FILTER_CLASS_NAME));
             }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -375,7 +375,7 @@ public class SmallRyeOpenApiProcessor {
 
         // Only scan if either RESTEasy, Quarkus REST, Spring Web or Vert.x Web (with @Route) is used
         boolean isRestEasy = capabilities.isPresent(Capability.RESTEASY);
-        boolean isQuarkusRest = capabilities.isPresent(Capability.QUARKUS_REST);
+        boolean isQuarkusRest = capabilities.isPresent(Capability.RESTEASY_REACTIVE);
         boolean isSpring = capabilities.isPresent(Capability.SPRING_WEB);
         boolean isVertx = isUsingVertxRoute(index);
         return isRestEasy || isQuarkusRest || isSpring || isVertx;
@@ -429,7 +429,7 @@ public class SmallRyeOpenApiProcessor {
 
     private String[] getScanners(Capabilities capabilities, IndexView index) {
         List<String> scanners = new ArrayList<>();
-        if (capabilities.isPresent(Capability.RESTEASY) || capabilities.isPresent(Capability.QUARKUS_REST)) {
+        if (capabilities.isPresent(Capability.RESTEASY) || capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
             scanners.add(JAX_RS);
         }
         if (capabilities.isPresent(Capability.SPRING_WEB)) {

--- a/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
+++ b/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
@@ -63,7 +63,7 @@ public class SmallRyeOpenTracingProcessor {
         } else if (capabilities.isPresent(Capability.RESTEASY)) {
             providers.produce(
                     new ResteasyJaxrsProviderBuildItem(QuarkusSmallRyeTracingStandaloneVertxDynamicFeature.class.getName()));
-        } else if (capabilities.isPresent(Capability.QUARKUS_REST)) {
+        } else if (capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
             customResponseFilters.produce(new CustomContainerResponseFilterBuildItem(
                     QuarkusSmallRyeTracingStandaloneContainerResponseFilter.class.getName()));
             dynamicFeatures.produce(new DynamicFeatureBuildItem(QuarkusSmallRyeTracingDynamicFeature.class.getName()));

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
@@ -16,7 +16,6 @@ import io.opentracing.Tracer;
 import io.opentracing.contrib.jaxrs2.server.OperationNameProvider;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 
-//TODO: For Quarkus REST we could really use something better than this...
 @Provider
 public class QuarkusSmallRyeTracingDynamicFeature implements DynamicFeature {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -49,6 +49,7 @@ public class RuntimeDeploymentManager {
     public static final ServerRestHandler[] EMPTY_REST_HANDLER_ARRAY = new ServerRestHandler[0];
     private final DeploymentInfo info;
     private final Supplier<Executor> executorSupplier;
+    private final Supplier<ServerRestHandler> blockingInputHandlerSupplier;
     private final Consumer<Closeable> closeTaskHandler;
     private final RequestContextFactory requestContextFactory;
     private final ThreadSetupAction threadSetupAction;
@@ -56,10 +57,12 @@ public class RuntimeDeploymentManager {
 
     public RuntimeDeploymentManager(DeploymentInfo info,
             Supplier<Executor> executorSupplier,
+            Supplier<ServerRestHandler> blockingInputHandlerSupplier,
             Consumer<Closeable> closeTaskHandler,
             RequestContextFactory requestContextFactory, ThreadSetupAction threadSetupAction, String rootPath) {
         this.info = info;
         this.executorSupplier = executorSupplier;
+        this.blockingInputHandlerSupplier = blockingInputHandlerSupplier;
         this.closeTaskHandler = closeTaskHandler;
         this.requestContextFactory = requestContextFactory;
         this.threadSetupAction = threadSetupAction;
@@ -91,6 +94,7 @@ public class RuntimeDeploymentManager {
                     }
                 });
         RuntimeResourceDeployment runtimeResourceDeployment = new RuntimeResourceDeployment(info, executorSupplier,
+                blockingInputHandlerSupplier,
                 interceptorDeployment, dynamicEntityWriter, resourceLocatorHandler);
         List<ResourceClass> possibleSubResource = new ArrayList<>(locatableResourceClasses);
         possibleSubResource.addAll(resourceClasses); //the TCK uses normal resources also as sub resources

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InputHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InputHandler.java
@@ -19,7 +19,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
  * to allow the request to stay on the IO thread. If the request is too large
  * it will be delegated to an executor and a blocking stream used instead.
  * <p>
- * TODO: the stream implementation here could be a lot more efficent.
+ * TODO: the stream implementation here could be a lot more efficient.
  */
 public class InputHandler implements ServerRestHandler {
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -283,7 +283,7 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
                         }
                     }
                 });
-        RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, () -> executor,
+        RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, () -> executor, null,
                 closeable -> closeTasks.add(closeable), new VertxRequestContextFactory(), ThreadSetupAction.NOOP, "/");
         Deployment deployment = runtimeDeploymentManager.deploy();
         RestInitialHandler initialHandler = new RestInitialHandler(deployment);


### PR DESCRIPTION
Fixes: #14058

The fix is made by ensuring that the offloading to the worker thread is done (if necessary) before the container request filters are executed.
This also means that the request needs to be read in a blocking manner for such blocking methods.