### PR TITLE
Bump adal4j version from 1.6.3 to 1.6.6

### DIFF
--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
-            <version>1.6.3</version>
+            <version>1.6.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Version 1.6.3 is over 2 years old now whereas 1.6.6 was released in September 2020. Further we would like to use a newer version of the transitive dependency `com.nimbusds:oauth2-oidc-sdk`, which is at 5.64.4 in the current version and at 7.4 in the new version of `com.microsoft.azure:adal4j`.