### PR TITLE
Prevent UOE when MessageBodyReader can handle multiple media types

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
@@ -91,11 +91,12 @@ public abstract class Serialisers {
             List<ResourceReader> goodTypeReaders) {
         if (goodTypeReaders != null && !goodTypeReaders.isEmpty()) {
             List<ResourceReader> mediaTypeMatchingReaders = new ArrayList<>(goodTypeReaders.size());
-            for (ResourceReader goodTypeReader : goodTypeReaders) {
+            for (int i = 0; i < goodTypeReaders.size(); i++) {
+                ResourceReader goodTypeReader = goodTypeReaders.get(i);
                 if (!goodTypeReader.matchesRuntimeType(runtimeType)) {
                     continue;
                 }
-                MediaType match = MediaTypeHelper.getBestMatch(mt, goodTypeReader.mediaTypes());
+                MediaType match = MediaTypeHelper.getFirstMatch(mt, goodTypeReader.mediaTypes());
                 if (match != null || mediaType == null) {
                     mediaTypeMatchingReaders.add(goodTypeReader);
                 }
@@ -134,8 +135,9 @@ public abstract class Serialisers {
                 if (produces == null || produces.isEmpty()) {
                     return null;
                 } else {
-                    for (ResourceWriter writer : entry.getValue()) {
-                        MediaType match = MediaTypeHelper.getBestMatch(produces, writer.modifiableMediaTypes());
+                    List<ResourceWriter> writers = entry.getValue();
+                    for (int i = 0; i < writers.size(); i++) {
+                        MediaType match = MediaTypeHelper.getFirstMatch(produces, writers.get(i).mediaTypes());
                         if (match != null) {
                             return null;
                         }
@@ -201,11 +203,12 @@ public abstract class Serialisers {
             List<ResourceWriter> goodTypeWriters) {
         if (goodTypeWriters != null && !goodTypeWriters.isEmpty()) {
             List<ResourceWriter> mediaTypeMatchingWriters = new ArrayList<>(goodTypeWriters.size());
-            for (ResourceWriter goodTypeWriter : goodTypeWriters) {
+            for (int i = 0; i < goodTypeWriters.size(); i++) {
+                ResourceWriter goodTypeWriter = goodTypeWriters.get(i);
                 if (!goodTypeWriter.matchesRuntimeType(runtimeType)) {
                     continue;
                 }
-                MediaType match = MediaTypeHelper.getBestMatch(mt, goodTypeWriter.modifiableMediaTypes());
+                MediaType match = MediaTypeHelper.getFirstMatch(mt, goodTypeWriter.mediaTypes());
                 if (match != null) {
                     mediaTypeMatchingWriters.add(goodTypeWriter);
                 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
@@ -69,11 +69,11 @@ public class ResourceReader {
         if (mediaTypes == null) {
             //todo: does this actually need to be threadsafe?
             synchronized (this) {
-                List<MediaType> ret = new ArrayList<>();
-                for (String i : mediaTypeStrings) {
-                    ret.add(MediaType.valueOf(i));
+                List<MediaType> mts = new ArrayList<>(mediaTypeStrings.size());
+                for (int i = 0; i < mediaTypeStrings.size(); i++) {
+                    mts.add(MediaType.valueOf(mediaTypeStrings.get(i)));
                 }
-                mediaTypes = Collections.unmodifiableList(ret);
+                mediaTypes = Collections.unmodifiableList(mts);
             }
         }
         return mediaTypes;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceWriter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceWriter.java
@@ -73,18 +73,14 @@ public class ResourceWriter {
         if (mediaTypes == null) {
             //todo: does this actually need to be threadsafe?
             synchronized (this) {
-                List<MediaType> ret = new ArrayList<>();
-                for (String i : mediaTypeStrings) {
-                    ret.add(MediaType.valueOf(i));
+                List<MediaType> mts = new ArrayList<>(mediaTypeStrings.size());
+                for (int i = 0; i < mediaTypeStrings.size(); i++) {
+                    mts.add(MediaType.valueOf(mediaTypeStrings.get(i)));
                 }
-                mediaTypes = Collections.unmodifiableList(ret);
+                mediaTypes = Collections.unmodifiableList(mts);
             }
         }
         return mediaTypes;
-    }
-
-    public List<MediaType> modifiableMediaTypes() {
-        return new ArrayList<>(mediaTypes());
     }
 
     public ServerMediaType serverMediaType() {


### PR DESCRIPTION
The basic idea of the PR is to get rid of the useless usages of `MediaTypeHelper#getBestMatch`.
Because of that we can now enforce the immutability of the media types in
`ResourceReader` and `ResourceWriter`. This change is also beneficial from a performance standpoint.
The places that do indeed need `getBestMatch` are very unlikely to be on the hot path, so I went ahead and made that method use a copy of the list and operate on it.

Furthermore the PR applies some extra polish to MediaTypeHelper and
does away with the Iterator allocation in during the lookup
of the appropriate `MessageBodyReader` and `MessageBodyWriter classes`

Related to: https://github.com/quarkusio/quarkus/pull/13997#issuecomment-767260680