### PR TITLE
Remove quarkus-resteasy-reactive-spi from the runtime dependencies of the HV extension

### DIFF
--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -31,10 +31,6 @@
            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-spi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
This SPI artifact depends on core-deployment which shouldn't found among the application's runtime dependencies.

Fixes #14114 