### PR TITLE
Use RESTEasy Reactive when in getting-started-reactive-crud example

### DIFF
--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -200,8 +200,6 @@ It generates the following in  `./getting-started-reactive`:
 * example `Dockerfile` files for both `native` and `jvm` modes in `src/main/docker`
 * the application configuration file
 
-The generated `pom.xml` also declares the RESTEasy Mutiny support and RESTEasy Jackson to serialize payloads.
-
 === Reactive JAX-RS resources
 
 During the project creation, the `src/main/java/org/acme/quickstart/ReactiveGreetingResource.java` file has been created with the following content:
@@ -291,24 +289,6 @@ public class ReactiveGreetingResource {
 
 The `ReactiveGreetingService` class contains a straightforward method producing a `Uni`.
 While, in this example, the resulting item is emitted immediately, you can imagine any async API producing a `Uni`. We cover this later in this guide.
-
-NOTE: In order to get Mutiny working properly with JAX-RS resources, make sure the Mutiny support for RESTEasy extension (`io.quarkus:quarkus-resteasy-mutiny`) is present, otherwise add the extension by executing the following command:
-
-[source,bash,subs=attributes+]
-----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:add-extensions \
-    -Dextensions="io.quarkus:quarkus-resteasy-reactive"
-----
-
-Or add `quarkus-resteasy-reactive` into your dependencies manually.
-
-[source, xml]
-----
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
-    </dependency>
-----
 
 Now, start the application using:
 
@@ -408,7 +388,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=getting-started-reactive-crud \
     -DclassName="org.acme.reactive.crud.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy-mutiny, resteasy-jackson, reactive-pg-client"
+    -Dextensions="resteasy-reactive-jackson, reactive-pg-client"
 cd getting-started-reactive-crud
 ----
 
@@ -512,6 +492,48 @@ These methods return either `Unis` or `Multis` as the produced items are emitted
 Notice that the reactive PostgreSQL client already provides `Uni` and `Multi` instances.
 So you only transform the results from the database into _business-friendly_ objects.
 
+For the purposes of initializing the database when the application starts, we will create a class named `DBInit` with the following content:
+
+[source, java]
+----
+package org.acme.reactive.crud;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.mutiny.pgclient.PgPool;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class DBInit {
+
+    private final PgPool client;
+    private final boolean schemaCreate;
+
+    public DBInit(PgPool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
+        this.client = client;
+        this.schemaCreate = schemaCreate;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        if (schemaCreate) {
+            initdb();
+        }
+    }
+
+    private void initdb() {
+        client.query("DROP TABLE IF EXISTS fruits").execute()
+                .flatMap(r -> client.query("CREATE TABLE fruits (id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute())
+                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Kiwi')").execute())
+                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Durian')").execute())
+                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Pomelo')").execute())
+                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Lychee')").execute())
+                .await().indefinitely();
+    }
+}
+----
+
 Then, let's use this `Fruit` class in the `FruitResource`.
 Edit the `FruitResource` class to match the following content:
 
@@ -519,14 +541,8 @@ Edit the `FruitResource` class to match the following content:
 ----
 package org.acme.reactive.crud;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import java.net.URI;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -538,23 +554,20 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-import java.net.URI;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.pgclient.PgPool;
 
 @Path("fruits")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
-    @Inject
-    @ConfigProperty(name = "myapp.schema.create", defaultValue = "true")
-    boolean schemaCreate;
+    private final PgPool client;
 
-    @Inject
-    PgPool client;
-
-    @PostConstruct
-    void config() {
-        if (schemaCreate) {
-            initdb();
-        }
+    public FruitResource(PgPool client) {
+        this.client = client;
     }
 
     private void initdb() {
@@ -574,7 +587,7 @@ public class FruitResource {
 
     @GET
     @Path("{id}")
-    public Uni<Response> getSingle(@PathParam Long id) {
+    public Uni<Response> getSingle(Long id) {
         return Fruit.findById(client, id)
                 .onItem().transform(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
                 .onItem().transform(ResponseBuilder::build);
@@ -589,7 +602,7 @@ public class FruitResource {
 
     @PUT
     @Path("{id}")
-    public Uni<Response> update(@PathParam Long id, Fruit fruit) {
+    public Uni<Response> update(Long id, Fruit fruit) {
         return fruit.update(client)
                 .onItem().transform(updated -> updated ? Status.OK : Status.NOT_FOUND)
                 .onItem().transform(status -> Response.status(status).build());
@@ -597,7 +610,7 @@ public class FruitResource {
 
     @DELETE
     @Path("{id}")
-    public Uni<Response> delete(@PathParam Long id) {
+    public Uni<Response> delete(Long id) {
         return Fruit.delete(client, id)
                 .onItem().transform(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
                 .onItem().transform(status -> Response.status(status).build());


### PR DESCRIPTION
It was brought to my attention that this guide was a little confusing
because it first used RESTEasy Reactive then RESTEasy Classic.
This change aims to clear the confusion by using the former for
both parts that use JAX-RS.

The corresponding change to the quickstart is done in https://github.com/quarkusio/quarkus-quickstarts/pull/760