### PR TITLE
Make the oidc-client doc title shorter and try to improve the introduction

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -3,12 +3,16 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Using OpenID Connect and OAuth2 Client and Filters to acquire, refresh and propagate access tokens
+= Quarkus - Using OpenID Connect and OAuth2 Client and Filters to manage access tokens
 
 include::./attributes.adoc[]
 :toc:
 
-This guide explains how to use Quarkus `quarkus-oidc-client`, `quarkus-oidc-client-filter` and `quarkus-oidc-token-propagation` extensions to acquire and refresh access tokens from OpenId Connect and OAuth 2.0 compliant Authorization Servers such as https://www.keycloak.org/about.html[Keycloak] and use these tokens as HTTP Authorization Bearer tokens to access the remote services.
+This guide explains how to use:
+ * `quarkus-oidc-client` and `quarkus-oidc-client-filter` extensions to acquire and refresh access tokens from OpenId Connect and OAuth 2.0 compliant Authorization Servers such as https://www.keycloak.org/about.html[Keycloak]
+ * `quarkus-oidc-token-propagation` extension to propagate the current bearer or authorization code flow access tokens
+
+The access tokens managed by these extensions can be used as HTTP Authorization Bearer tokens to access the remote services.
 
 == OidcClient
 


### PR DESCRIPTION
I've found the title to occupy too much space when I saw https://quarkus.io/guides/security-openid-connect-client.

Here is an attempt to make the title shorter as well make the introduction a little bit more structured - right now it is not clear there what is the point of `oidc-token-propagation` 