### PR TITLE
Add Dockerfile template for distroless in native mode

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-distroless
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-distroless
@@ -1,0 +1,23 @@
+####
+# This Dockerfile is used in order to build a distroless container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# {buildtool.cli} {buildtool.cmd.package-native}
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/{project.artifact-id} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
+#
+###
+FROM {dockerfile.native-distroless.from}
+COPY {buildtool.build-dir}/*-runner /application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-distroless
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-distroless
@@ -18,6 +18,6 @@ FROM {dockerfile.native-distroless.from}
 COPY {buildtool.build-dir}/*-runner /application
 
 EXPOSE 8080
-USER 1001
+USER nonroot
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/codestart.yml
@@ -14,3 +14,5 @@ language:
           run-java-version: 1.3.8
         native:
           from: registry.access.redhat.com/ubi8/ubi-minimal:8.3
+        native-distroless:
+          from: quay.io/quarkus/quarkus-distroless-image:20.3-java11

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/tooling/dockerfiles/codestart.yml
@@ -15,4 +15,4 @@ language:
         native:
           from: registry.access.redhat.com/ubi8/ubi-minimal:8.3
         native-distroless:
-          from: quay.io/quarkus/quarkus-distroless-image:20.3-java11
+          from: quay.io/quarkus/quarkus-distroless-image:1.0

--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native-distroless.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native-distroless.ftl
@@ -1,0 +1,23 @@
+####
+# This Dockerfile is used in order to build a distroless container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/${project_artifactId} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}
+#
+###
+FROM quay.io/quarkus/quarkus-distroless-image:20.3-java11
+COPY ${build-dir}/*-runner /application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native-distroless.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native-distroless.ftl
@@ -14,10 +14,10 @@
 # docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}
 #
 ###
-FROM quay.io/quarkus/quarkus-distroless-image:20.3-java11
+FROM quay.io/quarkus/quarkus-distroless-image:1.0
 COPY ${build-dir}/*-runner /application
 
 EXPOSE 8080
-USER 1001
+USER nonroot
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
A PR to build a distroless image has been merged here : https://github.com/quarkusio/quarkus-images/pull/118
This PR adds a new Dockerfile template to showcase how to use it.

**Question :**
Do we really need graalvm version + java version in the image tag name ? Since this is a distroless version, java is not installed in the image so it may be confusing.

A next step could be to update the guide. What do you think ?

cc @cescoffier and @matthyx