### PR TITLE
Align generated Maven project version in getting started guide

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -201,7 +201,7 @@ Use: `./mvnw compile quarkus:dev`:
 ----
 $ ./mvnw compile quarkus:dev
 [INFO] --------------------< org.acme:getting-started >---------------------
-[INFO] Building getting-started 1.0-SNAPSHOT
+[INFO] Building getting-started 1.0.0-SNAPSHOT
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO]
 [INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ getting-started ---
@@ -454,12 +454,12 @@ Be sure to read the link:cdi-reference#bean_discovery[Bean Discovery] section of
 The application is packaged using `./mvnw package`.
 It produces 2 jar files in `/target`:
 
-* `getting-started-1.0-SNAPSHOT.jar` - containing just the classes and resources of the projects, it's the regular
+* `getting-started-1.0.0-SNAPSHOT.jar` - containing just the classes and resources of the projects, it's the regular
 artifact produced by the Maven build;
-* `getting-started-1.0-SNAPSHOT-runner.jar` - being an executable _jar_. Be aware that it's not an _über-jar_ as
+* `getting-started-1.0.0-SNAPSHOT-runner.jar` - being an executable _jar_. Be aware that it's not an _über-jar_ as
 the dependencies are copied into the `target/lib` directory.
 
-You can run the application using: `java -jar target/getting-started-1.0-SNAPSHOT-runner.jar`
+You can run the application using: `java -jar target/getting-started-1.0.0-SNAPSHOT-runner.jar`
 
 NOTE: The `Class-Path` entry of the `MANIFEST.MF` from the _runner jar_ explicitly lists the jars from the `lib` directory.
 So if you want to deploy your application somewhere, you need to copy the _runner_ jar as well as the _lib_ directory.


### PR DESCRIPTION
 * 'mvn io.quarkus:quarkus-maven-plugin:1.11.0.Final:create' generates
   1.0.0-SNAPSHOT