### PR TITLE
Don't include on-demand indexed classes in getAllClasses

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.context.Destroyed;
 import javax.enterprise.context.Initialized;
@@ -92,17 +91,7 @@ public final class BeanArchives {
 
         @Override
         public Collection<ClassInfo> getKnownClasses() {
-            if (additionalClasses.isEmpty()) {
-                return index.getKnownClasses();
-            }
-            Collection<ClassInfo> known = index.getKnownClasses();
-            Collection<ClassInfo> additional = additionalClasses.values().stream().filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(Collectors.toList());
-            List<ClassInfo> all = new ArrayList<>(known.size() + additional.size());
-            all.addAll(known);
-            all.addAll(additional);
-            return all;
+            return index.getKnownClasses();
         }
 
         @Override


### PR DESCRIPTION
This can cause problems as on demand classes can be added
by other build steps concurrently, which can give an inconsistent
view. It can also lead to classes that are not in a bean archive
to be considered as beans.