### PR TITLE
DRAFT:[Docs Single-sourcing PoC]QUARKUS-184: Single-source the Spring DI guide between product and community documentation

### DIFF
--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -9,3 +9,4 @@
 :BrandName: Quarkus
 :BrandLongName: {BrandName}
 :maven-version: 3.6.3
+:JDKVersion: 8

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -12,4 +12,6 @@
 :brand-name: Quarkus
 :brand-name-long: {BrandName}
 :maven-version: 3.6.3
-:jdk-version: 8
+:jdk-distribution: JDK
+ifdef::downstream[:jdk-distribution: OpenJDK]
+:jdk-version: 11

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -6,6 +6,9 @@
 :icons: font
 :imagesdir: ./images
 
+//moved doctype to attributes.adoc to automatically enable it for all books when attribute file is included 
+:doctype: book
+
 :BrandName: Quarkus
 :BrandLongName: {BrandName}
 :maven-version: 3.6.3

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -8,5 +8,5 @@
 
 // Product-related attributes
 :ProductName: Quarkus
-:ProductLongName: Red Hat build of Quarkus
+:ProductLongName: {ProductName}
 :maven-version: 3.6.3

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -6,7 +6,6 @@
 :icons: font
 :imagesdir: ./images
 
-// Product-related attributes
-:ProductName: Quarkus
-:ProductLongName: {ProductName}
+:BrandName: Quarkus
+:BrandLongName: {BrandName}
 :maven-version: 3.6.3

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -5,3 +5,8 @@
 :idseparator: -
 :icons: font
 :imagesdir: ./images
+
+// Product-related attributes
+:ProductName: Quarkus
+:ProductLongName: Red Hat build of Quarkus
+:maven-version: 3.6.3

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -6,10 +6,10 @@
 :icons: font
 :imagesdir: ./images
 
-//moved doctype to attributes.adoc to automatically enable it for all books when attribute file is included 
+//moved doctype to attributes.adoc to automatically enable it for all books when attribute file is included
 :doctype: book
 
-:BrandName: Quarkus
-:BrandLongName: {BrandName}
+:brand-name: Quarkus
+:brand-name-long: {BrandName}
 :maven-version: 3.6.3
-:JDKVersion: 8
+:jdk-version: 8

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -11,6 +11,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 // TODO: consider moving this to the attributes file
 :doctype: book
 
+//TODO: Determine if title can be replaced by attribute
 //Top-Level Assembly
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
 = Using the Quarkus extension for Spring Dependency Injection (DI) API

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -64,12 +64,17 @@ However, when you add arbitrary libraries that are part of Spring Framework to y
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
+ifdef::product-docs[]
 * Have a {ProductName} Maven project.
+endif::[]
+ifndef::product-docs[]
+* Have access to an IDE
+endif::[]
 * Have OpenJDK 8 installed.
 * Have Maven {maven-version} installed.
 
+ifndef::product-docs[]
 // Alternative 1: generate project form scratch
-////
 [id="creating-the-spring-di-example-maven-project_{context}"]
 == Creating the Spring DI example Maven project
 
@@ -96,7 +101,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
-////
+endif::[]
 
 //Alternative 2: you have a project and need to add the required extension.
 [id="setting-up-your-spring-di-maven-project_{context}"]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -11,10 +11,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 // TODO: consider moving this to the attributes file
 :doctype: book
 
-//TODO: Determine if title can be replaced by attribute
 //Top-Level Assembly
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
-= Using the Quarkus extension for Spring Dependency Injection (DI) API
+= Using the Quarkus Extension for Spring DI API
 
 ifdef::context[:parent-context: {context}]
 
@@ -65,17 +64,12 @@ However, when you add arbitrary libraries that are part of Spring Framework to y
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
-ifdef::product-docs[]
 * Have a {ProductName} Maven project.
-endif::[]
-ifndef::product-docs[]
-* Have access to an IDE
-endif::[]
 * Have OpenJDK 8 installed.
 * Have Maven {maven-version} installed.
 
-ifndef::product-docs[]
 // Alternative 1: generate project form scratch
+////
 [id="creating-the-spring-di-example-maven-project_{context}"]
 == Creating the Spring DI example Maven project
 
@@ -84,7 +78,7 @@ You can create new a new Maven project for the Spring DI example application on 
 
 .Procedure
 
-. Enter the following commands to:
+. Execute the following commands to:
 
 * generate the directory structure of the project.
 * create the main class file of the example application.
@@ -102,7 +96,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
-endif::[]
+////
 
 //Alternative 2: you have a project and need to add the required extension.
 [id="setting-up-your-spring-di-maven-project_{context}"]
@@ -120,7 +114,7 @@ Add the required {ProductName} extension as a dependency of your Maven project.
 cd <name-of-your-project-directory>
 ----
 
-. Enter the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
+. Execute the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
 +
 [source,bash]
 ----
@@ -191,7 +185,12 @@ public class AppConfiguration {
     }
 }
 ----
