### PR TITLE
Fix jboss-jaxrs-api_2.1_spec build warning

### DIFF
--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -85,11 +85,6 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-smallrye-opentracing:jar:999-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:jar -> duplicate declaration of version (?) @ line 88, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
Was introduced here: https://github.com/quarkusio/quarkus/pull/14323