### PR TITLE
Move SwaggerUiBuildItem to an spi project so it can be accessed by other extensions

### DIFF
--- a/extensions/swagger-ui/deployment/pom.xml
+++ b/extensions/swagger-ui/deployment/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>quarkus-swagger-ui</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-swagger-ui-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-ui</artifactId>
         </dependency>

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
+import io.quarkus.swaggerui.spi.SwaggerUiBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;

--- a/extensions/swagger-ui/pom.xml
+++ b/extensions/swagger-ui/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>spi</module>
     </modules>
 
 </project>

--- a/extensions/swagger-ui/spi/pom.xml
+++ b/extensions/swagger-ui/spi/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-swagger-ui-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-swagger-ui-spi</artifactId>
+    <name>Quarkus - Swagger UI - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/swagger-ui/spi/src/main/java/io/quarkus/swaggerui/spi/SwaggerUiBuildItem.java
+++ b/extensions/swagger-ui/spi/src/main/java/io/quarkus/swaggerui/spi/SwaggerUiBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.swaggerui.deployment;
+package io.quarkus.swaggerui.spi;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 


### PR DESCRIPTION
I want to consume this BuildItem from my extension so I can build my Dev Console card pointing to the swagger UI.
Stuart Douglas replied my that I could either do this or adjust the `NotFoundPageDisplayableEndpointBuildItem`, but I preferred the first approach becazse it seems that people are using this class to pass along endpoint information, not really related to "Not Found Page".

As a side question: Is it a good idea to adjust this class name to `EndpointAvailableBuildItem` (or create such a class)? If yes I will create a ticket to do so.

