### PR TITLE
CI: Add mongodb-rest-data-panache and mongodb-panache-kotlin to native tests

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -45,7 +45,7 @@
         {
             "category": "Data4",
             "timeout": 55,
-            "test-modules": "mongodb-client mongodb-panache redis-client neo4j hibernate-orm-rest-data-panache"
+            "test-modules": "mongodb-client mongodb-panache mongodb-rest-data-panache mongodb-panache-kotlin redis-client neo4j hibernate-orm-rest-data-panache"
         },
         {
             "category": "Data5",


### PR DESCRIPTION
Came up here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Why.20is.20OidcClient.20test.20skipped

I noticed that `MongoDbRestDataPanacheTest` (non-native test) now runs twice, once in the JVM test builds and once in the "Data4" native build.
I did not try to fix it in this PR because it seems `quarkus-integration-test-mongodb-rest-data-panache` is not the only module with this problem. Or is it even intentional?