### PR TITLE
Increase timeout when deploying to Nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
                             <serverId>ossrh</serverId>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                             <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
The default timeout is 5 minutes which is not enough for large deployments and slow Sonatype servers/connections