### PR TITLE
Fix case where quarkus.kubernetes-config.enabled=false in properties file overrides env var

### DIFF
--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigRecorder.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigRecorder.java
@@ -46,9 +46,11 @@ public class KubernetesConfigRecorder {
             if (configSource instanceof AbstractRawDefaultConfigSource) {
                 return false;
             }
-            if (configSource.getPropertyNames().contains(CONFIG_ENABLED_PROPERTY_NAME)) {
+            // don't use configSource.getPropertyNames() as it returns an empty list for env vars
+            String strValue = configSource.getValue(CONFIG_ENABLED_PROPERTY_NAME);
+            if ((strValue != null) && !strValue.isEmpty()) {
                 // TODO: should probably use converter here
-                return !Boolean.parseBoolean(configSource.getValue(CONFIG_ENABLED_PROPERTY_NAME));
+                return !Boolean.parseBoolean(strValue);
             }
         }
         return false;


### PR DESCRIPTION
The was happening because `configSource.getPropertyNames()` always returns an empty list
when invoked on the `EnvConfigSource` (because it's expensive to calculate)

Fixes: #14275