### PR TITLE
Avoid threadlocal leaks on scaling of Executors when using SQL Client

### DIFF
--- a/extensions/reactive-datasource/deployment/pom.xml
+++ b/extensions/reactive-datasource/deployment/pom.xml
@@ -25,6 +25,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-datasource</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/ConnectionPoolsClosedTest.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/ConnectionPoolsClosedTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
+
+public class ConnectionPoolsClosedTest {
+
+    @Test
+    public void connectionsGetClosed() throws ExecutionException, InterruptedException {
+        /**
+         * When a thread is terminated, we don't immediately clean up
+         * any related Pool instances.
+         * But we do look for abandoned connections when we scale up again,
+         * so test for that specifically.
+         */
+        TestableThreadLocalPool globalPool = new TestableThreadLocalPool();
+        Assert.assertTrue(globalPool.trackedSize() == 0);
+        final TestPool p1 = grabPoolFromOtherThread(globalPool);
+        Assert.assertFalse(p1.isClosed());
+        Assert.assertTrue(globalPool.trackedSize() == 1);
+        final TestPool p2 = grabPoolFromOtherThread(globalPool);
+        Assert.assertTrue(p1.isClosed());
+        Assert.assertFalse(p2.isClosed());
+        Assert.assertTrue(globalPool.trackedSize() == 1);
+        globalPool.close();
+        Assert.assertTrue(p2.isClosed());
+        Assert.assertTrue(globalPool.trackedSize() == 0);
+    }
+
+    private TestPool grabPoolFromOtherThread(TestableThreadLocalPool globalPool)
+            throws ExecutionException, InterruptedException {
+        final ExecutorService e = Executors.newSingleThreadExecutor();
+        final Future<TestPool> creation = e.submit(() -> globalPool.pool());
+        final TestPool poolInstance = creation.get();
+        e.shutdownNow();
+        e.awaitTermination(1, TimeUnit.MILLISECONDS);
+        return poolInstance;
+    }
+
+}

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/ConnectionPoolsClosedTest.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/ConnectionPoolsClosedTest.java
@@ -18,6 +18,10 @@ public class ConnectionPoolsClosedTest {
          * any related Pool instances.
          * But we do look for abandoned connections when we scale up again,
          * so test for that specifically.
+         * Connections will be closed more aggressively in practice as implementors
+         * of ThreadLocalPool register a callback on close; so assuming clients
+         * actually close it and threads aren't terminated abruptly this
+         * should be unnecessary (still useful, since reality is often different).
          */
         TestableThreadLocalPool globalPool = new TestableThreadLocalPool();
         Assert.assertTrue(globalPool.trackedSize() == 0);

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPool.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPool.java
@@ -1,0 +1,45 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+
+class TestPool implements Pool {
+
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+    @Override
+    public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+    }
+
+    @Override
+    public Query<RowSet<Row>> query(String s) {
+        return null;
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+        return null;
+    }
+
+    @Override
+    public void begin(Handler<AsyncResult<Transaction>> handler) {
+    }
+
+    @Override
+    public void close() {
+        isClosed.set(true);
+    }
+
+    public boolean isClosed() {
+        return isClosed.get();
+    }
+}

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPool.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPool.java
@@ -4,7 +4,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.Query;
 import io.vertx.sqlclient.Row;
@@ -12,7 +11,7 @@ import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Transaction;
 
