### PR TITLE
Fix NPE in CacheManagerImpl

### DIFF
--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerImpl.java
@@ -14,11 +14,11 @@ import io.quarkus.cache.CacheManager;
 public class CacheManagerImpl implements CacheManager {
 
     // There's no need for concurrency here since the caches are created at build time and never modified after that.
-    private Map<String, Cache> caches;
-    private Set<String> cacheNames;
+    private Map<String, Cache> caches = Collections.emptyMap();
+    private Set<String> cacheNames = Collections.emptySet();
 
     public void setCaches(Map<String, Cache> caches) {
-        if (this.caches != null) {
+        if (this.caches != Collections.EMPTY_MAP) {
             throw new IllegalStateException("The caches map must only be set once at build time");
         }
         this.caches = Collections.unmodifiableMap(caches);


### PR DESCRIPTION
The caches are not always initialized now that we got rid of the empty
unnamed one and this can cause a NPE.

I think we should probably get rid of this and initialize a proper immutable synthetic bean but we need a quick fix that's backportable.