### PR TITLE
Handle projection in spring data repositories

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
@@ -4,7 +4,10 @@ import static io.quarkus.gizmo.FieldDescriptor.of;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import javax.transaction.Transactional;
 
@@ -17,7 +20,9 @@ import org.jboss.jandex.Type;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import io.quarkus.deployment.bean.JavaBeanUtil;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
@@ -35,17 +40,27 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
     private final IndexView index;
     private final String operationsName;
     private final FieldDescriptor operationsField;
+    private final ClassOutput nonBeansClassOutput;
+    private final Consumer<String> projectionClassCreatedCallback;
 
-    public DerivedMethodsAdder(IndexView index, TypeBundle typeBundle) {
+    public DerivedMethodsAdder(IndexView index, TypeBundle typeBundle, ClassOutput nonBeansClassOutput,
+            Consumer<String> projectionClassCreatedCallback) {
         this.index = index;
         operationsName = typeBundle.operations().dotName().toString();
         operationsField = of(operationsName, "INSTANCE", operationsName);
+        this.nonBeansClassOutput = nonBeansClassOutput;
+        this.projectionClassCreatedCallback = projectionClassCreatedCallback;
     }
 
     public void add(ClassCreator classCreator, FieldDescriptor entityClassFieldDescriptor,
             String generatedClassName, ClassInfo repositoryClassInfo, ClassInfo entityClassInfo) {
         MethodNameParser methodNameParser = new MethodNameParser(entityClassInfo, index);
         List<MethodInfo> repoMethods = new ArrayList<>(repositoryClassInfo.methods());
+
+        // Remember custom return type methods: {resultType:[methodName]}
+        Map<DotName, List<String>> customResultTypes = new HashMap<>(3);
+        Map<DotName, DotName> customResultTypeImplNames = new HashMap<>(3);
+
         //As intermediate interfaces are supported for spring data repositories, we need to search the methods declared in such interfaced and add them to the methods to implement list
         for (DotName extendedInterface : repositoryClassInfo.interfaceNames()) {
             if (GenerationUtil.isIntermediateRepository(extendedInterface, index)) {
@@ -149,8 +164,34 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
                             methodCreator.readInstanceField(entityClassFieldDescriptor, methodCreator.getThis()),
                             methodCreator.load(finalQuery), sort, paramsArray);
 
+                    Type resultType = verifyQueryResultType(method.returnType(), index);
+                    DotName customResultTypeName = resultType.name();
+
+                    if (customResultTypeName.equals(entityClassInfo.name())
+                            || isHibernateSupportedReturnType(customResultTypeName)) {
+                        // no special handling needed
+                        customResultTypeName = null;
+                    } else {
+                        // If the custom type is an interface, we need to generate the implementation
+                        ClassInfo resultClassInfo = index.getClassByName(customResultTypeName);
+                        if (Modifier.isInterface(resultClassInfo.flags())) {
+                            // Find the implementation name, and use that for subsequent query result generation
+                            customResultTypeName = customResultTypeImplNames.computeIfAbsent(customResultTypeName,
+                                    k -> createSimpleInterfaceImpl(resultType.name()));
+
+                            // Remember the parameters for this usage of the custom type, we'll deal with it later
+                            customResultTypes.computeIfAbsent(customResultTypeName,
+                                    k -> new ArrayList<>()).add(method.name());
+                        } else {
+                            throw new IllegalArgumentException(
+                                    method.name() + " of Repository " + repositoryClassInfo
+                                            + " can only use interfaces to map results to non-entity types.");
+                        }
+                    }
+
                     generateFindQueryResultHandling(methodCreator, panacheQuery, pageableParameterIndex, repositoryClassInfo,
-                            entityClassInfo, returnType.name(), parseResult.getTopCount(), method.name(), null);
+                            entityClassInfo, returnType.name(), parseResult.getTopCount(), method.name(), customResultTypeName,
+                            entityClassInfo.name().toString());
 
                 } else if (parseResult.getQueryType() == MethodNameParser.QueryType.COUNT) {
                     if (!DotNames.PRIMITIVE_LONG.equals(returnType.name()) && !DotNames.LONG.equals(returnType.name())) {
@@ -233,5 +274,81 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
                 }
             }
         }
