### PR TITLE
Connection handling fixes

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -1,0 +1,191 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.BaseSessionEventListener;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Check transaction lifecycle, including session flushes and the closing of the session.
+ */
+public abstract class AbstractTransactionLifecycleTest {
+
+    private static final String INITIAL_NAME = "Initial name";
+    private static final String UPDATED_NAME = "Updated name";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(SimpleEntity.class)
+                    .addAsResource("application.properties"))
+            // Expect no warnings (in particular from Agroal)
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    // Ignore this particular warning when building with Java 8: it's not relevant to this test.
+                    && !record.getMessage().contains("Using Java versions older than 11 to build Quarkus applications"))
+            .assertLogRecords(records -> assertThat(records)
+                    .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .isEmpty());
+
+    @Test
+    public void testLifecycle() {
+        long id = 1L;
+        TestCRUD crud = crud();
+
+        ValueAndExecutionMetadata<Void> created = crud.create(id, INITIAL_NAME);
+        checkPostConditions(created,
+                LifecycleOperation.FLUSH, LifecycleOperation.STATEMENT, // update
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
+                LifecycleOperation.TRANSACTION_COMPLETION);
+
+        ValueAndExecutionMetadata<String> retrieved = crud.retrieve(id);
+        checkPostConditions(retrieved,
+                LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.FLUSH,
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
+                LifecycleOperation.TRANSACTION_COMPLETION);
+        assertThat(retrieved.value).isEqualTo(INITIAL_NAME);
+
+        ValueAndExecutionMetadata<Void> updated = crud.update(id, UPDATED_NAME);
+        checkPostConditions(updated,
+                LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.FLUSH, LifecycleOperation.STATEMENT, // update
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
+                LifecycleOperation.TRANSACTION_COMPLETION);
+
+        retrieved = crud.retrieve(id);
+        checkPostConditions(retrieved,
+                LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.FLUSH,
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
+                LifecycleOperation.TRANSACTION_COMPLETION);
+        assertThat(retrieved.value).isEqualTo(UPDATED_NAME);
+
+        ValueAndExecutionMetadata<Void> deleted = crud.delete(id);
+        checkPostConditions(deleted,
+                LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.FLUSH, LifecycleOperation.STATEMENT, // delete
+                // No double flush here, since there's nothing in the session after the first flush.
+                LifecycleOperation.TRANSACTION_COMPLETION);
+
+        retrieved = crud.retrieve(id);
+        checkPostConditions(retrieved,
+                LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.TRANSACTION_COMPLETION);
+        assertThat(retrieved.value).isNull();
+    }
+
+    protected abstract TestCRUD crud();
+
+    protected abstract boolean expectDoubleFlush();
+
+    private void checkPostConditions(ValueAndExecutionMetadata<?> result, LifecycleOperation... expectedOperationsArray) {
+        List<LifecycleOperation> expectedOperations = new ArrayList<>();
+        Collections.addAll(expectedOperations, expectedOperationsArray);
+        expectedOperations.removeIf(Objects::isNull);
+        // No extra statements or flushes
+        assertThat(result.listener.operations)
+                .containsExactlyElementsOf(expectedOperations);
+        // Session was closed automatically
+        assertThat(result.sessionImplementor).returns(true, SharedSessionContractImplementor::isClosed);
+    }
+
+    public abstract static class TestCRUD {
+        public ValueAndExecutionMetadata<Void> create(long id, String name) {
+            return inTransaction(entityManager -> {
+                SimpleEntity entity = new SimpleEntity(name);
+                entity.setId(id);
+                entityManager.persist(entity);
+                return null;
+            });
+        }
+
+        public ValueAndExecutionMetadata<String> retrieve(long id) {
+            return inTransaction(entityManager -> {
+                SimpleEntity entity = entityManager.find(SimpleEntity.class, id);
+                return entity == null ? null : entity.getName();
+            });
+        }
+
+        public ValueAndExecutionMetadata<Void> update(long id, String name) {
+            return inTransaction(entityManager -> {
+                SimpleEntity entity = entityManager.find(SimpleEntity.class, id);
+                entity.setName(name);
+                return null;
+            });
+        }
+
+        public ValueAndExecutionMetadata<Void> delete(long id) {
+            return inTransaction(entityManager -> {
+                SimpleEntity entity = entityManager.find(SimpleEntity.class, id);
+                entityManager.remove(entity);
+                return null;
+            });
+        }
+
+        public abstract <T> ValueAndExecutionMetadata<T> inTransaction(Function<EntityManager, T> action);
+    }
+
+    protected static class ValueAndExecutionMetadata<T> {
+
+        public static <T> ValueAndExecutionMetadata<T> run(EntityManager entityManager, Function<EntityManager, T> action) {
+            LifecycleListener listener = new LifecycleListener();
+            entityManager.unwrap(Session.class).addEventListeners(listener);
+            T result = action.apply(entityManager);
+            return new ValueAndExecutionMetadata<>(result, entityManager, listener);
+        }
+
+        final T value;
+        final SessionImplementor sessionImplementor;
+        final LifecycleListener listener;
+
+        private ValueAndExecutionMetadata(T value, EntityManager entityManager, LifecycleListener listener) {
+            this.value = value;
+            // Make sure we don't return a wrapper, but the actual implementation.
+            this.sessionImplementor = entityManager.unwrap(SessionImplementor.class);
+            this.listener = listener;
+        }
+    }
+
+    private static class LifecycleListener extends BaseSessionEventListener {
+        private final List<LifecycleOperation> operations = new ArrayList<>();
+
+        @Override
+        public void jdbcExecuteStatementStart() {
+            operations.add(LifecycleOperation.STATEMENT);
+        }
+
+        @Override
+        public void flushStart() {
+            operations.add(LifecycleOperation.FLUSH);
+        }
+
+        @Override
+        public void transactionCompletion(boolean successful) {
+            operations.add(LifecycleOperation.TRANSACTION_COMPLETION);
+        }
+    }
+
+    private enum LifecycleOperation {
+        STATEMENT,
+        FLUSH,
+        TRANSACTION_COMPLETION;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/GetTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/GetTransactionLifecycleTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+public class GetTransactionLifecycleTest extends AbstractTransactionLifecycleTest {
+
+    @Inject
+    GetTransactionCRUD getTransactionCRUD;
+
+    @Override
+    protected TestCRUD crud() {
+        return getTransactionCRUD;
+    }
+
+    @Override
+    protected boolean expectDoubleFlush() {
+        // We expect double flushes in this case because EntityTransaction.commit() triggers a flush,
+        // and then the transaction synchronization will also trigger a flush before transaction completion.
+        // This may be a bug in ORM, but in any case there's nothing we can do about it.
+        return true;
+    }
+
+    @ApplicationScoped
+    public static class GetTransactionCRUD extends TestCRUD {
+        @Inject
+        EntityManagerFactory entityManagerFactory;
+
+        @Override
+        public <T> ValueAndExecutionMetadata<T> inTransaction(Function<EntityManager, T> action) {
+            EntityManager entityManager = entityManagerFactory.createEntityManager();
+            try (AutoCloseable closeable = entityManager::close) {
+                EntityTransaction tx = entityManager.getTransaction();
+                tx.begin();
+                ValueAndExecutionMetadata<T> result;
+                try {
+                    result = ValueAndExecutionMetadata.run(entityManager, action);
+                } catch (Exception e) {
+                    try {
+                        tx.rollback();
+                    } catch (Exception e2) {
+                        e.addSuppressed(e2);
+                    }
+                    throw e;
+                }
+                tx.commit();
+                return result;
+            } catch (Exception e) {
+                throw new IllegalStateException("Unexpected exception: " + e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SimpleEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SimpleEntity.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class SimpleEntity {
+
+    @Id
+    private long id;
+
+    private String name;
+
+    public SimpleEntity() {
+    }
+
+    public SimpleEntity(String name) {
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/TransactionAnnotationLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/TransactionAnnotationLifecycleTest.java
@@ -22,8 +22,7 @@ public class TransactionAnnotationLifecycleTest extends AbstractTransactionLifec
 
     @Override
     protected boolean expectDoubleFlush() {
-        // FIXME: We expect double flushes in this case, but that's a bug
-        return true;
+        return false;
     }
 
     @ApplicationScoped
@@ -41,6 +40,12 @@ public class TransactionAnnotationLifecycleTest extends AbstractTransactionLifec
         @Transactional
         public ValueAndExecutionMetadata<String> retrieve(long id) {
             return super.retrieve(id);
+        }
+
+        @Override
+        @Transactional
+        public ValueAndExecutionMetadata<String> callStoredProcedure(long id) {
+            return super.callStoredProcedure(id);
         }
 
         @Override

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/TransactionAnnotationLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/TransactionAnnotationLifecycleTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+/**
+ * Check transaction lifecycle, including session flushes and the closing of the session.
+ */
+public class TransactionAnnotationLifecycleTest extends AbstractTransactionLifecycleTest {
+
+    @Inject
+    TransactionAnnotationCRUD transactionAnnotationCRUD;
+
+    @Override
+    protected TestCRUD crud() {
+        return transactionAnnotationCRUD;
+    }
+
+    @Override
+    protected boolean expectDoubleFlush() {
+        // FIXME: We expect double flushes in this case, but that's a bug
+        return true;
+    }
+
+    @ApplicationScoped
+    public static class TransactionAnnotationCRUD extends TestCRUD {
+        @Inject
+        EntityManager entityManager;
+
+        @Override
+        @Transactional
+        public ValueAndExecutionMetadata<Void> create(long id, String name) {
+            return super.create(id, name);
+        }
+
+        @Override
+        @Transactional
+        public ValueAndExecutionMetadata<String> retrieve(long id) {
+            return super.retrieve(id);
+        }
+
+        @Override
+        @Transactional
+        public ValueAndExecutionMetadata<Void> update(long id, String name) {
+            return super.update(id, name);
+        }
+
+        @Override
+        @Transactional
+        public ValueAndExecutionMetadata<Void> delete(long id) {
+            return super.delete(id);
+        }
+
+        @Override
+        public <T> ValueAndExecutionMetadata<T> inTransaction(Function<EntityManager, T> action) {
+            // We should already be in a transaction
+            return ValueAndExecutionMetadata.run(entityManager, action);
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/UserTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/UserTransactionLifecycleTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+/**
+ * Check transaction lifecycle, including session flushes and the closing of the session.
+ */
+public class UserTransactionLifecycleTest extends AbstractTransactionLifecycleTest {
+
+    @Inject
+    UserTransactionCRUD userTransactionCRUD;
+
+    @Override
+    protected TestCRUD crud() {
+        return userTransactionCRUD;
+    }
+
+    @Override
+    protected boolean expectDoubleFlush() {
+        // FIXME: We expect double flushes in this case, but that's a bug
+        return true;
+    }
+
+    @ApplicationScoped
+    public static class UserTransactionCRUD extends TestCRUD {
+        @Inject
+        EntityManager entityManager;
+        @Inject
+        UserTransaction userTransaction;
+
+        @Override
+        public <T> ValueAndExecutionMetadata<T> inTransaction(Function<EntityManager, T> action) {
+            try {
+                userTransaction.begin();
+                ValueAndExecutionMetadata<T> result;
+                try {
+                    result = ValueAndExecutionMetadata.run(entityManager, action);
+                } catch (Exception e) {
+                    try {
+                        userTransaction.rollback();
+                    } catch (Exception e2) {
+                        e.addSuppressed(e2);
+                    }
+                    throw e;
+                }
+                userTransaction.commit();
+                return result;
+            } catch (NotSupportedException | SystemException | RollbackException | HeuristicMixedException
+                    | HeuristicRollbackException e) {
+                throw new IllegalStateException("Unexpected exception: " + e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/UserTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/UserTransactionLifecycleTest.java
@@ -27,8 +27,7 @@ public class UserTransactionLifecycleTest extends AbstractTransactionLifecycleTe
 
     @Override
     protected boolean expectDoubleFlush() {
-        // FIXME: We expect double flushes in this case, but that's a bug
-        return true;
+        return false;
     }
 
     @ApplicationScoped

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -64,6 +64,7 @@ import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.jpa.internal.util.LogHelper;
 import org.hibernate.jpa.internal.util.PersistenceUnitTransactionTypeHelper;
 import org.hibernate.jpa.spi.IdentifierGeneratorStrategyProvider;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.hibernate.service.Service;
@@ -240,6 +241,21 @@ public class FastBootMetadataBuilder {
         }
         //Agroal already does disable auto-commit, so Hibernate ORM should trust that:
         cfg.put(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE.toString());
+
+        /**
+         * Set CONNECTION_HANDLING to DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION
+         * as it generally performs better, at no known drawbacks.
+         * This is a new mode in Hibernate ORM, it might become the default in the future.
+         *
+         * @see org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode
+         */
+        {
+            final Object explicitSetting = cfg.get(AvailableSettings.CONNECTION_HANDLING);
+            if (explicitSetting == null) {
+                cfg.put(AvailableSettings.CONNECTION_HANDLING,
+                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
+            }
+        }
 
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -255,6 +255,9 @@ public class FastBootMetadataBuilder {
         cfg.putIfAbsent(AvailableSettings.CONNECTION_HANDLING,
                 PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
 
+        // Auto-close sessions before transaction completion, as they should be when using JTA.
+        cfg.putIfAbsent(AvailableSettings.AUTO_CLOSE_SESSION, "true");
+
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -255,9 +255,6 @@ public class FastBootMetadataBuilder {
         cfg.putIfAbsent(AvailableSettings.CONNECTION_HANDLING,
                 PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
 
-        // Auto-close sessions before transaction completion, as they should be when using JTA.
-        cfg.putIfAbsent(AvailableSettings.AUTO_CLOSE_SESSION, "true");
-
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -242,20 +242,18 @@ public class FastBootMetadataBuilder {
         //Agroal already does disable auto-commit, so Hibernate ORM should trust that:
         cfg.put(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE.toString());
 
-        /**
+        /*
          * Set CONNECTION_HANDLING to DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION
          * as it generally performs better, at no known drawbacks.
          * This is a new mode in Hibernate ORM, it might become the default in the future.
          *
+         * Note: other connection handling modes lead to leaked resources, statements in particular.
+         * See https://github.com/quarkusio/quarkus/issues/7242, https://github.com/quarkusio/quarkus/issues/13273
+         *
          * @see org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode
          */
-        {
-            final Object explicitSetting = cfg.get(AvailableSettings.CONNECTION_HANDLING);
-            if (explicitSetting == null) {
-                cfg.put(AvailableSettings.CONNECTION_HANDLING,
-                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
-            }
-        }
+        cfg.putIfAbsent(AvailableSettings.CONNECTION_HANDLING,
+                PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
 
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/JTASessionOpener.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/JTASessionOpener.java
@@ -1,0 +1,50 @@
+package io.quarkus.hibernate.orm.runtime.session;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionBuilder;
+import org.hibernate.SessionFactory;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
+
+/**
+ * A delegate for opening a JTA-enabled Hibernate ORM session.
+ * <p>
+ * The main purpose of this class is to cache session options when possible;
+ * if we didn't care about caching, we could just replace any call to
+ */
+public class JTASessionOpener {
+    public static JTASessionOpener create(SessionFactory sessionFactory) {
+        final CurrentTenantIdentifierResolver currentTenantIdentifierResolver = sessionFactory
+                .unwrap(SessionFactoryImplementor.class).getCurrentTenantIdentifierResolver();
+        if (currentTenantIdentifierResolver == null) {
+            // No tenant ID resolver: we can cache the options.
+            return new JTASessionOpener(sessionFactory, createOptions(sessionFactory));
+        } else {
+            // There is a tenant ID resolver: we cannot cache the options.
+            return new JTASessionOpener(sessionFactory, null);
+        }
+    }
+
+    private static SessionBuilder<?> createOptions(SessionFactory sessionFactory) {
+        return sessionFactory.withOptions()
+                .autoClose(true) // .owner() is deprecated as well, so it looks like we need to rely on deprecated code...
+                .connectionHandlingMode(
+                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION)
+                .flushMode(FlushMode.ALWAYS);
+    }
+
+    private final SessionFactory sessionFactory;
+    private final SessionBuilder<?> cachedOptions;
+
+    public JTASessionOpener(SessionFactory sessionFactory, SessionBuilder<?> cachedOptions) {
+        this.sessionFactory = sessionFactory;
+        this.cachedOptions = cachedOptions;
+    }
+
+    public Session openSession() {
+        SessionBuilder<?> options = cachedOptions != null ? cachedOptions : createOptions(sessionFactory);
+        return options.openSession();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -59,6 +59,7 @@ public class TransactionScopedSession implements Session {
     private final TransactionManager transactionManager;
     private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
     private final SessionFactory sessionFactory;
+    private final JTASessionOpener jtaSessionOpener;
     private final String unitName;
     private final String sessionKey;
     private final Instance<RequestScopedSessionHolder> requestScopedSessions;
@@ -71,6 +72,7 @@ public class TransactionScopedSession implements Session {
         this.transactionManager = transactionManager;
         this.transactionSynchronizationRegistry = transactionSynchronizationRegistry;
         this.sessionFactory = sessionFactory;
+        this.jtaSessionOpener = JTASessionOpener.create(sessionFactory);
         this.unitName = unitName;
         this.sessionKey = this.getClass().getSimpleName() + "-" + unitName;
         this.requestScopedSessions = requestScopedSessions;
@@ -82,7 +84,7 @@ public class TransactionScopedSession implements Session {
             if (session != null) {
                 return new SessionResult(session, false, true);
             }
-            Session newSession = sessionFactory.openSession();
+            Session newSession = jtaSessionOpener.openSession();
             // The session has automatically joined the JTA transaction when it was constructed.
             transactionSynchronizationRegistry.putResource(sessionKey, newSession);
             // No need to flush or close the session upon transaction completion:

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -83,7 +83,7 @@ public class TransactionScopedSession implements Session {
                 return new SessionResult(session, false, true);
             }
             Session newSession = sessionFactory.openSession();
-            newSession.joinTransaction();
+            // The session has automatically joined the JTA transaction when it was constructed.
             transactionSynchronizationRegistry.putResource(sessionKey, newSession);
             // No need to flush or close the session upon transaction completion:
             // Hibernate ORM itself registers a transaction that does just that.

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -149,7 +149,7 @@ class PrometheusMetricsRegistryTest {
                 .body(containsString(
                         "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 3.0"))
                 .body(containsString(
-                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 2.0"))
+                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 1.0"))
 
                 // Annotated counters
                 .body(not(containsString("metric_none")))


### PR DESCRIPTION
Fixes #7242, #13273.

I ended up keeping support for `getTransaction()` for now, since it still works. We can open another pull request if we want to drop it.

Opening as draft because:

* The build is expected to fail for now; we need to upgrade to a version of ORM that includes https://github.com/hibernate/hibernate-orm/pull/3693 first.
* We need some additional testing as a previous version of this patch used to trigger deadlocks in the database. The fixes in ORM may solve these deadlocks, but that's absolutely not certain since we haven't found the exact cause yet. @johnaohara is trying to reproduce the deadlocks.