### PR TITLE
CI: Fix skipping of wiremock in TCKs for initial build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
                 <skip.gradle.tests>true</skip.gradle.tests>
                 <invoker.skip>true</invoker.skip>   <!-- maven-invoker-plugin -->
                 <jbang.skip>true</jbang.skip> <!-- jbang-maven-plugin -->
-                <wiremock.skip>true</wiremock.skip> <!-- wiremock-maven-plugin -->
             </properties>
             <build>
                 <defaultGoal>clean install</defaultGoal>
@@ -146,7 +145,6 @@
                 <skip.gradle.tests>true</skip.gradle.tests>
                 <invoker.skip>true</invoker.skip>   <!-- maven-invoker-plugin -->
                 <jbang.skip>true</jbang.skip> <!-- jbang-maven-plugin -->
-                <wiremock.skip>true</wiremock.skip> <!-- wiremock-maven-plugin -->
             </properties>
         </profile>
         <profile>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -63,6 +63,7 @@
                         <configuration>
                             <dir>target/classes</dir>
                             <params>--port=8765 --verbose</params>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I got that a little wrong in #14383 because `quickly-ci` is not used for the initial build.