+        for (Map.Entry<DotName, DotName> mapping : customResultTypeImplNames.entrySet()) {
+            DotName interfaceName = mapping.getKey();
+            DotName implName = mapping.getValue();
+            generateCustomResultTypes(interfaceName, implName, entityClassInfo, customResultTypes.get(implName));
+            projectionClassCreatedCallback.accept(implName.toString());
+        }
+    }
+
+    private void generateCustomResultTypes(DotName interfaceName, DotName implName, ClassInfo entityClassInfo,
+            List<String> queryMethods) {
+
+        ClassInfo interfaceInfo = index.getClassByName(interfaceName);
+
+        try (ClassCreator implClassCreator = ClassCreator.builder().classOutput(nonBeansClassOutput)
+                .interfaces(interfaceName.toString()).className(implName.toString())
+                .build()) {
+
+            Map<String, FieldDescriptor> fields = new HashMap<>(3);
+
+            for (MethodInfo method : interfaceInfo.methods()) {
+                String getterName = method.name();
+                String propertyName = JavaBeanUtil.getPropertyNameFromGetter(getterName);
+
+                Type returnType = method.returnType();
+                if (returnType.kind() == Type.Kind.VOID) {
+                    throw new IllegalArgumentException("Method " + method.name() + " of interface " + interfaceName
+                            + " is not a getter method since it returns void");
+                }
+                DotName fieldTypeName = getPrimitiveTypeName(returnType.name());
+
+                FieldDescriptor field = implClassCreator.getFieldCreator(propertyName, fieldTypeName.toString())
+                        .getFieldDescriptor();
+
+                // create getter (based on the interface)
+                try (MethodCreator getter = implClassCreator.getMethodCreator(getterName, returnType.toString())) {
+                    getter.setModifiers(Modifier.PUBLIC);
+                    getter.returnValue(getter.readInstanceField(field, getter.getThis()));
+                }
+
+                fields.put(getterName, field);
+            }
+
+            // Add static methods to convert from Object[] to this type
+            for (String queryMethod : queryMethods) {
+                try (MethodCreator convert = implClassCreator.getMethodCreator("convert_" + queryMethod,
+                        implName.toString(), entityClassInfo.name().toString())) {
+                    convert.setModifiers(Modifier.STATIC);
+
+                    ResultHandle newObject = convert.newInstance(MethodDescriptor.ofConstructor(implName.toString()));
+
+                    ResultHandle entity = convert.getMethodParam(0);
+                    final List<MethodInfo> availableMethods = entityClassInfo.methods();
+                    for (Map.Entry<String, FieldDescriptor> field : fields.entrySet()) {
+                        if (!getterExists(availableMethods, field.getKey())) {
+                            throw new IllegalArgumentException(field.getKey() + " method does not exists in "
+                                    + entityClassInfo.name().toString() + " class.");
+                        }
+
+                        FieldDescriptor f = field.getValue();
+                        convert.writeInstanceField(f, newObject, convert.invokeVirtualMethod(
+                                MethodDescriptor.ofMethod(entityClassInfo.name().toString(), field.getKey(), f.getType()),
+                                entity));
+                    }
+                    convert.returnValue(newObject);
+                }
+            }
+        }
+    }
+
+    private boolean getterExists(List<MethodInfo> methods, String getterName) {
+        for (MethodInfo method : methods) {
+            if (method.name().equals(getterName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
@@ -47,7 +47,7 @@ public class SpringDataRepositoryCreator {
         this.index = index;
         this.fragmentMethodsAdder = new FragmentMethodsAdder(fragmentImplClassResolvedCallback, index);
         this.stockMethodsAdder = new StockMethodsAdder(index, typeBundle);
-        this.derivedMethodsAdder = new DerivedMethodsAdder(index, typeBundle);
+        this.derivedMethodsAdder = new DerivedMethodsAdder(index, typeBundle, otherClassOutput, customClassCreatedCallback);
 
         // custom queries may generate non-bean classes
         this.customQueryMethodsAdder = new CustomQueryMethodsAdder(index, otherClassOutput, customClassCreatedCallback,

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/MovieRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/MovieRepository.java
@@ -68,6 +68,9 @@ public interface MovieRepository extends CrudRepository<Movie, Long> {
     @Query("SELECT title, rating FROM Movie WHERE title = ?1")
     MovieRating findRatingByTitle(String title);
 
+    // issue 13050
+    List<MovieProjection> findTitleAndRatingByRating(String rating);
+
     interface MovieCountByRating {
         String getRating();
 
@@ -79,4 +82,11 @@ public interface MovieRepository extends CrudRepository<Movie, Long> {
 
         String getRating();
     }
+
+    interface MovieProjection {
+        String getTitle();
+
+        String getRating();
+    }
+
 }

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/MovieResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/MovieResource.java
@@ -137,7 +137,6 @@ public class MovieResource {
     @Produces("application/json")
     public Optional<MovieRepository.MovieRating> optionalTitleRating(@PathParam("title") String title) {
         Optional result = movieRepository.findOptionalRatingByTitle(title);
-        System.out.println(result);
         return result;
     }
 
@@ -158,4 +157,12 @@ public class MovieResource {
         movie.setDuration(1000);
         return movieRepository.save(movie);
     }
+
+    @GET
+    @Path("/titles/rating/{rating}")
+    @Produces("application/json")
+    public List<MovieRepository.MovieProjection> getTitlesByRating(@PathParam("rating") String rating) {
+        return movieRepository.findTitleAndRatingByRating(rating);
+    }
+
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/MovieResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/MovieResourceTest.java
@@ -236,4 +236,11 @@ public class MovieResourceTest {
                 .statusCode(200)
                 .body(is("1"));
     }
+
+    @Test
+    void getTitle() {
+        when().get("/movie/titles/rating/PG-13").then()
+                .statusCode(200)
+                .body(containsString("Godzilla"));
+    }
 }


### PR DESCRIPTION
Projections were supported for custom `@Query` but not in basics method (e.g `findAllByTitle`). 
This branch adds support for it. 

There still is one limitation in this implementation. If a projection class is used in both a basic and a custom method, such as:

```java
public MyProjection findAllByTitle(String title);

@Query("select foo, bar from mytable")
public MyProjection customQueryt(String foo);
```
 then, the basic implementation is lost. When parsing custom method, the implementation will be override. 

I don't know if this is blocking for this feature. 

close #13050