### PR TITLE
Preserve expected semantics of Maven execution with native profile enabled

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageIT.java
@@ -38,7 +38,7 @@ public class NativeImageIT extends MojoTestBase {
         // trigger mvn package -Pnative -Dquarkus.ssl.native=true
         final String[] mvnArgs = new String[] { "package", "-DskipTests", "-Pnative", "-Dquarkus.ssl.native=true" };
         final MavenProcessInvocationResult result = running.execute(Arrays.asList(mvnArgs), Collections.emptyMap());
-        await().atMost(5, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(10, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         final String processLog = running.log();
         try {
             assertThat(processLog).containsIgnoringCase("BUILD SUCCESS");

--- a/integration-tests/spring-data-jpa/src/main/resources/application.properties
+++ b/integration-tests/spring-data-jpa/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.package.type=fast-jar
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.jdbc.max-size=8


### PR DESCRIPTION
Fixes: #14320

This is certainly a hack, but I believe it is warranted by the fact that users expect `mvn package -Dnative` to work regardless of what they have configured in `application.properties`. Users most likely don't notice that 

```
      <properties>
        <quarkus.package.type>native</quarkus.package.type>
      </properties>
``` 

is being set in the `native` maven profile and certainly don't expect that it will not take effect if the same property is set in `application.properties`.

The reason we haven't encountered this before is because it only manifests if `quarkus.package.type` is set in `application.properties` **and** `pom.xml` is configured in the new style of using the `<quarkus.package.type>` Maven property (which most of our integration tests and quickstarts do not)