### PR TITLE
Dependency exclusions on extensions are ignored

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+
+/**
+ * The test allowing to make sure that if we exclude an extension from another extension, the
+ * exclusion will be also applied to the deployment dependencies.
+ */
+public class ExcludeExtensionDepsTest extends ExecutableOutputOutcomeTestBase {
+
+    @Override
+    protected TsArtifact modelApp() {
+
+        final TsArtifact extADep1 = TsArtifact.jar("ext-a-dep-1");
+        final TsArtifact extADep2 = TsArtifact.jar("ext-a-dep-2");
+        final TsArtifact extBDep1 = TsArtifact.jar("ext-b-dep-1");
+        addToExpectedLib(extBDep1);
+        final TsArtifact extBDep2 = TsArtifact.jar("ext-b-dep-2");
+        addToExpectedLib(extBDep2);
+        final TsArtifact extBDepTrans1 = TsArtifact.jar("ext-b-dep-trans-1");
+        addToExpectedLib(extBDepTrans1);
+        final TsArtifact extBDepTrans2 = TsArtifact.jar("ext-b-dep-trans-2");
+        addToExpectedLib(extBDepTrans2);
+        final TsArtifact depToExclude1 = TsArtifact.jar("ext-dep-exclude-1");
+        final TsArtifact depToExclude2 = TsArtifact.jar("ext-dep-exclude-2");
+        final TsArtifact depToExclude3 = TsArtifact.jar("ext-dep-exclude-3");
+        final TsArtifact depToExclude4 = TsArtifact.jar("ext-dep-exclude-4");
+        final TsArtifact depToExclude5 = TsArtifact.jar("ext-dep-exclude-5");
+        final TsArtifact depToExclude6 = TsArtifact.jar("ext-dep-exclude-6");
+        extBDepTrans2.addDependency(new TsDependency(extBDep2));
+        extBDepTrans2.addDependency(new TsDependency(depToExclude6));
+        extBDepTrans1.addDependency(new TsDependency(extBDepTrans2));
+        extBDepTrans1.addDependency(new TsDependency(depToExclude2));
+        extBDepTrans1.addDependency(new TsDependency(depToExclude5));
+        extBDep1.addDependency(extBDepTrans1, depToExclude5);
+        extBDep1.addDependency(new TsDependency(depToExclude1));
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.getRuntime()
+                .addDependency(extADep1);
+        extA.getDeployment()
+                .addDependency(extADep2);
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        addToExpectedLib(extB.getRuntime());
+        extB.getRuntime()
+                .addDependency(extBDep1, depToExclude6)
+                .addDependency(extA)
+                .addDependency(depToExclude4);
+        extB.getDeployment()
+                .addDependency(depToExclude3);
+
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(extB, extA.getRuntime(), depToExclude1, depToExclude2, depToExclude3, depToExclude4);
+    }
+
+    @Override
+    protected void assertAppModel(AppModel appModel) throws Exception {
+        final Set<AppDependency> expectedDeployDeps = new HashSet<>();
+        expectedDeployDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile"));
+        assertEquals(expectedDeployDeps, new HashSet<>(appModel.getDeploymentDependencies()));
+        final Set<AppDependency> expectedRuntimeDeps = new HashSet<>();
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-1", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-2", "1"), "compile"));
+        expectedRuntimeDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-1", "1"), "compile"));
+        expectedRuntimeDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-2", "1"), "compile"));
+        assertEquals(expectedRuntimeDeps, new HashSet<>(appModel.getUserDependencies()));
+        final Set<AppDependency> expectedFullDeps = new HashSet<>();
+        expectedFullDeps.addAll(expectedDeployDeps);
+        expectedFullDeps.addAll(expectedRuntimeDeps);
+        assertEquals(expectedFullDeps, new HashSet<>(appModel.getFullDeploymentDeps()));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+
+/**
+ * The test allowing to make sure that if we exclude a library from an extension, the
+ * exclusion will be also applied to the deployment dependencies.
+ */
+public class ExcludeLibDepsTest extends ExecutableOutputOutcomeTestBase {
+
+    @Override
+    protected TsArtifact modelApp() {
+
+        final TsArtifact extADep1 = TsArtifact.jar("ext-a-dep-1");
+        addToExpectedLib(extADep1);
+        final TsArtifact extADep2 = TsArtifact.jar("ext-a-dep-2");
+        addToExpectedLib(extADep2);
+        final TsArtifact extADepTrans1 = TsArtifact.jar("ext-a-dep-trans-1");
+        addToExpectedLib(extADepTrans1);
+        final TsArtifact extADepTrans2 = TsArtifact.jar("ext-a-dep-trans-2");
+        addToExpectedLib(extADepTrans2);
+        final TsArtifact depToExclude1 = TsArtifact.jar("ext-dep-exclude-1");
+        final TsArtifact depToExclude2 = TsArtifact.jar("ext-dep-exclude-2");
+        final TsArtifact depToExclude3 = TsArtifact.jar("ext-dep-exclude-3");
+        final TsArtifact depToExclude4 = TsArtifact.jar("ext-dep-exclude-4");
+        final TsArtifact depToExclude5 = TsArtifact.jar("ext-dep-exclude-5");
+        final TsArtifact depToExclude6 = TsArtifact.jar("ext-dep-exclude-6");
+        extADepTrans2.addDependency(new TsDependency(extADep2));
+        extADepTrans2.addDependency(new TsDependency(depToExclude6));
+        extADepTrans1.addDependency(new TsDependency(extADepTrans2));
+        extADepTrans1.addDependency(new TsDependency(depToExclude2));
+        extADepTrans1.addDependency(new TsDependency(depToExclude5));
+        extADep1.addDependency(extADepTrans1, depToExclude5);
+        extADep1.addDependency(new TsDependency(depToExclude1));
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        addToExpectedLib(extA.getRuntime());
+        extA.getRuntime()
+                .addDependency(extADep1, depToExclude6)
+                .addDependency(depToExclude3);
+        extA.getDeployment()
+                .addDependency(depToExclude4);
+
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(extA, depToExclude1, depToExclude2, depToExclude3, depToExclude4);
+    }
+
+    @Override
+    protected void assertAppModel(AppModel appModel) throws Exception {
+        final Set<AppDependency> expectedDeployDeps = new HashSet<>();
+        expectedDeployDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile"));
+        assertEquals(expectedDeployDeps, new HashSet<>(appModel.getDeploymentDependencies()));
+        final Set<AppDependency> expectedRuntimeDeps = new HashSet<>();
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-1", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-2", "1"), "compile"));
+        expectedRuntimeDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-1", "1"), "compile"));
+        expectedRuntimeDeps
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-2", "1"), "compile"));
+        assertEquals(expectedRuntimeDeps, new HashSet<>(appModel.getUserDependencies()));
+        final Set<AppDependency> expectedFullDeps = new HashSet<>();
+        expectedFullDeps.addAll(expectedDeployDeps);
+        expectedFullDeps.addAll(expectedRuntimeDeps);
+        assertEquals(expectedFullDeps, new HashSet<>(appModel.getFullDeploymentDeps()));
+    }
+}

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
@@ -112,16 +113,28 @@ public class TsArtifact {
         return addDependency(new TsDependency(dep));
     }
 
