### PR TITLE
Security fixes for RESTEasy Reactive

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2836,6 +2836,16 @@
                 <groupId>io.quarkus.security</groupId>
                 <artifactId>quarkus-security</artifactId>
                 <version>${quarkus-security.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/JaxRsSecurityConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/JaxRsSecurityConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.common.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@ConfigRoot(name = "security.jaxrs", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class JaxRsSecurityConfig {
+    /**
+     * if set to true, access to all JAX-RS resources will be denied by default
+     */
+    @ConfigItem(name = "deny-unannotated-endpoints")
+    public boolean denyJaxRs;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -57,7 +57,9 @@ import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.DynamicFeatures;
 import org.jboss.resteasy.reactive.server.model.Features;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -100,6 +102,7 @@ import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.Authenticati
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationRedirectExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.ForbiddenExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.UnauthorizedExceptionMapper;
+import io.quarkus.resteasy.reactive.server.runtime.security.SecurityContextOverrideHandler;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.DynamicFeatureBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
@@ -530,6 +533,16 @@ public class ResteasyReactiveProcessor {
                 UnauthorizedExceptionMapper.class.getName(),
                 UnauthorizedException.class.getName(),
                 Priorities.USER + 1, false));
+    }
+
+    @BuildStep
+    MethodScannerBuildItem integrateSecurityOverrideSupport() {
+        return new MethodScannerBuildItem(new MethodScanner() {
+            @Override
+            public List<HandlerChainCustomizer> scan(MethodInfo method, Map<String, Object> methodContext) {
+                return Collections.singletonList(new SecurityContextOverrideHandler.Customizer());
+            }
+        });
     }
 
     private String determineApplicationPath(IndexView index) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+public class DenyAllJaxRsTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PermitAllResource.class, UnsecuredResource.class,
+                            TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            UnsecuredSubResource.class)
+                    .addAsResource(new StringAsset("quarkus.security.jaxrs.deny-unannotated-endpoints = true\n"),
+                            "application.properties"));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void shouldDenyUnannotated() {
+        String path = "/unsecured/defaultSecurity";
+        assertStatus(path, 403, 401);
+    }
+
+    @Test
+    public void shouldDenyDenyAllMethod() {
+        String path = "/unsecured/denyAll";
+        assertStatus(path, 403, 401);
+    }
+
+    @Test
+    public void shouldPermitPermitAllMethod() {
+        assertStatus("/unsecured/permitAll", 200, 200);
+    }
+
+    @Test
+    public void shouldDenySubResource() {
+        String path = "/unsecured/sub/subMethod";
+        assertStatus(path, 403, 401);
+    }
+
+    @Test
+    public void shouldAllowPermitAllSubResource() {
+        String path = "/unsecured/permitAllSub/subMethod";
+        assertStatus(path, 200, 200);
+    }
+
+    @Test
+    public void shouldAllowPermitAllClass() {
+        String path = "/permitAll/sub/subMethod";
+        assertStatus(path, 200, 200);
+    }
+
+    private void assertStatus(String path, int status, int anonStatus) {
+        given().auth().preemptive()
+                .basic("admin", "admin").get(path)
+                .then()
+                .statusCode(status);
+        given().auth().preemptive()
+                .basic("user", "user").get(path)
+                .then()
+                .statusCode(status);
+        when().get(path)
+                .then()
+                .statusCode(anonStatus);
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
@@ -1,0 +1,53 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class LazyAuthRolesAllowedJaxRsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RolesAllowedResource.class, UserResource.class,
+                            TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            UnsecuredSubResource.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
+                            "application.properties"));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testRolesAllowed() {
+        RestAssured.get("/roles").then().statusCode(401);
+        RestAssured.given().auth().basic("admin", "admin").get("/roles").then().statusCode(200);
+        RestAssured.given().auth().basic("admin", "wrong").get("/roles").then().statusCode(401);
+        RestAssured.given().auth().basic("user", "user").get("/roles").then().statusCode(200);
+        RestAssured.given().auth().basic("admin", "admin").get("/roles/admin").then().statusCode(200);
+        RestAssured.given().auth().basic("user", "user").get("/roles/admin").then().statusCode(403);
+    }
+
+    @Test
+    public void testUser() {
+        RestAssured.get("/user").then().body(is(""));
+        RestAssured.given().auth().basic("admin", "admin").get("/user").then().body(is(""));
+        RestAssured.given().auth().preemptive().basic("admin", "admin").get("/user").then().body(is(""));
+        RestAssured.given().auth().basic("user", "user").get("/user").then().body(is(""));
+        RestAssured.given().auth().preemptive().basic("user", "user").get("/user").then().body(is(""));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermitAllResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermitAllResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@Path("/permitAll")
+@PermitAll
+public class PermitAllResource {
+    @Path("/defaultSecurity")
+    @GET
+    public String defaultSecurity() {
+        return "defaultSecurity";
+    }
+
+    @Path("/sub")
+    public UnsecuredSubResource sub() {
+        return new UnsecuredSubResource();
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase.java
@@ -1,0 +1,58 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ReplaceIdentityLazyAuthRolesAllowedJaxRsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RolesAllowedResource.class, UserResource.class,
+                            TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            SecurityOverrideFilter.class,
+                            UnsecuredSubResource.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
+                            "application.properties"));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testRolesAllowedModified() {
+        //make sure that things work as normal when no modification happens
+        RestAssured.given()
+                .header("user", "admin")
+                .header("role", "admin")
+                .get("/roles").then().statusCode(200);
+        RestAssured.given()
+                .auth().basic("user", "user")
+                .header("user", "admin")
+                .header("role", "admin").get("/roles/admin").then().statusCode(200);
+    }
+
+    @Test
+    public void testUser() {
+        RestAssured.given().auth().basic("user", "user")
+                .header("user", "admin")
+                .header("role", "admin").get("/user").then().body(is("admin"));
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .header("user", "admin")
+                .header("role", "admin").get("/user").then().body(is("admin"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedJaxRsTestCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class RolesAllowedJaxRsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RolesAllowedResource.class, UserResource.class,
+                            TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            UnsecuredSubResource.class));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testRolesAllowed() {
+        RestAssured.get("/roles").then().statusCode(401);
+        RestAssured.given().auth().basic("admin", "admin").get("/roles").then().statusCode(200);
+        RestAssured.given().auth().basic("user", "user").get("/roles").then().statusCode(200);
+        RestAssured.given().auth().basic("admin", "admin").get("/roles/admin").then().statusCode(200);
+        RestAssured.given().auth().basic("user", "user").get("/roles/admin").then().statusCode(403);
+    }
+
+    @Test
+    public void testUser() {
+        RestAssured.get("/user").then().body(is(""));
+        RestAssured.given().auth().preemptive().basic("admin", "admin").get("/user").then().statusCode(200).body(is("admin"));
+        RestAssured.given().auth().basic("admin", "admin").get("/user").then().body(is(""));
+        RestAssured.given().auth().basic("user", "user").get("/user").then().body(is(""));
+        RestAssured.given().auth().preemptive().basic("user", "user").get("/user").then().body(is("user"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.smallrye.common.annotation.Blocking;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@Path("/roles")
+@PermitAll
+@Blocking
+public class RolesAllowedResource {
+    @GET
+    @RolesAllowed({ "user", "admin" })
+    public String defaultSecurity() {
+        return "default";
+    }
+
+    @Path("/admin")
+    @RolesAllowed("admin")
+    @GET
+    public String admin() {
+        return "admin";
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityOverrideFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityOverrideFilter.java
@@ -1,0 +1,49 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@PreMatching
+public class SecurityOverrideFilter implements ContainerRequestFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String user = requestContext.getHeaders().getFirst("User");
+        String role = requestContext.getHeaders().getFirst("Role");
+        if (user != null && role != null) {
+            requestContext.setSecurityContext(new SecurityContext() {
+                @Override
+                public Principal getUserPrincipal() {
+                    return new Principal() {
+                        @Override
+                        public String getName() {
+                            return user;
+                        }
+                    };
+                }
+
+                @Override
+                public boolean isUserInRole(String r) {
+                    return role.equals(r);
+                }
+
+                @Override
+                public boolean isSecure() {
+                    return false;
+                }
+
+                @Override
+                public String getAuthenticationScheme() {
+                    return "basic";
+                }
+            });
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@Path("/unsecured")
+public class UnsecuredResource {
+    @Path("/defaultSecurity")
+    @GET
+    public String defaultSecurity() {
+        return "defaultSecurity";
+    }
+
+    @Path("/permitAll")
+    @GET
+    @PermitAll
+    public String permitAll() {
+        return "permitAll";
+    }
+
+    @Path("/denyAll")
+    @GET
+    @DenyAll
+    public String denyAll() {
+        return "denyAll";
+    }
+
+    @Path("/sub")
+    public UnsecuredSubResource sub() {
+        return new UnsecuredSubResource();
+    }
+
+    @PermitAll
+    @Path("/permitAllSub")
+    public UnsecuredSubResource permitAllSub() {
+        return new UnsecuredSubResource();
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredSubResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredSubResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+public class UnsecuredSubResource {
+    @GET
+    @Path("/subMethod")
+    public String subMethod() {
+        return "subMethod";
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UserResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UserResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+import io.smallrye.common.annotation.Blocking;
+
+@Path("/user")
+@Blocking
+public class UserResource {
+
+    @Context
+    SecurityContext securityContext;
+
+    @GET
+    public String get() {
+        if (securityContext.getUserPrincipal() == null) {
+            return null;
+        }
+        return securityContext.getUserPrincipal().getName();
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
@@ -1,0 +1,131 @@
+package io.quarkus.resteasy.reactive.server.runtime.security;
+
+import java.security.Permission;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.core.SecurityContext;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveSecurityContext;
+import io.quarkus.security.credential.Credential;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+public class SecurityContextOverrideHandler implements ServerRestHandler {
+
+    private volatile SecurityIdentity securityIdentity;
+    private volatile CurrentIdentityAssociation currentIdentityAssociation;
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+        if (!requestContext.isSecurityContextSet()) {
+            //nothing to do
+            return;
+        }
+        SecurityContext modified = requestContext.getSecurityContext();
+        if (modified instanceof ResteasyReactiveSecurityContext) {
+            //an original security context, it has not been modified
+            return;
+        }
+        updateIdentity(requestContext, modified);
+    }
+
+    private void updateIdentity(ResteasyReactiveRequestContext requestContext, SecurityContext modified) {
+        requestContext.requireCDIRequestScope();
+        CurrentIdentityAssociation currentIdentityAssociation = Arc.container().select(CurrentIdentityAssociation.class).get();
+        Uni<SecurityIdentity> oldIdentity = currentIdentityAssociation.getDeferredIdentity();
+        currentIdentityAssociation.setIdentity(oldIdentity.map(new Function<SecurityIdentity, SecurityIdentity>() {
+            @Override
+            public SecurityIdentity apply(SecurityIdentity old) {
+                Set<Credential> oldCredentials = old.getCredentials();
+                Map<String, Object> oldAttributes = old.getAttributes();
+                return new SecurityIdentity() {
+                    @Override
+                    public Principal getPrincipal() {
+                        return modified.getUserPrincipal();
+                    }
+
+                    @Override
+                    public boolean isAnonymous() {
+                        return modified.getUserPrincipal() == null;
+                    }
+
+                    @Override
+                    public Set<String> getRoles() {
+                        throw new UnsupportedOperationException(
+                                "retrieving all roles not supported when JAX-RS security context has been replaced");
+                    }
+
+                    @Override
+                    public boolean hasRole(String role) {
+                        return modified.isUserInRole(role);
+                    }
+
+                    @Override
+                    public <T extends Credential> T getCredential(Class<T> credentialType) {
+                        for (Credential cred : getCredentials()) {
+                            if (credentialType.isAssignableFrom(cred.getClass())) {
+                                return (T) cred;
+                            }
+                        }
+                        return null;
+                    }
+
+                    @Override
+                    public Set<Credential> getCredentials() {
+                        return oldCredentials;
+                    }
+
+                    @Override
+                    public <T> T getAttribute(String name) {
+                        return (T) oldAttributes.get(name);
+                    }
+
+                    @Override
+                    public Map<String, Object> getAttributes() {
+                        return oldAttributes;
+                    }
+
+                    @Override
+                    public Uni<Boolean> checkPermission(Permission permission) {
+                        return Uni.createFrom().nullItem();
+                    }
+                };
+            }
+        }));
+    }
+
+    private CurrentIdentityAssociation getCurrentIdentityAssociation() {
+        CurrentIdentityAssociation identityAssociation = this.currentIdentityAssociation;
+        if (identityAssociation == null) {
+            return this.currentIdentityAssociation = CDI.current().select(CurrentIdentityAssociation.class).get();
+        }
+        return identityAssociation;
+    }
+
+    private SecurityIdentity getSecurityIdentity() {
+        SecurityIdentity identity = this.securityIdentity;
+        if (identity == null) {
+            return this.securityIdentity = CDI.current().select(SecurityIdentity.class).get();
+        }
+        return identity;
+    }
+
+    public static class Customizer implements HandlerChainCustomizer {
+        @Override
+        public List<ServerRestHandler> handlers(Phase phase) {
+            return Collections.singletonList(new SecurityContextOverrideHandler());
+        }
+    }
+}

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/DenyJaxRsTransformer.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/DenyJaxRsTransformer.java
@@ -1,7 +1,7 @@
 package io.quarkus.resteasy.deployment;
 
-import static io.quarkus.resteasy.deployment.SecurityTransformerUtils.DENY_ALL;
-import static io.quarkus.resteasy.deployment.SecurityTransformerUtils.hasSecurityAnnotation;
+import static io.quarkus.security.spi.SecurityTransformerUtils.DENY_ALL;
+import static io.quarkus.security.spi.SecurityTransformerUtils.hasSecurityAnnotation;
 
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.resteasy.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
-import static io.quarkus.resteasy.deployment.SecurityTransformerUtils.hasSecurityAnnotation;
+import static io.quarkus.security.spi.SecurityTransformerUtils.hasSecurityAnnotation;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/extensions/security/spi/pom.xml
+++ b/extensions/security/spi/pom.xml
@@ -17,6 +17,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.security</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/SecurityTransformerUtils.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/SecurityTransformerUtils.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.deployment;
+package io.quarkus.security.spi;
 
 import static java.util.Arrays.asList;
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -879,13 +879,22 @@ public abstract class ResteasyReactiveRequestContext
         return securityContext;
     }
 
+    public boolean isSecurityContextSet() {
+        return securityContext != null;
+    }
+
     protected SecurityContext createSecurityContext() {
         throw new UnsupportedOperationException();
     }
 
     public ResteasyReactiveRequestContext setSecurityContext(SecurityContext securityContext) {
         this.securityContext = securityContext;
+        securityContextUpdated(securityContext);
         return this;
+    }
+
+    protected void securityContextUpdated(SecurityContext securityContext) {
+
     }
 
     public void setOutputStream(OutputStream outputStream) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ContextProducers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ContextProducers.java
@@ -113,7 +113,7 @@ public class ContextProducers {
         return ResourceContextImpl.INSTANCE;
     }
 
-    @ApplicationScoped
+    @RequestScoped
     @Produces
     SecurityContext securityContext() {
         return getContext().getSecurityContext();


### PR DESCRIPTION
- Add ability to deny access to unannotated endpoints
- Make sure setSecurityContext changes the current identity
- Port tests from RESTEasy extension