### PR TITLE
Reinitialize org.wildfly.common.net.HostName during native application's runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.runtime.ssl.SslContextConfigurationRecorder;
 
 //TODO: this should go away, once we decide on which one of the API's we want
@@ -86,6 +87,15 @@ class NativeImageConfigBuildStep {
         if (!nativeImageEnableAllCharsetsBuildItems.isEmpty()) {
             nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.enable-all-charsets", "true"));
         }
+    }
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    void reinitHostNameUtil(BuildProducer<RuntimeReinitializedClassBuildItem> runtimeReInitClass) {
+        // certain libraries like JBoss logging internally use this class to determine the hostname
+        // of the system. This HostName class computes and stores the hostname as a static field in a class,
+        // so we reinitialize this to re-compute the field (and other related fields) during native application's
+        // runtime
+        runtimeReInitClass.produce(new RuntimeReinitializedClassBuildItem("org.wildfly.common.net.HostName"));
     }
 
     private Boolean isSslNativeEnabled(SslNativeConfigBuildItem sslNativeConfig,


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/14423

The commit here re-initializes the `org.wildfly.common.net.HostName` so that this class recomputes various fields that it holds on to as static class level member variables.

I decided to add this `@BuildStep` in the `NativeImageConfigBuildStep` since although the issue happens in JBoss logging (which uses this class), given the nature and usage of this `HostName` class, it looked more appropriate to not have it tied to logging.

Manual testing of the linked issue after this fix worked fine for me locally.
