### PR TITLE
Make CacheInterceptionContext immutable

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptionContextTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptionContextTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.runtime.CacheInterceptionContext;
+
+public class CacheInterceptionContextTest {
+
+    @Test
+    public void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new CacheInterceptionContext<>(null, new ArrayList<>());
+        }, "A NullPointerException should be thrown when the interceptor bindings list is null");
+        assertThrows(NullPointerException.class, () -> {
+            new CacheInterceptionContext<>(new ArrayList<>(), null);
+        }, "A NullPointerException should be thrown when the cache key parameter positions list is null");
+        // Empty lists should be allowed.
+        new CacheInterceptionContext<>(new ArrayList<>(), new ArrayList<>());
+    }
+
+    @Test
+    public void testImmutability() {
+        CacheInterceptionContext<CacheResult> context = new CacheInterceptionContext<>(new ArrayList<>(), new ArrayList<>());
+        // Lists should be unmodifiable.
+        assertThrows(UnsupportedOperationException.class, () -> {
+            context.getInterceptorBindings().add(new CacheResult() {
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return CacheResult.class;
+                }
+
+                @Override
+                public String cacheName() {
+                    return "cacheName";
+                }
+
+                @Override
+                public long lockTimeout() {
+                    return 0;
+                }
+            });
+        });
+        assertThrows(UnsupportedOperationException.class, () -> {
+            context.getCacheKeyParameterPositions().add((short) 123);
+        });
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptorTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptorTest.java
@@ -2,6 +2,10 @@ package io.quarkus.cache.test.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.cache.runtime.AbstractCache;
@@ -23,14 +27,14 @@ public class CacheInterceptorTest {
         CaffeineCache cache = new CaffeineCache(cacheInfo);
 
         DefaultCacheKey expectedKey = new DefaultCacheKey(cacheInfo.name);
-        Object actualKey = getCacheKey(cache, new short[] {}, new Object[] {});
+        Object actualKey = getCacheKey(cache, Collections.emptyList(), new Object[] {});
         assertEquals(expectedKey, actualKey);
     }
 
     @Test
     public void testExplicitSimpleKey() {
         Object expectedKey = new Object();
-        Object actualKey = getCacheKey(new short[] { 1 }, new Object[] { new Object(), expectedKey });
+        Object actualKey = getCacheKey(Arrays.asList((short) 1), new Object[] { new Object(), expectedKey });
         // A cache key with one element should be the element itself (same object reference).
         assertEquals(expectedKey, actualKey);
     }
@@ -40,14 +44,15 @@ public class CacheInterceptorTest {
         Object keyElement1 = new Object();
         Object keyElement2 = new Object();
         Object expectedKey = new CompositeCacheKey(keyElement1, keyElement2);
-        Object actualKey = getCacheKey(new short[] { 0, 2 }, new Object[] { keyElement1, new Object(), keyElement2 });
+        Object actualKey = getCacheKey(Arrays.asList((short) 0, (short) 2),
+                new Object[] { keyElement1, new Object(), keyElement2 });
         assertEquals(expectedKey, actualKey);
     }
 
     @Test
     public void testImplicitSimpleKey() {
         Object expectedKey = new Object();
-        Object actualKey = getCacheKey(new short[] {}, new Object[] { expectedKey });
+        Object actualKey = getCacheKey(Collections.emptyList(), new Object[] { expectedKey });
         // A cache key with one element should be the element itself (same object reference).
         assertEquals(expectedKey, actualKey);
     }
@@ -57,22 +62,22 @@ public class CacheInterceptorTest {
         Object keyElement1 = new Object();
         Object keyElement2 = new Object();
         Object expectedKey = new CompositeCacheKey(keyElement1, keyElement2);
-        Object actualKey = getCacheKey(new short[] {}, new Object[] { keyElement1, keyElement2 });
+        Object actualKey = getCacheKey(Collections.emptyList(), new Object[] { keyElement1, keyElement2 });
         assertEquals(expectedKey, actualKey);
     }
 
-    private Object getCacheKey(AbstractCache cache, short[] cacheKeyParameterPositions, Object[] methodParameterValues) {
+    private Object getCacheKey(AbstractCache cache, List<Short> cacheKeyParameterPositions, Object[] methodParameterValues) {
         return TEST_CACHE_INTERCEPTOR.getCacheKey(cache, cacheKeyParameterPositions, methodParameterValues);
     }
 
-    private Object getCacheKey(short[] cacheKeyParameterPositions, Object[] methodParameterValues) {
+    private Object getCacheKey(List<Short> cacheKeyParameterPositions, Object[] methodParameterValues) {
         return TEST_CACHE_INTERCEPTOR.getCacheKey(null, cacheKeyParameterPositions, methodParameterValues);
     }
 
     // This inner class changes the CacheInterceptor#getCacheKey method visibility to public.
     private static class TestCacheInterceptor extends CacheInterceptor {
         @Override
-        public Object getCacheKey(AbstractCache cache, short[] cacheKeyParameterPositions, Object[] methodParameterValues) {
+        public Object getCacheKey(AbstractCache cache, List<Short> cacheKeyParameterPositions, Object[] methodParameterValues) {
             return super.getCacheKey(cache, cacheKeyParameterPositions, methodParameterValues);
         }
     }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInterceptionContext.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheInterceptionContext.java
@@ -1,23 +1,27 @@
 package io.quarkus.cache.runtime;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class CacheInterceptionContext<T extends Annotation> {
 
-    private final List<T> interceptorBindings = new ArrayList<>();
-    private short[] cacheKeyParameterPositions = new short[0];
+    private final List<T> interceptorBindings;
+    private final List<Short> cacheKeyParameterPositions;
+
+    public CacheInterceptionContext(List<T> interceptorBindings, List<Short> cacheKeyParameterPositions) {
+        Objects.requireNonNull(interceptorBindings);
+        Objects.requireNonNull(cacheKeyParameterPositions);
+        this.interceptorBindings = Collections.unmodifiableList(interceptorBindings);
+        this.cacheKeyParameterPositions = Collections.unmodifiableList(cacheKeyParameterPositions);
+    }
 
     public List<T> getInterceptorBindings() {
         return interceptorBindings;
     }
 
-    public short[] getCacheKeyParameterPositions() {
+    public List<Short> getCacheKeyParameterPositions() {
         return cacheKeyParameterPositions;
-    }
-
-    public void setCacheKeyParameterPositions(short[] cacheKeyParameterPositions) {
-        this.cacheKeyParameterPositions = cacheKeyParameterPositions;
     }
 }


### PR DESCRIPTION
As [suggested](https://github.com/quarkusio/quarkus/pull/13991#discussion_r551184370) by @mkouba in #13991, this makes CacheInterceptionContext immutable.