### PR TITLE
Re-enable checking the log in bouncycastle-fips-jsse

### DIFF
--- a/integration-tests/bouncycastle-fips-jsse/src/main/resources/application.properties
+++ b/integration-tests/bouncycastle-fips-jsse/src/main/resources/application.properties
@@ -12,6 +12,7 @@ quarkus.http.ssl.certificate.trust-store-file-type=BCFKS
 quarkus.http.ssl.certificate.trust-store-provider=BCFIPS
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.jks
 
+quarkus.log.category."org.bouncycastle.jsse".min-level=TRACE
 quarkus.log.category."org.bouncycastle.jsse".level=TRACE
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n

--- a/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
+++ b/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
@@ -51,7 +51,7 @@ public class BouncyCastleFipsJsseTestCase {
             return;
         }
         doTestListProviders();
-        //checkLog(false);
+        checkLog(false);
     }
 
     protected void doTestListProviders() throws Exception {


### PR DESCRIPTION
I'm starting with re-enabling checking the `bouncycastle-fips-jsse` log