### PR TITLE
Upgrading bouncycastle to 1.68

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <bouncycastle.version>1.66</bouncycastle.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
         <jandex.version>2.2.1.Final</jandex.version>
         <resteasy.version>4.5.8.Final</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>


### PR DESCRIPTION
The fix is already present in master and backported to 1.11. Adding it to 1.10