+    public TsArtifact addDependency(TsArtifact dep, TsArtifact... excludes) {
+        return addDependency(new TsDependency(dep).exclude(excludes));
+    }
+
     public TsArtifact addDependency(TsQuarkusExt dep) {
         return addDependency(dep, false);
     }
 
     public TsArtifact addDependency(TsQuarkusExt dep, boolean optional) {
+        return addDependency(dep, () -> new TsDependency(dep.getRuntime(), optional));
+    }
+
+    public TsArtifact addDependency(TsQuarkusExt dep, TsArtifact... excludes) {
+        return addDependency(dep, () -> new TsDependency(dep.getRuntime(), false).exclude(excludes));
+    }
+
+    private TsArtifact addDependency(TsQuarkusExt dep, Supplier<TsDependency> dependencyFactory) {
         if (extDeps.isEmpty()) {
             extDeps = new ArrayList<>(1);
         }
         extDeps.add(dep);
-        return addDependency(new TsDependency(dep.getRuntime(), optional));
+        return addDependency(dependencyFactory.get());
     }
 
     public TsArtifact addDependency(TsDependency dep) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsDependency.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsDependency.java
@@ -51,6 +51,13 @@ public class TsDependency {
         return this;
     }
 
+    public TsDependency exclude(TsArtifact... artifacts) {
+        for (TsArtifact artifact : artifacts) {
+            exclude(artifact);
+        }
+        return this;
+    }
+
     public Dependency toPomDependency() {
         final Dependency dep = new Dependency();
         dep.setGroupId(artifact.groupId);


### PR DESCRIPTION
Fixes #14485 

## Motivation

We have no way to exclude a dependency from a Quarkus extension.

## Modifications:

* Adds the exclusion of the original `DependencyNode` when replacing it with it deployment counter part
* Adds the ability to exclude dependencies from `TsArtifact`