### PR TITLE
Sync pom.xml snippets with the latest version of generated application

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -120,8 +120,8 @@ In addition, you can see the `quarkus-maven-plugin` responsible of the packaging
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bom</artifactId>
-            <version>${quarkus.version}</version>
+            <artifactId>quarkus-universe-bom</artifactId>
+            <version>${quarkus.platform.version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -133,11 +133,14 @@ In addition, you can see the `quarkus-maven-plugin` responsible of the packaging
         <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus-plugin.version}</version>
+            <extensions>true</extensions>
             <executions>
                 <execution>
                     <goals>
                         <goal>build</goal>
+                        <goal>generate-code</goal>
+                        <goal>generate-code-tests</goal>
                     </goals>
                 </execution>
             </executions>

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -35,12 +35,14 @@ If you wish to generate code from different `proto` files for tests, also add th
         <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-plugin.version}</version>
+            <extensions>true</extensions>
             <executions>
                 <execution>
                     <goals>
+                        <goal>build</goal>
                         <goal>generate-code</goal>
                         <goal>generate-code-tests</goal>
-                        <goal>build</goal>
                     </goals>
                 </execution>
             </executions>

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -422,7 +422,7 @@ If you have not used <<project-creation,project scaffolding>>, add the following
     <dependencies>
         <dependency> <1>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bom</artifactId>
+            <artifactId>quarkus-universe-bom</artifactId>
             <version>${quarkus.platform.version}</version>
             <type>pom</type>
             <scope>import</scope>
@@ -436,10 +436,13 @@ If you have not used <<project-creation,project scaffolding>>, add the following
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
             <version>${quarkus-plugin.version}</version>
+            <extensions>true</extensions>
             <executions>
                 <execution>
                     <goals>
                         <goal>build</goal>
+                        <goal>generate-code</goal>
+                        <goal>generate-code-tests</goal>
                     </goals>
                 </execution>
             </executions>


### PR DESCRIPTION
Sync pom.xml snippets with the latest version of generated application using `quarkus-maven-plugin:create`.

I have added `generate-code`  and `generate-code-tests` goals into getting-started and maven-tooling, mainly for consistency reasons. Atm those goals are used by grpc, so if you want to remove those additions from my PR I won't object.

My original goal was just to add `<extensions>true</extensions>` as that's what I spotted when comparing sample aps generated with 1.7.6. vs. 1.11.0.