### PR TITLE
Fix configuration of listeners and plugins properties

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
@@ -17,6 +17,7 @@ public class QuartzExtensionPointConfig {
     /**
      * The properties passed to the class.
      */
+    @ConfigItem
     @ConfigDocMapKey("property-name")
     public Map<String, String> properties;
 }

--- a/integration-tests/quartz/src/main/resources/application.properties
+++ b/integration-tests/quartz/src/main/resources/application.properties
@@ -16,5 +16,5 @@ quarkus.flyway.baseline-version=1.0
 quarkus.flyway.baseline-description=Quartz
 
 # Register de LoggingJobHistoryPlugin for testing
-quarkus.quartz.plugin.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
-quarkus.quartz.plugin.jobHistory.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}
+quarkus.quartz.plugins.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
+quarkus.quartz.plugins.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}


### PR DESCRIPTION
This fix the listeners and plugin configuration which otherwise printed a warning of unrecognised
configuration keys i.e  "quarkus.quartz.plugin.jobHistory.class" and "quarkus.quartz.plugins.jobHistory.jobSuccessMessage"