### PR TITLE
Add K8s Namespace property documentation

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -161,6 +161,22 @@ quarkus.container-image.tag=1.0       #optional, defaults to the application ver
 
 The image that will be used in the generated manifests will be `quarkus/demo-app:1.0`
 
+=== Namespace
+
+By default Quarkus omits the namespace in the generated manifests, rather than enforce the `default` namespace. That means that you can apply the manifest to your chosen namespace when using `kubctl`, which in the example below is `test`:
+
+[source,bash]
+----
+kubectl apply -f target/kubernetes/kubernetes.json -n=test
+----
+
+To specify the namespace in your manifest customize with the following property in your `application.properties`:
+
+[source,properties]
+----
+quarkus.kubernetes.namespace=mynamespace 
+----
+
 === Defining a Docker registry
 
 The Docker registry can be specified with the following property:
@@ -587,6 +603,7 @@ The table below describe all the available configuration options.
 | quarkus.kubernetes.version                         | String                                    |             | ${quarkus.container-image.tag}
 | quarkus.kubernetes.part-of                         | String                                    |             |
 | quarkus.kubernetes.init-containers                 | Map<String, Container>                    |             |
+| quarkus.kubernetes.namespace                       | String                                    |             |
 | quarkus.kubernetes.labels                          | Map                                       |             |
 | quarkus.kubernetes.annotations                     | Map                                       |             |
 | quarkus.kubernetes.env-vars                        | Map<String, Env>                          |             |


### PR DESCRIPTION
Per #10046 (fixed in #10674), the ability to use a property to define the K8s namespace was added.  

The documentation however was not updated to reflect this, which is updated here to explain how to use `kubectl apply -n` with the manifest or to leverage the property to specify it explicitly in `application.properties`

/cc @geoand 