### PR TITLE
Improve backward compatibility

### DIFF
--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/knative/events/AbstractCloudEvent.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/knative/events/AbstractCloudEvent.java
@@ -1,5 +1,8 @@
 package io.quarkus.funqy.knative.events;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public abstract class AbstractCloudEvent<T> implements CloudEvent<T> {
 
     @Override
@@ -18,9 +21,40 @@ public abstract class AbstractCloudEvent<T> implements CloudEvent<T> {
                 '}';
     }
 
+    private static final Pattern VERSION_REGEX = Pattern.compile("^(\\d+)\\.(\\d+)$");
+
+    public static int parseMajorSpecVersion(String ver) {
+        if (ver == null) {
+            return -1;
+        }
+        Matcher m = VERSION_REGEX.matcher(ver);
+        if (m.find()) {
+            ver = m.group(1);
+            if (ver == null) {
+                return -1;
+            }
+            try {
+                return Integer.parseInt(ver);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
     public static boolean isKnownSpecVersion(String ceSpecVersion) {
-        return ceSpecVersion != null &&
-                (ceSpecVersion.charAt(0) == '0' || ceSpecVersion.charAt(0) == '1') &&
-                ceSpecVersion.charAt(1) == '.';
+        int maj = parseMajorSpecVersion(ceSpecVersion);
+        return maj == 0 || maj == 1;
+    }
+
+    private boolean isMajorParsed;
+    private int majorSpecVersion;
+
+    protected int majorSpecVersion() {
+        if (!isMajorParsed) {
+            majorSpecVersion = parseMajorSpecVersion(specVersion());
+            isMajorParsed = true;
+        }
+        return majorSpecVersion;
     }
 }

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/knative/events/AbstractCloudEvent.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/knative/events/AbstractCloudEvent.java
@@ -1,6 +1,7 @@
 package io.quarkus.funqy.knative.events;
 
 public abstract class AbstractCloudEvent<T> implements CloudEvent<T> {
+
     @Override
     public String toString() {
         return "CloudEvent{" +
@@ -15,5 +16,11 @@ public abstract class AbstractCloudEvent<T> implements CloudEvent<T> {
                 ", dataContentType='" + dataContentType() + '\'' +
                 ", data=" + data() +
                 '}';
+    }
+
+    public static boolean isKnownSpecVersion(String ceSpecVersion) {
+        return ceSpecVersion != null &&
+                (ceSpecVersion.charAt(0) == '0' || ceSpecVersion.charAt(0) == '1') &&
+                ceSpecVersion.charAt(1) == '.';
     }
 }

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
@@ -59,10 +59,8 @@ class HeaderCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEven
     public String specVersion() {
         if (specVersion == null) {
             String sv = headers.get("ce-specversion");
-            if (sv != null && isKnownSpecVersion(sv)) {
+            if (sv != null) {
                 this.specVersion = sv;
-            } else {
-                this.specVersion = "1.0";
             }
         }
 
@@ -151,7 +149,7 @@ class HeaderCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEven
     @Override
     public String dataSchema() {
         if (dataSchema == null) {
-            String dsName = specVersion().charAt(0) == '0' ? "ce-schemaurl" : "ce-dataschema";
+            String dsName = specVersion() != null && specVersion().charAt(0) == '0' ? "ce-schemaurl" : "ce-dataschema";
             dataSchema = headers.get(dsName);
         }
         return dataSchema;

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
@@ -149,7 +149,7 @@ class HeaderCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEven
     @Override
     public String dataSchema() {
         if (dataSchema == null) {
-            String dsName = specVersion() != null && specVersion().charAt(0) == '0' ? "ce-schemaurl" : "ce-dataschema";
+            String dsName = majorSpecVersion() == 0 ? "ce-schemaurl" : "ce-dataschema";
             dataSchema = headers.get(dsName);
         }
         return dataSchema;

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/HeaderCloudEventImpl.java
@@ -58,7 +58,12 @@ class HeaderCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEven
     @Override
     public String specVersion() {
         if (specVersion == null) {
-            this.specVersion = headers.get("ce-specversion");
+            String sv = headers.get("ce-specversion");
+            if (sv != null && isKnownSpecVersion(sv)) {
+                this.specVersion = sv;
+            } else {
+                this.specVersion = "1.0";
+            }
         }
 
         return specVersion;

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
@@ -154,7 +154,7 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
     @Override
     public String dataSchema() {
         if (dataSchema == null) {
-            String dsName = specVersion() != null && specVersion().charAt(0) == '0' ? "schemaurl" : "dataschema";
+            String dsName = majorSpecVersion() == 0 ? "schemaurl" : "dataschema";
             JsonNode dataSchema = event.get(dsName);
             if (dataSchema != null) {
                 this.dataSchema = dataSchema.asText();
@@ -190,7 +190,7 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
             }
         } else if (byte[].class.equals(dataType)) {
             try {
-                if (specVersion() != null && specVersion().charAt(0) == '0') {
+                if (majorSpecVersion() == 0) {
                     boolean isBase64 = false;
                     if (event.has("datacontentencoding")) {
                         String dce = event.get("datacontentencoding").asText();

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
@@ -62,10 +62,8 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
     public String specVersion() {
         if (specVersion == null) {
             JsonNode specVersion = event.get("specversion");
-            if (specVersion != null && isKnownSpecVersion(specVersion.asText())) {
+            if (specVersion != null) {
                 this.specVersion = specVersion.asText();
-            } else {
-                this.specVersion = "1.0";
             }
         }
 
@@ -156,7 +154,7 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
     @Override
     public String dataSchema() {
         if (dataSchema == null) {
-            String dsName = specVersion().charAt(0) == '0' ? "schemaurl" : "dataschema";
+            String dsName = specVersion() != null && specVersion().charAt(0) == '0' ? "schemaurl" : "dataschema";
             JsonNode dataSchema = event.get(dsName);
             if (dataSchema != null) {
                 this.dataSchema = dataSchema.asText();
@@ -192,43 +190,45 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
             }
         } else if (byte[].class.equals(dataType)) {
             try {
-                switch (specVersion().charAt(0)) {
-                    case '0':
-                        boolean isBase64 = false;
-                        if (event.has("datacontentencoding")) {
-                            String dce = event.get("datacontentencoding").asText();
-                            if ("base64".equals(dce)) {
-                                isBase64 = true;
-                            } else {
-                                throw new RuntimeException("Cannot deserialize data for data-content-encoding: '" + dce + "'.");
-                            }
-                        }
-                        if (isBase64) {
-                            if (event.has("data")) {
-                                String txt = event.get("data").asText();
-                                data = (T) Base64.getDecoder().decode(txt);
-                                return data;
-                            }
+                if (specVersion() != null && specVersion().charAt(0) == '0') {
+                    boolean isBase64 = false;
+                    if (event.has("datacontentencoding")) {
+                        String dce = event.get("datacontentencoding").asText();
+                        if ("base64".equals(dce)) {
+                            isBase64 = true;
                         } else {
-                            if (event.has("data")) {
-                                data = (T) mapper.writeValueAsBytes(event.get("data"));
-                                return data;
-                            }
+                            throw new RuntimeException("Cannot deserialize data for data-content-encoding: '" + dce + "'.");
                         }
-                    case '1':
+                    }
+                    if (isBase64) {
                         if (event.has("data")) {
-                            data = (T) mapper.writeValueAsBytes(event.get("data"));
-                            return data;
-                        } else if (event.has("data_base64")) {
-                            String txt = event.get("data_base64").asText();
+                            String txt = event.get("data").asText();
                             data = (T) Base64.getDecoder().decode(txt);
                             return data;
                         } else {
                             return null;
                         }
-                    default:
-                        throw new RuntimeException("Cannot deserialize data for spec-version: '" + specVersion() + "'.");
+                    } else {
+                        if (event.has("data")) {
+                            data = (T) mapper.writeValueAsBytes(event.get("data"));
+                            return data;
+                        } else {
+                            return null;
+                        }
+                    }
+                } else {
+                    if (event.has("data")) {
+                        data = (T) mapper.writeValueAsBytes(event.get("data"));
+                        return data;
+                    } else if (event.has("data_base64")) {
+                        String txt = event.get("data_base64").asText();
+                        data = (T) Base64.getDecoder().decode(txt);
+                        return data;
+                    } else {
+                        return null;
+                    }
                 }
+
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/JsonCloudEventImpl.java
@@ -62,8 +62,10 @@ class JsonCloudEventImpl<T> extends AbstractCloudEvent<T> implements CloudEvent<
     public String specVersion() {
         if (specVersion == null) {
             JsonNode specVersion = event.get("specversion");
-            if (specVersion != null) {
+            if (specVersion != null && isKnownSpecVersion(specVersion.asText())) {
                 this.specVersion = specVersion.asText();
+            } else {
+                this.specVersion = "1.0";
             }
         }
 

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -218,10 +218,12 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                             id = getResponseId();
                         }
                         String specVersion;
-                        if (outputCloudEvent.specVersion() == null) {
-                            specVersion = inputCloudEvent.specVersion().toString();
+                        if (outputCloudEvent.specVersion() != null) {
+                            specVersion = outputCloudEvent.specVersion();
+                        } else if (inputCloudEvent.specVersion() != null) {
+                            specVersion = inputCloudEvent.specVersion();
                         } else {
-                            specVersion = outputCloudEvent.specVersion().toString();
+                            specVersion = "1.0";
                         }
                         String source = outputCloudEvent.source();
                         if (source == null) {
@@ -249,7 +251,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                             }
 
                             if (outputCloudEvent.dataSchema() != null) {
-                                String dsName = outputCloudEvent.specVersion().charAt(0) == '0' ? "ce-schemaurl"
+                                String dsName = specVersion.charAt(0) == '0' ? "ce-schemaurl"
                                         : "ce-dataschema";
                                 httpResponse.putHeader(dsName, outputCloudEvent.dataSchema());
                             }
@@ -295,7 +297,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                             }
 
                             if (outputCloudEvent.dataSchema() != null) {
-                                String dsName = outputCloudEvent.specVersion().charAt(0) == '0' ? "schemaurl" : "dataschema";
+                                String dsName = specVersion.charAt(0) == '0' ? "schemaurl" : "dataschema";
                                 responseEvent.put(dsName, outputCloudEvent.dataSchema());
                             }
 

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.funqy.runtime.bindings.knative.events;
 
+import static io.quarkus.funqy.knative.events.AbstractCloudEvent.isKnownSpecVersion;
 import static io.quarkus.funqy.runtime.bindings.knative.events.KnativeEventsBindingRecorder.DATA_OBJECT_READER;
 import static io.quarkus.funqy.runtime.bindings.knative.events.KnativeEventsBindingRecorder.DATA_OBJECT_WRITER;
 import static io.quarkus.funqy.runtime.bindings.knative.events.KnativeEventsBindingRecorder.INPUT_CE_DATA_TYPE;
@@ -139,10 +140,8 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                     }
                 }
 
-                if (!isSupportedSpecVersion(ceSpecVersion)) {
-                    log.errorf("Unexpected CloudEvent spec-version '%s'.", ceSpecVersion);
-                    routingContext.fail(400);
-                    return;
+                if (!isKnownSpecVersion(ceSpecVersion)) {
+                    log.warnf("Unexpected CloudEvent spec-version '%s'.", ceSpecVersion);
                 }
 
                 final FunctionInvoker invoker;
@@ -363,10 +362,6 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
             }
         }));
 
-    }
-
-    private static boolean isSupportedSpecVersion(String ceSpecVersion) {
-        return (ceSpecVersion.charAt(0) == '0' || ceSpecVersion.charAt(0) == '1') && ceSpecVersion.charAt(1) == '.';
     }
 
     private void regularFunqyHttp(RoutingContext routingContext) {


### PR DESCRIPTION
Previous version allowed requests with arbitrary or absenting specversion.
Despite the fact that the specversion is mandatory
this commit allows that for sake of backward compatibility.

Signed-off-by: Matej Vasek <mvasek@redhat.com>