### PR TITLE
Prevent Jackson serialization from resulting in an erroneous chunked transfer-encoding

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -2,6 +2,8 @@ package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.Supplier;
@@ -33,6 +35,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("transfer-encoding", nullValue())
+                .header("content-length", notNullValue())
                 .body("first", Matchers.equalTo("Bob"))
                 .body("last", Matchers.equalTo("Builder"));
 
@@ -44,6 +48,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("content-length", notNullValue())
+                .header("transfer-encoding", nullValue())
                 .body("first", Matchers.equalTo("Bob")).body("last", Matchers.equalTo("Builder"));
 
         RestAssured

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -246,6 +246,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("transfer-encoding", nullValue())
+                .header("content-length", notNullValue())
                 .body(containsString("Bob"))
                 .body(containsString("Builder"));
         // assert that our bi-function was created
@@ -260,6 +262,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("transfer-encoding", nullValue())
+                .header("content-length", notNullValue())
                 .body(containsString("Bob"))
                 .body(containsString("Builder"))
                 .body(containsString("Bob2"))

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
@@ -18,6 +18,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -43,14 +44,21 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
     public JacksonMessageBodyWriter(ObjectMapper mapper) {
         this.originalMapper = mapper;
         // we don't want the ObjectWriter to close the stream automatically, as we want to handle closing manually at the proper points
-        if (mapper.getFactory().isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
-            JsonFactory jsonFactory = mapper.getFactory().copy();
-            jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+        JsonFactory jsonFactory = mapper.getFactory();
+        if (needsNewFactory(jsonFactory)) {
+            jsonFactory = jsonFactory.copy();
+            jsonFactory.configure(Feature.AUTO_CLOSE_TARGET, false);
+            jsonFactory.configure(Feature.FLUSH_PASSED_TO_STREAM, false);
             this.defaultWriter = mapper.writer().with(jsonFactory);
         } else {
             this.defaultWriter = mapper.writer();
         }
     }
+
+    private boolean needsNewFactory(JsonFactory jsonFactory) {
+        return jsonFactory.isEnabled(Feature.AUTO_CLOSE_TARGET) || jsonFactory.isEnabled(Feature.FLUSH_PASSED_TO_STREAM);
+    }
+
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.jsonb.deployment.test;
 
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
 import java.util.function.Supplier;
 
 import org.hamcrest.Matchers;
@@ -29,6 +32,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("transfer-encoding", nullValue())
+                .header("content-length", notNullValue())
                 .body("first", Matchers.equalTo("Bob"))
                 .body("last", Matchers.equalTo("Builder"));
 
@@ -40,6 +45,8 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("content-length", notNullValue())
+                .header("transfer-encoding", nullValue())
                 .body("first", Matchers.equalTo("Bob")).body("last", Matchers.equalTo("Builder"));
 
         RestAssured


### PR DESCRIPTION
Without this PR, when Jackson wrote objects, because it was flushing the OutputStream, RESTEasy Reactive would send the `transfer-encoding: chunked` HTTP header and also not write the `content-length` header