### PR TITLE
Add guard task to ensure log messages are dropped when the process isn't a Quarkus application

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
@@ -1,8 +1,12 @@
 package io.quarkus.bootstrap.logging;
 
 import io.quarkus.bootstrap.graal.ImageInfo;
+import io.quarkus.bootstrap.runner.Timing;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import org.jboss.logmanager.EmbeddedConfigurator;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
@@ -28,6 +32,15 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
             Class<?> root = Class.forName(InitialConfigurator.class.getName(), false, ClassLoader.getSystemClassLoader());
             if (root.getClassLoader() != cl) {
                 handler = (DelayedHandler) root.getDeclaredField("DELAYED_HANDLER").get(null);
+            }
+
+            if (!isQuarkusApplication(cl)) {
+                // For tests, InitialConfigurator is called before Quarkus has come into play so we don't really know
+                // if the application is a Quarkus application or not.
+                // In order to avoid having log records queue indefinitely for tests that are not Quarkus tests,
+                // the idea here is to check after a few seconds if any logging has been enabled
+                // (which it will be if it's a Quarkus test), and if not, to simply drop all log records
+                new Timer().schedule(new DropLogRecordersTask(cl), 5_000);
             }
         } catch (Exception e) {
             //ignore, happens on native image build
@@ -65,5 +78,64 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
         ConsoleHandler handler = new ConsoleHandler(new PatternFormatter("%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
         handler.setLevel(Level.INFO);
         return handler;
+    }
+
+    private static boolean isQuarkusApplication(ClassLoader cl) {
+        if (Timing.bootStartTime >= 0) { // prod mode
+            return true;
+        }
+        if (forNameOrFalse(cl, "io.quarkus.runner.ApplicationImpl")) { // prod mode fallback
+            return true;
+        }
+        if (cl.getResource("META-INF/dev-mode-context.dat") != null) { // dev mode
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean forNameOrFalse(ClassLoader cl, String name) {
+        try {
+            Class.forName(name, false, cl);
+            return true;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private static class NoopHandler extends Handler {
+        @Override
+        public void publish(LogRecord record) {
+
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() throws SecurityException {
+
+        }
+    }
+
+    private static class DropLogRecordersTask extends TimerTask {
+
+        private final ClassLoader cl;
+
+        public DropLogRecordersTask(ClassLoader cl) {
+            this.cl = cl;
+        }
+
+        @Override
+        public void run() {
+            if (DELAYED_HANDLER.isActivated()) {
+                return;
+            }
+            // add a dummy handler in order to activate the delayed handler and thus dump the results
+            // this still leaves the delayed handler with a large array of log records (as there is no
+            // straightforward way to resize its Deque), but at least it doesn't grow
+            DELAYED_HANDLER.addHandler(new NoopHandler());
+        }
     }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
@@ -14,7 +14,7 @@ import org.jboss.logging.Logger;
  */
 public class Timing {
 
-    private static volatile long bootStartTime = -1;
+    public static volatile long bootStartTime = -1;
 
     private static volatile long bootStopTime = -1;
 


### PR DESCRIPTION
Fixes: #14295

This solution really sucks but I couldn't come up with anything better that 

1) Had no penalty for a prod run
2) Worked properly for prod, dev and test mode