### PR TITLE
Upgrade to Hibernate Reactive 1.0.0.Beta2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.27.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.Beta1</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.Beta2</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Final</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -97,12 +97,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -98,12 +98,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -98,12 +98,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemProperties>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
@@ -123,7 +123,7 @@ public class HibernateReactiveTestEndpoint {
                 pgPool.query("DELETE FROM Pig").execute(),
                 pgPool.query("DELETE FROM Cow").execute())
                 .asTuple()
-                .then(() -> pgPool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
+                .chain(() -> pgPool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
     }
 
     private Uni<String> selectNameFromId(Integer id) {

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
@@ -76,7 +76,7 @@ public class HibernateReactiveTestEndpoint {
                         throw new AssertionError("Database was not populated properly");
                 })
                 .chain(() -> mutinySession.merge(new GuineaPig(5, "Aloi")))
-                .invoke(aloi -> mutinySession.remove(aloi))
+                .chain(aloi -> mutinySession.remove(aloi))
                 .chain(() -> mutinySession.flush())
                 .chain(() -> selectNameFromId(5))
                 .map(result -> {
@@ -91,6 +91,11 @@ public class HibernateReactiveTestEndpoint {
     @Path("/reactiveRemoveManagedEntity")
     public Uni<String> reactiveRemoveManagedEntity() {
         return populateDB()
+                .chain(() -> selectNameFromId(5))
+                .invoke(name -> {
+                    if (name == null)
+                        throw new AssertionError("Database was not populated properly");
+                })
                 .chain(() -> mutinySession.find(GuineaPig.class, 5))
                 .chain(aloi -> mutinySession.remove(aloi))
                 .chain(() -> mutinySession.flush())


### PR DESCRIPTION

This fixes several issues related to using the Hibernate Reactive API from a blocking thread.

It does _not_ address the problem for Panache Reactive yet, we will need to follow up to improve on that.

Also (partially) related to #14087 : it doesn't address the problem with direct pool access, but it allows Hibernate to use the pool correctly.