### PR TITLE
Init socket options before Mongo Start

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -41,6 +41,13 @@ public class MongoTestBase {
 
     @BeforeAll
     public static void startMongoDatabase() throws IOException {
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -175,6 +175,13 @@ public class MongoWithReplicasTestBase {
 
     private static IMongodConfig buildMongodConfiguration(String url, int port, final boolean configureReplicaSet)
             throws IOException {
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
         final MongodConfigBuilder builder = new MongodConfigBuilder()
                 .version(Version.Main.V4_0)
                 .net(new Net(url, port, Network.localhostIsIPv6()));

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -76,6 +76,14 @@ public class MongoClients {
     public MongoClients(MongodbConfig mongodbConfig, MongoClientSupport mongoClientSupport) {
         this.mongodbConfig = mongodbConfig;
         this.mongoClientSupport = mongoClientSupport;
+
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
     }
 
     public MongoClient createMongoClient(String clientName) throws MongoException {

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
@@ -54,6 +54,13 @@ public class MongoTestBase {
 
     @BeforeAll
     public static void startMongoDatabase() throws IOException {
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
@@ -183,6 +183,13 @@ public class MongoWithReplicasTestBase {
 
     private static IMongodConfig buildMongodConfiguration(String url, int port, final boolean configureReplicaSet)
             throws IOException {
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
         final MongodConfigBuilder builder = new MongodConfigBuilder()
                 .version(Version.Main.V4_0)
                 .net(new Net(url, port, Network.localhostIsIPv6()));

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/MongoTestResource.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/MongoTestResource.java
@@ -27,6 +27,13 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
         try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
+        try {
             Version.Main version = Version.Main.V4_0;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);

--- a/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/MongoTestResource.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/MongoTestResource.kt
@@ -22,6 +22,13 @@ class MongoTestResource : QuarkusTestResourceLifecycleManager {
     private var mongod: MongodExecutable? = null
 
     override fun start(): Map<String, String> {
+        try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (e: ClassNotFoundException) {
+        }
         return try {
             val version: Version.Main = Version.Main.V4_0
             val port = 27018

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResource.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResource.java
@@ -26,6 +26,13 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
         try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
+        try {
             Version.Main version = Version.Main.V4_0;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);

--- a/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoTestResource.java
+++ b/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoTestResource.java
@@ -22,6 +22,13 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
         try {
+            //JDK bug workaround
+            //https://github.com/quarkusio/quarkus/issues/14424
+            //force class init to prevent possible deadlock when done by mongo threads
+            Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
+        } catch (ClassNotFoundException e) {
+        }
+        try {
             Version.Main version = Version.Main.V4_0;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);


### PR DESCRIPTION
There is a JDK bug where both jdk.net.ExtendedSocketOptions and
sun.net.ext.ExtendedSocketOptions reference each other in their
static init blocks. If they get initialized in a different order
by different threads then the JDK will deadlock.

Unfortunatly Mongo seems to create this situation, as it starts
multiple different threads that perform network tasks, and they
can init these classes in different orders.

This workaround simply forces the initialization before the
Mongo startup.

Fixes #14424