### PR TITLE
Expose custom gradle configuration for quarkusDevMode

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -57,6 +57,7 @@ public class QuarkusPlugin implements Plugin<Project> {
     public static final String GENERATE_CONFIG_TASK_NAME = "generateConfig";
     public static final String QUARKUS_DEV_TASK_NAME = "quarkusDev";
     public static final String QUARKUS_REMOTE_DEV_TASK_NAME = "quarkusRemoteDev";
+    public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
 
     @Deprecated
     public static final String BUILD_NATIVE_TASK_NAME = "buildNative";
@@ -168,8 +169,14 @@ public class QuarkusPlugin implements Plugin<Project> {
                                     .plus(mainSourceSet.getOutput())
                                     .plus(testSourceSet.getOutput()));
 
-                    // create a custom configuration to be used for the dependencies of the testNative task
                     ConfigurationContainer configurations = project.getConfigurations();
+
+                    // create a custom configuration for devmode
+                    configurations.create(DEV_MODE_CONFIGURATION_NAME).extendsFrom(
+                            configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME),
+                            configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+
+                    // create a custom configuration to be used for the dependencies of the testNative task
                     configurations.maybeCreate(NATIVE_TEST_IMPLEMENTATION_CONFIGURATION_NAME)
                             .extendsFrom(configurations.findByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
                     configurations.maybeCreate(NATIVE_TEST_RUNTIME_ONLY_CONFIGURATION_NAME)

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -58,6 +58,7 @@ import io.quarkus.bootstrap.resolver.model.impl.SourceSetImpl;
 import io.quarkus.bootstrap.resolver.model.impl.WorkspaceImpl;
 import io.quarkus.bootstrap.resolver.model.impl.WorkspaceModuleImpl;
 import io.quarkus.bootstrap.util.QuarkusModelHelper;
+import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.gradle.tasks.QuarkusGradleUtils;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.HashUtil;
@@ -69,9 +70,7 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             return project.getConfigurations().getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
         }
         if (LaunchMode.DEVELOPMENT.equals(mode)) {
-            return project.getConfigurations().create("quarkusDevMode").extendsFrom(
-                    project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME),
-                    project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+            return project.getConfigurations().getByName(QuarkusPlugin.DEV_MODE_CONFIGURATION_NAME);
         }
         return project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
     }

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -206,6 +206,15 @@ By default, `quarkusDev` sets the debug host to `localhost` (for security reason
 ./gradlew quarkusDev -DdebugHost=0.0.0.0
 ----
 ====
+The plugin also exposes a `quarkusDev` configuration. Using this configuration to declare a dependency will restrict the usage of that dependency to development mode.
+The `quarkusDev` configuration can be used as following:
+
+[source,groovy]
+----
+dependencies {
+    quarkusDev 'io.quarkus:quarkus-jdbc-h2'
+}
+----
 
 === Remote Development Mode
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevDependencyDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevDependencyDevModeTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuarkusDevDependencyDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "quarkus-dev-dependency";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("Quarkus");
+    }
+}

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'application'
+}
+
+repositories {
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    implementation 'io.quarkus:quarkus-hibernate-orm-panache'
+    quarkusDev 'io.quarkus:quarkus-jdbc-h2'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+application {
+    mainClass = 'org.acme.EntryPoint'
+}
+
+run {
+    // propagate the custom local maven repo, in case it's configured
+    if (System.properties.containsKey('maven.repo.local')) {
+        systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
+    }
+}

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,17 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        Project quarkus = Project.findById(100000L);
+        return quarkus.label;
+    }
+}

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/java/org/acme/Project.java
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/java/org/acme/Project.java
@@ -1,0 +1,15 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Project extends PanacheEntity {
+    String label;
+}

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+quarkus.datasource.jdbc.driver=org.h2.Driver
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/resources/import.sql
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/src/main/resources/import.sql
@@ -1,0 +1,3 @@
+DELETE FROM Project WHERE id=100000;
+INSERT INTO Project (id, label)
+VALUES (100000,'Quarkus');


### PR DESCRIPTION
This branch allows to declare `quarkusDev` dependency which are only available in dev mode. 
This can be used for example if you want to import `io.quarkus:quarkus-jdbc-h2` only for devMode. 

close #14334