### PR TITLE
Test REST endpoint parameter validation with @ConvertGroup 

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -359,6 +359,76 @@ provided the supported locales have been properly specified in the `application.
 quarkus.locales=en-US,es-ES,fr-FR
 ----
 
+=== Validation groups for REST endpoint or service method validation
+
+It's sometimes necessary to enable different validation constraints
+for the same class when it's passed to a different method.
+
+For example, a `Book` may need to have a `null` identifier when passed to the `put` method
+(because the identifier will be generated),
+but a non-`null` identifier when passed to the `post` method
+(because the method needs the identifier to know what to update).
+
+To address this, you can take advantage of validation groups.
+Validation groups are markers that you put on your constraints in order to enable or disable them at will.
+
+First, define the `Put` and `Post` groups, which are just Java interfaces.
+
+[source, java]
+----
+public interface ValidationGroups {
+    interface Put extends Default { // <1>
+    }
+    interface Post extends Default { // <1>
+    }
+}
+----
+<1> Make the custom groups extend the `Default` group.
+This means that whenever these groups are enabled, the `Default` group is also enabled.
+This is useful if you have constraints that you want validated in both the `Put` and `Post` method:
+you can simply use the default group on those constraints, like on the `title` property below.
+
+Then add the relevant constraints to `Book`, assigning the right group to each constraint:
+
+[source, java]
+----
+public class Book {
+
+    @Null(groups = ValidationGroups.Put.class)
+    @NotNull(groups = ValidationGroups.Post.class)
+    public Long id;
+
+    @NotBlank
+    public String title;
+
+}
+----
+
+Finally, add a `@ConvertGroup` annotation next to your `@Valid` annotation in your validated method.
+
+[source, java]
+----
+@Path("/")
+@PUT
+@Consumes(MediaType.APPLICATION_JSON)
+public void put(@Valid @ConvertGroup(to = ValidationGroups.Put.class) Book book) { // <1>
+    // ...
+}
+
+@Path("/")
+@POST
+@Consumes(MediaType.APPLICATION_JSON)
+public void post(@Valid @ConvertGroup(to = ValidationGroups.Post.class) Book book) { // <2>
+    // ...
+}
+----
+<1> Enable the `Put` group, meaning only constraints assigned to the `Put` (and `Default`) groups
+will be validated for the `book` parameter of the `put` method.
+In this case, it means `Book.id` must be `null` and `Book.title` must not be blank.
+<2> Enable the `Post` group, meaning only constraints assigned to the `Post` (and `Default`) groups
+will be validated for the `book` parameter of the `post` method.
+In this case, it means `Book.id` must not be `null` and `Book.title` must not be blank.
+
 [[configuration-reference]]
 == Hibernate Validator Configuration Reference
 

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/interceptor/AbstractMethodValidationInterceptor.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/interceptor/AbstractMethodValidationInterceptor.java
@@ -46,7 +46,6 @@ public abstract class AbstractMethodValidationInterceptor implements Serializabl
      * return value of the intercepted method.
      *
      * @param ctx The context of the intercepted method invocation.
-     * @param customValidator Custom Validator
      *
      * @return The result of the method invocation.
      *

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -24,17 +24,24 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
+import javax.validation.groups.ConvertGroup;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.hibernate.validator.constraints.Length;
 
 import io.quarkus.it.hibernate.validator.custom.MyOtherBean;
+import io.quarkus.it.hibernate.validator.groups.MyBeanWithGroups;
+import io.quarkus.it.hibernate.validator.groups.ValidationGroups;
 import io.quarkus.it.hibernate.validator.injection.InjectedConstraintValidatorConstraint;
 import io.quarkus.it.hibernate.validator.injection.MyService;
 import io.quarkus.it.hibernate.validator.orm.TestEntity;
@@ -239,6 +246,56 @@ public class HibernateValidatorTestResource
     public String testHibernateOrmIntegration() {
         em.persist(new TestEntity());
         return "FAILED";
+    }
+
+    @PUT
+    @Path("/rest-end-point-validation-groups/")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public String testRestEndPointValidationGroups_Put(
+            @Valid @ConvertGroup(to = ValidationGroups.Put.class) MyBeanWithGroups bean) {
+        return "passed";
+    }
+
+    @POST
+    @Path("/rest-end-point-validation-groups/")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public String testRestEndPointValidationGroups_Post(
+            @Valid @ConvertGroup(to = ValidationGroups.Post.class) MyBeanWithGroups bean) {
+        return "passed";
+    }
+
+    @GET
+    @Path("/rest-end-point-validation-groups/{id}/")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Valid
+    @ConvertGroup(to = ValidationGroups.Get.class)
+    public MyBeanWithGroups testRestEndPointValidationGroups_Get(@PathParam("id") long id,
+            @QueryParam("simulateDeleted") boolean simulateDeleted,
+            @QueryParam("simulateNullName") boolean simulateNullName) {
+        MyBeanWithGroups result = new MyBeanWithGroups();
+        result.setId(id);
+        result.setName(simulateNullName ? null : "someName");
+        result.setDeleted(simulateDeleted);
+        return result;
+    }
+
+    @DELETE
+    @Path("/rest-end-point-validation-groups/{id}/")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Valid
+    @ConvertGroup(to = ValidationGroups.Delete.class)
+    public MyBeanWithGroups testRestEndPointValidationGroups_Delete(@PathParam("id") long id,
+            @QueryParam("simulateDeleted") boolean simulateDeleted,
+            @QueryParam("simulateNullName") boolean simulateNullName) {
+        MyBeanWithGroups result = new MyBeanWithGroups();
+        result.setId(id);
+        result.setName(simulateNullName ? null : "someName");
+        result.setDeleted(simulateDeleted);
+        return result;
     }
 
     private String formatViolations(Set<? extends ConstraintViolation<?>> violations) {

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/MyBeanWithGroups.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/MyBeanWithGroups.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.hibernate.validator.groups;
+
+import javax.validation.constraints.AssertFalse;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+public class MyBeanWithGroups {
+
+    @Null(groups = ValidationGroups.Put.class)
+    @NotNull(groups = { ValidationGroups.Post.class, ValidationGroups.Get.class, ValidationGroups.Delete.class })
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @AssertFalse(groups = { ValidationGroups.Put.class, ValidationGroups.Post.class, ValidationGroups.Get.class })
+    @AssertTrue(groups = ValidationGroups.Delete.class)
+    private boolean deleted;
+
+    public MyBeanWithGroups() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/ValidationGroups.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/ValidationGroups.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.hibernate.validator.groups;
+
+import javax.validation.groups.Default;
+
+public interface ValidationGroups {
+    interface Put extends Default {
+    }
+
+    interface Post extends Default {
+    }
+
+    interface Get extends Default {
+    }
+
+    interface Delete extends Default {
+    }
+}


### PR DESCRIPTION
Fixes #14293 .

Turns out we don't need a new annotation: the use case mentioned in #14293 can be addressed with the standard annotation `@ConvertGroup`.

We just take advantage of the fact that the `Default` group is active by default, and turn it into another group using e.g. `@ConvertGroup(to = ValidationGroups.Post.class)` on the method parameter.

`@ConvertGroup.to` is single-valued, unfortunately, so we cannot write `@ConvertGroup(to = {ValidationGroups.Post.class, Default.class})` to activate both the `Post` and `Default` groups.
However, we can make the custom interface `ValidationGroups.Post` extend the built-in `Default` interface. Then, activating `Post` will automatically activate `Default`, even after the group conversion.

See the tests added in this PR for more information.

I *personnally* think this is better than introducing a Quarkus-specific annotation, because one can use different groups for each parameter, or for the return value. But of course, YMMV.