### PR TITLE
Introduce JSON by default support RESTEasy Reactive

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RecordableConstructor.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RecordableConstructor.java
@@ -11,6 +11,8 @@ import java.lang.annotation.Target;
  * The constructor parameters will be read from the fields of the object, and matched
  * to the constructor parameter names.
  *
+ * TODO: move this out of Quarkus core and into a tiny annotation-only module
+ * that could then be used outside of Quarkus (for example in RESTEasy Reactive)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.CONSTRUCTOR)

--- a/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
@@ -101,7 +101,7 @@ public class JaxrsClientProcessor {
                 .setExistingConverters(new HashMap<>())
                 .setScannedResourcePaths(result.getScannedResourcePaths())
                 .setConfig(new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(config.inputBufferSize.asLongValue(),
-                        config.singleDefaultProduces))
+                        config.singleDefaultProduces, config.defaultProduces))
                 .setAdditionalReaders(additionalReaders)
                 .setHttpAnnotationToMethod(result.getHttpAnnotationToMethod())
                 .setInjectableBeans(new HashMap<>())

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JsonDefaultProducersHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JsonDefaultProducersHandler.java
@@ -1,0 +1,50 @@
+package io.quarkus.resteasy.reactive.common.deployment;
+
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COLLECTION;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LIST;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MAP;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SET;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.common.processor.DefaultProducesHandler;
+
+public class JsonDefaultProducersHandler implements DefaultProducesHandler {
+
+    private static final List<MediaType> PRODUCES_APPLICATION_JSON = Collections.singletonList(MediaType.APPLICATION_JSON_TYPE);
+
+    private static final Set<DotName> SUPPORTED_JAVA_TYPES = new HashSet<>(Arrays.asList(COLLECTION, LIST, SET, MAP));
+
+    @Override
+    public List<MediaType> handle(Context context) {
+        if (context.config().isDefaultProduces() && isJsonCompatibleType(context)) {
+            return PRODUCES_APPLICATION_JSON;
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean isJsonCompatibleType(Context context) {
+        Type type = context.nonAsyncReturnType();
+        // this doesn't catch every single case, but it should be good enough to cover most common cases
+        if ((type.kind() != Type.Kind.CLASS) && (type.kind() != Type.Kind.PARAMETERIZED_TYPE)) {
+            return false;
+        }
+        DotName dotName = type.name();
+        if (dotName.toString().startsWith("java")) {
+            return SUPPORTED_JAVA_TYPES.contains(dotName);
+        }
+        if (dotName.toString().startsWith("jakarta")) { // let's be forward compatible
+            return false;
+        }
+        // check if the class is an application class
+        return context.index().getClassByName(dotName) != null;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ServerDefaultProducesHandlerBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ServerDefaultProducesHandlerBuildItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.common.deployment;
+
+import org.jboss.resteasy.reactive.common.processor.DefaultProducesHandler;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Enable the registration of additional default produces handlers for server endpoints
+ */
+public final class ServerDefaultProducesHandlerBuildItem extends MultiBuildItem {
+
+    private final DefaultProducesHandler defaultProducesHandler;
+
+    public ServerDefaultProducesHandlerBuildItem(DefaultProducesHandler defaultProducesHandler) {
+        this.defaultProducesHandler = defaultProducesHandler;
+    }
+
+    public DefaultProducesHandler getDefaultProducesHandler() {
+        return defaultProducesHandler;
+    }
+
+    public static ServerDefaultProducesHandlerBuildItem json() {
+        return new ServerDefaultProducesHandlerBuildItem(new JsonDefaultProducersHandler());
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -4,6 +4,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.common.annotation.Experimental;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED, name = "rest")
 public class ResteasyReactiveConfig {
@@ -23,4 +24,14 @@ public class ResteasyReactiveConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean singleDefaultProduces;
+
+    /**
+     * When one of the quarkus-resteasy-reactive-jackson or quarkus-resteasy-reactive-jsonb extension are active
+     * and the result type of an endpoint is an application class or one of {@code Collection}, {@code List}, {@code Set} or
+     * {@code Map},
+     * we assume the default return type is "application/json" if this configuration is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    @Experimental("This flag has a high probability of going away in the future")
+    public boolean defaultProduces;
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ResourceScanningResultBuildItem;
+import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
@@ -32,6 +33,11 @@ public class ResteasyReactiveJacksonProcessor {
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(Feature.RESTEASY_REACTIVE_JACKSON));
+    }
+
+    @BuildStep
+    ServerDefaultProducesHandlerBuildItem jsonDefault() {
+        return ServerDefaultProducesHandlerBuildItem.json();
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -23,7 +23,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
 
     @GET
     @Path("/person")
-    @Produces(MediaType.APPLICATION_JSON)
     public Person getPerson() {
         Person person = new Person();
         person.setFirst("Bob");
@@ -77,7 +76,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
 
     @POST
     @Path("/people")
-    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public List<Person> getPeople(List<Person> people) {
         if (BlockingOperationControl.isBlockingAllowed()) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
@@ -9,6 +9,7 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
 import io.quarkus.resteasy.reactive.jsonb.runtime.serialisers.JsonbMessageBodyReader;
 import io.quarkus.resteasy.reactive.jsonb.runtime.serialisers.JsonbMessageBodyWriter;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
@@ -19,6 +20,11 @@ public class ResteasyReactiveJsonbProcessor {
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(Feature.RESTEASY_REACTIVE_JSONB));
+    }
+
+    @BuildStep
+    ServerDefaultProducesHandlerBuildItem jsonDefault() {
+        return ServerDefaultProducesHandlerBuildItem.json();
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
@@ -21,7 +21,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
 
     @GET
     @Path("/person")
-    @Produces(MediaType.APPLICATION_JSON)
     public Person getPerson() {
         Person person = new Person();
         person.setFirst("Bob");
@@ -75,7 +74,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
 
     @POST
     @Path("/people")
-    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public List<Person> getPeople(List<Person> people) {
         if (BlockingOperationControl.isBlockingAllowed()) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/deployment/pom.xml
@@ -62,11 +62,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/DefaultProducesHandler.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/DefaultProducesHandler.java
@@ -1,0 +1,54 @@
+package org.jboss.resteasy.reactive.common.processor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.ws.rs.core.MediaType;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
+
+public interface DefaultProducesHandler {
+
+    List<MediaType> handle(Context context);
+
+    interface Context {
+        Type nonAsyncReturnType();
+
+        IndexView index();
+
+        ResteasyReactiveConfig config();
+    }
+
+    class Noop implements DefaultProducesHandler {
+
+        public static Noop INSTANCE = new Noop();
+
+        private Noop() {
+        }
+
+        @Override
+        public List<MediaType> handle(Context context) {
+            return Collections.emptyList();
+        }
+    }
+
+    class DelegatingDefaultProducesHandler implements DefaultProducesHandler {
+        private final List<DefaultProducesHandler> delegates;
+
+        public DelegatingDefaultProducesHandler(List<DefaultProducesHandler> delegates) {
+            this.delegates = Objects.requireNonNull(delegates);
+        }
+
+        @Override
+        public List<MediaType> handle(Context context) {
+            for (DefaultProducesHandler delegate : delegates) {
+                List<MediaType> result = delegate.handle(context);
+                if ((result != null) && !result.isEmpty()) {
+                    return result;
+                }
+            }
+            return Collections.emptyList();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -109,6 +109,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             ResteasyReactiveDotNames.RESOURCE_INFO)));
 
     protected static final Logger log = Logger.getLogger(EndpointIndexer.class);
+    protected static final String[] EMPTY_STRING_ARRAY = new String[] {};
     private static final String[] PRODUCES_PLAIN_TEXT_NEGOTIATED = new String[] { MediaType.TEXT_PLAIN, MediaType.WILDCARD };
     private static final String[] PRODUCES_PLAIN_TEXT = new String[] { MediaType.TEXT_PLAIN };
 
@@ -153,7 +154,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     protected final IndexView index;
     private final Map<String, String> existingConverters;
     private final Map<DotName, String> scannedResourcePaths;
-    private final ResteasyReactiveConfig config;
+    protected final ResteasyReactiveConfig config;
     private final AdditionalReaders additionalReaders;
     private final Map<DotName, String> httpAnnotationToMethod;
     private final Map<String, InjectableBean> injectableBeans;
@@ -501,8 +502,11 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         // FIXME: primitives
         if (STRING.equals(nonAsyncReturnType.name()))
             return config.isSingleDefaultProduces() ? PRODUCES_PLAIN_TEXT : PRODUCES_PLAIN_TEXT_NEGOTIATED;
-        // FIXME: JSON
-        return produces;
+        return applyAdditionalDefaults(nonAsyncReturnType);
+    }
+
+    protected String[] applyAdditionalDefaults(Type nonAsyncReturnType) {
+        return EMPTY_STRING_ARRAY;
     }
 
     private Type getNonAsyncReturnType(Type returnType) {
@@ -888,6 +892,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         return NameBindingUtil.nameBindingNames(index, methodInfo, forClass);
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static abstract class Builder<T extends EndpointIndexer<T, ?, METHOD>, B extends Builder<T, B, METHOD>, METHOD extends ResourceMethod> {
         private Function<String, BeanFactory<Object>> factoryCreator = new ReflectionBeanFactoryCreator();
         private boolean defaultBlocking;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -9,8 +9,10 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -151,9 +153,11 @@ public final class ResteasyReactiveDotNames {
     public static final DotName SUSPENDED = DotName.createSimple(Suspended.class.getName());
     public static final DotName PRE_MATCHING = DotName.createSimple(PreMatching.class.getName());
 
+    public static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
     public static final DotName LIST = DotName.createSimple(List.class.getName());
     public static final DotName SET = DotName.createSimple(Set.class.getName());
     public static final DotName SORTED_SET = DotName.createSimple(SortedSet.class.getName());
+    public static final DotName MAP = DotName.createSimple(Map.class.getName());
     public static final DotName MULTI_VALUED_MAP = DotName.createSimple(MultivaluedMap.class.getName());
     public static final DotName PATH_SEGMENT = DotName.createSimple(PathSegment.class.getName());
 

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
@@ -16,29 +16,44 @@ public class ResteasyReactiveConfig {
      */
     private boolean singleDefaultProduces;
 
+    /**
+     * When one of the quarkus-resteasy-reactive-jackson or quarkus-resteasy-reactive-jsonb extension are active
+     * and the result type of an endpoint is an application class or one of {@code Collection}, {@code List}, {@code Set} or
+     * {@code Map}, we assume the default return type is "application/json".
+     */
+    private boolean defaultProduces;
+
+    // we need this (and the setters) due to Bytecode Recording
     public ResteasyReactiveConfig() {
     }
 
-    public ResteasyReactiveConfig(long inputBufferSize, boolean singleDefaultProduces) {
+    public ResteasyReactiveConfig(long inputBufferSize, boolean singleDefaultProduces, boolean defaultProduces) {
         this.inputBufferSize = inputBufferSize;
         this.singleDefaultProduces = singleDefaultProduces;
+        this.defaultProduces = defaultProduces;
     }
 
     public long getInputBufferSize() {
         return inputBufferSize;
     }
 
+    public void setInputBufferSize(long inputBufferSize) {
+        this.inputBufferSize = inputBufferSize;
+    }
+
     public boolean isSingleDefaultProduces() {
         return singleDefaultProduces;
     }
 
-    public ResteasyReactiveConfig setInputBufferSize(long inputBufferSize) {
-        this.inputBufferSize = inputBufferSize;
-        return this;
+    public void setSingleDefaultProduces(boolean singleDefaultProduces) {
+        this.singleDefaultProduces = singleDefaultProduces;
     }
 
-    public ResteasyReactiveConfig setSingleDefaultProduces(boolean singleDefaultProduces) {
-        this.singleDefaultProduces = singleDefaultProduces;
-        return this;
+    public boolean isDefaultProduces() {
+        return defaultProduces;
+    }
+
+    public void setDefaultProduces(boolean defaultProduces) {
+        this.defaultProduces = defaultProduces;
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -239,11 +239,16 @@ public class ServerEndpointIndexer
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     public static class AbstractBuilder<B extends EndpointIndexer.Builder<ServerEndpointIndexer, B, ServerResourceMethod>>
             extends EndpointIndexer.Builder<ServerEndpointIndexer, B, ServerResourceMethod> {
 
         private MethodCreator initConverters;
         private EndpointInvokerFactory endpointInvokerFactory = new ReflectionEndpointInvokerFactory();
+
+        public EndpointInvokerFactory getEndpointInvokerFactory() {
+            return endpointInvokerFactory;
+        }
 
         public B setEndpointInvokerFactory(EndpointInvokerFactory endpointInvokerFactory) {
             this.endpointInvokerFactory = endpointInvokerFactory;

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -217,7 +217,7 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
                 .setScannedResourcePaths(resources.getScannedResourcePaths())
                 .setClassLevelExceptionMappers(new HashMap<>())
                 .setInjectableBeans(new HashMap<>())
-                .setConfig(new ResteasyReactiveConfig(10000, true))
+                .setConfig(new ResteasyReactiveConfig(10000, true, true))
                 .setHttpAnnotationToMethod(resources.getHttpAnnotationToMethod())
                 .build();
 


### PR DESCRIPTION
This is done when the JSON-B or Jackson extensions are used
and only applies to application classes and the most common
collection classes.

This is probably more complex than absolutely necessary, but it introduces a general way
to determine default produces Media Types.