### PR TITLE
Support custom named Entities in Spring Data JPA repositories

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
+import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Version;
@@ -86,6 +87,7 @@ public final class DotNames {
     public static final DotName JPA_ID = DotName.createSimple(Id.class.getName());
     public static final DotName VERSION = DotName.createSimple(Version.class.getName());
     public static final DotName JPA_MAPPED_SUPERCLASS = DotName.createSimple(MappedSuperclass.class.getName());
+    public static final DotName JPA_ENTITY = DotName.createSimple(Entity.class.getName());;
     public static final DotName VOID = DotName.createSimple(void.class.getName());
     public static final DotName LONG = DotName.createSimple(Long.class.getName());
     public static final DotName PRIMITIVE_LONG = DotName.createSimple(long.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
@@ -8,6 +8,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -483,7 +485,11 @@ public class MethodNameParser {
     }
 
     private String getEntityName() {
-        // TODO: not true?
+        AnnotationInstance annotationInstance = entityClass.classAnnotation(DotNames.JPA_ENTITY);
+        if (annotationInstance != null && annotationInstance.value("name") != null) {
+            AnnotationValue annotationValue = annotationInstance.value("name");
+            return annotationValue.asString().length() > 0 ? annotationValue.asString() : entityClass.simpleName();
+        }
         return entityClass.simpleName();
     }
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Car.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Car.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.Entity;
+
+@Entity(name = "MotorCar")
+public class Car extends AbstractEntity {
+
+    private String brand;
+    private String model;
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CarRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CarRepository.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CarRepository extends JpaRepository<Car, Long> {
+
+    List<Car> findByBrand(String brand);
+
+    Car findByBrandAndModel(String brand, String model);
+
+    @Query("SELECT m.model FROM MotorCar m WHERE m.brand = :brand")
+    List<String> findModelsByBrand(@Param("brand") String brand);
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CarResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CarResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@Path("/car")
+public class CarResource {
+
+    private final CarRepository carRepository;
+
+    public CarResource(CarRepository carRepository) {
+        this.carRepository = carRepository;
+    }
+
+    @Path("brand/{brand}")
+    @GET
+    @Produces("application/json")
+    public List<Car> carsByBrand(@PathParam("brand") String brand) {
+        return carRepository.findByBrand(brand);
+    }
+
+    @Path("brand/{brand}/model/{model}")
+    @GET
+    @Produces("application/json")
+    public Car findByBrandAndModel(@PathParam("brand") String brand, @PathParam("model") String model) {
+        return carRepository.findByBrandAndModel(brand, model);
+    }
+
+    @Path("{id}")
+    @GET
+    @Produces("application/json")
+    public Car carById(@PathParam("id") Long id) {
+        return carRepository.findById(id).orElse(null);
+    }
+
+    @Path("brand/{brand}/models")
+    @GET
+    @Produces("application/json")
+    public List<String> carModelsByBrand(@PathParam("brand") String brand) {
+        return carRepository.findModelsByBrand(brand);
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/resources/import.sql
+++ b/integration-tests/spring-data-jpa/src/main/resources/import.sql
@@ -77,3 +77,7 @@ INSERT INTO team(id, name, unit_id) VALUES (11, 'Sales Team', 2);
 INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (100, 'johdoe', 'John', 'Doe', 10);
 INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (101, 'petdig', 'Peter', 'Digger', 10);
 INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (102, 'stesmi', 'Stella', 'Smith', 11);
+
+INSERT INTO MotorCar(id, brand, model) VALUES (1, 'Monteverdi', 'Hai 450');
+INSERT INTO MotorCar(id, brand, model) VALUES (2, 'Rinspeed', 'iChange');
+INSERT INTO MotorCar(id, brand, model) VALUES (3, 'Rinspeed', 'Oasis');

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CarResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CarResourceTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.spring.data.jpa;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CarResourceTest {
+
+    @Test
+    void testFindByBrand() {
+        final List<Car> cars = when().get("/car/brand/Rinspeed").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getList(".", Car.class);
+        assertThat(cars).hasSize(2);
+    }
+
+    @Test
+    void findByBrandAndModel() {
+        final Car car = when().get("/car/brand/Rinspeed/model/Oasis").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getObject(".", Car.class);
+        assertThat(car).extracting(Car::getBrand).isEqualTo("Rinspeed");
+        assertThat(car).extracting(Car::getModel).isEqualTo("Oasis");
+    }
+
+    @Test
+    void findById() {
+        final Car car = when().get("/car/1").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getObject(".", Car.class);
+        assertThat(car).extracting(Car::getBrand).isEqualTo("Monteverdi");
+        assertThat(car).extracting(Car::getModel).isEqualTo("Hai 450");
+    }
+
+    @Test
+    void findModelsByBrand() {
+        final List<String> models = when().get("/car/brand/Rinspeed/models").then()
+                .statusCode(200)
+                .extract().body().jsonPath().getList(".", String.class);
+        assertThat(models).contains("iChange", "Oasis");
+    }
+}


### PR DESCRIPTION
This pull request fixes `MethodNameParser.getEntityName()`. Currently the name set in the `@Entity`annotation is ignored. With this fix if a name set on the `@Entity`annotation that one will be used instead of the class name.