### PR TITLE
Remove resteasy-json-p-provider and jakarta-servlet-api dependencies for quarkus-smallrye-jwt

### DIFF
--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -38,14 +38,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-json-p-provider</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
`quarkus-jsonp` is a better option compared to the original `resteasy-json-p-provider` dependency and `jakarta-servlet-api` is no longer needed now that it is based on Vert.x