### PR TITLE
Some Non-Application path updates

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -47,6 +47,7 @@ import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLRecorder;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLRuntimeConfig;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
@@ -92,6 +93,8 @@ public class SmallRyeGraphQLProcessor {
     private static final String FILE_TO_UPDATE = "render.js";
     private static final String LINE_TO_UPDATE = "const api = '";
     private static final String LINE_FORMAT = LINE_TO_UPDATE + "%s';";
+    private static final String UI_LINE_TO_UPDATE = "const ui = '";
+    private static final String UI_LINE_FORMAT = UI_LINE_TO_UPDATE + "%s';";
 
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> featureProducer) {
@@ -205,15 +208,21 @@ public class SmallRyeGraphQLProcessor {
         // add graphql endpoint for not found display in dev or test mode
         if (launchMode.getLaunchMode().isDevOrTest()) {
             notFoundPageDisplayableEndpointProducer
-                    .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLConfig.rootPath));
+                    .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLConfig.rootPath,
+                            "MicroProfile GraphQL Endpoint"));
             notFoundPageDisplayableEndpointProducer
-                    .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLConfig.rootPath + SCHEMA_PATH));
+                    .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLConfig.rootPath + SCHEMA_PATH,
+                            "MicroProfile GraphQL Schema"));
         }
 
         Boolean allowGet = ConfigProvider.getConfig().getOptionalValue(ConfigKey.ALLOW_GET, boolean.class).orElse(false);
 
         Handler<RoutingContext> executionHandler = recorder.executionHandler(allowGet);
-        routeProducer.produce(new RouteBuildItem(graphQLConfig.rootPath, executionHandler, HandlerType.BLOCKING));
+        routeProducer.produce(new RouteBuildItem.Builder()
+                .route(graphQLConfig.rootPath)
+                .handler(executionHandler)
+                .blockingRoute()
+                .build());
 
     }
 
@@ -431,6 +440,7 @@ public class SmallRyeGraphQLProcessor {
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> notFoundPageDisplayableEndpointProducer,
             BuildProducer<SmallRyeGraphQLBuildItem> smallRyeGraphQLBuildProducer,
             HttpRootPathBuildItem httpRootPath,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchMode,
             SmallRyeGraphQLConfig graphQLConfig) throws Exception {
@@ -443,6 +453,8 @@ public class SmallRyeGraphQLProcessor {
             }
 
             String graphQLPath = httpRootPath.adjustPath(graphQLConfig.rootPath);
+            String graphQLUiPath = nonApplicationRootPathBuildItem
+                    .adjustPath(httpRootPath.adjustPath(graphQLConfig.ui.rootPath));
 
             AppArtifact artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, GRAPHQL_UI_WEBJAR_GROUP_ID,
                     GRAPHQL_UI_WEBJAR_ARTIFACT_ID);
@@ -450,11 +462,12 @@ public class SmallRyeGraphQLProcessor {
                 Path tempPath = WebJarUtil.copyResourcesForDevOrTest(curateOutcomeBuildItem, launchMode, artifact,
                         GRAPHQL_UI_WEBJAR_PREFIX);
                 WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLPath, LINE_TO_UPDATE, LINE_FORMAT);
+                WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLUiPath, UI_LINE_TO_UPDATE, UI_LINE_FORMAT);
 
                 smallRyeGraphQLBuildProducer.produce(new SmallRyeGraphQLBuildItem(tempPath.toAbsolutePath().toString(),
-                        httpRootPath.adjustPath(graphQLConfig.ui.rootPath)));
+                        graphQLUiPath));
                 notFoundPageDisplayableEndpointProducer
-                        .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLConfig.ui.rootPath + "/"));
+                        .produce(new NotFoundPageDisplayableEndpointBuildItem(graphQLUiPath + "/", "MicroProfile GraphQL UI"));
 
             } else {
                 Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(curateOutcomeBuildItem, artifact,
@@ -469,6 +482,10 @@ public class SmallRyeGraphQLProcessor {
                                 .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLPath, LINE_TO_UPDATE,
                                         LINE_FORMAT)
                                 .getBytes(StandardCharsets.UTF_8);
+                        content = WebJarUtil
+                                .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLPath, UI_LINE_TO_UPDATE,
+                                        UI_LINE_FORMAT)
+                                .getBytes(StandardCharsets.UTF_8);
                     }
                     fileName = GRAPHQL_UI_FINAL_DESTINATION + "/" + fileName;
 
