### PR TITLE
Replace '.' with '_' when generating env var in Kubernetes extension

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
@@ -41,6 +41,6 @@ public class EnvConverter {
     }
 
     public static String convertName(String name) {
-        return name != null ? name.toUpperCase().replace("-", "_") : null;
+        return name != null ? name.toUpperCase().replace('-', '_').replace('.', '_') : null;
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -115,7 +115,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
@@ -57,6 +57,9 @@ public class KubernetesWithNewStyleEnvTest {
                             assertThat(container.getEnv())
                                     .filteredOn(env -> "ENVVAR".equals(env.getName()))
                                     .singleElement().satisfies(env -> assertThat(env.getValue()).isEqualTo("value"));
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "QUARKUS_KUBERNETES_CONFIG_ENABLED".equals(env.getName()))
+                                    .singleElement().satisfies(env -> assertThat(env.getValue()).isEqualTo("true"));
                             final List<EnvFromSource> envFrom = container.getEnvFrom();
                             assertThat(envFrom).hasSize(2);
                             assertThat(envFrom)

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
@@ -1,4 +1,5 @@
 quarkus.kubernetes.env.fields.fromfield=metadata.name
 quarkus.kubernetes.env.vars.envvar=value
+quarkus.kubernetes.env.vars."quarkus.kubernetes-config.enabled"=true
 quarkus.kubernetes.env.configmaps=configName
 quarkus.kubernetes.env.secrets=secretName


### PR DESCRIPTION
Fixes: #14291