### PR TITLE
Skip inherit level and min-level settings

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -218,30 +218,32 @@ public final class LoggingResourceProcessor {
                 BytecodeCreator current = mc;
                 for (Map.Entry<String, CategoryBuildTimeConfig> entry : categories.entrySet()) {
                     final String category = entry.getKey();
-                    final int categoryLevelIntValue = entry.getValue().minLevel.getLevel().intValue();
+                    if (!entry.getValue().minLevel.isInherited()) {
+                        final int categoryLevelIntValue = entry.getValue().minLevel.getLevel().intValue();
 
-                    ResultHandle equalsResult = current.invokeVirtualMethod(
-                            MethodDescriptor.ofMethod(Object.class, "equals", boolean.class, Object.class),
-                            name, current.load(category));
+                        ResultHandle equalsResult = current.invokeVirtualMethod(
+                                MethodDescriptor.ofMethod(Object.class, "equals", boolean.class, Object.class),
+                                name, current.load(category));
 
-                    BranchResult equalsBranch = current.ifTrue(equalsResult);
-                    try (BytecodeCreator false1 = equalsBranch.falseBranch()) {
-                        ResultHandle startsWithResult = false1.invokeVirtualMethod(
-                                MethodDescriptor.ofMethod(String.class, "startsWith", boolean.class, String.class),
-                                name, false1.load(category));
+                        BranchResult equalsBranch = current.ifTrue(equalsResult);
+                        try (BytecodeCreator false1 = equalsBranch.falseBranch()) {
+                            ResultHandle startsWithResult = false1.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(String.class, "startsWith", boolean.class, String.class),
+                                    name, false1.load(category));
 
-                        BranchResult startsWithBranch = false1.ifTrue(startsWithResult);
+                            BranchResult startsWithBranch = false1.ifTrue(startsWithResult);
 
-                        final BytecodeCreator startsWithTrue = startsWithBranch.trueBranch();
-                        final BranchResult levelCompareBranch = startsWithTrue.ifIntegerGreaterEqual(level,
-                                startsWithTrue.load(categoryLevelIntValue));
-                        levelCompareBranch.trueBranch().returnValue(levelCompareBranch.trueBranch().load(true));
-                        levelCompareBranch.falseBranch().returnValue(levelCompareBranch.falseBranch().load(false));
+                            final BytecodeCreator startsWithTrue = startsWithBranch.trueBranch();
+                            final BranchResult levelCompareBranch = startsWithTrue.ifIntegerGreaterEqual(level,
+                                    startsWithTrue.load(categoryLevelIntValue));
+                            levelCompareBranch.trueBranch().returnValue(levelCompareBranch.trueBranch().load(true));
+                            levelCompareBranch.falseBranch().returnValue(levelCompareBranch.falseBranch().load(false));
 
-                        current = startsWithBranch.falseBranch();
+                            current = startsWithBranch.falseBranch();
+                        }
+
+                        equalsBranch.trueBranch().returnValue(equalsBranch.trueBranch().load(true));
                     }
-
-                    equalsBranch.trueBranch().returnValue(equalsBranch.trueBranch().load(true));
                 }
 
                 final ResultHandle infoLevelIntValue = getLogManagerLevelIntValue(defaultMinLevelName, current);

--- a/integration-tests/logging-min-level-set/src/main/resources/application.properties
+++ b/integration-tests/logging-min-level-set/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.log.min-level=DEBUG
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.above".min-level=INFO
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.below".min-level=TRACE
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.promote".min-level=ERROR
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.inherit.level_only".level=inherit
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.inherit.min_level_only".level=WARNING
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.inherit.min_level_only".min-level=inherit


### PR DESCRIPTION
Closes #14154.

Skip promoting log levels to min-level, or computing build time min-level substitutions when levels are inherited.