### PR TITLE
Allow adding inline attachement using MailTemplate

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -1,5 +1,6 @@
 package io.quarkus.mailer;
 
+import java.io.File;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -47,6 +48,8 @@ public interface MailTemplate {
         MailTemplateInstance replyTo(String replyTo);
 
         MailTemplateInstance bounceAddress(String bounceAddress);
+
+        MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId);
 
         MailTemplateInstance data(String key, Object value);
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.mailer.runtime;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -75,6 +76,12 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
     @Override
     public MailTemplateInstance bounceAddress(String bounceAddress) {
         this.mail.setBounceAddress(bounceAddress);
+        return this;
+    }
+
+    @Override
+    public MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId) {
+        this.mail.addInlineAttachment(name, file, contentType, contentId);
         return this;
     }
 


### PR DESCRIPTION
As suggested in #13564 this branch adds a `addInlineAttachement` in the `MailTemplate` interface.

close #13564