### PR TITLE
Render template based email as Uni

### DIFF
--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
@@ -17,6 +17,7 @@ import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
 import io.quarkus.qute.api.CheckedTemplate;
 import io.quarkus.qute.api.ResourcePath;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.mail.MailClient;
 
 @SuppressWarnings("WeakerAccess")
@@ -75,8 +76,8 @@ public class InjectionTest {
         beanUsingReactiveMailer.verify().toCompletableFuture().join();
         beanUsingLegacyReactiveMailer.verify().toCompletableFuture().join();
         templates.send1();
-        templates.send2().toCompletableFuture().join();
-        templates.sendNative().toCompletableFuture().join();
+        templates.send2().await();
+        templates.sendNative().await();
     }
 
     @ApplicationScoped
@@ -171,15 +172,15 @@ public class InjectionTest {
         @ResourcePath("mails/test2")
         MailTemplate testMail;
 
-        CompletionStage<Void> send1() {
+        Uni<Void> send1() {
             return test1.to("quarkus@quarkus.io").subject("Test").data("name", "John").send();
         }
 
-        CompletionStage<Void> send2() {
+        Uni<Void> send2() {
             return testMail.to("quarkus@quarkus.io").subject("Test").data("name", "Lu").send();
         }
 
-        CompletionStage<Void> sendNative() {
+        Uni<Void> sendNative() {
             return Templates.testNative("John").to("quarkus@quarkus.io").subject("Test").send();
         }
     }

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateValidationTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateValidationTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.mailer;
 
-import java.util.concurrent.CompletionStage;
-
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -14,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
 
 public class MailTemplateValidationTest {
 
@@ -38,7 +37,7 @@ public class MailTemplateValidationTest {
         @Inject
         MailTemplate doesNotExist;
 
-        CompletionStage<Void> send() {
+        Uni<Void> send() {
             return doesNotExist.to("quarkus@quarkus.io").subject("Test").data("name", "Foo").send();
         }
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -1,7 +1,8 @@
 package io.quarkus.mailer;
 
 import java.io.File;
-import java.util.concurrent.CompletionStage;
+
+import io.smallrye.mutiny.Uni;
 
 /**
  * Represents an e-mail definition based on a template.
@@ -53,8 +54,7 @@ public interface MailTemplate {
 
         MailTemplateInstance data(String key, Object value);
 
-        CompletionStage<Void> send();
-
+        Uni<Void> send();
     }
 
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
@@ -92,7 +92,7 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
     }
 
     @Override
-    public CompletionStage<Void> send() {
+    public Uni<Void> send() {
         Object variantsAttr = templateInstance.getAttribute(TemplateInstance.VARIANTS);
         if (variantsAttr != null) {
             List<Result> results = new ArrayList<>();
@@ -123,8 +123,7 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
                         public Uni<? extends Void> apply(Mail m) {
                             return mailer.send(m);
                         }
-                    })
-                    .subscribeAsCompletionStage();
+                    });
         } else {
             throw new IllegalStateException("No template variant found");
         }


### PR DESCRIPTION
This branch changes the `MailTemplateInstance#send` method return type to `Uni`.

As it's a breaking change, I will update the migration guide if this branch is ok.

close #14105  