### PR TITLE
Avoid Hibernate ORM enhancer to auto-detect the target JVM version

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
@@ -12,6 +12,7 @@ import org.objectweb.asm.ClassWriter;
 
 import io.quarkus.deployment.QuarkusClassWriter;
 import io.quarkus.gizmo.Gizmo;
+import net.bytebuddy.ClassFileVersion;
 
 /**
  * Used to transform bytecode by registering to
@@ -27,7 +28,8 @@ import io.quarkus.gizmo.Gizmo;
  */
 public final class HibernateEntityEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
 
-    private static final BytecodeProvider PROVIDER = new org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl();
+    private static final BytecodeProvider PROVIDER = new org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl(
+            ClassFileVersion.JAVA_V8);
 
     @Override
     public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Modifier;
 import org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl;
 import org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper;
 
+import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.dynamic.DynamicType;
 
 /**
@@ -29,7 +30,7 @@ final class ProxyBuildingHelper implements AutoCloseable {
         //Lazy initialization of Byte Buddy: we'll likely need it, but if we can avoid loading it
         //in some corner cases it's worth avoiding it.
         if (this.byteBuddyProxyHelper == null) {
-            bytecodeProvider = new BytecodeProviderImpl();
+            bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
             this.byteBuddyProxyHelper = bytecodeProvider.getByteBuddyProxyHelper();
         }
         return this.byteBuddyProxyHelper;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
@@ -7,6 +7,8 @@ import org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl;
 import org.hibernate.bytecode.spi.ProxyFactoryFactory;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
+import net.bytebuddy.ClassFileVersion;
+
 /**
  * We need a different implementation of ProxyFactoryFactory during the build than at runtime,
  * so to allow metadata validation. This implementation is then swapped after the metadata has been recorded.
@@ -22,7 +24,7 @@ public final class BootstrapOnlyProxyFactoryFactoryInitiator implements Standard
 
     @Override
     public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
-        BytecodeProviderImpl bbProvider = new BytecodeProviderImpl();
+        BytecodeProviderImpl bbProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
         return bbProvider.getProxyFactoryFactory();
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
@@ -18,6 +18,8 @@ import org.hibernate.proxy.pojo.ProxyFactoryHelper;
 import org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper;
 import org.jboss.logging.Logger;
 
+import net.bytebuddy.ClassFileVersion;
+
 /**
  * Runtime proxies are used by Hibernate ORM to handle a number of corner cases;
  * in particular Enhanced Proxies need special consideration in Quarkus as
@@ -191,7 +193,7 @@ public final class ProxyDefinitions {
         @Override
         public ByteBuddyProxyHelper get() {
             if (helper == null) {
-                bytecodeProvider = new BytecodeProviderImpl();
+                bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
                 helper = bytecodeProvider.getByteBuddyProxyHelper();
             }
             return helper;


### PR DESCRIPTION
Fixes #13871

We now expose a parameter in Hibernate ORM, allowing to request compatibility with a specific target version for the generated code.
When not setting this (in the current version of the code), ByteBuddy would auto-detect this from the runtime JVM; but in Quarkus the runtime JVM might be more recent than the _target_ build JVM the user intends to use at runtime.

I'm setting the target to Java 8 for simplicity, as the generated code doesn't need anything fancy.

I didn't add a test but tested it externally; not sure how to add a test without spending way too much time on it.