+<<<<<<< HEAD
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
+=======
++
+As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
+>>>>>>> f8979760ea (QUARKUS-184: add information introduced in Aurea's PR)
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
@@ -377,7 +376,7 @@ Package and start your Spring DI example application using Maven.
 cd <name-of-your-project-directory>
 ----
 
-. Enter the following command to compile and start your application in development mode:
+. Execute the following command to compile and start your application in development mode:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -460,6 +459,14 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 |`@Scope`
 |
 |Does not have a one-to-one mapping to a CDI annotation. Depending on the value of `@Scope`, you can use `@Singleton`, `@ApplicationScoped`, `@SessionScoped`, `@RequestScoped`, or `@Dependent`
+
+|`@ComponentScan`
+|
+|Does not have a one-to-one mapping to a CDI annotation. It is not used in Quarkus because Quarkus does all classpath scanning at build time.
+
+|`@Import`
+|
+|Does not have a one-to-one mapping to a CDI annotation.
 |===
 //END: REFERENCE module
 

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -459,7 +459,7 @@ The various Spring Boot test features are not supported by {brand-name}. For tes
 endif::[]
 
 ifdef::downstream[]
-[id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
+[id="overview-of-annotation-equivalents-in-spring-di-and-cdi-{context}"]
 endif::[]
 == Overview of annotation equivalents in Spring DI and MicroProfile CDI
 

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -106,11 +106,13 @@ ifdef::downstream[]
 [role="_abstract"]
 endif::[]
 You can create a new Maven project for the Spring Dependency Injection example application on the command line.
-You can also add the `quarkus-spring-di` to an existing project using the {BrandName} Maven plugin
+If you already have a {BrandName} Maven project, you add the `quarkus-spring-di` extension to it using the {BrandName} Maven plugin.
+This section describes steps for both alternatives.
 
 .Procedure
 
-* Enter the following commands to:
+* To create a new Maven project for your Spring DI example, you can use the {BrandName} Maven Plugin.
+Enter the following commands to:
 
 ** generate the directory structure of the project.
 ** create the main class file of the example application.
@@ -129,7 +131,8 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
 cd spring-di-quickstart
 ----
 
-* If you already have a {BrandName} project you can add the `quarkus-spring-di` extension to it using the command line:
+* To add the `quarkus-spring-di` extension to an existing {BrandName} Maven Project:
+// Open block markup required for downstream doc build. Do not remove.
 --
 . Navigate to the the top-level directory of your {BrandName} Maven project:
 +
@@ -154,6 +157,7 @@ This adds the following dependency to your `pom.xml` file:
     <artifactId>quarkus-spring-di</artifactId>
 </dependency>
 ----
+// Open block markup required for downstream doc build. Do not remove.
 --
 
 ifdef::downstream[]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -25,7 +25,6 @@ The `quarkus-spring-di` extension provides a compatibility layer for Spring Depe
 This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.
 
 ifndef::product-docs[]
-//TODO: What should we do with this? Leave it as community-only?
 
 This guide is maintained in the main Quarkus repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
@@ -45,21 +44,22 @@ ifndef::product-docs[]
 :extension-status: preview
 endif::[]
 
+//tech preview info for product docs
 ifdef::product-docs[]
 NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
 endif::[]
 
+// community-only note about the community suport status of this extension
 ifndef::product-docs[]
 include::./status-include.adoc[]
 endif::[]
 
-ifndef::product-docs[]
+ifdef::product-docs[]
 [IMPORTANT]
 ====
-Note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
-Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
-What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
-classes (like `org.springframework.beans.factory.config.BeanPostProcessor` for example) will not be executed.
+The Spring compatibility layer that {ProductName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you run your application.
+{ProductName} can only read metadata from Spring classes and annotations and can parse user code method return types and parameter types that are provided by Spring.
+However, when you add arbitrary libraries that are part of Spring to your {ProductName} application, {ProductName} is not able to use them.
 ====
 endif::[]
 
@@ -71,6 +71,7 @@ endif::[]
 * You have Maven {maven-version} installed.
 
 // Alternative 1: generate project form scratch
+////
 [id="creating-the-spring-di-example-maven-project_{context}"]
 == Creating the Spring DI Example Maven project
 
@@ -97,7 +98,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
-
+////
 
 //Alternative 2: you have a project and need to add the required extension.
 [id="setting-up-your-spring-di-maven-project_{context}"]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -8,18 +8,17 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 // comment out to show community version
 :downstream:
-// TODO: consider moving this to the attributes file
+//:upstream:
 :doctype: book
 
-//Top-Level Assembly
-[id="using-the-quarkus-extension-for-spring-di-api_{context}"]
+[id="proc-using-the-quarkus-extension-for-spring-di-api_{context}"]
 = Using the Quarkus Extension for Spring DI API
 
 ifdef::context[:parent-context: {context}]
 
 :context: using-the-quarkus-extension-for-spring-di
 
-include::./attributes.adoc[]
+include::attributes.adoc[]
 
 ifdef::downstream[]
 //file not present in upstream repo, commented out to allow build to pass
@@ -27,11 +26,9 @@ ifdef::downstream[]
 endif::[]
 
 [role="_abstract"]
-The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {BrandName} application.
-This guide explains how your {BrandName} application can leverage Dependency Injection annotations provided by the Spring Framework.
+As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework as an alternative to using MicroProfile CDI annotations.
 
-ifndef::downstream[]
-
+ifdef::upstream[]
 This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
@@ -45,32 +42,29 @@ Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {q
 The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
 endif::[]
 
-// Tech preview info for community purposes, different from product
+// upstream tech preview status and notes
 ifndef::downstream[]
 include::./status-include.adoc[]
 :extension-status: preview
 endif::[]
 
-//tech preview info for product docs
+//tech preview info for downstream docs
 ifdef::downstream[]
 NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
 endif::[]
 
-
-//ifdef::downstream[]
 [IMPORTANT]
 ====
 The Spring compatibility layer that {BrandName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
 {BrandName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
 However, when you add arbitrary libraries that are part of Spring Framework to your {BrandName} application, such libraries will not function properly, because {BrandName} is not able to use them.
 ====
-//endif::[]
 
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
 * Have a {BrandName} Maven project.
-* Have OpenJDK 8 installed.
+* Have OpenJDK {JDKVersion} installed.
 * Have Maven {maven-version} installed.
 
 // Alternative 1: generate project form scratch

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -66,21 +66,21 @@ endif::[]
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
-* You have a {ProductName} Maven project.
-* You have OpenJDK 8 installed.
-* You have Maven {maven-version} installed.
+* Have a {ProductName} Maven project.
+* Have OpenJDK 8 installed.
+* Have Maven {maven-version} installed.
 
 // Alternative 1: generate project form scratch
 ////
 [id="creating-the-spring-di-example-maven-project_{context}"]
-== Creating the Spring DI Example Maven project
+== Creating the Spring DI example Maven project
 
 [role="_abstract"]
 You can create new a new Maven project for the Spring DI example application on the command line.
 
 .Procedure
 
-. Execute the following commands to:
+. Run the following commands to:
 
 * generate the directory structure of the project
 * create the main class file of the example application
@@ -294,7 +294,7 @@ public class GreeterBean {
 == Updating the JAX-RS resource
 
 [role="_abstract"]
-When you create the class files of you example applications, you must also update the `GreeterResource.java` class file.
+When you create the class files of your example applications, you must also update the `GreeterResource.java` class file.
 // TODO: explain why this needs to be done.
 
 .Procedure
@@ -374,7 +374,7 @@ Package and run your Spring DI example application using Maven.
 cd <name-of-your-project-directory>
 ----
 
-. Execute the following command to compile and run your application in development mode:
+. Run the following command to compile and start your application in development mode:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -394,9 +394,9 @@ You can create a native image by following the guide about link:building-native-
 endif::[]
 
 ifndef::product-docs[]
-== Important Technical Note
+== Important technical note
 
-Note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -21,6 +21,10 @@ ifdef::context[:parent-context: {context}]
 
 include::./attributes.adoc[]
 
+ifdef::product-docs[]
+include::common/making-open-source-more-inclusive.adoc[]
+endif::[]
+
 [role="_abstract"]
 The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {ProductName} application.
 This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -10,25 +10,15 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 :product-docs:
 :doctype: book
 
-ifdef::product-docs[]
-//TODO: copy product attribute files over to community repo
-//include::common/attributes.adoc[]
-//temporary attributes
-:ProductName: Quarkus
-:ProductLongName: Red Hat build of Quarkus
-:maven-version: 3.6.3
-endif::[]
-
-
-
 //Top-Level Assembly
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
 = Using the Quarkus Extension for Spring DI API
 
 ifdef::context[:parent-context: {context}]
-//temporary context value, will be changed before going into production
-:context: guide-quarkus-spring-di
 
+:context: using-the-quarkus-extension-for-spring-di
+
+include::./attributes.adoc[]
 
 [role="_abstract"]
 The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
@@ -52,7 +42,6 @@ endif::[]
 
 // Tech preview info for community purposes, different from product
 ifndef::product-docs[]
-include::./attributes.adoc[]
 :extension-status: preview
 endif::[]
 
@@ -413,6 +402,7 @@ classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `or
 Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
 The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
 
+//BEGIN: REFERENCE module
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
 == Overview of annotation equivalents in Spring DI and CDI
 
@@ -459,7 +449,7 @@ The following table shows how Spring DI annotations can be converted to CDI anno
 |
 |Does not have a one-to-one mapping to a CDI annotation. Depending on the value of `@Scope`, you can use `@Singleton`, `@ApplicationScoped`, `@SessionScoped`, `@RequestScoped`, or `@Dependent`
 |===
-
+//END: REFERENCE module
 
 ifdef::product-docs[]
 [role="_additional-resources"]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -3,27 +3,31 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Quarkus - Quarkus Extension for Spring DI API
+[id="using-the-quarkus-extension-for-spring-di-api_{context}"]
+= Using the Quarkus Extension for Spring DI API
 
-include::./attributes.adoc[]
-:extension-status: preview
+//TODO: need to use product attributes, but also keep compatibility with community ones
+//include::./attributes.adoc[]
+// Tech preview info for community purposes, different form product
+//:extension-status: preview
 
-While users are encouraged to use CDI annotations for injection, Quarkus provides a compatibility layer for Spring dependency injection in the form of the `spring-di` extension.
+[role="_abstract"]
+The Quarkus `spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
+This guide explains how your Quarkus application can leverage Dependency Injection annotations provided by the Spring Framework.
 
-This guide explains how a Quarkus application can leverage the well known Dependency Injection annotations included in the Spring Framework.
-
+// conditionalized the inclusion of community-only status info section
+ifdef::product-docs[]
 include::./status-include.adoc[]
+endif::[]
 
-== Prerequisites
+.Prerequisites
 
-To complete this guide, you need:
-
-* less than 15 minutes
-* an IDE
-* JDK 11+ installed with `JAVA_HOME` configured appropriately
-* Apache Maven {maven-version}
+* You have a {ProductName} Maven project.
+* You have OpenJDK 8 installed.
+* You have Maven {maven-version} installed.
 
 
+////
 == Solution
 
 We recommend that you follow the instructions in the next sections and create the application step by step.
@@ -32,7 +36,9 @@ However, you can go right to the completed example.
 Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
 
 The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
+////
 
+////
 == Creating the Maven project
 
 First, we need a new project. Create a new project with the following command:
@@ -67,14 +73,37 @@ This will add the following to your `pom.xml`:
     <artifactId>quarkus-spring-di</artifactId>
 </dependency>
 ----
+////
 
-== Add beans using Spring annotations
 
-Let's proceed to create some beans using various Spring annotations.
+//== Add beans using Spring annotations
+//PROC
+[id="additng-beans-to-your-applications-using-spring-annotations"]
+= Adding beans to your application using Spring annotations
 
-First we will create a `StringFunction` interface that some of our beans will implement and which will be injected into another bean later on.
-Create a `src/main/java/org/acme/spring/di/StringFunction.java` file and set the following content:
+. Navigate to the directory that contains your {ProductName} project.
 
+. Add the `quarkus-spring-di` extension as a dependency of your application:
++
+[source,bash]
+----
+./mvnw quarkus:add-extension -Dextensions="spring-di"
+----
++
+This command adds the following dependency to your `pom.xml` file:
++
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-spring-di</artifactId>
+</dependency>
+----
+
+//. Create some beans for your application using Spring annotations.
+
+. Create a `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface:
++
 [source,java]
 ----
 package org.acme.spring.di;
@@ -85,10 +114,12 @@ public interface StringFunction extends Function<String, String> {
 
 }
 ----
++
+Other beans in this example implement this interface, and the interface is injected into another bean later on.
+//WHEN? Move this information to the relevant place
 
-With the interface in place, we will add an `AppConfiguration` class which will use the Spring's Java Config style for defining a bean.
-It will be used to create a `StringFunction` bean that will capitalize the text passed as parameter.
-Create a `src/main/java/org/acme/spring/di/AppConfiguration.java` file with the following content:
+. Create a `src/main/java/org/acme/spring/di/AppConfiguration.java` file that contains an `AppConfiguration` class and annotate it with the `@Configuration` annotation from Spring Java Config.
+Inside the `AppConfiguration` class, create a `StringFunction` bean that changes a string that you pass to it to uppercase:
 
 [source,java]
 ----
@@ -109,10 +140,11 @@ public class AppConfiguration {
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 
-Now we define another bean that will implement `StringFunction` using Spring's stereotype annotation style.
-This bean will effectively be a no-op bean that simply returns the input as is.
-Create a `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file and set the following content:
-
+. Create a `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file that contains the `NoOpSingleStringFunction` bean.
+The `NoOpSingleStringFunction` implements the `StringFunction` bean using the `@Component` stereotype annotation provided by Spring.
+//TODO: this sounds a little ambiguous
+This bean does not process the string, but returns the string as is.
++
 [source,java]
 ----
 package org.acme.spring.di;
@@ -129,18 +161,19 @@ public class NoOpSingleStringFunction implements StringFunction {
 }
 ----
 
-Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-To see that in action, first edit the `src/main/resources/application.properties` with the following content:
-
+//. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
+. With Quarkus, you can also use the `@Value` annotations to inject inject values of configuration properties into beans.
+.. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
++
 [source,properties]
 ----
 # Your configuration properties
 greeting.message = hello
 ----
 
-Next create a new Spring bean in `src/main/java/org/acme/spring/di/MessageProducer.java` with the following content:
-
-
+.. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file that contains a `MessageProducer` bean.
+Use the `@Value` annotation to set the value of the `greeting.message` property as the message String inside the `MessageProducer` bean:
++
 [source,java]
 ----
 package org.acme.spring.di;
@@ -160,9 +193,12 @@ public class MessageProducer {
 }
 ----
 
-The final bean we will create ties together all the previous beans.
-Create a `src/main/java/org/acme/spring/di/GreeterBean.java` file and copy the following content:
-
+//The final bean we will create ties together all the previous beans.
+. Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code shown in the example below.
+Note, that the `GreeterBean` bean relies on both contructor-based and field-based injection.
+In the example below, you do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
+Also note, that the `@Value` annotation on the `suffix` String has a default value assigned. The default value is used because you have not previously defined a `greeting.suffix` in the `application.properties` file.
++
 [source,java]
 ----
 package org.acme.spring.di;
@@ -199,11 +235,8 @@ public class GreeterBean {
 }
 ----
 
-In the code above, we see that both field injection and constructor injection are being used (note that constructor injection does not need the `@Autowired` annotation since there is a single constructor).
-Furthermore, the `@Value` annotation on `suffix` has also a default value defined, which in this case will be used since we have not defined `greeting.suffix` in `application.properties`.
-
-
-=== Update the JAX-RS resource
+[id="updating-the-jax-rs-resource_{context}"]
+=== Updating the JAX-RS resource
 
 Open the `src/main/java/org/acme/spring/di/GreeterResource.java` file and update it with the following content:
 
@@ -232,12 +265,16 @@ public class GreeterResource {
 }
 ----
 
-== Update the test
+[id='updating-the-application-test_{context}']
+== Updating the application test
 
-We also need to update the functional test to reflect the changes made to the endpoint.
-Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method to:
+[role="_abstract"]
+You must update the functional test to reflect the changes that you made to the endpoint.
 
+.Procedure
 
+. Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method to the following:
++
 [source, java]
 ----
 import io.quarkus.test.junit.QuarkusTest;
@@ -261,17 +298,28 @@ public class GreetingResourceTest {
 }
 ----
 
-== Package and run the application
+[id="packaging-and-running-your-application_{context}"]
+== Packaging and running your application:
 
-Run the application with: `./mvnw compile quarkus:dev`.
-Open your browser to http://localhost:8080/greeting.
+//[role="_abstract"]
+.Procedure
 
-The result should be: `HELLO WORLD!`.
+. To compile and run your application in development mode, execute the following command in the project directory:
++
+[source,bash]
+----
+./mvnw compile quarkus:dev
+----
 
-== Run the application as a native
+. Navigate to `http://localhost:8080/greeting` using a web browser. You receive `HELLO WORLD!` as a response.
+
+. To stop the application, press kbd:[CTRL+C].
+
+== Running your the application in native mode
 
 You can of course create a native image using instructions similar to link:building-native-image[this] guide.
 
+//TODO: MOve this up front, make it a con_
 == Important Technical Note
 
 Please note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
@@ -281,58 +329,59 @@ classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `or
 Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
 The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
 
-== Conversion Table
+//REF
+[id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
+== Overview of annotation equivalents in Spring DI and CDI
 
+//[role="_abstract"]
 The following table shows how Spring DI annotations can be converted to CDI and / or MicroProfile annotations.
 
 |===
 |Spring |CDI / MicroProfile |Comments
 
-|@Autowired
-|@Inject
+|`@Autowired`
+|`@Inject`
 |
 
-|@Qualifier
-|@Named
+|`@Qualifier`
+|`@Named`
 |
 
-|@Value
-|@ConfigProperty
-|@ConfigProperty doesn't support an expression language the way @Value does, but makes the typical use cases much easier to handle
+|`@Value`
+|`@ConfigProperty`
+|`@ConfigProperty` does not support an expression language the way `@Value` does, but makes the typical use cases much easier to handle
 
-|@Component
-|@Singleton
+|`@Component`
+|`@Singleton`
 |By default Spring stereotype annotations are singleton beans
 
-|@Service
-|@Singleton
+|`@Service`
+|`@Singleton`
 |By default Spring stereotype annotations are singleton beans
 
-|@Repository
-|@Singleton
+|`@Repository`
+|`@Singleton`
 |By default Spring stereotype annotations are singleton beans
 
-|@Configuration
-|@ApplicationScoped
-|In CDI a producer bean isn't limited to the application scope, it could just as well be @Singleton or @Dependent
+|`@Configuration`
+|`@ApplicationScoped`
+|In CDI a producer bean is not limited to the application scope, it could just as well be `@Singleton` or `@Dependent`
 
-|@Bean
-|@Produces
+|`@Bean`
+|`@Produces`
 |
 
-|@Scope
+|`@Scope`
 |
-|Doesn't have a one-to-one mapping to a CDI annotation. Depending on the value of @Scope, one of the @Singleton, @ApplicationScoped, @SessionScoped, @RequestScoped, @Dependent could be used
-
-|@ComponentScan
-|
-|Doesn't have a one-to-one mapping to a CDI annotation. It is not used in Quarkus because Quarkus does all classpath scanning at build time.
-
-|@Import
-|
-|Doesn't have a one-to-one mapping to a CDI annotation.
+|Does not have a one-to-one mapping to a CDI annotation. Depending on the value of `@Scope`, you can use `@Singleton`, `@ApplicationScoped`, `@SessionScoped`, `@RequestScoped`, or `@Dependent`
 |===
 
+
+//[role="_additional-resources"]
+//.Additional resources
+
+// next steps?  links
+//might have to be ommitted from the product version
 == More Spring guides
 
 Quarkus has more Spring compatibility features. See the following guides for more details:

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -216,20 +216,11 @@ public class AppConfiguration {
     }
 }
 ----
-As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
-In the same vein, Quarkus does not support the Spring `@Import` annotation.
-=======
 +
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation to define specific packages to scan for additional beans.
-<<<<<<< HEAD
-Note, that `@ComponentScan` is unnecessary because {BrandName} performs link:cdi#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
-Moreover, note, that the bean discovery in {BrandName} happens at build time.
-Similarly, {BrandName} does not support the Spring `@Import` annotation.
-=======
-Note, that `@ComponentScan` is unnecessary because {brand-name} performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
+Note, that `@ComponentScan` is unnecessary because {brand-name} performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
 Moreover, note, that the bean discovery in {brand-name} happens at build time.
 Similarly, {brand-name} does not support the Spring `@Import` annotation.
->>>>>>> 49cc6e9b34 (QUARKUS-184: switch to consistent lowercase attributes)
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
 The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -28,7 +28,8 @@ endif::[]
 include::attributes.adoc[]
 
 ifdef::downstream[]
-//file not present in upstream repo, commented out to allow build to pass
+//file not present in upstream repo, but required for downstream content
+//commented out to allow build to pass
 //include::common/making-open-source-more-inclusive.adoc[]
 endif::[]
 
@@ -438,8 +439,6 @@ ifndef::downstream[]
 //Only the -product-appropriate wording of the note should be used in both the community and product versions of this document.
 //I am retaining the original wording for purposes of verification and factual corrections.
 
-=======
-
 ifdef::upstream[]
 >>>>>>> 8e06509e82 (QUARKUS-184: Replace Quarkus with attribute except in section titles, conditionalize downstream-only markup features)
 == Important technical note
@@ -448,17 +447,10 @@ Spring support in {BrandName} does not start a Spring Application Context nor ar
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
-<<<<<<< HEAD
-
-Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
-The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
-//endif::[]
-////
-=======
-Regarding the dependency injection in particular, {BrandName} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the https://quarkus.io/guides/cdi[{BrandName} introduction to CDI] and the https://quarkus.io/guides/cdi-reference#arc-configuration-reference[CDI reference guide]
+Regarding the dependency injection in particular, {BrandName} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide].
 The various Spring Boot test features are not supported by {BrandName}. For testing purposes, please, check the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
 endif::[]
->>>>>>> 8e06509e82 (QUARKUS-184: Replace Quarkus with attribute except in section titles, conditionalize downstream-only markup features)
+////
 
 ifdef::downstream[]
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 //TODO: need to use product attributes, but also keep compatibility with community ones
 
 // comment out to show community version
-:product-docs:
+:downstream:
 // TODO: consider moving this to the attributes file
 :doctype: book
 
@@ -21,18 +21,18 @@ ifdef::context[:parent-context: {context}]
 
 include::./attributes.adoc[]
 
-ifdef::product-docs[]
+ifdef::downstream[]
 //file not present in upstream repo, commented out to allow build to pass
 //include::common/making-open-source-more-inclusive.adoc[]
 endif::[]
 
 [role="_abstract"]
-The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {ProductName} application.
-This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.
+The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {ProjectName} application.
+This guide explains how your {ProjectName} application can leverage Dependency Injection annotations provided by the Spring Framework.
 
-ifndef::product-docs[]
+ifndef::downstream[]
 
-This guide is maintained in the main {ProductName} repository and pull requests should be submitted there:
+This guide is maintained in the main {ProjectName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 == Solution
@@ -46,30 +46,30 @@ The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spr
 endif::[]
 
 // Tech preview info for community purposes, different from product
-ifndef::product-docs[]
+ifndef::downstream[]
 include::./status-include.adoc[]
 :extension-status: preview
 endif::[]
 
 //tech preview info for product docs
-ifdef::product-docs[]
+ifdef::downstream[]
 NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
 endif::[]
 
 
-//ifdef::product-docs[]
+//ifdef::downstream[]
 [IMPORTANT]
 ====
-The Spring compatibility layer that {ProductName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
-{ProductName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
-However, when you add arbitrary libraries that are part of Spring Framework to your {ProductName} application, such libraries will not function properly, because {ProductName} is not able to use them.
+The Spring compatibility layer that {ProjectName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
+{ProjectName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
+However, when you add arbitrary libraries that are part of Spring Framework to your {ProjectName} application, such libraries will not function properly, because {ProjectName} is not able to use them.
 ====
 //endif::[]
 
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
-* Have a {ProductName} Maven project.
+* Have a {ProjectName} Maven project.
 * Have OpenJDK 8 installed.
 * Have Maven {maven-version} installed.
 
@@ -108,11 +108,11 @@ cd spring-di-quickstart
 == Setting up your Spring DI example Maven project
 
 [role="_abstract"]
-Add the required {ProductName} extension as a dependency of your Maven project.
+Add the required {ProjectName} extension as a dependency of your Maven project.
 
 .Procedure
 
-. Navigate to the the top-level directory of your {ProductName} Maven project:
+. Navigate to the the top-level directory of your {ProjectName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -125,7 +125,7 @@ cd <name-of-your-project-directory>
 ----
 ./mvnw quarkus:add-extension -Dextensions="spring-di"
 ----
-ifndef::product-docs[]
+ifndef::downstream[]
 +
 This adds the following entry to your `pom.xml` file:
 
@@ -143,10 +143,10 @@ endif::[]
 == Adding beans to your application using Spring annotations
 
 [role="_abstract"]
-You can add the required beans to your {ProductName} application using annotations provided by Spring.
+You can add the required beans to your {ProjectName} application using annotations provided by Spring.
 
 .Procedure
-. Navigate to the the top-level directory of your {ProductName} Maven project:
+. Navigate to the the top-level directory of your {ProjectName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -220,7 +220,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 ----
 +
 //. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-. In {ProductName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
+. In {ProjectName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties,options="nowrap",subs="+quotes,attributes+"]
@@ -374,7 +374,7 @@ Package and start your Spring DI example application using Maven.
 
 .Procedure
 
-. Navigate to the the top-level directory of your {ProductName} Maven project:
+. Navigate to the the top-level directory of your {ProjectName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -394,21 +394,21 @@ You receive `HELLO WORLD!` as the response.
 . Press _CTRL + C_ to stop the application.
 
 
-ifndef::product-docs[]
+ifndef::downstream[]
 == Compile and start the application as a native executable
 
 You can create a native image by following the guide about link:building-native-image[Building a Native Executable].
 endif::[]
 
 ////
-//ifndef::product-docs[]
+ifndef::downstream[]
 //TODO: This note is replaced by a rewritten version that is based on style mandated by the IBM style guide.
 //Only the -product-appropriate wording of the note should be used in both the community and product versions of this document.
 //I am retaining the original wording for purposes of verification and factual corrections.
 
 == Important technical note
 
-Spring support in {ProductName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring support in {ProjectName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
@@ -475,26 +475,26 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 |===
 //END: REFERENCE module
 
-ifdef::product-docs[]
+ifdef::downstream[]
 [role="_additional-resources"]
 .Additional resources
-* link:building-native-image[Compiling and starting your {ProductName} application as a native executable.]
+* link:building-native-image[Compiling and starting your {ProjectName} application as a native executable.]
 endif::[]
 
-ifndef::product-docs[]
+ifndef::downstream[]
 == More Spring guides
 
-{ProductName} provides more Spring compatibility features.
+{ProjectName} provides more Spring compatibility features.
 See the following guides for details:
 
-* link:spring-web[{ProductName} - Extension for Spring Web]
-* link:spring-data-jpa[{ProductName} - Extension for Spring Data JPA]
-* link:spring-data-rest[{ProductName} - Extension for Spring Data REST]
-* link:spring-security[{ProductName} - Extension for Spring Security]
-* link:spring-cloud-config-client[{ProductName} - Reading properties from Spring Cloud Config Server]
-* link:spring-boot-properties[{ProductName} - Extension for Spring Boot properties]
-* link:spring-cache[{ProductName} - Extension for Spring Cache]
-* link:spring-scheduled[{ProductName} - Extension for Spring Scheduled]
+* link:spring-web[{ProjectName} - Extension for Spring Web]
+* link:spring-data-jpa[{ProjectName} - Extension for Spring Data JPA]
+* link:spring-data-rest[{ProjectName} - Extension for Spring Data REST]
+* link:spring-security[{ProjectName} - Extension for Spring Security]
+* link:spring-cloud-config-client[{ProjectName} - Reading properties from Spring Cloud Config Server]
+* link:spring-boot-properties[{ProjectName} - Extension for Spring Boot properties]
+* link:spring-cache[{ProjectName} - Extension for Spring Cache]
+* link:spring-scheduled[{ProjectName} - Extension for Spring Scheduled]
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -1,32 +1,70 @@
-// add :context: to the asembly and {context} to individual section IDs
-//TODO: No variables in section titles
-//TODO: need to use product attributes, but also keep compatibility with community ones
-// Tech preview info for community purposes, different from product
-
-ifdef::product-docs[]
-include::common/attributes.adoc[]
-endif::[]
-
-ifndef::product-docs[]
-include::./attributes.adoc[]
-:extension-status: preview
-endif::[]
-
 //TODO: What should we do with this?
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+//TODO: need to use product attributes, but also keep compatibility with community ones
 
+// comment out to show community version
+:product-docs:
+:doctype: book
+
+ifdef::product-docs[]
+//TODO: copy product attribute files over to community repo
+//include::common/attributes.adoc[]
+//temporary attributes
+:ProductName: Quarkus
+:ProductLongName: Red Hat build of Quarkus
+:maven-version: 3.6.3
+endif::[]
+
+
+
+//Top-Level Assembly
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
 = Using the Quarkus Extension for Spring DI API
+
+ifdef::context[:parent-context: {context}]
+//temporary context value, will be changed before going into production
+:context: guide-quarkus-spring-di
+
 
 [role="_abstract"]
 The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
 This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.
 
+ifndef::product-docs[]
+//TODO: What should we do with this? Leave it as community-only?
+
+This guide is maintained in the main Quarkus repository and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
+endif::[]
+
+// Tech preview info for community purposes, different from product
+ifndef::product-docs[]
+include::./attributes.adoc[]
+:extension-status: preview
+endif::[]
+
 ifdef::product-docs[]
+NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
+endif::[]
+
+ifndef::product-docs[]
+include::./status-include.adoc[]
+endif::[]
+
+ifndef::product-docs[]
 [IMPORTANT]
 ====
 Note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
@@ -36,33 +74,15 @@ classes (like `org.springframework.beans.factory.config.BeanPostProcessor` for e
 ====
 endif::[]
 
-
-// conditionalized the inclusion of community-only status info section
-ifndef::product-docs[]
-include::./status-include.adoc[]
-endif::[]
-
 .Prerequisites
 
-// Uncomment this for alternative 2
-//* You have a {ProductName} Maven project.
+// comment out the following prerequisite in the alternative 1 layout of the document.
+* You have a {ProductName} Maven project.
 * You have OpenJDK 8 installed.
 * You have Maven {maven-version} installed.
 
-
-////
-// rewrite this as additional resource on the assembly?
-== Solution
-
-We recommend that you follow the instructions in the next sections and create the application step by step.
-However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
-////
-
 // Alternative 1: generate project form scratch
+[id="creating-the-spring-di-example-maven-project_{context}"]
 == Creating the Spring DI Example Maven project
 
 [role="_abstract"]
@@ -75,7 +95,7 @@ You can create new a new Maven project for the Spring DI example application on 
 * generate the directory structure of the project
 * create the main class file of the example application
 * create the endpoint that exposes the service that your application provides
-* add the required extensions to the `pom.xml` file of your project
+* add the `quarkus-spring-di` extension to the `pom.xml` file of your project
 * navigate to the top-level directory of your project
 +
 [source,bash,subs=attributes+]
@@ -88,13 +108,9 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
-//This command generates a Maven project with a REST endpoint and imports the `spring-di` extension.
 
-////
-//Alternative 2: you have a project and need to add the required dependencies.
-////
 
-//If you already have your Quarkus project configured, you can add the `spring-di` extension to your project by running the following command in your project base directory:
+//Alternative 2: you have a project and need to add the required extension.
 [id="setting-up-your-spring-di-maven-project_{context}"]
 == Setting up your Spring DI example Maven project
 
@@ -157,9 +173,12 @@ public interface StringFunction extends Function<String, String> {
 
 }
 ----
-//+
-//Other beans in this example implement this interface, and the interface is injected into another bean later on.
-//WHEN? Move this information to the relevant place
+ifndef::product-docs[]
++
+//TODO: Not sure where to place this
+Other beans in this example implement this interface, and the interface is injected into another bean later on.
+endif::[]
+
 
 . Create the `src/main/java/org/acme/spring/di/AppConfiguration.java` file.
 Inside the file that you created, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
@@ -204,7 +223,7 @@ public class NoOpSingleStringFunction implements StringFunction {
     }
 }
 ----
-
++
 //. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
 . With Quarkus, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
@@ -214,7 +233,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 # Your configuration properties
 greeting.message = hello
 ----
-
++
 .. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file.
 Inside the file that you created, crate a `MessageProducer` bean.
 Use the `@Value` annotation to set the value of the `greeting.message` property as the message String inside the `MessageProducer` bean:
@@ -237,7 +256,7 @@ public class MessageProducer {
     }
 }
 ----
-
++
 //The final bean we will create ties together all the previous beans.
 . Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code shown in the example below.
 Note, that the `GreeterBean` bean relies on both constructor-based and field-based injection.
@@ -318,10 +337,10 @@ public class GreeterResource {
 ----
 
 [id='updating-the-application-test-class_{context}']
-== Updating the application test class
+== Updating the application test
 
 [role="_abstract"]
-You must update the functional test for your application to reflect the changes that you made to the `/greeting` endpoint.
+You must update the class file that contains the functional test for your application to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
@@ -377,7 +396,7 @@ You receive `HELLO WORLD!` as the response.
 
 . Press _CTRL + C_ to stop the application.
 
-//
+
 ifndef::product-docs[]
 == Run the application as a native
 
@@ -462,3 +481,6 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * link:spring-cache[Quarkus - Extension for Spring Cache]
 * link:spring-scheduled[Quarkus - Extension for Spring Scheduled]
 endif::[]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -8,11 +8,11 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 // comment out to show community version
 :downstream:
-//:upstream:
-:doctype: book
 
 :doctype: book
 
+
+//TODO: Insert context using a script instead of conditionalizing
 ifdef::downstream[]
 ifndef::context[]
 [id="proc-using-the-quarkus-extension-for-spring-di-api"]
@@ -42,7 +42,7 @@ endif::[]
 As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework.
 You can use Spring DI annotations as an alternative to MicroProfile CDI annotations.
 
-ifdef::upstream[]
+ifndef::downstream[]
 This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
@@ -68,7 +68,7 @@ You can find the Spring Web example in the link:{URL_GITHUB_QUICKSTARTS_DIRECTOR
 endif::[]
 
 // upstream tech preview status and notes
-ifdef::upstream[]
+ifndef::downstream[]
 include::./status-include.adoc[]
 :extension-status: preview
 endif::[]
@@ -276,7 +276,7 @@ public class MessageProducer {
 }
 ----
 +
-ifdef::upstream[]
+ifndef::downstream[]
 The final bean we will create ties together all the previous beans.
 endif::[]
 
@@ -430,21 +430,14 @@ You receive `HELLO WORLD!` as the response.
 
 . Press _CTRL + C_ to stop the application.
 
-ifdef::upstream[]
+ifndef::downstream[]
 == Compile and start the application as a native executable
 
 You can create a native image by following the guide about link:building-native-image[Building a Native Executable].
 endif::[]
 
-<<<<<<< HEAD
-////
-ifndef::downstream[]
-//TODO: This note is replaced by a rewritten version that is based on style mandated by the IBM style guide.
-//Only the -product-appropriate wording of the note should be used in both the community and product versions of this document.
-//I am retaining the original wording for purposes of verification and factual corrections.
 
-ifdef::upstream[]
->>>>>>> 8e06509e82 (QUARKUS-184: Replace Quarkus with attribute except in section titles, conditionalize downstream-only markup features)
+ifndef::downstream[]
 == Important technical note
 
 Spring support in {BrandName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
@@ -454,7 +447,6 @@ classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `or
 Regarding the dependency injection in particular, {BrandName} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide].
 The various Spring Boot test features are not supported by {BrandName}. For testing purposes, please, check the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
 endif::[]
-////
 
 ifdef::downstream[]
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
@@ -513,7 +505,7 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 |Does not have a one-to-one mapping to a CDI annotation.
 |===
 
-ifdef::upstream[]
+ifndef::downstream[]
 == More Spring guides
 
 {BrandName} provides more Spring compatibility features.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -11,12 +11,15 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 //:upstream:
 :doctype: book
 
+:doctype: book
+
 ifdef::downstream[]
 ifndef::context[]
 [id="proc-using-the-quarkus-extension-for-spring-di-api"]
 endif::[]
 ifdef::context[]
 [id="proc-using-the-quarkus-extension-for-spring-di-api_{context}"]
+endif::[]
 endif::[]
 = Using the Quarkus Extension for Spring DI API
 
@@ -36,7 +39,8 @@ endif::[]
 ifdef::downstream[]
 [role="_abstract"]
 endif::[]
-As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework as an alternative to using MicroProfile CDI annotations.
+As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework.
+You can use Spring DI annotations as an alternative to MicroProfile CDI annotations.
 
 ifdef::upstream[]
 This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
@@ -61,7 +65,7 @@ You can follow this guide and create the example that uses the {PRODUCTNAME} ext
 To view the completed {ProductName} Spring Web example, download it as an link:{URL_GITHUB_QUICKSTARTS_REPO_ARCHIVE}[archive] or clone the {PRODUCTNAME} examples Git link:{URL_GITHUB_QUICKSTARTS_REPO_BASE}.git[repository].
 You can find the Spring Web example in the link:{URL_GITHUB_QUICKSTARTS_DIRECTORY_BASE}spring-di-quickstart[`spring-di-quickstart` directory].
 ====
-ifdef::[]
+endif::[]
 
 // upstream tech preview status and notes
 ifdef::upstream[]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -190,17 +190,18 @@ public class AppConfiguration {
     }
 }
 ----
-<<<<<<< HEAD
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
-=======
-+
-As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
->>>>>>> f8979760ea (QUARKUS-184: add information introduced in Aurea's PR)
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
+=======
+As a Spring developer, you might be tempted to add the `@ComponentScan` annotation to define specific packages to scan for additional beans.
+Note that adding `@ComponentScan` is unnecessary, because {ProductName} performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only when in `annotated` mode with no visibility boundaries.
+Moreover, note that the bean discovery in {ProductName} happens at build time.
+In a similar way, {ProductName} does not support the `@Import` annotation form Spring.
+>>>>>>> 64cc7da2dd (QUARKUS-184: resolve merge conflicts resulting from attribute name change)
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
 The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.
-This bean returns the string without processing it:
+This bean returns the input string as is:
 +
 .src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
@@ -332,8 +333,8 @@ public class GreeterResource {
 }
 ----
 
-[id='updating-the-integration-test-of-your-application_{context}']
-== Updating the integration test of your application
+[id='updating-the-unit-test_{context}']
+== Updating the units test
 
 [role="_abstract"]
 You must update the class file that contains the integration test for your application to reflect the changes that you made to the `/greeting` endpoint.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -134,9 +134,9 @@ cd <name-of-your-project-directory>
 ----
 ifndef::product-docs[]
 +
-This will add the following to your `pom.xml`:
+This adds the following entry to your `pom.xml` file:
 
-[source,xml]
+[source,xml,options="nowrap",subs="+quotes,attributes+"s]
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
@@ -184,7 +184,7 @@ endif::[]
 Inside the file that you created, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
 Inside the `AppConfiguration` class, create a `StringFunction` bean that changes a string that you pass to it to uppercase:
 +
-[source,java]
+[source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
 
@@ -208,7 +208,7 @@ Inside the file that you created, crate a `NoOpSingleStringFunction` bean.
 The `NoOpSingleStringFunction` implements the `StringFunction` bean using the `@Component` stereotype annotation provided by Spring.
 Note, that this bean does not process the string, but returns the string as is:
 +
-[source,java]
+[source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
 
@@ -228,7 +228,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 . With Quarkus, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
-[source,properties]
+[source,properties,options="nowrap",subs="+quotes,attributes+"]
 ----
 # Your configuration properties
 greeting.message = hello
@@ -264,7 +264,7 @@ Note, that you do not need to use the `@Autowired` annotation on the field-based
 Also note, that the `@Value` annotation on the `suffix` String contains a default value.
 The default value is used when you do not set a value for the `greeting.suffix` property in the `application.properties` file.
 +
-[source,java]
+[source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
 
@@ -310,8 +310,8 @@ When you create the class files of you example applications, you must also updat
 .Procedure
 
 . Add the following content to the `src/main/java/org/acme/spring/di/GreeterResource.java` file:
-
-[source,java]
++
+[source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
 
@@ -346,7 +346,7 @@ You must update the class file that contains the functional test for your applic
 
 . Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method as shown in the example below:
 +
-[source, java]
+[source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -386,7 +386,7 @@ cd <name-of-your-project-directory>
 
 . Execute the following command to compile and run your application in development mode:
 +
-[source,bash]
+[source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
 ./mvnw compile quarkus:dev
 ----

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -22,7 +22,8 @@ ifdef::context[:parent-context: {context}]
 include::./attributes.adoc[]
 
 ifdef::product-docs[]
-include::common/making-open-source-more-inclusive.adoc[]
+//file not present in upstream repo, commented out to allow build to pass
+//include::common/making-open-source-more-inclusive.adoc[]
 endif::[]
 
 [role="_abstract"]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -11,12 +11,19 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 //:upstream:
 :doctype: book
 
+ifdef::downstream[]
+ifndef::context[]
+[id="proc-using-the-quarkus-extension-for-spring-di-api"]
+endif::[]
+ifdef::context[]
 [id="proc-using-the-quarkus-extension-for-spring-di-api_{context}"]
+endif::[]
 = Using the Quarkus Extension for Spring DI API
 
+ifdef::downstream[]
 ifdef::context[:parent-context: {context}]
-
 :context: using-the-quarkus-extension-for-spring-di
+endif::[]
 
 include::attributes.adoc[]
 
@@ -25,13 +32,16 @@ ifdef::downstream[]
 //include::common/making-open-source-more-inclusive.adoc[]
 endif::[]
 
+ifdef::downstream[]
 [role="_abstract"]
+endif::[]
 As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework as an alternative to using MicroProfile CDI annotations.
 
 ifdef::upstream[]
 This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
+//upstream version of notes about GitHub links
 == Solution
 
 Follow the instructions in the next sections and create the application step by step.
@@ -42,8 +52,18 @@ Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {q
 The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
 endif::[]
 
+//downstream version of notes about GitHub links with downstream-only attributes
+ifdef::downstream[]
+[NOTE]
+====
+You can follow this guide and create the example that uses the {PRODUCTNAME} extension for the Spring Web API, or you can download and view the completed example.
+To view the completed {ProductName} Spring Web example, download it as an link:{URL_GITHUB_QUICKSTARTS_REPO_ARCHIVE}[archive] or clone the {PRODUCTNAME} examples Git link:{URL_GITHUB_QUICKSTARTS_REPO_BASE}.git[repository].
+You can find the Spring Web example in the link:{URL_GITHUB_QUICKSTARTS_DIRECTORY_BASE}spring-di-quickstart[`spring-di-quickstart` directory].
+====
+ifdef::[]
+
 // upstream tech preview status and notes
-ifndef::downstream[]
+ifdef::upstream[]
 include::./status-include.adoc[]
 :extension-status: preview
 endif::[]
@@ -53,37 +73,45 @@ ifdef::downstream[]
 NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
 endif::[]
 
+ifdef::downstream[]
 [IMPORTANT]
 ====
-The Spring compatibility layer that {BrandName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
+The Spring compatibility layer that {BrandName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor` or `org.springframework.context.ApplicationContext`) when you start your application.
 {BrandName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
 However, when you add arbitrary libraries that are part of Spring Framework to your {BrandName} application, such libraries will not function properly, because {BrandName} is not able to use them.
+
+{BrandName} uses a Dependency Injection mechanism called ArC that is based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for the Java 2.0 specification]. If you want to learn more about it we recommend you to read the https://quarkus.io/guides/cdi[{BrandName} introduction to CDI] and the https://quarkus.io/guides/cdi-reference#arc-configuration-reference[CDI reference guide].
+{BrandName} does not support test features provided by Spring Boot.
+To learn more about testing your {BrandName} code, see the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
 ====
+endif::[]
 
 .Prerequisites
 
-// comment out the following prerequisite in the alternative 1 layout of the document.
 * Have a {BrandName} Maven project.
 * Have OpenJDK {JDKVersion} installed.
 * Have Maven {maven-version} installed.
 
-// Alternative 1: generate project form scratch
-////
-[id="creating-the-spring-di-example-maven-project_{context}"]
+ifdef::downstream[]
+[id="proc-creating-the-spring-di-example-maven-project_{context}"]
+endif::[]
 == Creating the Spring DI example Maven project
 
+ifdef::downstream[]
 [role="_abstract"]
-You can create new a new Maven project for the Spring DI example application on the command line.
+endif::[]
+You can create a new Maven project for the Spring Dependency Injection example application on the command line.
+You can also add the `quarkus-spring-di` to an existing project using the {BrandName} Maven plugin
 
 .Procedure
 
-. Execute the following commands to:
+* Enter the following commands to:
 
-* generate the directory structure of the project.
-* create the main class file of the example application.
-* create the endpoint that exposes the service that your application provides.
-* add the `quarkus-spring-di` extension to the `pom.xml` file of your project.
-* navigate to the top-level directory of your project .
+** generate the directory structure of the project.
+** create the main class file of the example application.
+** create the endpoint that exposes the service that your application provides.
+** add the `quarkus-spring-di` extension to the `pom.xml` file of your project.
+** navigate to the top-level directory of your project .
 +
 [source,bash,subs=attributes+]
 ----
@@ -95,34 +123,25 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
-////
 
-//Alternative 2: you have a project and need to add the required extension.
-[id="setting-up-your-spring-di-maven-project_{context}"]
-== Setting up your Spring DI example Maven project
-
-[role="_abstract"]
-Add the required {BrandName} extension as a dependency of your Maven project.
-
-.Procedure
-
+* If you already have a {BrandName} project you can add the `quarkus-spring-di` extension to it using the command line:
+--
 . Navigate to the the top-level directory of your {BrandName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
-cd <name-of-your-project-directory>
+cd <project_directory>
 ----
 
-. Execute the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
+. Enter the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
 +
 [source,bash]
 ----
 ./mvnw quarkus:add-extension -Dextensions="spring-di"
 ----
-ifndef::downstream[]
 +
-This adds the following entry to your `pom.xml` file:
-
+This adds the following dependency to your `pom.xml` file:
++
 [source,xml,options="nowrap",subs="+quotes,attributes+"s]
 ----
 <dependency>
@@ -130,21 +149,24 @@ This adds the following entry to your `pom.xml` file:
     <artifactId>quarkus-spring-di</artifactId>
 </dependency>
 ----
+--
+
+ifdef::downstream[]
+[id="proc-adding-beans-to-your-project-using-spring-annotations"]
 endif::[]
+== Adding beans to your project using Spring annotations
 
-
-[id="additng-beans-to-your-applications-using-spring-annotations"]
-== Adding beans to your application using Spring annotations
-
+ifdef::downstream[]
 [role="_abstract"]
-You can add the required beans to your {BrandName} application using annotations provided by Spring.
+endif::[]
+You can add the required beans to your {BrandName} application using Spring annotations.
 
 .Procedure
 . Navigate to the the top-level directory of your {BrandName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
-cd <name-of-your-project-directory>
+cd <project_directory>
 ----
 
 . Create the `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface.
@@ -162,12 +184,13 @@ public interface StringFunction extends Function<String, String> {
 ----
 +
 The `GreeterBean` and `NoOpSingleStringFunction` beans that are part of the Spring DI example application also implement the `StringFunction` interface.
-//Other beans in this example implement this interface, and the interface is injected into another bean later on.
+Other beans in this example implement this interface, and the interface is injected into another bean later on.
 
 . Create the `src/main/java/org/acme/spring/di/AppConfiguration.java` file.
-Inside the file that you created, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
+Inside the file, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
 Inside the `AppConfiguration` class, create a `StringFunction` bean that changes a string that you pass to it to uppercase:
 +
+.src/main/java/org/acme/spring/di/AppConfiguration.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
@@ -188,13 +211,14 @@ As a Spring developer, you might be tempted to add the `@ComponentScan` annotati
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 =======
 +
-As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
-In the same vein, Quarkus does not support the Spring `@Import` annotation.
->>>>>>> 3f6ff02c85 (QUARKUS-184: change product name to brand name in remaining instances after rebase)
+As a Spring developer, you might be tempted to add the `@ComponentScan` annotation to define specific packages to scan for additional beans.
+Note, that `@ComponentScan` is unnecessary because {BrandName} performs link:cdi#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
+Moreover, note, that the bean discovery in {BrandName} happens at build time.
+Similarly, {BrandName} does not support the Spring `@Import` annotation.
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
 The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.
-This bean returns the string without processing it:
+This bean returns the string as is:
 +
 .src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
@@ -212,9 +236,9 @@ public class NoOpSingleStringFunction implements StringFunction {
     }
 }
 ----
-+
-//. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-. In {BrandName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
+
+
+. {BrandName} also supports injecting configuration values using the `@Value` annotation from Spring:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties,options="nowrap",subs="+quotes,attributes+"]
@@ -222,11 +246,12 @@ public class NoOpSingleStringFunction implements StringFunction {
 # Your configuration properties
 greeting.message = hello
 ----
-+
+
 .. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file.
-Inside the file crate a `MessageProducer` bean.
+Inside the file, crate a `MessageProducer` bean.
 Use the `@Value` annotation to set the value of the `greeting.message` property as the message String inside the `MessageProducer` bean:
 +
+.src/main/java/org/acme/spring/di/MessageProducer.java
 [source,java]
 ----
 package org.acme.spring.di;
@@ -246,8 +271,11 @@ public class MessageProducer {
 }
 ----
 +
-//The final bean we will create ties together all the previous beans.
-. Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code shown in the example below.
+ifdef::upstream[]
+The final bean we will create ties together all the previous beans.
+endif::[]
+
+. Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code in the following example.
 The `GreeterBean` bean relies on both constructor-based and field-based injection.
 You do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
 The `@Value` annotation on the `suffix` String contains a default value, which is used when you do not set a value for the `greeting.suffix` property in the `application.properties` file.
@@ -289,12 +317,14 @@ public class GreeterBean {
 }
 ----
 
+ifdef::downstream[]
 [id="updating-the-jax-rs-resource_{context}"]
+endif::[]
 == Updating the JAX-RS resource
 // Updating GreeterResource.java
 
 [role="_abstract"]
-When you create the class files of your example applications, you must update the `GreeterResource.java` file to reflect the changes that you made to the `/greeting` endpoint.
+When you create the class files of your example applications, you must update the `GreeterResource` class file to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
@@ -326,11 +356,15 @@ public class GreeterResource {
 }
 ----
 
-[id='updating-the-integration-test-of-your-application_{context}']
-== Updating the integration test of your application
+ifdef::downstream[]
+[id='updating-the-unit-test-of-your-application_{context}']
+endif::[]
+== Updating the unit test of your application
 
+ifdef::downstream[]
 [role="_abstract"]
-You must update the class file that contains the integration test for your application to reflect the changes that you made to the `/greeting` endpoint.
+endif::[]
+You must update the class file that contains the unit test for your application to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
@@ -360,11 +394,15 @@ public class GreetingResourceTest {
 }
 ----
 
-[id="packaging-and-starting-your-spring-di-example-application_{context}"]
-== Packaging and starting your Spring DI example application
+ifdef::downstream[]
+[id="Compiling-and-starting-your-spring-di-example-application_{context}"]
+endif::[]
+== Compiling and starting your Spring DI example
 
+ifdef::downstream[]
 [role="_abstract"]
-Package and start your Spring DI example application using Maven.
+endif::[]
+You can compile and start your Spring DI example project using the {BrandName} Maven plugin in development mode.
 
 .Procedure
 
@@ -372,10 +410,10 @@ Package and start your Spring DI example application using Maven.
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
-cd <name-of-your-project-directory>
+cd <project_directory>
 ----
 
-. Execute the following command to compile and start your application in development mode:
+. Enter the following command to compile and start your application in development mode:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -387,34 +425,45 @@ You receive `HELLO WORLD!` as the response.
 
 . Press _CTRL + C_ to stop the application.
 
-
-ifndef::downstream[]
+ifdef::upstream[]
 == Compile and start the application as a native executable
 
 You can create a native image by following the guide about link:building-native-image[Building a Native Executable].
 endif::[]
 
+<<<<<<< HEAD
 ////
 ifndef::downstream[]
 //TODO: This note is replaced by a rewritten version that is based on style mandated by the IBM style guide.
 //Only the -product-appropriate wording of the note should be used in both the community and product versions of this document.
 //I am retaining the original wording for purposes of verification and factual corrections.
 
+=======
+
+ifdef::upstream[]
+>>>>>>> 8e06509e82 (QUARKUS-184: Replace Quarkus with attribute except in section titles, conditionalize downstream-only markup features)
 == Important technical note
 
 Spring support in {BrandName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
+<<<<<<< HEAD
 
 Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
 The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
 //endif::[]
 ////
+=======
+Regarding the dependency injection in particular, {BrandName} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the https://quarkus.io/guides/cdi[{BrandName} introduction to CDI] and the https://quarkus.io/guides/cdi-reference#arc-configuration-reference[CDI reference guide]
+The various Spring Boot test features are not supported by {BrandName}. For testing purposes, please, check the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
+endif::[]
+>>>>>>> 8e06509e82 (QUARKUS-184: Replace Quarkus with attribute except in section titles, conditionalize downstream-only markup features)
 
-//BEGIN: REFERENCE module
+ifdef::downstream[]
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
-== Overview of annotation equivalents in Spring DI and CDI
+endif::[]
+== Overview of annotation equivalents in Spring DI and MicroProfile CDI
 
 [role="_abstract"]
 The following table lists Spring DI annotations and their equivalent CDI annotations or MicroProfile annotations, respectively.
@@ -461,21 +510,14 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 
 |`@ComponentScan`
 |
-|Does not have a one-to-one mapping to a CDI annotation. It is not used in Quarkus because Quarkus does all classpath scanning at build time.
+|Does not have a one-to-one mapping to a CDI annotation. It is not used in {BrandName} because {BrandName} does all classpath scanning at build time.
 
 |`@Import`
 |
 |Does not have a one-to-one mapping to a CDI annotation.
 |===
-//END: REFERENCE module
 
-ifdef::downstream[]
-[role="_additional-resources"]
-.Additional resources
-* link:building-native-image[Compiling and starting your {BrandName} application as a native executable.]
-endif::[]
-
-ifndef::downstream[]
+ifdef::upstream[]
 == More Spring guides
 
 {BrandName} provides more Spring compatibility features.
@@ -489,6 +531,12 @@ See the following guides for details:
 * link:spring-boot-properties[{BrandName} - Extension for Spring Boot properties]
 * link:spring-cache[{BrandName} - Extension for Spring Cache]
 * link:spring-scheduled[{BrandName} - Extension for Spring Scheduled]
+endif::[]
+
+ifdef::downstream[]
+[role="_additional-resources"]
+.Additional resources
+* link:{NATIVE_EXECUTABLE_QUARKUS}[Compiling and starting your {BrandName} application as a native executable.]
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -13,7 +13,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 //Top-Level Assembly
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
-= Using the Quarkus Extension for Spring DI API
+= Using the Quarkus extension for Spring Dependency Injection (DI) API
 
 ifdef::context[:parent-context: {context}]
 
@@ -78,7 +78,7 @@ You can create new a new Maven project for the Spring DI example application on 
 
 .Procedure
 
-. Execute the following commands to:
+. Enter the following commands to:
 
 * generate the directory structure of the project.
 * create the main class file of the example application.
@@ -114,7 +114,7 @@ Add the required {ProductName} extension as a dependency of your Maven project.
 cd <name-of-your-project-directory>
 ----
 
-. Execute the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
+. Enter the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
 +
 [source,bash]
 ----
@@ -371,7 +371,7 @@ Package and start your Spring DI example application using Maven.
 cd <name-of-your-project-directory>
 ----
 
-. Execute the following command to compile and start your application in development mode:
+. Enter the following command to compile and start your application in development mode:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -1,33 +1,57 @@
+// add :context: to the asembly and {context} to individual section IDs
+//TODO: No variables in section titles
+//TODO: need to use product attributes, but also keep compatibility with community ones
+// Tech preview info for community purposes, different from product
+
+ifdef::product-docs[]
+include::common/attributes.adoc[]
+endif::[]
+
+ifndef::product-docs[]
+include::./attributes.adoc[]
+:extension-status: preview
+endif::[]
+
+//TODO: What should we do with this?
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+
 [id="using-the-quarkus-extension-for-spring-di-api_{context}"]
 = Using the Quarkus Extension for Spring DI API
 
-//TODO: need to use product attributes, but also keep compatibility with community ones
-//include::./attributes.adoc[]
-// Tech preview info for community purposes, different form product
-//:extension-status: preview
-
 [role="_abstract"]
-The Quarkus `spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
-This guide explains how your Quarkus application can leverage Dependency Injection annotations provided by the Spring Framework.
+The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
+This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.
+
+ifdef::product-docs[]
+[IMPORTANT]
+====
+Note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
+What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
+classes (like `org.springframework.beans.factory.config.BeanPostProcessor` for example) will not be executed.
+====
+endif::[]
+
 
 // conditionalized the inclusion of community-only status info section
-ifdef::product-docs[]
+ifndef::product-docs[]
 include::./status-include.adoc[]
 endif::[]
 
 .Prerequisites
 
-* You have a {ProductName} Maven project.
+// Uncomment this for alternative 2
+//* You have a {ProductName} Maven project.
 * You have OpenJDK 8 installed.
 * You have Maven {maven-version} installed.
 
 
 ////
+// rewrite this as additional resource on the assembly?
 == Solution
 
 We recommend that you follow the instructions in the next sections and create the application step by step.
@@ -38,11 +62,22 @@ Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {q
 The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spring-di-quickstart[directory].
 ////
 
-////
-== Creating the Maven project
+// Alternative 1: generate project form scratch
+== Creating the Spring DI Example Maven project
 
-First, we need a new project. Create a new project with the following command:
+[role="_abstract"]
+You can create new a new Maven project for the Spring DI example application on the command line.
 
+.Procedure
+
+. Execute the following commands to:
+
+* generate the directory structure of the project
+* create the main class file of the example application
+* create the endpoint that exposes the service that your application provides
+* add the required extensions to the `pom.xml` file of your project
+* navigate to the top-level directory of your project
++
 [source,bash,subs=attributes+]
 ----
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
@@ -53,17 +88,36 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
+//This command generates a Maven project with a REST endpoint and imports the `spring-di` extension.
 
-This command generates a Maven project with a REST endpoint and imports the `spring-di` extension.
+////
+//Alternative 2: you have a project and need to add the required dependencies.
+////
 
-If you already have your Quarkus project configured, you can add the `spring-di` extension
-to your project by running the following command in your project base directory:
+//If you already have your Quarkus project configured, you can add the `spring-di` extension to your project by running the following command in your project base directory:
+[id="setting-up-your-spring-di-maven-project_{context}"]
+== Setting up your Spring DI example Maven project
 
+[role="_abstract"]
+Add the required {ProductName} extension as a dependency of your Maven project.
+
+.Procedure
+
+. Navigate to the the top-level directory of your {ProductName} Maven project:
++
+[source,bash,options="nowrap",subs="+quotes,attributes+"]
+----
+cd <name-of-your-project-directory>
+----
+
+. Execute the following command to add the `quarkus-spring-di` extension to the `pom.xml` file of your project:
++
 [source,bash]
 ----
 ./mvnw quarkus:add-extension -Dextensions="spring-di"
 ----
-
+ifndef::product-docs[]
++
 This will add the following to your `pom.xml`:
 
 [source,xml]
@@ -73,36 +127,25 @@ This will add the following to your `pom.xml`:
     <artifactId>quarkus-spring-di</artifactId>
 </dependency>
 ----
-////
+endif::[]
 
 
-//== Add beans using Spring annotations
-//PROC
 [id="additng-beans-to-your-applications-using-spring-annotations"]
-= Adding beans to your application using Spring annotations
+== Adding beans to your application using Spring annotations
 
-. Navigate to the directory that contains your {ProductName} project.
+[role="_abstract"]
+You can add the required beans to your {ProductName} application using annotations provided by Spring.
 
-. Add the `quarkus-spring-di` extension as a dependency of your application:
+.Procedure
+//. Navigate to the directory that contains your {ProductName} project.
+. Navigate to the the top-level directory of your {ProductName} Maven project:
 +
-[source,bash]
+[source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
-./mvnw quarkus:add-extension -Dextensions="spring-di"
-----
-+
-This command adds the following dependency to your `pom.xml` file:
-+
-[source,xml]
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-spring-di</artifactId>
-</dependency>
+cd <name-of-your-project-directory>
 ----
 
-//. Create some beans for your application using Spring annotations.
-
-. Create a `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface:
+. Create the `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface:
 +
 [source,java]
 ----
@@ -114,13 +157,14 @@ public interface StringFunction extends Function<String, String> {
 
 }
 ----
-+
-Other beans in this example implement this interface, and the interface is injected into another bean later on.
+//+
+//Other beans in this example implement this interface, and the interface is injected into another bean later on.
 //WHEN? Move this information to the relevant place
 
-. Create a `src/main/java/org/acme/spring/di/AppConfiguration.java` file that contains an `AppConfiguration` class and annotate it with the `@Configuration` annotation from Spring Java Config.
+. Create the `src/main/java/org/acme/spring/di/AppConfiguration.java` file.
+Inside the file that you created, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
 Inside the `AppConfiguration` class, create a `StringFunction` bean that changes a string that you pass to it to uppercase:
-
++
 [source,java]
 ----
 package org.acme.spring.di;
@@ -140,10 +184,10 @@ public class AppConfiguration {
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 
-. Create a `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file that contains the `NoOpSingleStringFunction` bean.
+. Create the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file,
+Inside the file that you created, crate a `NoOpSingleStringFunction` bean.
 The `NoOpSingleStringFunction` implements the `StringFunction` bean using the `@Component` stereotype annotation provided by Spring.
-//TODO: this sounds a little ambiguous
-This bean does not process the string, but returns the string as is.
+Note, that this bean does not process the string, but returns the string as is:
 +
 [source,java]
 ----
@@ -162,7 +206,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 ----
 
 //. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-. With Quarkus, you can also use the `@Value` annotations to inject inject values of configuration properties into beans.
+. With Quarkus, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties]
@@ -171,7 +215,8 @@ public class NoOpSingleStringFunction implements StringFunction {
 greeting.message = hello
 ----
 
-.. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file that contains a `MessageProducer` bean.
+.. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file.
+Inside the file that you created, crate a `MessageProducer` bean.
 Use the `@Value` annotation to set the value of the `greeting.message` property as the message String inside the `MessageProducer` bean:
 +
 [source,java]
@@ -195,9 +240,10 @@ public class MessageProducer {
 
 //The final bean we will create ties together all the previous beans.
 . Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code shown in the example below.
-Note, that the `GreeterBean` bean relies on both contructor-based and field-based injection.
-In the example below, you do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
-Also note, that the `@Value` annotation on the `suffix` String has a default value assigned. The default value is used because you have not previously defined a `greeting.suffix` in the `application.properties` file.
+Note, that the `GreeterBean` bean relies on both constructor-based and field-based injection.
+Note, that you do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
+Also note, that the `@Value` annotation on the `suffix` String contains a default value.
+The default value is used when you do not set a value for the `greeting.suffix` property in the `application.properties` file.
 +
 [source,java]
 ----
@@ -236,9 +282,15 @@ public class GreeterBean {
 ----
 
 [id="updating-the-jax-rs-resource_{context}"]
-=== Updating the JAX-RS resource
+== Updating the JAX-RS resource
 
-Open the `src/main/java/org/acme/spring/di/GreeterResource.java` file and update it with the following content:
+[role="_abstract"]
+When you create the class files of you example applications, you must also update the `GreeterResource.java` class file.
+// TODO: explain why this needs to be done.
+
+.Procedure
+
+. Add the following content to the `src/main/java/org/acme/spring/di/GreeterResource.java` file:
 
 [source,java]
 ----
@@ -265,15 +317,15 @@ public class GreeterResource {
 }
 ----
 
-[id='updating-the-application-test_{context}']
-== Updating the application test
+[id='updating-the-application-test-class_{context}']
+== Updating the application test class
 
 [role="_abstract"]
-You must update the functional test to reflect the changes that you made to the endpoint.
+You must update the functional test for your application to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
-. Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method to the following:
+. Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method as shown in the example below:
 +
 [source, java]
 ----
@@ -298,46 +350,59 @@ public class GreetingResourceTest {
 }
 ----
 
-[id="packaging-and-running-your-application_{context}"]
-== Packaging and running your application:
+[id="packaging-and-running-your-spring-di-example-application_{context}"]
+== Packaging and running your Spring DI example application
 
-//[role="_abstract"]
+[role="_abstract"]
+Package and run your Spring DI example application using Maven.
+
 .Procedure
 
-. To compile and run your application in development mode, execute the following command in the project directory:
+. Navigate to the the top-level directory of your {ProductName} Maven project:
++
+[source,bash,options="nowrap",subs="+quotes,attributes+"]
+----
+cd <name-of-your-project-directory>
+----
+
+. Execute the following command to compile and run your application in development mode:
 +
 [source,bash]
 ----
 ./mvnw compile quarkus:dev
 ----
 
-. Navigate to `http://localhost:8080/greeting` using a web browser. You receive `HELLO WORLD!` as a response.
+. Navigate to `http://localhost:8080/greeting` using a web browser.
+You receive `HELLO WORLD!` as the response.
 
-. To stop the application, press kbd:[CTRL+C].
+. Press _CTRL + C_ to stop the application.
 
-== Running your the application in native mode
+//
+ifndef::product-docs[]
+== Run the application as a native
 
-You can of course create a native image using instructions similar to link:building-native-image[this] guide.
+You can create a native image by following the guide about link:building-native-image[Building a Native Executable].
+endif::[]
 
-//TODO: MOve this up front, make it a con_
+ifndef::product-docs[]
 == Important Technical Note
 
-Please note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
 Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
 The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
 
-//REF
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
 == Overview of annotation equivalents in Spring DI and CDI
 
-//[role="_abstract"]
-The following table shows how Spring DI annotations can be converted to CDI and / or MicroProfile annotations.
+[role="_abstract"]
+The following table shows how Spring DI annotations can be converted to CDI annotations or MicroProfile annotations, respectively.
 
+[options="header"]
 |===
-|Spring |CDI / MicroProfile |Comments
+|Spring Annotation |CDI / MicroProfile Annotation |Note
 
 |`@Autowired`
 |`@Inject`
@@ -377,11 +442,13 @@ The following table shows how Spring DI annotations can be converted to CDI and 
 |===
 
 
-//[role="_additional-resources"]
-//.Additional resources
+ifdef::product-docs[]
+[role="_additional-resources"]
+.Additional resources
+* link:building-native-image[Compiling and running your {ProductName} application as a native executable.]
+endif::[]
 
-// next steps?  links
-//might have to be ommitted from the product version
+ifndef::product-docs[]
 == More Spring guides
 
 Quarkus has more Spring compatibility features. See the following guides for more details:
@@ -394,3 +461,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * link:spring-boot-properties[Quarkus - Extension for Spring Boot properties]
 * link:spring-cache[Quarkus - Extension for Spring Cache]
 * link:spring-scheduled[Quarkus - Extension for Spring Scheduled]
+endif::[]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -94,7 +94,8 @@ endif::[]
 .Prerequisites
 
 * Have a {brand-name} Maven project.
-* Have OpenJDK {jdk-version} installed.
+* Have {jdk-distribution} {jdk-version} installed
+* Have the `JAVA_HOME` environment variable configured set to the directory where {jdk-distribution} is installed on your system.
 * Have Maven {maven-version} installed.
 
 ifdef::downstream[]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -39,11 +39,11 @@ endif::[]
 ifdef::downstream[]
 [role="_abstract"]
 endif::[]
-As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {BrandName} application using Dependency Injection annotations provided by the Spring Framework.
+As a developer, you can add the `quarkus-spring-di` extension to your project and inject dependencies in your {brand-name} application using Dependency Injection annotations provided by the Spring Framework.
 You can use Spring DI annotations as an alternative to MicroProfile CDI annotations.
 
 ifndef::downstream[]
-This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
+This guide is maintained in the main {brand-name} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 //upstream version of notes about GitHub links
@@ -81,20 +81,20 @@ endif::[]
 ifdef::downstream[]
 [IMPORTANT]
 ====
-The Spring compatibility layer that {BrandName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor` or `org.springframework.context.ApplicationContext`) when you start your application.
-{BrandName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
-However, when you add arbitrary libraries that are part of Spring Framework to your {BrandName} application, such libraries will not function properly, because {BrandName} is not able to use them.
+The Spring compatibility layer that {brand-name} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor` or `org.springframework.context.ApplicationContext`) when you start your application.
+{brand-name} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
+However, when you add arbitrary libraries that are part of Spring Framework to your {brand-name} application, such libraries will not function properly, because {brand-name} is not able to use them.
 
-{BrandName} uses a Dependency Injection mechanism called ArC that is based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for the Java 2.0 specification]. If you want to learn more about it we recommend you to read the https://quarkus.io/guides/cdi[{BrandName} introduction to CDI] and the https://quarkus.io/guides/cdi-reference#arc-configuration-reference[CDI reference guide].
-{BrandName} does not support test features provided by Spring Boot.
-To learn more about testing your {BrandName} code, see the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
+{brand-name} uses a Dependency Injection mechanism called ArC that is based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for the Java 2.0 specification]. If you want to learn more about it we recommend you to read the https://quarkus.io/guides/cdi[{brand-name} introduction to CDI] and the https://quarkus.io/guides/cdi-reference#arc-configuration-reference[CDI reference guide].
+{brand-name} does not support test features provided by Spring Boot.
+To learn more about testing your {brand-name} code, see the https://quarkus.io/guides/getting-started-testing[{brand-name} testing guide].
 ====
 endif::[]
 
 .Prerequisites
 
-* Have a {BrandName} Maven project.
-* Have OpenJDK {JDKVersion} installed.
+* Have a {brand-name} Maven project.
+* Have OpenJDK {jdk-version} installed.
 * Have Maven {maven-version} installed.
 
 ifdef::downstream[]
@@ -106,12 +106,12 @@ ifdef::downstream[]
 [role="_abstract"]
 endif::[]
 You can create a new Maven project for the Spring Dependency Injection example application on the command line.
-If you already have a {BrandName} Maven project, you add the `quarkus-spring-di` extension to it using the {BrandName} Maven plugin.
+If you already have a {brand-name} Maven project, you add the `quarkus-spring-di` extension to it using the {brand-name} Maven plugin.
 This section describes steps for both alternatives.
 
 .Procedure
 
-* To create a new Maven project for your Spring DI example, you can use the {BrandName} Maven Plugin.
+* To create a new Maven project for your Spring DI example, you can use the {brand-name} Maven Plugin.
 Enter the following commands to:
 
 ** generate the directory structure of the project.
@@ -131,10 +131,10 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
 cd spring-di-quickstart
 ----
 
-* To add the `quarkus-spring-di` extension to an existing {BrandName} Maven Project:
+* To add the `quarkus-spring-di` extension to an existing {brand-name} Maven Project:
 // Open block markup required for downstream doc build. Do not remove.
 --
-. Navigate to the the top-level directory of your {BrandName} Maven project:
+. Navigate to the the top-level directory of your {brand-name} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -168,10 +168,10 @@ endif::[]
 ifdef::downstream[]
 [role="_abstract"]
 endif::[]
-You can add the required beans to your {BrandName} application using Spring annotations.
+You can add the required beans to your {brand-name} application using Spring annotations.
 
 .Procedure
-. Navigate to the the top-level directory of your {BrandName} Maven project:
+. Navigate to the the top-level directory of your {brand-name} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -221,9 +221,15 @@ In the same vein, Quarkus does not support the Spring `@Import` annotation.
 =======
 +
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation to define specific packages to scan for additional beans.
+<<<<<<< HEAD
 Note, that `@ComponentScan` is unnecessary because {BrandName} performs link:cdi#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
 Moreover, note, that the bean discovery in {BrandName} happens at build time.
 Similarly, {BrandName} does not support the Spring `@Import` annotation.
+=======
+Note, that `@ComponentScan` is unnecessary because {brand-name} performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries.
+Moreover, note, that the bean discovery in {brand-name} happens at build time.
+Similarly, {brand-name} does not support the Spring `@Import` annotation.
+>>>>>>> 49cc6e9b34 (QUARKUS-184: switch to consistent lowercase attributes)
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
 The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.
@@ -247,7 +253,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 ----
 
 
-. {BrandName} also supports injecting configuration values using the `@Value` annotation from Spring:
+. {brand-name} also supports injecting configuration values using the `@Value` annotation from Spring:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties,options="nowrap",subs="+quotes,attributes+"]
@@ -411,11 +417,11 @@ endif::[]
 ifdef::downstream[]
 [role="_abstract"]
 endif::[]
-You can compile and start your Spring DI example project using the {BrandName} Maven plugin in development mode.
+You can compile and start your Spring DI example project using the {brand-name} Maven plugin in development mode.
 
 .Procedure
 
-. Navigate to the the top-level directory of your {BrandName} Maven project:
+. Navigate to the the top-level directory of your {brand-name} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -444,12 +450,12 @@ endif::[]
 ifndef::downstream[]
 == Important technical note
 
-Spring support in {BrandName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring support in {brand-name} does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
-Regarding the dependency injection in particular, {BrandName} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide].
-The various Spring Boot test features are not supported by {BrandName}. For testing purposes, please, check the https://quarkus.io/guides/getting-started-testing[{BrandName} testing guide].
+Regarding the dependency injection in particular, {brand-name} uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[{brand-name} introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
+The various Spring Boot test features are not supported by {brand-name}. For testing purposes, please, check the link:getting-started-testing[{brand-name} testing guide].
 endif::[]
 
 ifdef::downstream[]
@@ -502,7 +508,7 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 
 |`@ComponentScan`
 |
-|Does not have a one-to-one mapping to a CDI annotation. It is not used in {BrandName} because {BrandName} does all classpath scanning at build time.
+|Does not have a one-to-one mapping to a CDI annotation. It is not used in {brand-name} because {brand-name} does all classpath scanning at build time.
 
 |`@Import`
 |
@@ -512,23 +518,23 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 ifndef::downstream[]
 == More Spring guides
 
-{BrandName} provides more Spring compatibility features.
+{brand-name} provides more Spring compatibility features.
 See the following guides for details:
 
-* link:spring-web[{BrandName} - Extension for Spring Web]
-* link:spring-data-jpa[{BrandName} - Extension for Spring Data JPA]
-* link:spring-data-rest[{BrandName} - Extension for Spring Data REST]
-* link:spring-security[{BrandName} - Extension for Spring Security]
-* link:spring-cloud-config-client[{BrandName} - Reading properties from Spring Cloud Config Server]
-* link:spring-boot-properties[{BrandName} - Extension for Spring Boot properties]
-* link:spring-cache[{BrandName} - Extension for Spring Cache]
-* link:spring-scheduled[{BrandName} - Extension for Spring Scheduled]
+* link:spring-web[{brand-name} - Extension for Spring Web]
+* link:spring-data-jpa[{brand-name} - Extension for Spring Data JPA]
+* link:spring-data-rest[{brand-name} - Extension for Spring Data REST]
+* link:spring-security[{brand-name} - Extension for Spring Security]
+* link:spring-cloud-config-client[{brand-name} - Reading properties from Spring Cloud Config Server]
+* link:spring-boot-properties[{brand-name} - Extension for Spring Boot properties]
+* link:spring-cache[{brand-name} - Extension for Spring Cache]
+* link:spring-scheduled[{brand-name} - Extension for Spring Scheduled]
 endif::[]
 
 ifdef::downstream[]
 [role="_additional-resources"]
 .Additional resources
-* link:{NATIVE_EXECUTABLE_QUARKUS}[Compiling and starting your {BrandName} application as a native executable.]
+* link:{NATIVE_EXECUTABLE_QUARKUS}[Compiling and starting your {brand-name} application as a native executable.]
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -8,6 +8,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 // comment out to show community version
 :product-docs:
+// TODO: consider moving this to the attributes file
 :doctype: book
 
 //Top-Level Assembly
@@ -21,18 +22,18 @@ ifdef::context[:parent-context: {context}]
 include::./attributes.adoc[]
 
 [role="_abstract"]
-The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection, that you can use as an alternative to MicroProfile CDI annotations in your Quarkus application.
+The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {ProductName} application.
 This guide explains how your {ProductName} application can leverage Dependency Injection annotations provided by the Spring Framework.
 
 ifndef::product-docs[]
 
-This guide is maintained in the main Quarkus repository and pull requests should be submitted there:
+This guide is maintained in the main {ProductName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 == Solution
 
-We recommend that you follow the instructions in the next sections and create the application step by step.
-However, you can go right to the completed example.
+Follow the instructions in the next sections and create the application step by step.
+Alternatively, you can clone and use the completed example.
 
 Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
 
@@ -41,6 +42,7 @@ endif::[]
 
 // Tech preview info for community purposes, different from product
 ifndef::product-docs[]
+include::./status-include.adoc[]
 :extension-status: preview
 endif::[]
 
@@ -49,19 +51,15 @@ ifdef::product-docs[]
 NOTE: The `quarkus-spring-di` extension is available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] with {ProductLongName}.
 endif::[]
 
-// community-only note about the community suport status of this extension
-ifndef::product-docs[]
-include::./status-include.adoc[]
-endif::[]
 
-ifdef::product-docs[]
+//ifdef::product-docs[]
 [IMPORTANT]
 ====
-The Spring compatibility layer that {ProductName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you run your application.
-{ProductName} can only read metadata from Spring classes and annotations and can parse user code method return types and parameter types that are provided by Spring.
-However, when you add arbitrary libraries that are part of Spring to your {ProductName} application, {ProductName} is not able to use them.
+The Spring compatibility layer that {ProductName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
+{ProductName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
+However, when you add arbitrary libraries that are part of Spring Framework to your {ProductName} application, such libraries will not function properly, because {ProductName} is not able to use them.
 ====
-endif::[]
+//endif::[]
 
 .Prerequisites
 
@@ -80,13 +78,13 @@ You can create new a new Maven project for the Spring DI example application on 
 
 .Procedure
 
-. Run the following commands to:
+. Execute the following commands to:
 
-* generate the directory structure of the project
-* create the main class file of the example application
-* create the endpoint that exposes the service that your application provides
-* add the `quarkus-spring-di` extension to the `pom.xml` file of your project
-* navigate to the top-level directory of your project
+* generate the directory structure of the project.
+* create the main class file of the example application.
+* create the endpoint that exposes the service that your application provides.
+* add the `quarkus-spring-di` extension to the `pom.xml` file of your project.
+* navigate to the top-level directory of your project .
 +
 [source,bash,subs=attributes+]
 ----
@@ -143,7 +141,6 @@ endif::[]
 You can add the required beans to your {ProductName} application using annotations provided by Spring.
 
 .Procedure
-//. Navigate to the directory that contains your {ProductName} project.
 . Navigate to the the top-level directory of your {ProductName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
@@ -151,8 +148,9 @@ You can add the required beans to your {ProductName} application using annotatio
 cd <name-of-your-project-directory>
 ----
 
-. Create the `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface:
+. Create the `src/main/java/org/acme/spring/di/StringFunction.java` file that contains a `StringFunction` interface.
 +
+.src/main/java/org/acme/spring/di/StringFunction.java
 [source,java]
 ----
 package org.acme.spring.di;
@@ -163,12 +161,9 @@ public interface StringFunction extends Function<String, String> {
 
 }
 ----
-ifndef::product-docs[]
 +
-//TODO: Not sure where to place this
-Other beans in this example implement this interface, and the interface is injected into another bean later on.
-endif::[]
-
+The `GreeterBean` and `NoOpSingleStringFunction` beans that are part of the Spring DI example application also implement the `StringFunction` interface.
+//Other beans in this example implement this interface, and the interface is injected into another bean later on.
 
 . Create the `src/main/java/org/acme/spring/di/AppConfiguration.java` file.
 Inside the file that you created, create an `AppConfiguration` class and annotate it with the `@Configuration` annotation provided by Spring Java Config.
@@ -193,11 +188,11 @@ public class AppConfiguration {
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 
-. Create the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file,
-Inside the file that you created, crate a `NoOpSingleStringFunction` bean.
-The `NoOpSingleStringFunction` implements the `StringFunction` bean using the `@Component` stereotype annotation provided by Spring.
-Note, that this bean does not process the string, but returns the string as is:
+. Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
+The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.
+This bean returns the string without processing it:
 +
+.src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
@@ -215,7 +210,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 ----
 +
 //. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-. With Quarkus, you can also use the `@Value` annotations to inject values of configuration properties into beans:
+. In {ProductName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties,options="nowrap",subs="+quotes,attributes+"]
@@ -225,7 +220,7 @@ greeting.message = hello
 ----
 +
 .. Create the `src/main/java/org/acme/spring/di/MessageProducer.java` file.
-Inside the file that you created, crate a `MessageProducer` bean.
+Inside the file crate a `MessageProducer` bean.
 Use the `@Value` annotation to set the value of the `greeting.message` property as the message String inside the `MessageProducer` bean:
 +
 [source,java]
@@ -249,11 +244,11 @@ public class MessageProducer {
 +
 //The final bean we will create ties together all the previous beans.
 . Create the `src/main/java/org/acme/spring/di/GreeterBean.java` file that contains the code shown in the example below.
-Note, that the `GreeterBean` bean relies on both constructor-based and field-based injection.
-Note, that you do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
-Also note, that the `@Value` annotation on the `suffix` String contains a default value.
-The default value is used when you do not set a value for the `greeting.suffix` property in the `application.properties` file.
+The `GreeterBean` bean relies on both constructor-based and field-based injection.
+You do not need to use the `@Autowired` annotation on the field-based constructor, because the bean only contains a single field-based constructor.
+The `@Value` annotation on the `suffix` String contains a default value, which is used when you do not set a value for the `greeting.suffix` property in the `application.properties` file.
 +
+.src/main/java/org/acme/spring/di/GreeterBean.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
@@ -292,15 +287,16 @@ public class GreeterBean {
 
 [id="updating-the-jax-rs-resource_{context}"]
 == Updating the JAX-RS resource
+// Updating GreeterResource.java
 
 [role="_abstract"]
-When you create the class files of your example applications, you must also update the `GreeterResource.java` class file.
-// TODO: explain why this needs to be done.
+When you create the class files of your example applications, you must update the `GreeterResource.java` file to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
 . Add the following content to the `src/main/java/org/acme/spring/di/GreeterResource.java` file:
 +
+.src/main/java/org/acme/spring/di/GreeterResource.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 package org.acme.spring.di;
@@ -326,16 +322,17 @@ public class GreeterResource {
 }
 ----
 
-[id='updating-the-application-test-class_{context}']
-== Updating the application test
+[id='updating-the-integration-test-of-your-application_{context}']
+== Updating the integration test of your application
 
 [role="_abstract"]
-You must update the class file that contains the functional test for your application to reflect the changes that you made to the `/greeting` endpoint.
+You must update the class file that contains the integration test for your application to reflect the changes that you made to the `/greeting` endpoint.
 
 .Procedure
 
 . Edit the `src/test/java/org/acme/spring/di/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method as shown in the example below:
 +
+.src/test/java/org/acme/spring/di/GreetingResourceTest.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
 ----
 import io.quarkus.test.junit.QuarkusTest;
@@ -359,11 +356,11 @@ public class GreetingResourceTest {
 }
 ----
 
-[id="packaging-and-running-your-spring-di-example-application_{context}"]
-== Packaging and running your Spring DI example application
+[id="packaging-and-starting-your-spring-di-example-application_{context}"]
+== Packaging and starting your Spring DI example application
 
 [role="_abstract"]
-Package and run your Spring DI example application using Maven.
+Package and start your Spring DI example application using Maven.
 
 .Procedure
 
@@ -374,7 +371,7 @@ Package and run your Spring DI example application using Maven.
 cd <name-of-your-project-directory>
 ----
 
-. Run the following command to compile and start your application in development mode:
+. Execute the following command to compile and start your application in development mode:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -388,27 +385,35 @@ You receive `HELLO WORLD!` as the response.
 
 
 ifndef::product-docs[]
-== Run the application as a native
+== Compile and start the application as a native executable
 
 You can create a native image by following the guide about link:building-native-image[Building a Native Executable].
 endif::[]
 
-ifndef::product-docs[]
+////
+//ifndef::product-docs[]
+//TODO: This note is replaced by a rewritten version that is based on style mandated by the IBM style guide.
+//Only the -product-appropriate wording of the note should be used in both the community and product versions of this document.
+//I am retaining the original wording for purposes of verification and factual corrections.
+
 == Important technical note
 
-Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring support in {ProductName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
+
 Regarding the dependency injection in particular, Quarkus uses a Dependency Injection mechanism (called ArC) based on the https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html[Contexts and Dependency Injection for Java 2.0] specification. If you want to learn more about it we recommend you to read the link:cdi[Quarkus introduction to CDI] and the link:cdi-reference#arc-configuration-reference[CDI reference guide]
 The various Spring Boot test features are not supported by Quarkus. For testing purposes, please, check the link:getting-started-testing[Quarkus testing guide].
+//endif::[]
+////
 
 //BEGIN: REFERENCE module
 [id="overview-of-annotation-equivalents-in-spring-di-and-cdi"]
 == Overview of annotation equivalents in Spring DI and CDI
 
 [role="_abstract"]
-The following table shows how Spring DI annotations can be converted to CDI annotations or MicroProfile annotations, respectively.
+The following table lists Spring DI annotations and their equivalent CDI annotations or MicroProfile annotations, respectively.
 
 [options="header"]
 |===
@@ -455,22 +460,23 @@ The following table shows how Spring DI annotations can be converted to CDI anno
 ifdef::product-docs[]
 [role="_additional-resources"]
 .Additional resources
-* link:building-native-image[Compiling and running your {ProductName} application as a native executable.]
+* link:building-native-image[Compiling and starting your {ProductName} application as a native executable.]
 endif::[]
 
 ifndef::product-docs[]
 == More Spring guides
 
-Quarkus has more Spring compatibility features. See the following guides for more details:
+{ProductName} provides more Spring compatibility features.
+See the following guides for details:
 
-* link:spring-web[Quarkus - Extension for Spring Web]
-* link:spring-data-jpa[Quarkus - Extension for Spring Data JPA]
-* link:spring-data-rest[Quarkus - Extension for Spring Data REST]
-* link:spring-security[Quarkus - Extension for Spring Security]
-* link:spring-cloud-config-client[Quarkus - Reading properties from Spring Cloud Config Server]
-* link:spring-boot-properties[Quarkus - Extension for Spring Boot properties]
-* link:spring-cache[Quarkus - Extension for Spring Cache]
-* link:spring-scheduled[Quarkus - Extension for Spring Scheduled]
+* link:spring-web[{ProductName} - Extension for Spring Web]
+* link:spring-data-jpa[{ProductName} - Extension for Spring Data JPA]
+* link:spring-data-rest[{ProductName} - Extension for Spring Data REST]
+* link:spring-security[{ProductName} - Extension for Spring Security]
+* link:spring-cloud-config-client[{ProductName} - Reading properties from Spring Cloud Config Server]
+* link:spring-boot-properties[{ProductName} - Extension for Spring Boot properties]
+* link:spring-cache[{ProductName} - Extension for Spring Cache]
+* link:spring-scheduled[{ProductName} - Extension for Spring Scheduled]
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -27,12 +27,12 @@ ifdef::downstream[]
 endif::[]
 
 [role="_abstract"]
-The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {ProjectName} application.
-This guide explains how your {ProjectName} application can leverage Dependency Injection annotations provided by the Spring Framework.
+The `quarkus-spring-di` extension provides a compatibility layer for Spring Dependency Injection that you can use as an alternative to MicroProfile CDI annotations in your {BrandName} application.
+This guide explains how your {BrandName} application can leverage Dependency Injection annotations provided by the Spring Framework.
 
 ifndef::downstream[]
 
-This guide is maintained in the main {ProjectName} repository and pull requests should be submitted there:
+This guide is maintained in the main {BrandName} repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 == Solution
@@ -60,16 +60,16 @@ endif::[]
 //ifdef::downstream[]
 [IMPORTANT]
 ====
-The Spring compatibility layer that {ProjectName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
-{ProjectName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
-However, when you add arbitrary libraries that are part of Spring Framework to your {ProjectName} application, such libraries will not function properly, because {ProjectName} is not able to use them.
+The Spring compatibility layer that {BrandName} provides does not start a Spring Application Context or execute any infrastructure classes that are provided by Spring (for example, `org.springframework.beans.factory.config.BeanPostProcessor`) when you start your application.
+{BrandName} can only read metadata from Spring classes and annotations and parse user code method return types and parameter types that are specific to Spring.
+However, when you add arbitrary libraries that are part of Spring Framework to your {BrandName} application, such libraries will not function properly, because {BrandName} is not able to use them.
 ====
 //endif::[]
 
 .Prerequisites
 
 // comment out the following prerequisite in the alternative 1 layout of the document.
-* Have a {ProjectName} Maven project.
+* Have a {BrandName} Maven project.
 * Have OpenJDK 8 installed.
 * Have Maven {maven-version} installed.
 
@@ -108,11 +108,11 @@ cd spring-di-quickstart
 == Setting up your Spring DI example Maven project
 
 [role="_abstract"]
-Add the required {ProjectName} extension as a dependency of your Maven project.
+Add the required {BrandName} extension as a dependency of your Maven project.
 
 .Procedure
 
-. Navigate to the the top-level directory of your {ProjectName} Maven project:
+. Navigate to the the top-level directory of your {BrandName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -143,10 +143,10 @@ endif::[]
 == Adding beans to your application using Spring annotations
 
 [role="_abstract"]
-You can add the required beans to your {ProjectName} application using annotations provided by Spring.
+You can add the required beans to your {BrandName} application using annotations provided by Spring.
 
 .Procedure
-. Navigate to the the top-level directory of your {ProjectName} Maven project:
+. Navigate to the the top-level directory of your {BrandName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -193,15 +193,14 @@ public class AppConfiguration {
 As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs link:cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
 In the same vein, Quarkus does not support the Spring `@Import` annotation.
 =======
-As a Spring developer, you might be tempted to add the `@ComponentScan` annotation to define specific packages to scan for additional beans.
-Note that adding `@ComponentScan` is unnecessary, because {ProductName} performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only when in `annotated` mode with no visibility boundaries.
-Moreover, note that the bean discovery in {ProductName} happens at build time.
-In a similar way, {ProductName} does not support the `@Import` annotation form Spring.
->>>>>>> 64cc7da2dd (QUARKUS-184: resolve merge conflicts resulting from attribute name change)
++
+As a Spring developer, you might be tempted to add the `@ComponentScan` annotation in order to define specific packages to scan for additional beans. Do note that `@ComponentScan` is entirely unnecessary since Quarkus performs https://quarkus.io/guides/cdi-reference#bean_discovery[bean discovery] only in `annotated` mode with no visibility boundaries. Moreover, note that the bean discovery in Quarkus happens at build time.
+In the same vein, Quarkus does not support the Spring `@Import` annotation.
+>>>>>>> 3f6ff02c85 (QUARKUS-184: change product name to brand name in remaining instances after rebase)
 
 . Create a `NoOpSingleStringFunction` bean inside the the `src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java` file.
 The `NoOpSingleStringFunction` implements the `StringFunction` interface using the `@Component` stereotype annotation provided by Spring.
-This bean returns the input string as is:
+This bean returns the string without processing it:
 +
 .src/main/java/org/acme/spring/di/NoOpSingleStringFunction.java
 [source,java,options="nowrap",subs="+quotes,attributes+"]
@@ -221,7 +220,7 @@ public class NoOpSingleStringFunction implements StringFunction {
 ----
 +
 //. Quarkus also provides support for injecting configuration values using Spring's `@Value` annotation.
-. In {ProjectName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
+. In {BrandName} applications, you can also use the `@Value` annotations to inject values of configuration properties into beans:
 .. Set the value of the `greeting.message` property to `hello` in the `src/main/resources/application.properties` file:
 +
 [source,properties,options="nowrap",subs="+quotes,attributes+"]
@@ -333,8 +332,8 @@ public class GreeterResource {
 }
 ----
 
-[id='updating-the-unit-test_{context}']
-== Updating the units test
+[id='updating-the-integration-test-of-your-application_{context}']
+== Updating the integration test of your application
 
 [role="_abstract"]
 You must update the class file that contains the integration test for your application to reflect the changes that you made to the `/greeting` endpoint.
@@ -375,7 +374,7 @@ Package and start your Spring DI example application using Maven.
 
 .Procedure
 
-. Navigate to the the top-level directory of your {ProjectName} Maven project:
+. Navigate to the the top-level directory of your {BrandName} Maven project:
 +
 [source,bash,options="nowrap",subs="+quotes,attributes+"]
 ----
@@ -409,7 +408,7 @@ ifndef::downstream[]
 
 == Important technical note
 
-Spring support in {ProjectName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring support in {BrandName} does not start a Spring Application Context nor are any Spring infrastructure classes run.
 Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
 What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
 classes (like `org.springframework.beans.factory.config.BeanPostProcessor` , `org.springframework.context.ApplicationContext` for example) will not be executed.
@@ -479,23 +478,23 @@ The following table lists Spring DI annotations and their equivalent CDI annotat
 ifdef::downstream[]
 [role="_additional-resources"]
 .Additional resources
-* link:building-native-image[Compiling and starting your {ProjectName} application as a native executable.]
+* link:building-native-image[Compiling and starting your {BrandName} application as a native executable.]
 endif::[]
 
 ifndef::downstream[]
 == More Spring guides
 
-{ProjectName} provides more Spring compatibility features.
+{BrandName} provides more Spring compatibility features.
 See the following guides for details:
 
-* link:spring-web[{ProjectName} - Extension for Spring Web]
-* link:spring-data-jpa[{ProjectName} - Extension for Spring Data JPA]
-* link:spring-data-rest[{ProjectName} - Extension for Spring Data REST]
-* link:spring-security[{ProjectName} - Extension for Spring Security]
-* link:spring-cloud-config-client[{ProjectName} - Reading properties from Spring Cloud Config Server]
-* link:spring-boot-properties[{ProjectName} - Extension for Spring Boot properties]
-* link:spring-cache[{ProjectName} - Extension for Spring Cache]
-* link:spring-scheduled[{ProjectName} - Extension for Spring Scheduled]
+* link:spring-web[{BrandName} - Extension for Spring Web]
+* link:spring-data-jpa[{BrandName} - Extension for Spring Data JPA]
+* link:spring-data-rest[{BrandName} - Extension for Spring Data REST]
+* link:spring-security[{BrandName} - Extension for Spring Security]
+* link:spring-cloud-config-client[{BrandName} - Reading properties from Spring Cloud Config Server]
+* link:spring-boot-properties[{BrandName} - Extension for Spring Boot properties]
+* link:spring-cache[{BrandName} - Extension for Spring Cache]
+* link:spring-scheduled[{BrandName} - Extension for Spring Scheduled]
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
This is a PoC single-sourced version of the Quarkus Spring DI extension guide.
Sections of the guide had to be rewritten to conform to the Red Hat CCS product documentation standards in  terms of language and metadata required by the company content publishing system. 
At this stage, this PR is still a work in progress and there are still a few pending changes.
This copy should be reviewed by CCS  stakeholders before being reviewed by Engineering stakeholders to ensure that stylistic changes do not interfere with factual clarity and technical correctness.

In case you have questions or comments please feel free to reach out to Stefan Sitani
RH ID: ssitani
Github ID: inoxx03 