### PR TITLE
Support OIDC cookie-path-header and storing id and refresh tokens

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -206,6 +206,11 @@ then most likely you also need to set a `quarkus.oidc.authentication.cookie-path
 
 Otherwise the browser cache manager may keep request path specific cookies which in turn may lead to some difficult to diagnoze errors. For example, an authorization code flow may fail due to a missing state cookie if a user has initially accessed `/index.html` but configured a callback URI to `/web-app/callback`.
 
+You can also set a `quarkus.oidc.authentication.cookie-path-header` property if the cookie path needs to be set dynamically.
+For example, setting `quarkus.oidc.authentication.cookie-path-header=X-Forwarded-Prefix` means that the value of HTTP `X-Forwarded-Prefix` header will be used to set a cookie path.
+
+If `quarkus.oidc.authentication.cookie-path-header` is set but no configured HTTP header is available in the current request then the `quarkus.oidc.authentication.cookie-path` will be checked.
+
 If your application is deployed across multiple domains, make sure to set a `quarkus.oidc.authentication.cookie-domain` property for the session cookie be visible to all protected Quarkus services, for example, if you have 2 services deployed at:
 
 * https://whatever.wherever.company.net/
@@ -366,10 +371,10 @@ Note this user session can not be extended forever - the returning user with the
 
 OIDC `CodeAuthenticationMechanism` is using the default `io.quarkus.oidc.TokenStateManager' interface implementation to keep the ID, access and refresh tokens returned in the authorization code or refresh grant responses in a session cookie. It makes Quarkus OIDC endpoints completely stateless.
 
