### PR TITLE
Qute - add content filters

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -916,12 +916,42 @@ NOTE: The template rendering is divided in two phases. During the first phase, w
 
 === Engine Configuration
 
+==== Value Resolvers
+
+Value resolvers are used when evaluating expressions.
+A custom `io.quarkus.qute.ValueResolver` can be registered programmatically via `EngineBuilder.addValueResolver()`.
+
+.`ValueResolver` Builder Example
+[source,java]
+----
+engineBuilder.addValueResolver(ValueResolver.builder()
+    .appliesTo(ctx -> ctx.getBase() instanceof Long && ctx.getName().equals("tenTimes"))
+    .resolveSync(ctx -> (Long) ctx.getBase() * 10)
+    .build());
+----
+
 ==== Template Locator
 
 Manual registration is sometimes handy but it's also possible to register a template locator using `EngineBuilder.addLocator(Function<String, Optional<Reader>>)`.
 This locator is used whenever the `Engine.getTemplate()` method is called and the engine has no template for a given id stored in the cache.
 
 NOTE: In Quarkus, all templates from the `src/main/resources/templates` are located automatically.
+
+==== Content Filters
+
+Content filters can be used to modify the template contents before parsing.
+
+.Content Filter Example
+[source,java]
+----
+engineBuilder.addParserHook(new ParserHook() {
+    @Override
+    public void beforeParsing(ParserHelper parserHelper) {
+        parserHelper.addContentFilter(contents -> contents.replace("${", "$\\{")); <1>
+    }
+});
+----
+<1> Escape all occurences of `${`.
 
 [[quarkus_integration]]
 == Quarkus Integration
@@ -960,6 +990,24 @@ class MyBean {
 <1> If there is no `ResourcePath` qualifier provided, the field name is used to locate the template. In this particular case, the container will attempt to locate a template with path `src/main/resources/templates/items.html`.
 <2> The `ResourcePath` qualifier instructs the container to inject a template from a path relative from `src/main/resources/templates`. In this case, the full path is `src/main/resources/templates/detail/items2_v1.html`. 
 <3> Inject the configured `Engine` instance.
+
+It's also possible to contribute to the engine configuration via a CDI observer method.
+
+.`EngineBuilder` Observer Example
+[source,java]
+----
+import io.quarkus.qute.EngineBuilder;
+
+class MyBean {
+
+    void configureEngine(@Observes EngineBuilder builder) {
+       builder.addValueResolver(ValueResolver.builder()
+                .appliesTo(ctx -> ctx.getBase() instanceof Long && ctx.getName().equals("tenTimes"))
+                .resolveSync(ctx -> (Long) ec.getBase() * 10)
+                .build());
+    }
+}
+----
 
 === Template Variants
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -376,28 +376,25 @@ public class QuteProcessor {
         }).addParserHook(new ParserHook() {
 
             @Override
-            public void beforeParsing(ParserHelper parserHelper, String id) {
-                if (id != null) {
-                    for (CheckedTemplateBuildItem checkedTemplate : checkedTemplates) {
-                        // FIXME: check for dot/extension?
-                        if (id.startsWith(checkedTemplate.templateId)) {
-                            for (Entry<String, String> entry : checkedTemplate.bindings.entrySet()) {
-                                parserHelper.addParameter(entry.getKey(), entry.getValue());
-                            }
+            public void beforeParsing(ParserHelper parserHelper) {
+                for (CheckedTemplateBuildItem checkedTemplate : checkedTemplates) {
+                    // FIXME: check for dot/extension?
+                    if (parserHelper.getTemplateId().startsWith(checkedTemplate.templateId)) {
+                        for (Entry<String, String> entry : checkedTemplate.bindings.entrySet()) {
+                            parserHelper.addParameter(entry.getKey(), entry.getValue());
                         }
                     }
-
-                    // Add params to message bundle templates
-                    for (MessageBundleMethodBuildItem messageBundleMethod : messageBundleMethods) {
-                        if (id.equals(messageBundleMethod.getTemplateId())) {
-                            MethodInfo method = messageBundleMethod.getMethod();
-                            for (ListIterator<Type> it = method.parameters().listIterator(); it.hasNext();) {
-                                Type paramType = it.next();
-                                parserHelper.addParameter(method.parameterName(it.previousIndex()),
-                                        JandexUtil.getBoxedTypeName(paramType));
-                            }
-                            break;
+                }
+                // Add params to message bundle templates
+                for (MessageBundleMethodBuildItem messageBundleMethod : messageBundleMethods) {
+                    if (parserHelper.getTemplateId().equals(messageBundleMethod.getTemplateId())) {
+                        MethodInfo method = messageBundleMethod.getMethod();
+                        for (ListIterator<Type> it = method.parameters().listIterator(); it.hasNext();) {
+                            Type paramType = it.next();
+                            parserHelper.addParameter(method.parameterName(it.previousIndex()),
+                                    JandexUtil.getBoxedTypeName(paramType));
                         }
+                        break;
                     }
                 }
             }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
@@ -1,5 +1,28 @@
 package io.quarkus.qute;
 
+import java.util.function.Function;
+
 public interface ParserHelper {
-    public void addParameter(String name, String type);
+
+    /**
+     * 
+     * @return the template id
+     */
+    String getTemplateId();
+
+    /**
+     * Adds an <em>implicit</em> parameter declaration. This an alternative approach to <em>explicit</em> parameter declarations
+     * used directly in the templates, e.g. <code>{@org.acme.Foo foo}</code>.
+     * 
+     * @param name
+     * @param type
+     */
+    void addParameter(String name, String type);
+
+    /**
+     * The filter is used before the template contents is parsed.
+     * 
+     * @param filter
+     */
+    void addContentFilter(Function<String, String> filter);
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHook.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHook.java
@@ -2,6 +2,10 @@ package io.quarkus.qute;
 
 public interface ParserHook {
 
-    void beforeParsing(ParserHelper parser, String id);
+    /**
+     * 
+     * @param parserHelper
+     */
+    void beforeParsing(ParserHelper parserHelper);
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -273,6 +273,18 @@ public class ParserTest {
         assertEquals("foo.name", expressions.get(4).toOriginalString());
     }
 
+    @Test
+    public void testParserHook() {
+        Template template = Engine.builder().addDefaults().addParserHook(new ParserHook() {
+            @Override
+            public void beforeParsing(ParserHelper parserHelper) {
+                parserHelper.addContentFilter(contents -> contents.replace("bard", "bar"));
+                parserHelper.addContentFilter(contents -> contents.replace("${", "$\\{"));
+            }
+        }).build().parse("${foo}::{bard}");
+        assertEquals("${foo}::true", template.data("bar", true).render());
+    }
+
     private void assertParserError(String template, String message, int line) {
         Engine engine = Engine.builder().addDefaultSectionHelpers().build();
         try {


### PR DESCRIPTION
- makes it possible to modify the template contents before parsing, e.g.
to escape some sequences of characters
- resolves #11281