### PR TITLE
Fix NPE in NativeTestExtension on missing native image

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -197,11 +197,13 @@ public class NativeTestExtension
 
     @Override
     public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
-        TestHTTPResourceManager.inject(testInstance);
-        ExtensionContext root = context.getRoot();
-        ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
-        ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
-        state.testResourceManager.inject(testInstance);
+        if (!failedBoot) {
+            TestHTTPResourceManager.inject(testInstance);
+            ExtensionContext root = context.getRoot();
+            ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
+            ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
+            state.testResourceManager.inject(testInstance);
+        }
     }
 
     private void throwBootFailureException() throws Exception {


### PR DESCRIPTION
Without this fix, in case no native image can be found `NativeTestExtension` fails on line 204 with a NPE because there is no `state`.
This NPE is then thrown for each test method:
```
Error:  Tests run: 10, Failures: 0, Errors: 10, Skipped: 0, Time elapsed: 0.593 s <<< FAILURE! - in io.quarkus.it.spring.data.jpa.PostResourceIT
Error:  io.quarkus.it.spring.data.jpa.PostResourceIT.testAll  Time elapsed: 0.01 s  <<< ERROR!
java.lang.NullPointerException
	at io.quarkus.test.junit.NativeTestExtension$ExtensionState.access$000(NativeTestExtension.java:217)
	at io.quarkus.test.junit.NativeTestExtension.postProcessTestInstance(NativeTestExtension.java:204)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$6(ClassBasedTestDescriptor.java:350)
[...]
Error:  io.quarkus.it.spring.data.jpa.PostResourceIT.testByBypassTrue  Time elapsed: 0.001 s  <<< ERROR!
java.lang.NullPointerException
	at io.quarkus.test.junit.NativeTestExtension$ExtensionState.access$000(NativeTestExtension.java:217)
	at io.quarkus.test.junit.NativeTestExtension.postProcessTestInstance(NativeTestExtension.java:204)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$6(ClassBasedTestDescriptor.java:350)
[...]
Error:    PostResourceIT.testPostCommentByPostId » NullPointer
Error:    SongResourceIT.testAll » NullPointer
Error:    SongResourceIT.testDefaultMethod » NullPointer
Error:    SongResourceIT.testDeleteAllWithCascade » NullPointer
Error:    SongResourceIT.testDeleteByIdWithCascade » NullPointer
Error:    SongResourceIT.testFindFirstPageWithTwoElements » NullPointer
[INFO] 
Error:  Tests run: 108, Failures: 0, Errors: 108, Skipped: 0
```

With this fix, everything is much clearer because only one exception is logged that contains the actual cause:
```
Error:  Tests run: 10, Failures: 0, Errors: 1, Skipped: 9, Time elapsed: 0.514 s <<< FAILURE! - in io.quarkus.it.spring.data.jpa.PostResourceIT
Error:  io.quarkus.it.spring.data.jpa.PostResourceIT.testAll  Time elapsed: 0.017 s  <<< ERROR!
java.lang.RuntimeException: java.io.IOException: Cannot run program "/home/runner/work/quarkus/quarkus/integration-tests/spring-data-jpa/target/quarkus-integration-test-spring-data-jpa-999-SNAPSHOT-runner": error=2, No such file or directory
	at io.quarkus.test.junit.NativeTestExtension.throwBootFailureException(NativeTestExtension.java:213)
	at io.quarkus.test.junit.NativeTestExtension.beforeEach(NativeTestExtension.java:56)
[...]
[INFO] 
Error:  Tests run: 108, Failures: 0, Errors: 1, Skipped: 107
```