@@ -477,7 +494,7 @@ public class SmallRyeGraphQLProcessor {
                 }
 
                 smallRyeGraphQLBuildProducer.produce(new SmallRyeGraphQLBuildItem(GRAPHQL_UI_FINAL_DESTINATION,
-                        httpRootPath.adjustPath(graphQLConfig.ui.rootPath)));
+                        graphQLUiPath));
             }
         }
     }
@@ -495,8 +512,16 @@ public class SmallRyeGraphQLProcessor {
         if (shouldInclude(launchMode, graphQLConfig)) {
             Handler<RoutingContext> handler = recorder.uiHandler(smallRyeGraphQLBuildItem.getGraphqlUiFinalDestination(),
                     smallRyeGraphQLBuildItem.getGraphqlUiPath(), runtimeConfig);
-            routeProducer.produce(new RouteBuildItem(graphQLConfig.ui.rootPath, handler));
-            routeProducer.produce(new RouteBuildItem(graphQLConfig.ui.rootPath + "/*", handler));
+            routeProducer.produce(new RouteBuildItem.Builder()
+                    .nonApplicationRoute(true)
+                    .route(graphQLConfig.ui.rootPath)
+                    .handler(handler)
+                    .build());
+            routeProducer.produce(new RouteBuildItem.Builder()
+                    .nonApplicationRoute(true)
+                    .route(graphQLConfig.ui.rootPath + "/*")
+                    .handler(handler)
+                    .build());
         }
     }
 

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthOpenAPITest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthOpenAPITest.java
@@ -30,9 +30,9 @@ public class HealthOpenAPITest {
                 .when().get(OPEN_API_PATH)
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
-                .body("paths", Matchers.hasKey("/health/ready"))
-                .body("paths", Matchers.hasKey("/health/live"))
-                .body("paths", Matchers.hasKey("/health"))
+                .body("paths", Matchers.hasKey("/q/health/ready"))
+                .body("paths", Matchers.hasKey("/q/health/live"))
+                .body("paths", Matchers.hasKey("/q/health"))
                 .body("components.schemas.HealthCheckResponse.type", Matchers.equalTo("object"));
 
     }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -67,6 +67,7 @@ import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRecorder;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRuntimeConfig;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.smallrye.openapi.api.OpenApiConfig;
@@ -149,6 +150,7 @@ public class SmallRyeOpenApiProcessor {
     RouteBuildItem handler(LaunchModeBuildItem launch,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints,
             OpenApiRecorder recorder,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             OpenApiRuntimeConfig openApiRuntimeConfig,
             ShutdownContextBuildItem shutdownContext,
             SmallRyeOpenApiConfig openApiConfig) {
@@ -165,7 +167,8 @@ public class SmallRyeOpenApiProcessor {
          */
         if (launch.getLaunchMode() == LaunchMode.DEVELOPMENT) {
             recorder.setupClDevMode(shutdownContext);
-            displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(openApiConfig.path, "Open API"));
+            displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(
+                    nonApplicationRootPathBuildItem.adjustPath(openApiConfig.path), "Open API Schema document"));
         }
 
         Handler<RoutingContext> handler = recorder.handler(openApiRuntimeConfig);

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -77,7 +77,8 @@ public class SwaggerUiProcessor {
 
                 swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(tempPath.toAbsolutePath().toString(),
                         nonApplicationRootPathBuildItem.adjustPath(swaggerUiConfig.path)));
-                displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(swaggerUiConfig.path + "/"));
+                displayableEndpoints.produce(new NotFoundPageDisplayableEndpointBuildItem(
+                        nonApplicationRootPathBuildItem.adjustPath(swaggerUiConfig.path + "/"), "Open API UI"));
             } else {
                 Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(curateOutcomeBuildItem, artifact,
                         SWAGGER_UI_WEBJAR_PREFIX);


### PR DESCRIPTION
This PR add some more Non application root path fixes, more specifically:

Health 
* Fix the NotFound paths to include the non application path
* Fix the OpenAPI Filter to include the non application path
* Fix the UI to use the adjusted paths

GraphQL
* Move the GraphQL UI to also be under non application path

OpenAPI
* Fix the NotFound paths to include the non application path

Swagger UI
* Fix the NotFound paths to include the non application path


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>