### PR TITLE
Add public modifier to generated DevModeTest

### DIFF
--- a/devtools/maven/src/main/resources/create-extension-templates/DevModeTest.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/DevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class [=artifactIdBaseCamelCase]DevModeTest {
+public class [=artifactIdBaseCamelCase]DevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/test/java/org/acme/my/project/add/to/bom/test/AddToBomDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class AddToBomDevModeTest {
+public class AddToBomDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/test/java/org/acme/my/project/itest/test/ItestDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class ItestDevModeTest {
+public class ItestDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/src/test/java/org/acme/my/project/minimal/extension/test/MinimalExtensionDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class MinimalExtensionDevModeTest {
+public class MinimalExtensionDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/deployment/src/test/java/org/acme/myproject/with/grand/parent/test/WithGrandParentDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class WithGrandParentDevModeTest {
+public class WithGrandParentDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/new-extension-current-directory-project/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-current-directory-project/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class MyExtDevModeTest {
+public class MyExtDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project-with-jboss-parent/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class MyExtDevModeTest {
+public class MyExtDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/test/java/org/acme/my/ext/test/MyExtDevModeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
-class MyExtDevModeTest {
+public class MyExtDevModeTest {
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));


### PR DESCRIPTION
The generated extension project contains a DevModeTest class which is package-protected. 

When running test, the following exception is thrown: 
```
Caused by: java.lang.IllegalAccessException: class io.quarkus.test.QuarkusDevModeTest cannot access a member of class org.acme.quarkus.greeting.test.QuarkusGreetingDevModeTest with modifiers ""
```

This branch adds the `public` modifier to the class. 

close #14166 