### PR TITLE
Fix warning when using Panache CRUD services

### DIFF
--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -1,5 +1,6 @@
 package io.quarkus.rest.data.panache.deployment;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,7 +46,7 @@ class JaxRsResourceImplementor {
 
     /**
      * Implement a JAX-RS resource with a following structure.
-     * 
+     *
      * <pre>
      * {@code
      *      &#64;Path("/my-entities')
@@ -80,7 +81,7 @@ class JaxRsResourceImplementor {
 
     private FieldDescriptor implementResourceField(ClassCreator classCreator, ResourceMetadata resourceMetadata) {
         FieldCreator resourceFieldCreator = classCreator.getFieldCreator("resource", resourceMetadata.getResourceClass());
-        resourceFieldCreator.addAnnotation(Inject.class);
+        resourceFieldCreator.setModifiers(resourceFieldCreator.getModifiers() & ~Modifier.PRIVATE).addAnnotation(Inject.class);
         return resourceFieldCreator.getFieldDescriptor();
     }
 


### PR DESCRIPTION
This fixes the unrecommended warning in the logs:

```
2021-01-06 09:42:27,312 INFO  [io.qua.arc.pro.BeanProcessor] (build-35) Found unrecommended usage of private members (use package-private instead) in application beans:
	- @Inject field io.quarkus.registry.category.CategoryResourceJaxRs_b85ca14b1d8b6fe84071db5740b9268005ed57f4#resource
```