### PR TITLE
Fix guides code generation to be consistent with content

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -102,13 +102,35 @@ public class CreateProjectMojo extends AbstractMojo {
     @Parameter(property = "platformVersion", required = false)
     private String bomVersion;
 
+    /**
+     * The {@link #path} will define the REST path of the generated code when picking only one of those extensions resteasy,
+     * resteasy-reactive and spring-web.
+     * <br />
+     * If more than one of those extensions are picked, this parameter will be ignored.
+     * <br />
+     * This is @Deprecated because using a generic path parameters with multiple example does not make sense and lead to
+     * confusion.
+     * More info: https://github.com/quarkusio/quarkus/issues/14437
+     * <br />
+     * {@code className}
+     */
     @Parameter(property = "path")
+    @Deprecated
     private String path;
 
     /**
-     * This parameter is only working with the RESTEasy and Spring Web extensions and is going to be removed.
-     * Use packageName instead.
-     *
+     * The {@link #className} will define the generated class names when picking only one of those extensions resteasy,
+     * resteasy-reactive and spring-web.
+     * <br />
+     * If more than one of those extensions are picked, then only the package name part will be used as {@link #packageName}
+     * <br />
+     * This is @Deprecated because using a generic className parameters with multiple example does not make sense and lead to
+     * confusion.
+     * More info: https://github.com/quarkusio/quarkus/issues/14437
+     * <br />
+     * By default, the {@link #projectGroupId} is used as package for generated classes (you can also use {@link #packageName}
+     * to have them different).
+     * <br />
      * {@code className}
      */
     @Parameter(property = "className")
@@ -116,7 +138,11 @@ public class CreateProjectMojo extends AbstractMojo {
     private String className;
 
     /**
-     * If not set, groupId will be used
+     * Set the package name of the generated classes.
+     * <br />
+     * If not set, {@link #projectGroupId} will be used as {@link #packageName}
+     *
+     * {@code packageName}
      */
     @Parameter(property = "packageName")
     private String packageName;

--- a/docs/src/main/asciidoc/amazon-dynamodb.adoc
+++ b/docs/src/main/asciidoc/amazon-dynamodb.adoc
@@ -105,7 +105,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-dynamodb-quickstart \
     -DclassName="org.acme.dynamodb.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson,amazon-dynamodb,resteasy-mutiny"
+    -Dextensions="resteasy,resteasy-jackson,amazon-dynamodb,resteasy-mutiny"
 cd amazon-dynamodb-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -97,7 +97,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-kms-quickstart \
     -DclassName="org.acme.kms.QuarkusKmsSyncResource" \
     -Dpath="/sync" \
-    -Dextensions="resteasy-jackson,amazon-kms,resteasy-mutiny"
+    -Dextensions="resteasy,resteasy-jackson,amazon-kms,resteasy-mutiny"
 cd amazon-kms-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -86,7 +86,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-s3-quickstart \
     -DclassName="org.acme.s3.S3SyncClientResource" \
     -Dpath="/s3" \
-    -Dextensions="resteasy-jackson,amazon-s3"
+    -Dextensions="resteasy,resteasy-jackson,amazon-s3"
 cd amazon-s3-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amazon-ses.adoc
+++ b/docs/src/main/asciidoc/amazon-ses.adoc
@@ -106,7 +106,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-ses-quickstart \
     -DclassName="org.acme.ses.QuarkusSesSyncResource" \
     -Dpath="/sync" \
-    -Dextensions="resteasy-jackson,amazon-ses,resteasy-mutiny"
+    -Dextensions="resteasy,resteasy-jackson,amazon-ses,resteasy-mutiny"
 cd amazon-ses-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amazon-sns.adoc
+++ b/docs/src/main/asciidoc/amazon-sns.adoc
@@ -94,7 +94,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-sns-quickstart \
     -DclassName="org.acme.sns.QuarksCannonSyncResource" \
     -Dpath="/sync-cannon" \
-    -Dextensions="resteasy-jackson,amazon-sns,resteasy-mutiny"
+    -Dextensions="resteasy,resteasy-jackson,amazon-sns,resteasy-mutiny"
 cd amazon-sns-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -95,7 +95,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-sqs-quickstart \
     -DclassName="org.acme.sqs.QuarksCannonSyncResource" \
     -Dpath="/sync-cannon" \
-    -Dextensions="resteasy-jackson,amazon-sqs,resteasy-mutiny"
+    -Dextensions="resteasy,resteasy-jackson,amazon-sqs,resteasy-mutiny"
 cd amazon-sqs-quickstart
 ----
 

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -51,7 +51,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amqp-quickstart \
-    -Dextensions="amqp"
+    -Dextensions="amqp" \
+    -DnoExamples
 cd amqp-quickstart
 ----
 

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -49,7 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=cache-quickstart \
     -DclassName="org.acme.cache.WeatherForecastResource" \
     -Dpath="/weather" \
-    -Dextensions="cache,resteasy-jackson"
+    -Dextensions="resteasy,cache,resteasy-jackson"
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `cache` and `resteasy-jackson` extensions.

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -30,7 +30,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=gelf-logging \
     -DclassName="org.acme.quickstart.GelfLoggingResource" \
     -Dpath="/gelf-logging" \
-    -Dextensions="logging-gelf"
+    -Dextensions="resteasy,logging-gelf"
 ----
 
 If you already have your Quarkus project configured, you can add the `logging-gelf` extension

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -34,7 +34,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=kubernetes-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
-    -Dextensions="kubernetes, jib"
+    -Dextensions="resteasy,kubernetes,jib"
 cd kubernetes-quickstart
 ----
 

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -32,7 +32,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=openshift-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
-    -Dextensions="openshift"
+    -Dextensions="resteasy,openshift"
 
 cd openshift-quickstart
 ----

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -56,7 +56,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=elasticsearch-quickstart \
     -DclassName="org.acme.elasticsearch.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson,elasticsearch-rest-client"
+    -Dextensions="resteasy,resteasy-jackson,elasticsearch-rest-client"
 cd elasticsearch-quickstart
 ----
 

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -58,7 +58,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=funqy-google-cloud-functions \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="funqy-google-cloud-functions"
+    -Dextensions="resteasy,funqy-google-cloud-functions"
 ----
 
 Now, let's remove what's not needed inside the generated application:

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -51,7 +51,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=google-cloud-functions-http \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="google-cloud-functions-http,resteasy-json,undertow,vertx-web,funqy-http"
+    -Dextensions="resteasy,google-cloud-functions-http,resteasy-json,undertow,vertx-web,funqy-http"
 ----
 
 == Login to Google Cloud

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -49,7 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=google-cloud-functions \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="google-cloud-functions"
+    -Dextensions="resteasy,google-cloud-functions"
 ----
 
 Now, let's remove what's not needed inside the generated application:

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -388,7 +388,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=getting-started-reactive-crud \
     -DclassName="org.acme.reactive.crud.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-reactive-jackson, reactive-pg-client"
+    -Dextensions="resteasy-reactive,resteasy-reactive-jackson,reactive-pg-client"
 cd getting-started-reactive-crud
 ----
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -24,7 +24,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=my-artifactId \
     -DprojectVersion=my-version \
     -DclassName="org.my.group.MyResource" \
-    -Dextensions="resteasy-jackson" \
+    -Dextensions="resteasy,resteasy-jackson" \
     -DbuildTool=gradle
 ----
 

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -54,7 +54,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=hibernate-search-orm-elasticsearch-quickstart \
     -DclassName="org.acme.hibernate.search.elasticsearch.LibraryResource" \
     -Dpath="/library" \
-    -Dextensions="hibernate-orm-panache, hibernate-search-orm-elasticsearch, resteasy-jackson, jdbc-postgresql"
+    -Dextensions="resteasy,hibernate-orm-panache,hibernate-search-orm-elasticsearch,resteasy-jackson,jdbc-postgresql"
 cd hibernate-search-orm-elasticsearch-quickstart
 ----
 

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -66,7 +66,9 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
-    -Dextensions="qpid-jms"
+    -DclassName="org.acme.jms.PriceResource" \
+    -Dpath="/prices" \
+    -Dextensions="resteasy,qpid-jms"
 cd jms-quickstart
 ----
 
@@ -367,7 +369,9 @@ Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
-    -Dextensions="artemis-jms"
+    -DclassName="org.acme.jms.PriceResource" \
+    -Dpath="/prices" \
+    -Dextensions="resteasy,artemis-jms"
 cd jms-quickstart
 ----
 

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -241,7 +241,7 @@ Create another project like so:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-streams-quickstart-aggregator \
-    -Dextensions="kafka-streams,resteasy-jackson" \
+    -Dextensions="resteasy,kafka-streams,resteasy-jackson" \
     -DnoExamples \
     && mv kafka-streams-quickstart-aggregator aggregator
 ----

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -48,7 +48,9 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-quickstart \
-    -Dextensions="smallrye-reactive-messaging-kafka"
+    -DclassName="org.acme.kafka.PriceResource" \
+    -Dpath="/prices" \
+    -Dextensions="resteasy,smallrye-reactive-messaging-kafka"
 cd kafka-quickstart
 ----
 

--- a/docs/src/main/asciidoc/kogito.adoc
+++ b/docs/src/main/asciidoc/kogito.adoc
@@ -85,7 +85,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-quickstart \
-    -Dextensions="kogito"
+    -Dextensions="kogito" \
+    -DnoExamples
 cd kogito-quickstart
 ----
 

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -36,7 +36,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-kotlin-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
-    -Dextensions="kotlin,resteasy-jackson"
+    -Dextensions="resteasy,kotlin,resteasy-jackson"
 cd rest-kotlin-quickstart
 ----
 

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -34,7 +34,9 @@ Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=sending-email-quickstart \
-    -Dextensions="mailer"
+    -DclassName="org.acme.mailer.SimpleMailerResource" \
+    -Dpath="/simple" \
+    -Dextensions="resteasy,mailer"
 cd sending-email-quickstart
 ----
 

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -55,7 +55,9 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=micrometer-quickstart \
-    -Dextensions="micrometer-registry-prometheus"
+    -DclassName="org.acme.micrometer.PrimeNumberResource" \
+    -Dpath="/" \
+    -Dextensions="resteasy,micrometer-registry-prometheus"
 cd micrometer-quickstart
 ----
 

--- a/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/microprofile-fault-tolerance.adoc
@@ -51,7 +51,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=microprofile-fault-tolerance-quickstart \
     -DclassName="org.acme.microprofile.faulttolerance.CoffeeResource" \
     -Dpath="/coffee" \
-    -Dextensions="smallrye-fault-tolerance, resteasy-jackson"
+    -Dextensions="resteasy,smallrye-fault-tolerance,resteasy-jackson"
 cd microprofile-fault-tolerance-quickstart
 ----
 

--- a/docs/src/main/asciidoc/microprofile-graphql.adoc
+++ b/docs/src/main/asciidoc/microprofile-graphql.adoc
@@ -71,7 +71,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-graphql-quickstart \
     -DclassName="org.acme.microprofile.graphql.FilmResource" \
-    -Dextensions="graphql"
+    -Dextensions="resteasy,graphql"
 cd microprofile-graphql-quickstart
 ----
 

--- a/docs/src/main/asciidoc/microprofile-metrics.adoc
+++ b/docs/src/main/asciidoc/microprofile-metrics.adoc
@@ -56,7 +56,9 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-metrics-quickstart \
-    -Dextensions="smallrye-metrics"
+    -DclassName="org.acme.microprofile.metrics.PrimeNumberResource" \
+    -Dpath="/" \
+    -Dextensions="resteasy,smallrye-metrics"
 cd microprofile-metrics-quickstart
 ----
 

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -70,7 +70,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=mongodb-panache-quickstart \
     -DclassName="org.acme.mongodb.panache.PersonResource" \
     -Dpath="/persons" \
-    -Dextensions="resteasy-jackson,mongodb-panache"
+    -Dextensions="resteasy,resteasy-jackson,mongodb-panache"
 cd mongodb-panache-quickstart
 ----
 

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -48,7 +48,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=mongodb-quickstart \
     -DclassName="org.acme.mongodb.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson,mongodb-client,resteasy-mutiny,context-propagation"
+    -Dextensions="resteasy,resteasy-jackson,mongodb-client,resteasy-mutiny,context-propagation"
 cd mongodb-quickstart
 ----
 

--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -128,7 +128,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=neo4j-quickstart \
     -DclassName="org.acme.datasource.GreetingResource" \
-    -Dextensions="neo4j,resteasy-jackson"
+    -Dextensions="resteasy,neo4j,resteasy-jackson"
 cd neo4j-quickstart
 ----
 

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -44,7 +44,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=openapi-swaggerui-quickstart \
     -DclassName="org.acme.openapi.swaggerui.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson"
+    -Dextensions="resteasy,resteasy-jackson"
 cd openapi-swaggerui-quickstart
 ----
 

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -46,7 +46,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=opentracing-quickstart \
     -DclassName="org.acme.opentracing.TracedResource" \
     -Dpath="/hello" \
-    -Dextensions="quarkus-smallrye-opentracing"
+    -Dextensions="resteasy,quarkus-smallrye-opentracing"
 cd opentracing-quickstart
 ----
 

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -70,7 +70,8 @@ Alternatively, generate it from the command line with Maven:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=optaplanner-quickstart \
-    -Dextensions="resteasy,resteasy-jackson,optaplanner-quarkus,optaplanner-quarkus-jackson"
+    -Dextensions="resteasy,resteasy-jackson,optaplanner-quarkus,optaplanner-quarkus-jackson" \
+    -DnoExamples
 cd optaplanner-quickstart
 ----
 

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -49,7 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=quartz-quickstart \
     -DclassName="org.acme.quartz.TaskResource" \
     -Dpath="/tasks" \
-    -Dextensions="quartz,hibernate-orm-panache,flyway,resteasy-jackson,jdbc-postgresql"
+    -Dextensions="resteasy,quartz,hibernate-orm-panache,flyway,resteasy-jackson,jdbc-postgresql"
 cd quartz-quickstart
 ----
 

--- a/docs/src/main/asciidoc/reactive-messaging-http.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging-http.adoc
@@ -47,7 +47,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=reactive-messaging-http-quickstart \
-    -Dextensions="reactive-messaging-http"
+    -Dextensions="reactive-messaging-http" \
+    -DnoExamples
 cd reactive-http
 ----
 

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -67,7 +67,9 @@ If you are creating a new project, set the `extensions` parameter as follows:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=reactive-pg-client-quickstart \
-    -Dextensions="reactive-pg-client"
+    -DclassName="org.acme.vertx.FruitResource" \
+    -Dpath="/fruits" \
+    -Dextensions="resteasy,reactive-pg-client,resteasy-mutiny"
 cd reactive-pg-client-quickstart
 ----
 

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -41,7 +41,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-client-quickstart \
     -DclassName="org.acme.rest.client.CountriesResource" \
     -Dpath="/country" \
-    -Dextensions="rest-client, resteasy-jackson"
+    -Dextensions="resteasy,rest-client,resteasy-jackson"
 cd rest-client-quickstart
 ----
 

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -48,7 +48,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-json-quickstart \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson"
+    -Dextensions="resteasy,resteasy-jackson"
 cd rest-json-quickstart
 ----
 

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -34,7 +34,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=security-jwt-quickstart \
     -DclassName="org.acme.security.jwt.TokenSecuredResource" \
     -Dpath="/secured" \
-    -Dextensions="resteasy-jackson, smallrye-jwt, smallrye-jwt-build"
+    -Dextensions="resteasy,resteasy-jackson,smallrye-jwt,smallrye-jwt-build"
 cd security-jwt-quickstart
 ----
 

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -42,7 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=security-oauth2-quickstart \
     -DclassName="org.acme.security.oauth2.TokenSecuredResource" \
     -Dpath="/secured" \
-    -Dextensions="resteasy-jackson, security-oauth2"
+    -Dextensions="resteasy,resteasy-jackson,security-oauth2"
 cd security-oauth2-quickstart
 ----
 

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -53,7 +53,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-web-authentication-quickstart \
-    -Dextensions="oidc"
+    -Dextensions="resteasy,oidc" \
+    -DnoExamples
 cd security-openid-connect-web-authentication-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -42,7 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-boot-properties-quickstart \
     -DclassName="org.acme.spring.boot.properties.GreetingResource" \
     -Dpath="/greeting" \
-    -Dextensions="spring-boot-properties"
+    -Dextensions="resteasy,spring-boot-properties"
 cd spring-boot-properties-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -36,7 +36,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-cache-quickstart \
     -DclassName="org.acme.spring.cache.GreeterResource" \
     -Dpath="/greeting" \
-    -Dextensions="spring-di,spring-cache"
+    -Dextensions="resteasy,spring-di,spring-cache"
 cd spring-cache-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -42,7 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-data-jpa-quickstart \
     -DclassName="org.acme.spring.data.jpa.FruitResource" \
     -Dpath="/greeting" \
-    -Dextensions="spring-data-jpa,resteasy-jackson,quarkus-jdbc-postgresql"
+    -Dextensions="resteasy,spring-data-jpa,resteasy-jackson,quarkus-jdbc-postgresql"
 cd spring-data-jpa-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -41,7 +41,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-data-rest-quickstart \
-    -Dextensions="spring-data-rest,resteasy-jackson,quarkus-jdbc-postgresql"
+    -Dextensions="spring-data-rest,resteasy-jackson,quarkus-jdbc-postgresql" \
+    -DnoExamples
 cd spring-data-rest-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -44,7 +44,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-di-quickstart \
     -DclassName="org.acme.spring.di.GreeterResource" \
     -Dpath="/greeting" \
-    -Dextensions="spring-di"
+    -Dextensions="resteasy,spring-di"
 cd spring-di-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -45,7 +45,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-scheduler-quickstart \
     -DclassName="org.acme.spring.scheduler.CountResource" \
     -Dpath="/count" \
-    -Dextensions="spring-scheduled"
+    -Dextensions="resteasy,spring-scheduled"
 cd spring-scheduler-quickstart
 ----
 

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -45,7 +45,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=spring-security-quickstart \
     -DclassName="org.acme.spring.security.GreetingController" \
     -Dpath="/greeting" \
-    -Dextensions="spring-web, spring-security, quarkus-elytron-security-properties-file"
+    -Dextensions="spring-web,spring-security,quarkus-elytron-security-properties-file"
 cd spring-security-quickstart
 ----
 
@@ -56,7 +56,7 @@ to your project by running the following command in your project base directory:
 
 [source,bash]
 ----
-./mvnw quarkus:add-extension -Dextensions="spring-web, spring-security, quarkus-elytron-security-properties-file"
+./mvnw quarkus:add-extension -Dextensions="spring-web,spring-security,quarkus-elytron-security-properties-file"
 ----
 
 This will add the following to your `pom.xml`:

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -49,7 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=validation-quickstart \
     -DclassName="org.acme.validation.BookResource" \
     -Dpath="/books" \
-    -Dextensions="resteasy-jackson, hibernate-validator"
+    -Dextensions="resteasy,resteasy-jackson,hibernate-validator"
 cd validation-quickstart
 ----
 

--- a/docs/src/main/asciidoc/vault-transit.adoc
+++ b/docs/src/main/asciidoc/vault-transit.adoc
@@ -151,7 +151,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=vault-transit-quickstart \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="vault,resteasy-jackson"
+    -Dextensions="resteasy,vault,resteasy-jackson"
 cd vault-transit-quickstart
 ----
 

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -241,7 +241,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=vault-quickstart \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="vault"
+    -Dextensions="resteasy,vault"
 cd vault-quickstart
 ----
 

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -27,7 +27,9 @@ If you are creating a new project, set the `extensions` parameter are follows:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-quickstart \
-    -Dextensions="vertx"
+    -DclassName="org.acme.vertx.GreetingResource" \
+    -Dpath="/hello" \
+    -Dextensions="resteasy,vertx"
 cd vertx-quickstart
 ----
 

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -45,7 +45,8 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=websockets-quickstart \
-    -Dextensions="undertow-websockets"
+    -Dextensions="undertow-websockets" \
+    -DnoExamples
 cd websockets-quickstart
 ----
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2157,7 +2157,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-json \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-jackson"
+    -Dextensions="resteasy,resteasy-jackson"
 cd rest-json
 ----
 


### PR DESCRIPTION
Added `resteasy` or `spring-web` everywhere when the `create` command is using `-Dpath` to make sure the generated code is consistent with the content of the guide.

Added `-DnoExamples` when the command was not using `-Dpath` (it wasn't generating any code in the legacy codegen)

**This also @Deprecate `devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo#path` and improves the description for `className`.**

Also, in a quick glimpse, I think some of the `-DnoExample` could be removed to at least create the endpoint for the tuto.

Until we have https://github.com/quarkusio/quarkus/issues/12957 the generated code may contain more class than expected (if some of the extensions have codestarts)

Related to https://github.com/quarkusio/quarkus/issues/14391
Fixes https://github.com/quarkusio/quarkus/issues/13917

cc @maxandersen @rsvoboda @gsmet 