### PR TITLE
Fix regressions in Kubernetes health handling

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -70,6 +70,7 @@ import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.smallrye.health.SmallRyeHealthReporter;
 import io.smallrye.health.api.HealthGroup;
 import io.smallrye.health.api.HealthGroups;
@@ -299,17 +300,19 @@ class SmallRyeHealthProcessor {
     }
 
     @BuildStep
-    public void kubernetes(NonApplicationRootPathBuildItem frameworkRootPath,
+    public void kubernetes(HttpBuildTimeConfig httpConfig, NonApplicationRootPathBuildItem frameworkRootPath,
             SmallRyeHealthConfig healthConfig,
             BuildProducer<KubernetesHealthLivenessPathBuildItem> livenessPathItemProducer,
             BuildProducer<KubernetesHealthReadinessPathBuildItem> readinessPathItemProducer) {
 
         livenessPathItemProducer.produce(
                 new KubernetesHealthLivenessPathBuildItem(
-                        frameworkRootPath.adjustPath(healthConfig.rootPath + healthConfig.livenessPath)));
+                        httpConfig
+                                .adjustPath(frameworkRootPath.adjustPath(healthConfig.rootPath + healthConfig.livenessPath))));
         readinessPathItemProducer.produce(
                 new KubernetesHealthReadinessPathBuildItem(
-                        frameworkRootPath.adjustPath(healthConfig.rootPath + healthConfig.readinessPath)));
+                        httpConfig
+                                .adjustPath(frameworkRootPath.adjustPath(healthConfig.rootPath + healthConfig.readinessPath))));
     }
 
     @BuildStep

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -46,4 +46,14 @@ public class HttpBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean redirectToNonApplicationRootPath;
+
+    public String adjustPath(String path) {
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException("Path must start with /");
+        }
+        if (rootPath.equals("/")) {
+            return path;
+        }
+        return rootPath + path;
+    }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
@@ -54,10 +54,10 @@ public class KubernetesWithRootAndHealthTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).satisfies(p -> {
-                                assertProbePath(p, "/q/health/ready");
+                                assertProbePath(p, "/api/q/health/ready");
                             });
                             assertThat(container.getLivenessProbe()).satisfies(p -> {
-                                assertProbePath(p, "/q/health/liveness");
+                                assertProbePath(p, "/api/q/health/liveness");
                             });
                         });
                     });


### PR DESCRIPTION
This was introduced when we moved framework specific endpoint under /q.
It seems like `KubernetesWithRootAndHealthTest` was erroneously updated then

Fixes: #14438