### PR TITLE
Upgrade to SmallRye OpenAPI 2.0.19

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -42,7 +42,7 @@
         <smallrye-config.version>1.10.0</smallrye-config.version>
         <smallrye-health.version>2.2.5</smallrye-health.version>
         <smallrye-metrics.version>2.4.4</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.17</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.19</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.20</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>


### PR DESCRIPTION
Small PR that update the SmallRye OpenAPI library to 2.0.19 (see https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.18 and https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.19)

New attempt of closed #14404

This include:

- Better support for RESTEasy Reactive (Thanks @MikeEdgar !!)
- Fix #11206
- Update swagger-ui to 3.40.0

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>