### PR TITLE
Re-add xstream to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,7 @@ updates:
       - dependency-name: org.testcontainers:*
       - dependency-name: org.mockito:*
       - dependency-name: org.awaitility:awaitility
+      - dependency-name: com.thoughtworks.xstream:xstream
       # Maven plugins
       - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
       - dependency-name: net.revelc.code:impsort-maven-plugin


### PR DESCRIPTION
As there is no interfering *-java7 artifact anymore.
See https://x-stream.github.io/changes.html, 1.4.15, "Delivery".

I added it to the test dependencies, but it's really a mix of test and non-test.

FTR: #12274, #13739