-If all of these tokens are JWT tokens then combining them may produce a session cookie value larger than 4KB and the browsers may not keep this cookie.
-In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` to have a unique session token per each of these three tokens.
+Note that some endpoints do not require the access token. An access token is only required if the endpoint needs to retrieve `UserInfo` or access the downstream service with this access token or use the roles associated with the access token (the roles in the ID token are checked by default). In such cases you can set either `quarkus.oidc.state-session-manager.strategy=id-refresh-token` (keep ID and refresh tokens only) or `quarkus.oidc.state-session-manager.strategy=id-token` (keep ID token only).
 
-Alternatively, if having an ID token only is sufficient for your Quarkus endpoint and no access or refresh tokens are used then set `quarkus.oidc.state-session-manager.stategy=id-token`.
+If the ID, access and refresh tokens are JWT tokens then combining all of them (if the strategy is the default `keep-all-tokens`) or only ID and refresh tokens (if the strategy is `id-refresh-token`) may produce a session cookie value larger than 4KB and the browsers may not be able to keep this cookie.
+In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` to have a unique session token per each of these tokens.
 
 Register your own `io.quarkus.oidc.TokenStateManager' implementation as an `@ApplicationScoped` CDI bean if you need to customize the way the tokens are associated with the session cookie. For example, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -162,7 +162,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
             /**
              * Keep ID token only
              */
-            ID_TOKEN
+            ID_TOKEN,
+
+            /**
+             * Keep ID and refresh tokens only
+             */
+            ID_REFRESH_TOKENS
         }
 
         /**
@@ -440,11 +445,20 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Map<String, String> extraParams;
 
         /**
-         * Cookie path parameter value which, if set, will be used for the session, state and post logout cookies.
-         * It may need to be set when the redirect path has a root different to that of the original request URL.
+         * Cookie path parameter value which, if set, will be used to set a path parameter for the session, state and post
+         * logout cookies.
+         * The `cookie-path-header` property, if set, will be checked first.
          */
         @ConfigItem
         public Optional<String> cookiePath = Optional.empty();
+
+        /**
+         * Cookie path header parameter value which, if set, identifies the incoming HTTP header
+         * whose value will be used to set a path parameter for the session, state and post logout cookies.
+         * If the header is missing then the `cookie-path` property will be checked.
+         */
+        @ConfigItem
+        public Optional<String> cookiePathHeader = Optional.empty();
 
         /**
          * Cookie domain parameter value which, if set, will be used for the session, state and post logout cookies.
@@ -575,6 +589,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setSessionAgeExtension(Duration sessionAgeExtension) {
             this.sessionAgeExtension = sessionAgeExtension;
+        }
+
+        public Optional<String> getCookiePathHeader() {
+            return cookiePathHeader;
+        }
+
+        public void setCookiePathHeader(String cookiePathHeader) {
+            this.cookiePathHeader = Optional.of(cookiePathHeader);
         }
 
     }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -39,6 +39,14 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-split-tokens";
         }
 
+        if (path.contains("tenant-id-refresh-token")) {
+            return "tenant-id-refresh-token";
+        }
+
+        if (path.contains("tenant-split-id-refresh-token")) {
+            return "tenant-split-id-refresh-token";
+        }
+
         if (path.contains("tenant-autorefresh")) {
             return "tenant-autorefresh";
         }
@@ -53,6 +61,10 @@ public class CustomTenantResolver implements TenantResolver {
 
         if (path.contains("tenant-javascript")) {
             return "tenant-javascript";
+        }
+
+        if (path.contains("tenant-cookie-path-header")) {
+            return "tenant-cookie-path-header";
         }
 
         if (path.contains("callback-before-wrong-redirect")) {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -69,9 +69,21 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("tenant-id-refresh-token")
+    public String getNameIdRefreshTokenOnly() {
+        return "tenant-id-refresh-token:" + getName();
+    }
+
+    @GET
     @Path("tenant-split-tokens")
     public String getNameSplitTokens() {
         return "tenant-split-tokens:" + getName();
+    }
+
+    @GET
+    @Path("tenant-split-id-refresh-token")
+    public String getNameIdRefreshSplitTokens() {
+        return "tenant-split-id-refresh-token:" + getName();
     }
 
     @GET
@@ -138,15 +150,31 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("access/tenant-id-refresh-token")
+    public String getAccessTokenIdRefreshTokensOnly() {
+        return "tenant-id-refresh-token:" + getAccessToken();
+    }
+
+    @GET
     @Path("access/tenant-split-tokens")
     public String getAccessTokenSplitTokens() {
         return "tenant-split-tokens:" + getAccessToken();
     }
 
     @GET
+    @Path("access/tenant-split-id-refresh-token")
+    public String getAccessIdRefreshTokenSplitTokens() {
+        return "tenant-split-id-refresh-token:" + getAccessToken();
+    }
+
+    @GET
     @Path("refresh")
     public String getRefreshToken() {
-        if (refreshToken.getToken() != null
+        return doGetRefreshToken(true);
+    }
+
+    private String doGetRefreshToken(boolean refreshWithAccessTokenCheckRequired) {
+        if (refreshWithAccessTokenCheckRequired && refreshToken.getToken() != null
                 && !accessTokenCredential.getRefreshToken().getToken().equals(refreshToken.getToken())) {
             throw new OIDCException("Refresh token values are not equal");
         }
@@ -166,6 +194,18 @@ public class ProtectedResource {
     @Path("refresh/tenant-idtoken-only")
     public String getRefreshTokenIdTokenOnly() {
         return "tenant-idtoken-only:" + getRefreshToken();
+    }
+
+    @GET
+    @Path("refresh/tenant-id-refresh-token")
+    public String getRefreshTokenIdRefreshTokensOnly() {
+        return "tenant-id-refresh-token:" + doGetRefreshToken(false);
+    }
+
+    @GET
+    @Path("refresh/tenant-split-id-refresh-token")
+    public String getRefreshTokenIdRefreshTokensSplit() {
+        return "tenant-split-id-refresh-token:" + doGetRefreshToken(false);
     }
 
     @GET

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -8,6 +8,7 @@ quarkus.oidc.authentication.redirect-path=/web-app
 # and next they try /web-app/* (when a state cookie might not be available)
 # Adding 'cookie-path=/' may prevent the intermittent CI failures to do with the missing state cookie
 quarkus.oidc.authentication.cookie-path=/
+quarkus.oidc.authentication.cookie-path-header=some-header
 quarkus.oidc.authentication.cookie-domain=localhost
 quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.oidc.application-type=web-app
@@ -111,11 +112,30 @@ quarkus.oidc.tenant-javascript.credentials.secret=secret
 quarkus.oidc.tenant-javascript.authentication.java-script-auto-redirect=false
 quarkus.oidc.tenant-javascript.application-type=web-app
 
+quarkus.oidc.tenant-cookie-path-header.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-cookie-path-header.client-id=quarkus-app
+quarkus.oidc.tenant-cookie-path-header.credentials.secret=secret
+quarkus.oidc.tenant-cookie-path-header.authentication.cookie-path-header=X-Forwarded-Prefix
+quarkus.oidc.tenant-cookie-path-header.application-type=web-app
+
 quarkus.oidc.tenant-idtoken-only.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-idtoken-only.client-id=quarkus-app
 quarkus.oidc.tenant-idtoken-only.credentials.secret=secret
 quarkus.oidc.tenant-idtoken-only.token-state-manager.strategy=id-token
 quarkus.oidc.tenant-idtoken-only.application-type=web-app
+
+quarkus.oidc.tenant-id-refresh-token.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-id-refresh-token.client-id=quarkus-app
+quarkus.oidc.tenant-id-refresh-token.credentials.secret=secret
+quarkus.oidc.tenant-id-refresh-token.token-state-manager.strategy=id-refresh-tokens
+quarkus.oidc.tenant-id-refresh-token.application-type=web-app
+
+quarkus.oidc.tenant-split-id-refresh-token.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-split-id-refresh-token.client-id=quarkus-app
+quarkus.oidc.tenant-split-id-refresh-token.credentials.secret=secret
+quarkus.oidc.tenant-split-id-refresh-token.token-state-manager.strategy=id-refresh-tokens
+quarkus.oidc.tenant-split-id-refresh-token.token-state-manager.split-tokens=true
+quarkus.oidc.tenant-split-id-refresh-token.application-type=web-app
 
 quarkus.oidc.tenant-split-tokens.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-split-tokens.client-id=quarkus-app
@@ -137,6 +157,9 @@ quarkus.http.auth.permission.autorefresh.policy=authenticated
 
 quarkus.http.auth.permission.javascript.paths=/tenant-javascript
 quarkus.http.auth.permission.javascript.policy=authenticated
+
+quarkus.http.auth.permission.tenant-cookie-path-header.paths=/tenant-cookie-path-header
+quarkus.http.auth.permission.tenant-cookie-path-header.policy=authenticated
 
 quarkus.http.auth.permission.post-logout.paths=/tenant-logout/post-logout
 quarkus.http.auth.permission.post-logout.policy=permit


### PR DESCRIPTION
Fixes #14189
Fixes #13485

This PR:

- Makes it possible to use the headers such as `X-Forwarded-Prefix` to set a cookie path. This is important in the cases where unique SSO sessions/applications are managed with the same domain, such as `example.org/app1` and `example.org/app2`
- Added a missing ID  + Refresh default token strategy - this should be recommended for all the cases where the access token is not required - which is likely to be 70-80% cases
- tests and docs have been updated