### PR TITLE
fix: add JAXRS API as SR opentracing depends on it but didn't declare it

### DIFF
--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -31,6 +31,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+            smallrye-opentracing depends on opentracing:jaxrs2 that defines JAXRS-API as provided.
+            So we need to add it in case we use opentracing without resteasy.
+            See https://github.com/opentracing-contrib/java-interceptors/issues/15
+        -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>


### PR DESCRIPTION
More info on this Zulip discussion: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/opentracing.20without.20JAX-RS.20(without.20resteasy)