-class TestPool implements Pool {
+class TestPool implements TestPoolInterface {
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
@@ -39,6 +38,7 @@ class TestPool implements Pool {
         isClosed.set(true);
     }
 
+    @Override
     public boolean isClosed() {
         return isClosed.get();
     }

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPoolInterface.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestPoolInterface.java
@@ -1,0 +1,11 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import io.vertx.sqlclient.Pool;
+
+/**
+ * Having an interface here is useful to mimic the
+ * same patterns as DB2Pool, MySQLPool, PgPool, etc..
+ */
+public interface TestPoolInterface extends Pool {
+    boolean isClosed();
+}

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
@@ -53,8 +53,8 @@ final class TestableThreadLocalPool extends ThreadLocalPool<TestPoolInterface> {
         public void close() {
             if (open) {
                 delegate.close();
+                TestableThreadLocalPool.this.removeSelfFromTracking(this);
             }
-            TestableThreadLocalPool.this.removeSelfFromTracking(this);
         }
 
         @Override

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
@@ -1,14 +1,66 @@
 package io.quarkus.reactive.datasource.runtime;
 
-final class TestableThreadLocalPool extends ThreadLocalPool<TestPool> {
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+
+final class TestableThreadLocalPool extends ThreadLocalPool<TestPoolInterface> {
 
     public TestableThreadLocalPool() {
         super(null, null);
     }
 
     @Override
-    protected TestPool createThreadLocalPool() {
-        return new TestPool();
+    protected TestPoolInterface createThreadLocalPool() {
+        return new TestPoolWrapper(new TestPool());
+    }
+
+    private class TestPoolWrapper implements TestPoolInterface {
+
+        private final TestPool delegate;
+        private boolean open = true;
+
+        private TestPoolWrapper(TestPool delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+            delegate.getConnection(handler);
+        }
+
+        @Override
+        public Query<RowSet<Row>> query(String s) {
+            return delegate.query(s);
+        }
+
+        @Override
+        public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+            return delegate.preparedQuery(s);
+        }
+
+        @Override
+        public void begin(Handler<AsyncResult<Transaction>> handler) {
+            delegate.begin(handler);
+        }
+
+        @Override
+        public void close() {
+            if (open) {
+                delegate.close();
+            }
+            TestableThreadLocalPool.this.removeSelfFromTracking(this);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
     }
 
 }

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/runtime/TestableThreadLocalPool.java
@@ -1,0 +1,14 @@
+package io.quarkus.reactive.datasource.runtime;
+
+final class TestableThreadLocalPool extends ThreadLocalPool<TestPool> {
+
+    public TestableThreadLocalPool() {
+        super(null, null);
+    }
+
+    @Override
+    protected TestPool createThreadLocalPool() {
+        return new TestPool();
+    }
+
+}

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ThreadLocalPool.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ThreadLocalPool.java
@@ -1,5 +1,6 @@
 package io.quarkus.reactive.datasource.runtime;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +19,7 @@ import io.vertx.sqlclient.Transaction;
 public abstract class ThreadLocalPool<PoolType extends Pool> implements Pool {
 
     //List of all opened pools. Access requires synchronization on the list instance.
-    private final List<Pool> threadLocalPools = new ArrayList<>();
+    private final List<PoolAndThread> allConnections = new ArrayList<>();
 
     //The pool instance for the current thread
     private final ThreadLocal<PoolType> threadLocal = new ThreadLocal<>();
@@ -36,18 +37,28 @@ public abstract class ThreadLocalPool<PoolType extends Pool> implements Pool {
         this.poolOptions = poolOptions;
     }
 
-    private PoolType pool() {
+    PoolType pool() {
         checkPoolIsOpen();
         PoolType pool = threadLocal.get();
         if (pool == null) {
-            synchronized (threadLocalPools) {
+            synchronized (allConnections) {
                 checkPoolIsOpen();
                 pool = createThreadLocalPool();
-                threadLocalPools.add(pool);
+                allConnections.add(new PoolAndThread(pool));
                 threadLocal.set(pool);
+                scanForAbandonedConnections();
             }
         }
         return pool;
+    }
+
+    private final void scanForAbandonedConnections() {
+        for (PoolAndThread pair : allConnections) {
+            if (pair.isDead()) {
+                pair.close();
+                allConnections.remove(pair);
+            }
+        }
     }
 
     private void checkPoolIsOpen() {
@@ -80,12 +91,46 @@ public abstract class ThreadLocalPool<PoolType extends Pool> implements Pool {
 
     @Override
     public void close() {
-        synchronized (threadLocalPools) {
+        synchronized (allConnections) {
             this.closed = true;
-            for (Pool threadLocalPool : threadLocalPools) {
-                threadLocalPool.close();
+            for (PoolAndThread pair : allConnections) {
+                pair.close();
             }
+            allConnections.clear();
+            threadLocal.remove();
         }
+    }
+
+    public int trackedSize() {
+        synchronized (allConnections) {
+            return allConnections.size();
+        }
+    }
+
+    private static class PoolAndThread {
+        private final Pool pool;
+        private final WeakReference<Thread> threadReference;
+
+        private PoolAndThread(Pool pool) {
+            this.pool = pool;
+            this.threadReference = new WeakReference<>(Thread.currentThread());
+        }
+
+        /**
+         * @return true if this pools is associated to a Thread which is no longer alive.
+         */
+        boolean isDead() {
+            final Thread thread = threadReference.get();
+            return thread == null || (!thread.isAlive());
+        }
+
+        /**
+         * Closes the connection
+         */
+        void close() {
+            pool.close();
+        }
+
     }
 
 }

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/ThreadLocalDB2Pool.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/ThreadLocalDB2Pool.java
@@ -61,8 +61,8 @@ public class ThreadLocalDB2Pool extends ThreadLocalPool<DB2Pool> implements DB2P
         public void close() {
             if (open) {
                 delegate.close();
+                ThreadLocalDB2Pool.this.removeSelfFromTracking(this);
             }
-            ThreadLocalDB2Pool.this.removeSelfFromTracking(this);
         }
     }
 }

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/ThreadLocalDB2Pool.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/ThreadLocalDB2Pool.java
@@ -1,10 +1,18 @@
 package io.quarkus.reactive.db2.client.runtime;
 
 import io.quarkus.reactive.datasource.runtime.ThreadLocalPool;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.db2client.DB2ConnectOptions;
 import io.vertx.db2client.DB2Pool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
 
 public class ThreadLocalDB2Pool extends ThreadLocalPool<DB2Pool> implements DB2Pool {
 
@@ -17,6 +25,44 @@ public class ThreadLocalDB2Pool extends ThreadLocalPool<DB2Pool> implements DB2P
 
     @Override
     protected DB2Pool createThreadLocalPool() {
-        return DB2Pool.pool(vertx, db2ConnectOptions, poolOptions);
+        return new DB2PoolWrapper(DB2Pool.pool(vertx, db2ConnectOptions, poolOptions));
+    }
+
+    private class DB2PoolWrapper implements DB2Pool {
+
+        private final DB2Pool delegate;
+        private boolean open = true;
+
+        private DB2PoolWrapper(DB2Pool delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+            delegate.getConnection(handler);
+        }
+
+        @Override
+        public Query<RowSet<Row>> query(String s) {
+            return delegate.query(s);
+        }
+
+        @Override
+        public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+            return delegate.preparedQuery(s);
+        }
+
+        @Override
+        public void begin(Handler<AsyncResult<Transaction>> handler) {
+            delegate.begin(handler);
+        }
+
+        @Override
+        public void close() {
+            if (open) {
+                delegate.close();
+            }
+            ThreadLocalDB2Pool.this.removeSelfFromTracking(this);
+        }
     }
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/ThreadLocalMySQLPool.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/ThreadLocalMySQLPool.java
@@ -61,8 +61,8 @@ public class ThreadLocalMySQLPool extends ThreadLocalPool<MySQLPool> implements 
         public void close() {
             if (open) {
                 delegate.close();
+                ThreadLocalMySQLPool.this.removeSelfFromTracking(this);
             }
-            ThreadLocalMySQLPool.this.removeSelfFromTracking(this);
         }
     }
 

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/ThreadLocalMySQLPool.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/ThreadLocalMySQLPool.java
@@ -1,10 +1,18 @@
 package io.quarkus.reactive.mysql.client.runtime;
 
 import io.quarkus.reactive.datasource.runtime.ThreadLocalPool;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.mysqlclient.MySQLConnectOptions;
 import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
 
 public class ThreadLocalMySQLPool extends ThreadLocalPool<MySQLPool> implements MySQLPool {
 
@@ -17,6 +25,45 @@ public class ThreadLocalMySQLPool extends ThreadLocalPool<MySQLPool> implements 
 
     @Override
     protected MySQLPool createThreadLocalPool() {
-        return MySQLPool.pool(vertx, mySQLConnectOptions, poolOptions);
+        return new MySQLPoolWrapper(MySQLPool.pool(vertx, mySQLConnectOptions, poolOptions));
     }
+
+    private class MySQLPoolWrapper implements MySQLPool {
+
+        private final MySQLPool delegate;
+        private boolean open = true;
+
+        private MySQLPoolWrapper(MySQLPool delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+            delegate.getConnection(handler);
+        }
+
+        @Override
+        public Query<RowSet<Row>> query(String s) {
+            return delegate.query(s);
+        }
+
+        @Override
+        public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+            return delegate.preparedQuery(s);
+        }
+
+        @Override
+        public void begin(Handler<AsyncResult<Transaction>> handler) {
+            delegate.begin(handler);
+        }
+
+        @Override
+        public void close() {
+            if (open) {
+                delegate.close();
+            }
+            ThreadLocalMySQLPool.this.removeSelfFromTracking(this);
+        }
+    }
+
 }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/ThreadLocalPgPool.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/ThreadLocalPgPool.java
@@ -61,8 +61,8 @@ public class ThreadLocalPgPool extends ThreadLocalPool<PgPool> implements PgPool
         public void close() {
             if (open) {
                 delegate.close();
+                ThreadLocalPgPool.this.removeSelfFromTracking(this);
             }
-            ThreadLocalPgPool.this.removeSelfFromTracking(this);
         }
     }
 }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/ThreadLocalPgPool.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/ThreadLocalPgPool.java
@@ -1,10 +1,18 @@
 package io.quarkus.reactive.pg.client.runtime;
 
 import io.quarkus.reactive.datasource.runtime.ThreadLocalPool;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
 
 public class ThreadLocalPgPool extends ThreadLocalPool<PgPool> implements PgPool {
 
@@ -17,6 +25,44 @@ public class ThreadLocalPgPool extends ThreadLocalPool<PgPool> implements PgPool
 
     @Override
     protected PgPool createThreadLocalPool() {
-        return PgPool.pool(vertx, pgConnectOptions, poolOptions);
+        return new PgPoolWrapper(PgPool.pool(vertx, pgConnectOptions, poolOptions));
+    }
+
+    private class PgPoolWrapper implements PgPool {
+
+        private final PgPool delegate;
+        private boolean open = true;
+
+        private PgPoolWrapper(PgPool delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+            delegate.getConnection(handler);
+        }
+
+        @Override
+        public Query<RowSet<Row>> query(String s) {
+            return delegate.query(s);
+        }
+
+        @Override
+        public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+            return delegate.preparedQuery(s);
+        }
+
+        @Override
+        public void begin(Handler<AsyncResult<Transaction>> handler) {
+            delegate.begin(handler);
+        }
+
+        @Override
+        public void close() {
+            if (open) {
+                delegate.close();
+            }
+            ThreadLocalPgPool.this.removeSelfFromTracking(this);
+        }
     }
 }


### PR DESCRIPTION
Fixes #14087 