### PR TITLE
Fix bug with non application endpoint redirect for root-path

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -130,7 +130,7 @@ class VertxHttpProcessor {
         RuntimeValue<Router> router = recorder.initializeRouter(vertx.getVertx());
         RuntimeValue<Router> frameworkRouter = recorder.initializeRouter(vertx.getVertx());
         boolean frameworkRouterFound = false;
-        recorder.setNonApplicationRedirectHandler(nonApplicationRootPath.getFrameworkRootPath());
+        recorder.setNonApplicationRedirectHandler(nonApplicationRootPath.getFrameworkRootPath(), httpBuildTimeConfig.rootPath);
 
         for (RouteBuildItem route : routes) {
             if (nonApplicationRootPath.isSeparateRoot() && route.isFrameworkRoute()) {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationAndRootPathTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationAndRootPathTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.vertx.http;
+
+import java.util.function.Consumer;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class NonApplicationAndRootPathTest {
+    private static final String APP_PROPS = "" +
+            "quarkus.http.root-path=/api\n";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties")
+                    .addClasses(MyObserver.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new RouteBuildItem.Builder()
+                                .route("/non-app")
+                                .handler(new MyHandler())
+                                .blockingRoute()
+                                .nonApplicationRoute()
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext routingContext) {
+            routingContext.response()
+                    .setStatusCode(200)
+                    .end(routingContext.request().path());
+        }
+    }
+
+    @Test
+    public void testNonApplicationEndpointOnRootPathWithRedirect() {
+        RestAssured.given().get("/api/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
+    }
+
+    @Test
+    public void testNonApplicationEndpointDirect() {
+        RestAssured.given().get("/api/q/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        void test(@Observes String event) {
+            //Do Nothing
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationAndRootPathTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationAndRootPathTest.java
@@ -63,12 +63,14 @@ public class NonApplicationAndRootPathTest {
 
     @Test
     public void testNonApplicationEndpointOnRootPathWithRedirect() {
-        RestAssured.given().get("/api/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
+        // Note RestAssured knows the path prefix is /api
+        RestAssured.given().get("/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
     }
 
     @Test
     public void testNonApplicationEndpointDirect() {
-        RestAssured.given().get("/api/q/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
+        // Note RestAssured knows the path prefix is /api
+        RestAssured.given().get("/q/non-app").then().statusCode(200).body(Matchers.equalTo("/api/q/non-app"));
     }
 
     @Singleton

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -779,7 +779,8 @@ public class VertxHttpRecorder {
             public void handle(RoutingContext context) {
                 String absoluteURI = context.request().absoluteURI();
                 int pathStart = absoluteURI.indexOf(context.request().path());
-                if (absoluteURI.contains(rootPath)) {
+                if (rootPath.length() > 1 && absoluteURI.contains(rootPath)) {
+                    // Only do this when rootPath is not '/'
                     pathStart = pathStart + rootPath.length();
                 }
                 String redirectTo = absoluteURI.substring(0, pathStart) + nonApplicationPath

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -773,12 +773,15 @@ public class VertxHttpRecorder {
         }
     }
 
-    public void setNonApplicationRedirectHandler(String nonApplicationPath) {
+    public void setNonApplicationRedirectHandler(String nonApplicationPath, String rootPath) {
         nonApplicationRedirectHandler = new Handler<RoutingContext>() {
             @Override
             public void handle(RoutingContext context) {
                 String absoluteURI = context.request().absoluteURI();
                 int pathStart = absoluteURI.indexOf(context.request().path());
+                if (absoluteURI.contains(rootPath)) {
+                    pathStart = pathStart + rootPath.length();
+                }
                 String redirectTo = absoluteURI.substring(0, pathStart) + nonApplicationPath
                         + absoluteURI.substring(pathStart);
 


### PR DESCRIPTION
When `root-path` is not `/`

Fixes #14109