### PR TITLE
Make Dev Console work properly  in the face of non ASCII chars in FS paths

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -432,7 +433,7 @@ public class DevConsoleProcessor {
                         jarPath = jarPath.substring(1).replace('/', '\\');
                     }
                     try (FileSystem fs = FileSystems
-                            .newFileSystem(Paths.get(jarPath), classLoader)) {
+                            .newFileSystem(Paths.get(URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name())), classLoader)) {
                         scanTemplates(fs, devTemplatePaths);
                     }
                 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -10,7 +10,6 @@ import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -210,8 +209,7 @@ public class JarClassPathElement implements ClassPathElement {
     public ProtectionDomain getProtectionDomain(ClassLoader classLoader) {
         final URL url;
         try {
-            URI uri = new URI("file", null, jarPath.getPath(), null);
-            url = uri.toURL();
+            url = jarPath.toURI().toURL();
         } catch (URISyntaxException | MalformedURLException e) {
             throw new RuntimeException("Unable to create protection domain for " + jarPath, e);
         }


### PR DESCRIPTION
Fixes: #14504

I tested this with a file system path that had both spaces and greek characters and it worked fine