### PR TITLE
Use Google Mirror also for Initial JDK 11 Build

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -10,39 +10,24 @@
   </servers>
   <profiles>
     <profile>
-      <id>google-mirror-jboss-proxy</id>
+      <id>google-mirror</id>
       <repositories>
         <repository>
           <id>google-maven-central</id>
           <name>GCS Maven Central mirror EU</name>
-          <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
-        </repository>
-        <repository>
-          <id>jboss-maven-central-proxy</id>
-          <name>JBoss Maven Central proxy</name>
-          <url>https://repository.jboss.org/nexus/content/repositories/central/</url>
-        </repository>
-        <repository>
-            <id>gradle-official-repository</id>
-            <name>Gradle Official Repository</name>
-            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>google-maven-central</id>
           <name>GCS Maven Central mirror EU</name>
-          <url>https://maven-central-eu.storage-download.googleapis.com/repos/central/data/</url>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-maven-central-proxy</id>
-          <name>JBoss Maven Central proxy</name>
-          <url>https://repository.jboss.org/nexus/content/repositories/central/</url>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
         </pluginRepository>
       </pluginRepositories>
     </profile>
   </profiles>
   <activeProfiles>
-    <activeProfile>google-mirror-jboss-proxy</activeProfile>
+    <activeProfile>google-mirror</activeProfile>
   </activeProfiles>
 </settings>

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -91,7 +91,7 @@ jobs:
           key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build
         run: |
-          mvn -e -B -DskipTests -DskipITs -Dno-format clean install
+          mvn -e -B -DskipTests -DskipITs -Dno-format --settings .github/mvn-settings.xml clean install
       - name: Tar Maven Repo
         shell: bash
         run: tar -czf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
This was apparently forgotten and it should stabilize the Initial JDK 11 Build downloads.