### PR TITLE
Make SwaggerUiBuildITem public

### DIFF
--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiBuildItem.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiBuildItem.java
@@ -2,7 +2,7 @@ package io.quarkus.swaggerui.deployment;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
-final class SwaggerUiBuildItem extends SimpleBuildItem {
+public final class SwaggerUiBuildItem extends SimpleBuildItem {
 
     private final String swaggerUiFinalDestination;
     private final String swaggerUiPath;


### PR DESCRIPTION
I am creating a Dev Console tile for my extension. There I want to link: the extension's ui, the openapi specification (as a file), and the swagger ui "description" for my openapi specification.
Unfortunately the `SwaggerUiBuildItem` class is package-private, all the other classes in this package are public. So it seems to be OK that this class is also public (specially because BuildItems are though to be something people can listen on and this class is immutable).