### PR TITLE
Handle 'inherit' logging min-level settings

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.logging;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -45,6 +46,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.logging.CategoryBuildTimeConfig;
+import io.quarkus.runtime.logging.InheritableLevel;
 import io.quarkus.runtime.logging.LogBuildTimeConfig;
 import io.quarkus.runtime.logging.LogConfig;
 import io.quarkus.runtime.logging.LogMetricsHandlerRecorder;
@@ -189,9 +191,9 @@ public final class LoggingResourceProcessor {
         generateLogManagerLogger(output, LoggingResourceProcessor.generateMinLevelDefault(minLevel.getName()));
     }
 
-    private static void generateCategoryMinLevelLoggers(Map<String, CategoryBuildTimeConfig> categories, Level minLevel,
+    private static void generateCategoryMinLevelLoggers(Map<String, CategoryBuildTimeConfig> categories, Level rootMinLevel,
             ClassOutput output) {
-        generateMinLevelCompute(categories, minLevel.toString(), output);
+        generateMinLevelCompute(categories, rootMinLevel, output);
         generateDefaultLoggerNode(output);
         generateLogManagerLogger(output, LoggingResourceProcessor::generateMinLevelCheckCategory);
     }
@@ -202,7 +204,7 @@ public final class LoggingResourceProcessor {
         return method.ifTrue(method.invokeStaticMethod(IS_MIN_LEVEL_ENABLED, levelIntValue, nameAlias));
     }
 
-    private static void generateMinLevelCompute(Map<String, CategoryBuildTimeConfig> categories, String defaultMinLevelName,
+    private static void generateMinLevelCompute(Map<String, CategoryBuildTimeConfig> categories, Level rootMinLevel,
             ClassOutput output) {
         try (ClassCreator cc = ClassCreator.builder().setFinal(true)
                 .className(MIN_LEVEL_COMPUTE_CLASS_NAME)
@@ -217,7 +219,8 @@ public final class LoggingResourceProcessor {
                 BytecodeCreator current = mc;
                 for (Map.Entry<String, CategoryBuildTimeConfig> entry : categories.entrySet()) {
                     final String category = entry.getKey();
-                    final int categoryLevelIntValue = entry.getValue().minLevel.getLevel().intValue();
+                    final int categoryLevelIntValue = getLogMinLevel(entry.getKey(), entry.getValue(), categories, rootMinLevel)
+                            .intValue();
 
                     ResultHandle equalsResult = current.invokeVirtualMethod(
                             MethodDescriptor.ofMethod(Object.class, "equals", boolean.class, Object.class),
@@ -243,12 +246,30 @@ public final class LoggingResourceProcessor {
                     equalsBranch.trueBranch().returnValue(equalsBranch.trueBranch().load(true));
                 }
 
-                final ResultHandle infoLevelIntValue = getLogManagerLevelIntValue(defaultMinLevelName, current);
+                final ResultHandle infoLevelIntValue = getLogManagerLevelIntValue(rootMinLevel.toString(), current);
                 final BranchResult isInfoOrHigherBranch = current.ifIntegerGreaterEqual(level, infoLevelIntValue);
                 isInfoOrHigherBranch.trueBranch().returnValue(isInfoOrHigherBranch.trueBranch().load(true));
                 isInfoOrHigherBranch.falseBranch().returnValue(isInfoOrHigherBranch.falseBranch().load(false));
             }
         }
+    }
+
+    private static Level getLogMinLevel(String categoryName, CategoryBuildTimeConfig categoryConfig,
+            Map<String, CategoryBuildTimeConfig> categories,
+            Level rootMinLevel) {
+        if (Objects.isNull(categoryConfig))
+            return rootMinLevel;
+
+        final InheritableLevel inheritableLevel = categoryConfig.minLevel;
+        if (!inheritableLevel.isInherited())
+            return inheritableLevel.getLevel();
+
+        int lastDotIndex = categoryName.lastIndexOf('.');
+        if (lastDotIndex == -1)
+            return rootMinLevel;
+
+        String parent = categoryName.substring(0, lastDotIndex);
+        return getLogMinLevel(parent, categories.get(parent), categories, rootMinLevel);
     }
 
     private static void generateDefaultLoggerNode(ClassOutput output) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -230,7 +230,7 @@ public final class LoggingResourceProcessor {
                     try (BytecodeCreator false1 = equalsBranch.falseBranch()) {
                         ResultHandle startsWithResult = false1.invokeVirtualMethod(
                                 MethodDescriptor.ofMethod(String.class, "startsWith", boolean.class, String.class),
-                                name, false1.load(category));
+                                name, false1.load(category + "."));
 
                         BranchResult startsWithBranch = false1.ifTrue(startsWithResult);
 

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/below/child/LoggingMinLevelBelowChild.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/below/child/LoggingMinLevelBelowChild.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.logging.minlevel.set.below.child;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.logging.minlevel.set.LoggingWitness;
+
+@Path("/log/below/child")
+public class LoggingMinLevelBelowChild {
+
+    static final Logger LOG = Logger.getLogger(LoggingMinLevelBelowChild.class);
+
+    @GET
+    @Path("/trace")
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean isTrace() {
+        return LOG.isTraceEnabled() && LoggingWitness.loggedTrace("trace-message", LOG);
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/main/resources/application.properties
+++ b/integration-tests/logging-min-level-set/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.log.min-level=DEBUG
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.above".min-level=INFO
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.below".min-level=TRACE
+quarkus.log.category."io.quarkus.it.logging.minlevel.set.below.child".min-level=inherit
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.promote".min-level=ERROR

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowChildTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowChildTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Test verifies that a min-level override that goes below the default min-level is applied correctly.
+ */
+@QuarkusTest
+@QuarkusTestResource(SetRuntimeLogLevels.class)
+public class LoggingMinLevelBelowChildTest {
+
+    @Test
+    public void testTrace() {
+        given()
+                .when().get("/log/below/child/trace")
+                .then()
+                .statusCode(200)
+                .body(is("true"));
+    }
+
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelBelowChildIT.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/NativeLoggingMinLevelBelowChildIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.logging.minlevel.set;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeLoggingMinLevelBelowChildIT extends LoggingMinLevelBelowChildTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/SetRuntimeLogLevels.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/SetRuntimeLogLevels.java
@@ -13,6 +13,7 @@ public final class SetRuntimeLogLevels implements QuarkusTestResourceLifecycleMa
         systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.bydefault\".level", "DEBUG");
         systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.above\".level", "WARN");
         systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.below\".level", "TRACE");
+        systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.below.child\".level", "inherit");
         systemProperties.put("quarkus.log.category.\"io.quarkus.it.logging.minlevel.set.promote\".level", "INFO");
         return systemProperties;
     }


### PR DESCRIPTION
Closes #14154. This PR replaces #14160.

Fixed by searching through parent categories until a non-inherit one is found, or use default category instead.
