### PR TITLE
Update versions used in codestarts generation

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/codestart.yml
@@ -5,15 +5,15 @@ language:
   base:
     data:
       kotlin:
-        version: 1.3.72
+        version: 1.4.20
       scala:
-        version: 2.12.8
+        version: 2.12.9
       scala-maven-plugin:
         version: 4.1.1
       maven-compiler-plugin:
         version: 3.8.1
       maven-surefire-plugin:
-        version: 2.22.1
+        version: 3.0.0-M5
     shared-data:
       buildtool:
         build-dir: target


### PR DESCRIPTION
Fixes #14479

@rsvoboda I think this will fix #14479 but... I also think this file should be generated (via Maven filtering for instance) as otherwise this will be a chronic issue. @ia3andy could you have a look at that part?