### PR TITLE
Engage logging InitialConfigurator only when running a Quarkus application

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
@@ -3,12 +3,25 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class GeneratedResourceBuildItem extends MultiBuildItem {
-    final String name;
-    final byte[] classData;
+    private final String name;
+    private final byte[] classData;
+    /**
+     * This setting is only relevant for the fast-jar package and determines whether the generated file should be included in
+     * the
+     * quarkus-run jar (if set to {@code true}) or the generated-bytecode jar (if set to {@code false}).
+     * This option is generally not needed except for services that need to be loadable by the (few) jars that are included
+     * in the quarkus-run (that is the bootstrap) jar
+     */
+    private final boolean includeInBootstrap;
 
     public GeneratedResourceBuildItem(String name, byte[] classData) {
+        this(name, classData, false);
+    }
+
+    public GeneratedResourceBuildItem(String name, byte[] classData, boolean includeInBootstrap) {
         this.name = name;
         this.classData = classData;
+        this.includeInBootstrap = includeInBootstrap;
     }
 
     public String getName() {
@@ -17,5 +30,9 @@ public final class GeneratedResourceBuildItem extends MultiBuildItem {
 
     public byte[] getClassData() {
         return classData;
+    }
+
+    public boolean isIncludeInBootstrap() {
+        return includeInBootstrap;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.logging;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ConsoleFormatterBannerBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.LogConsoleFormatBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
@@ -109,12 +111,15 @@ public final class LoggingResourceProcessor {
     void miscSetup(
             Consumer<RuntimeInitializedClassBuildItem> runtimeInit,
             Consumer<NativeImageSystemPropertyBuildItem> systemProp,
-            Consumer<ServiceProviderBuildItem> provider) {
+            Consumer<ServiceProviderBuildItem> provider,
+            Consumer<GeneratedResourceBuildItem> generatedResource) {
         runtimeInit.accept(new RuntimeInitializedClassBuildItem("org.jboss.logmanager.formatters.TrueColorHolder"));
         systemProp
                 .accept(new NativeImageSystemPropertyBuildItem("java.util.logging.manager", "org.jboss.logmanager.LogManager"));
         provider.accept(
                 new ServiceProviderBuildItem(EmbeddedConfigurator.class.getName(), InitialConfigurator.class.getName()));
+        generatedResource.accept(new GeneratedResourceBuildItem("META-INF/services/" + EmbeddedConfigurator.class.getName(),
+                InitialConfigurator.class.getName().getBytes(StandardCharsets.UTF_8), true));
     }
 
     @BuildStep

--- a/independent-projects/bootstrap/runner/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
+++ b/independent-projects/bootstrap/runner/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
@@ -1,1 +1,0 @@
-io.quarkus.bootstrap.logging.InitialConfigurator


### PR DESCRIPTION
This is done by generating the Service file during build time instead
of embedding it inside the quarkus-bootstrap-runner jar unconditionally

Fixes: #14295