### PR TITLE
Upgrade commons-lang3 from 3.9 to 3.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,6 +97,7 @@ updates:
       - dependency-name: com.amazonaws:aws-lambda-java-events
       # Apache Commons
       - dependency-name: commons-io:commons-io
+      - dependency-name: org.apache.commons:commons-lang3
       # Micrometer
       - dependency-name: io.micrometer:micrometer-bom
       # BouncyCastle

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <jackson.version>2.12.1</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jboss-logging-jdk.version>2.1.2.GA</jboss-logging-jdk.version>
-        <commons-lang3.version>3.9</commons-lang3.version>
+        <commons-lang3.version>3.11</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.27.Final</hibernate-orm.version>


### PR DESCRIPTION
Version 3.11 is backwards compatible. For changes see https://commons.apache.org/proper/commons-lang/changes-report.html

I am proposing this change because using the quarkus-bom (at least in our case) results in a version downgrade of the commons-lang transitive dependency of other (non-quarkus) project dependencies.