### PR TITLE
Containerized native image build on remote docker daemons (issue #1610)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -158,6 +158,12 @@ public class NativeConfig {
     public boolean containerBuild;
 
     /**
+     * If this build is done using a remote docker daemon.
+     */
+    @ConfigItem
+    public boolean remoteContainerBuild;
+
+    /**
      * The docker image to use to do the image build
      */
     @ConfigItem(defaultValue = "${platform.quarkus.native.builder-image}")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -1,0 +1,156 @@
+package io.quarkus.deployment.pkg.steps;
+
+import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.deployment.util.ProcessUtil;
+
+public class NativeImageBuildContainerRunner extends NativeImageBuildRunner {
+
+    private static final Logger log = Logger.getLogger(NativeImageBuildContainerRunner.class);
+
+    private final NativeConfig nativeConfig;
+    private final NativeConfig.ContainerRuntime containerRuntime;
+    private final String[] baseContainerRuntimeArgs;
+    private final String outputPath;
+
+    public NativeImageBuildContainerRunner(NativeConfig nativeConfig, Path outputDir) {
+        this.nativeConfig = nativeConfig;
+        containerRuntime = nativeConfig.containerRuntime.orElseGet(NativeImageBuildContainerRunner::detectContainerRuntime);
+        log.infof("Using %s to run the native image builder", containerRuntime.getExecutableName());
+
+        List<String> containerRuntimeArgs = new ArrayList<>();
+        Collections.addAll(containerRuntimeArgs, "run", "--env", "LANG=C");
+
+        String outputPath = outputDir.toAbsolutePath().toString();
+        if (SystemUtils.IS_OS_WINDOWS) {
+            outputPath = FileUtil.translateToVolumePath(outputPath);
+        }
+        this.outputPath = outputPath;
+
+        if (SystemUtils.IS_OS_LINUX) {
+            String uid = getLinuxID("-ur");
+            String gid = getLinuxID("-gr");
+            if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
+                Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
+                if (containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
+                    // Needed to avoid AccessDeniedExceptions
+                    containerRuntimeArgs.add("--userns=keep-id");
+                }
+            }
+        }
+        Collections.addAll(containerRuntimeArgs, "--rm");
+        this.baseContainerRuntimeArgs = containerRuntimeArgs.toArray(new String[0]);
+    }
+
+    @Override
+    public void setup(boolean processInheritIODisabled) {
+        if (containerRuntime == NativeConfig.ContainerRuntime.DOCKER
+                || containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
+            // we pull the docker image in order to give users an indication of which step the process is at
+            // it's not strictly necessary we do this, however if we don't the subsequent version command
+            // will appear to block and no output will be shown
+            log.info("Checking image status " + nativeConfig.builderImage);
+            Process pullProcess = null;
+            try {
+                final ProcessBuilder pb = new ProcessBuilder(
+                        Arrays.asList(containerRuntime.getExecutableName(), "pull", nativeConfig.builderImage));
+                pullProcess = ProcessUtil.launchProcess(pb, processInheritIODisabled);
+                pullProcess.waitFor();
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException("Failed to pull builder image " + nativeConfig.builderImage, e);
+            } finally {
+                if (pullProcess != null) {
+                    pullProcess.destroy();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String[] getGraalVMVersionCommand(List<String> args) {
+        return buildCommand(Collections.emptyList(), args);
+    }
+
+    @Override
+    protected String[] getBuildCommand(List<String> args) {
+        List<String> containerRuntimeArgs = new ArrayList<>();
+        Collections.addAll(containerRuntimeArgs, "-v",
+                outputPath + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + ":z");
+        nativeConfig.containerRuntimeOptions.ifPresent(containerRuntimeArgs::addAll);
+        if (nativeConfig.debugBuildProcess && nativeConfig.publishDebugBuildProcessPort) {
+            // publish the debug port onto the host if asked for
+            containerRuntimeArgs.add("--publish=" + NativeImageBuildStep.DEBUG_BUILD_PROCESS_PORT + ":"
+                    + NativeImageBuildStep.DEBUG_BUILD_PROCESS_PORT);
+        }
+        return buildCommand(containerRuntimeArgs, args);
+    }
+
+    private String[] buildCommand(List<String> containerRuntimeArgs, List<String> command) {
+        return Stream
+                .of(Stream.of(containerRuntime.getExecutableName()), Stream.of(baseContainerRuntimeArgs),
+                        containerRuntimeArgs.stream(), Stream.of(nativeConfig.builderImage), command.stream())
+                .flatMap(Function.identity()).toArray(String[]::new);
+    }
+
+    /**
+     * @return {@link NativeConfig.ContainerRuntime#DOCKER} if it's available, or {@link NativeConfig.ContainerRuntime#PODMAN}
+     *         if the podman
+     *         executable exists in the environment or if the docker executable is an alias to podman
+     * @throws IllegalStateException if no container runtime was found to build the image
+     */
+    private static NativeConfig.ContainerRuntime detectContainerRuntime() {
+        // Docker version 19.03.14, build 5eb3275d40
+        String dockerVersionOutput = getVersionOutputFor(NativeConfig.ContainerRuntime.DOCKER);
+        boolean dockerAvailable = dockerVersionOutput.contains("Docker version");
+        // Check if Podman is installed
+        // podman version 2.1.1
+        String podmanVersionOutput = getVersionOutputFor(NativeConfig.ContainerRuntime.PODMAN);
+        boolean podmanAvailable = podmanVersionOutput.startsWith("podman version");
+        if (dockerAvailable) {
+            // Check if "docker" is an alias to "podman"
+            if (dockerVersionOutput.equals(podmanVersionOutput)) {
+                return NativeConfig.ContainerRuntime.PODMAN;
+            }
+            return NativeConfig.ContainerRuntime.DOCKER;
+        } else if (podmanAvailable) {
+            return NativeConfig.ContainerRuntime.PODMAN;
+        } else {
+            throw new IllegalStateException("No container runtime was found to run the native image builder");
+        }
+    }
+
+    private static String getVersionOutputFor(NativeConfig.ContainerRuntime containerRuntime) {
+        Process versionProcess = null;
+        try {
+            ProcessBuilder pb = new ProcessBuilder(containerRuntime.getExecutableName(), "--version")
+                    .redirectErrorStream(true);
+            versionProcess = pb.start();
+            versionProcess.waitFor();
+            return new String(FileUtil.readFileContents(versionProcess.getInputStream()), StandardCharsets.UTF_8);
+        } catch (IOException | InterruptedException e) {
+            // If an exception is thrown in the process, just return an empty String
+            log.debugf(e, "Failure to read version output from %s", containerRuntime.getExecutableName());
+            return "";
+        } finally {
+            if (versionProcess != null) {
+                versionProcess.destroy();
+            }
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -1,0 +1,29 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.SystemUtils;
+
+import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.util.FileUtil;
+
+public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
+
+    public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig, Path outputDir) {
+        super(nativeConfig, outputDir);
+    }
+
+    @Override
+    protected List<String> getContainerRuntimeBuildArgs() {
+        List<String> containerRuntimeArgs = super.getContainerRuntimeBuildArgs();
+        String volumeOutputPath = outputPath;
+        if (SystemUtils.IS_OS_WINDOWS) {
+            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
+        }
+        Collections.addAll(containerRuntimeArgs, "--rm", "-v",
+                volumeOutputPath + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + ":z");
+        return containerRuntimeArgs;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
@@ -1,0 +1,40 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import io.quarkus.deployment.util.ProcessUtil;
+
+public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
+
+    private final String nativeImageExecutable;
+
+    public NativeImageBuildLocalRunner(String nativeImageExecutable) {
+        this.nativeImageExecutable = nativeImageExecutable;
+    }
+
+    @Override
+    public void cleanupServer(File outputDir, boolean processInheritIODisabled) throws InterruptedException, IOException {
+        final ProcessBuilder pb = new ProcessBuilder(nativeImageExecutable, "--server-shutdown");
+        pb.directory(outputDir);
+        final Process process = ProcessUtil.launchProcess(pb, processInheritIODisabled);
+        process.waitFor();
+    }
+
+    @Override
+    protected String[] getGraalVMVersionCommand(List<String> args) {
+        return buildCommand(args);
+    }
+
+    @Override
+    protected String[] getBuildCommand(List<String> args) {
+        return buildCommand(args);
+    }
+
+    private String[] buildCommand(List<String> args) {
+        return Stream.concat(Stream.of(nativeImageExecutable), args.stream()).toArray(String[]::new);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -1,0 +1,53 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.quarkus.deployment.pkg.NativeConfig;
+
+public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildContainerRunner {
+
+    private final String nativeImageName;
+    private String containerId;
+
+    public NativeImageBuildRemoteContainerRunner(NativeConfig nativeConfig, Path outputDir, String nativeImageName) {
+        super(nativeConfig, outputDir);
+        this.nativeImageName = nativeImageName;
+    }
+
+    @Override
+    protected void preBuild(List<String> buildArgs) throws InterruptedException, IOException {
+        List<String> containerRuntimeArgs = getContainerRuntimeBuildArgs();
+        String[] createContainerCommand = buildCommand("create", containerRuntimeArgs, buildArgs);
+        Process createContainerProcess = new ProcessBuilder(createContainerCommand).start();
+        createContainerProcess.waitFor();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(createContainerProcess.getInputStream()))) {
+            containerId = reader.readLine();
+        }
+        String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp", outputPath + "/.",
+                containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH };
+        Process copyProcess = new ProcessBuilder(copyCommand).start();
+        copyProcess.waitFor();
+        super.preBuild(buildArgs);
+    }
+
+    @Override
+    protected String[] getBuildCommand(List<String> args) {
+        return new String[] { containerRuntime.getExecutableName(), "start", "--attach", containerId };
+    }
+
+    @Override
+    protected void postBuild() throws InterruptedException, IOException {
+        String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp",
+                containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + "/" + nativeImageName, outputPath };
+        Process copyProcess = new ProcessBuilder(copyCommand).start();
+        copyProcess.waitFor();
+        String[] removeCommand = new String[] { containerRuntime.getExecutableName(), "container", "rm", "--volumes",
+                containerId };
+        Process removeProcess = new ProcessBuilder(removeCommand).start();
+        removeProcess.waitFor();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -1,0 +1,62 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM;
+import io.quarkus.deployment.util.ProcessUtil;
+
+public abstract class NativeImageBuildRunner {
+
+    public GraalVM.Version getGraalVMVersion() {
+        final GraalVM.Version graalVMVersion;
+        try {
+            String[] versionCommand = getGraalVMVersionCommand(Collections.singletonList("--version"));
+            Process versionProcess = new ProcessBuilder(versionCommand)
+                    .redirectErrorStream(true)
+                    .start();
+            versionProcess.waitFor();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(versionProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                graalVMVersion = GraalVM.Version.of(reader.lines());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get GraalVM version", e);
+        }
+        return graalVMVersion;
+    }
+
+    public void setup(boolean processInheritIODisabled) {
+    }
+
+    public void cleanupServer(File outputDir, boolean processInheritIODisabled) throws InterruptedException, IOException {
+    }
+
+    public int build(List<String> args, Path outputDir, boolean processInheritIODisabled)
+            throws InterruptedException, IOException {
+        CountDownLatch errorReportLatch = new CountDownLatch(1);
+        final ProcessBuilder processBuilder = new ProcessBuilder(getBuildCommand(args))
+                .directory(outputDir.toFile());
+        final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.submit(new ErrorReplacingProcessReader(process.getErrorStream(), outputDir.resolve("reports").toFile(),
+                errorReportLatch));
+        executor.shutdown();
+        errorReportLatch.await();
+        return process.waitFor();
+    }
+
+    protected abstract String[] getGraalVMVersionCommand(List<String> args);
+
+    protected abstract String[] getBuildCommand(List<String> args);
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -87,7 +87,7 @@ public class NativeImageBuildStep {
 
         String noPIE = "";
 
-        boolean isContainerBuild = nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild;
+        boolean isContainerBuild = isContainerBuild(nativeConfig);
         if (!isContainerBuild && SystemUtils.IS_OS_LINUX) {
             noPIE = detectNoPIE();
         }
@@ -287,10 +287,13 @@ public class NativeImageBuildStep {
         }
     }
 
+    public static boolean isContainerBuild(NativeConfig nativeConfig) {
+        return nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild || nativeConfig.remoteContainerBuild;
+    }
+
     private static NativeImageBuildRunner getNativeImageBuildRunner(NativeConfig nativeConfig, Path outputDir,
             String nativeImageName) {
-        boolean isContainerBuild = nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild;
-        if (!isContainerBuild) {
+        if (!isContainerBuild(nativeConfig)) {
             NativeImageBuildLocalRunner localRunner = getNativeImageBuildLocalRunner(nativeConfig);
             if (localRunner != null) {
                 return localRunner;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -316,22 +316,7 @@ public class NativeImageBuildStep {
             Path outputDir) {
         boolean isContainerBuild = nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild;
         if (!isContainerBuild) {
-            Optional<String> graal = nativeConfig.graalvmHome;
-            File java = nativeConfig.javaHome;
-            if (java == null) {
-                // try system property first - it will be the JAVA_HOME used by the current JVM
-                String home = System.getProperty(JAVA_HOME_SYS);
-                if (home == null) {
-                    // No luck, somewhat a odd JVM not enforcing this property
-                    // try with the JAVA_HOME environment variable
-                    home = System.getenv(JAVA_HOME_ENV);
-                }
-
-                if (home != null) {
-                    java = new File(home);
-                }
-            }
-            List<String> nativeImageExecutable = getNativeImageExecutable(graal, java);
+            List<String> nativeImageExecutable = getNativeImageExecutable(nativeConfig);
             if (nativeImageExecutable != null) {
                 return nativeImageExecutable;
             }
@@ -589,12 +574,27 @@ public class NativeImageBuildStep {
         }
     }
 
-    private static List<String> getNativeImageExecutable(Optional<String> graalVmHome, File javaHome) {
+    private static List<String> getNativeImageExecutable(NativeConfig nativeConfig) {
         String executableName = getNativeImageExecutableName();
-        if (graalVmHome.isPresent()) {
-            File file = Paths.get(graalVmHome.get(), "bin", executableName).toFile();
+        if (nativeConfig.graalvmHome.isPresent()) {
+            File file = Paths.get(nativeConfig.graalvmHome.get(), "bin", executableName).toFile();
             if (file.exists()) {
                 return Collections.singletonList(file.getAbsolutePath());
+            }
+        }
+
+        File javaHome = nativeConfig.javaHome;
+        if (javaHome == null) {
+            // try system property first - it will be the JAVA_HOME used by the current JVM
+            String home = System.getProperty(JAVA_HOME_SYS);
+            if (home == null) {
+                // No luck, somewhat a odd JVM not enforcing this property
+                // try with the JAVA_HOME environment variable
+                home = System.getenv(JAVA_HOME_ENV);
+            }
+
+            if (home != null) {
+                javaHome = new File(home);
             }
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -315,9 +315,7 @@ public class NativeImageBuildStep {
             Optional<ProcessInheritIODisabled> processInheritIODisabled,
             Path outputDir) {
         boolean isContainerBuild = nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild;
-        if (isContainerBuild) {
-            return setupContainerBuild(nativeConfig, processInheritIODisabled, outputDir);
-        } else {
+        if (!isContainerBuild) {
             Optional<String> graal = nativeConfig.graalvmHome;
             File java = nativeConfig.javaHome;
             if (java == null) {
@@ -335,6 +333,7 @@ public class NativeImageBuildStep {
             }
             return getNativeImageExecutable(graal, java, nativeConfig, processInheritIODisabled, outputDir);
         }
+        return setupContainerBuild(nativeConfig, processInheritIODisabled, outputDir);
     }
 
     public static List<String> setupContainerBuild(NativeConfig nativeConfig,

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.steps.NativeImageBuildStep;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsProducer;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRecorder;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
@@ -116,7 +117,7 @@ class KafkaStreamsProcessor {
 
     private void addSupportForRocksDbLib(BuildProducer<NativeImageResourceBuildItem> nativeLibs, NativeConfig nativeConfig) {
         // for RocksDB, either add linux64 native lib when targeting containers
-        if (nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild) {
+        if (NativeImageBuildStep.isContainerBuild(nativeConfig)) {
             nativeLibs.produce(new NativeImageResourceBuildItem("librocksdbjni-linux64.so"));
         }
         // otherwise the native lib of the platform this build runs on


### PR DESCRIPTION
Container builds for native images on a *remote* docker host are currently not possible (#1610). The issue is that the native build step mounts a volume to the build container containing the sources for the native image build and to which the final native image is written back to the host. However, volume mounts are not available for remote docker daemons. Still, using remote docker daemons is a pretty common scenario.

I outlined a solution to this problem in a comment on the above mentioned issue https://github.com/quarkusio/quarkus/issues/1610#issuecomment-674521423, which is to copy the build sources into the container as well as copy the final native image out of the container back to the host, instead of using the volume mount.

This PR introduces separate runners for native image builds. The `NativeImageBuildStep` class now acts as a driver for the different native image build runners (local and containerized). Moreover, thanks to this new driver/runner structure, a new runner for containerized native image builds on remote docker daemon is provided as well, implementing the above mentioned strategy fixing #1610. It can be enabled with the new property `quarkus.native.remote-container-build=true`. Please note that due to a permission problem, the new runner does not work with the officially provided native build docker images yet (see PR https://github.com/quarkusio/quarkus-images/pull/128).

In the future, more runners could easily be added, e.g. a runner using the docker-java library (https://github.com/docker-java/docker-java) for communicating with docker, instead of explicitly invoking the docker CLI.

Resolves: #1610 