### PR TITLE
Optimise bean destruction iterator

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -166,13 +166,8 @@ class RequestContext implements ManagedContext {
                 } catch (Exception e) {
                     LOGGER.warn("An error occurred during delivery of the @BeforeDestroyed(RequestScoped.class) event", e);
                 }
-                for (Map.Entry<Contextual<?>, ContextInstanceHandle<?>> entry : currentContext.entrySet()) {
-                    try {
-                        entry.getValue().destroy();
-                    } catch (Exception e) {
-                        throw new IllegalStateException("Unable to destroy instance" + entry.getValue().get(), e);
-                    }
-                }
+                //Performance: avoid an iterator on the map elements
+                currentContext.forEach(this::destroyContextElement);
                 // Fire an event with qualifier @Destroyed(RequestScoped.class) if there are any observers for it
                 try {
                     fireIfNotEmpty(destroyedNotifier);
@@ -181,6 +176,14 @@ class RequestContext implements ManagedContext {
                 }
                 currentContext.clear();
             }
+        }
+    }
+
+    private void destroyContextElement(Contextual<?> contextual, ContextInstanceHandle<?> contextInstanceHandle) {
+        try {
+            contextInstanceHandle.destroy();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to destroy instance" + contextInstanceHandle.get(), e);
         }
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -123,7 +123,7 @@ class RequestContext implements ManagedContext {
             if (initialState instanceof RequestContextState) {
                 currentContext.set(((RequestContextState) initialState).value);
             } else {
-                throw new IllegalArgumentException("Invalid inital state: " + initialState.getClass().getName());
+                throw new IllegalArgumentException("Invalid initial state: " + initialState.getClass().getName());
             }
         }
     }


### PR DESCRIPTION
This is a minor allocation rate improvement, identified by profiling under load.

The destruction of context can be very "hot" in some scenarios, this patch will have it allocate less.