### PR TITLE
Fix and get OIDC client tests running in CI native builds

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -75,7 +75,7 @@
         {
             "category": "Security2",
             "timeout": 70,
-            "test-modules": "oidc oidc-code-flow oidc-tenancy keycloak-authorization oidc-client oidc-wiremock"
+            "test-modules": "oidc oidc-code-flow oidc-tenancy keycloak-authorization oidc-client oidc-token-propagation oidc-wiremock"
         },
         {
             "category": "Security3",

--- a/extensions/oidc-client-filter/deployment/pom.xml
+++ b/extensions/oidc-client-filter/deployment/pom.xml
@@ -96,7 +96,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -118,7 +118,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -120,7 +120,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -142,7 +142,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -9,6 +9,9 @@ import io.smallrye.mutiny.Uni;
 
 public class TokensHelper {
 
+    @SuppressWarnings("unused")
+    private volatile TokenRequestState tokenRequestState;
+
     private static final AtomicReferenceFieldUpdater<TokensHelper, TokenRequestState> tokenRequestStateUpdater = AtomicReferenceFieldUpdater
             .newUpdater(TokensHelper.class, TokenRequestState.class, "tokenRequestState");
 

--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -136,7 +136,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -236,7 +236,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>

--- a/integration-tests/oidc-client/src/main/resources/application.properties
+++ b/integration-tests/oidc-client/src/main/resources/application.properties
@@ -13,6 +13,7 @@ io.quarkus.it.keycloak.ProtectedResourceServiceRegisterProvider/mp-rest/url=http
 io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceNoOidcClient/mp-rest/url=http://localhost:8081/protected
 
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -85,7 +85,12 @@ public class OidcClientTest {
                 .untilAsserted(new ThrowingRunnable() {
                     @Override
                     public void run() throws Throwable {
-                        final Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        boolean fileExists = Files.exists(accessLogFilePath);
+                        if (!fileExists) {
+                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
+                            fileExists = Files.exists(accessLogFilePath);
+                        }
                         Assertions.assertTrue(Files.exists(accessLogFilePath),
                                 "quarkus log file " + accessLogFilePath + " is missing");
 

--- a/integration-tests/oidc-token-propagation/pom.xml
+++ b/integration-tests/oidc-token-propagation/pom.xml
@@ -131,7 +131,7 @@
             <id>test-keycloak</id>
             <activation>
                 <property>
-                    <name>test-keycloak</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -231,7 +231,7 @@
             <id>docker-keycloak</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>


### PR DESCRIPTION
@stuartwdouglas Hi Stuart, not sure how it happened, but somehow I got the volatile field lost - possibly during a rebase because the field was `unused`, after I run the tests - in CI some of them have been skipped.

@gsmet Guillaume - please consider it for a backport into the next `1.11.x`

thanks