### PR TITLE
Revert "Use proper config phase for JacksonBuildTimeConfig"

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -29,9 +29,12 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -43,6 +46,9 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.jackson.runtime.JacksonBuildTimeConfig;
+import io.quarkus.jackson.runtime.JacksonConfigSupport;
+import io.quarkus.jackson.runtime.JacksonRecorder;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
@@ -166,6 +172,16 @@ public class JacksonProcessor {
             classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(moduleClassName));
         } catch (Exception ignored) {
         }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    SyntheticBeanBuildItem pushConfigurationBean(JacksonRecorder jacksonRecorder,
+            JacksonBuildTimeConfig jacksonBuildTimeConfig) {
+        return SyntheticBeanBuildItem.configure(JacksonConfigSupport.class)
+                .scope(Singleton.class)
+                .supplier(jacksonRecorder.jacksonConfigSupport(jacksonBuildTimeConfig))
+                .done();
     }
 
     // Generate a ObjectMapperCustomizer bean that registers each serializer / deserializer as well as detected modules with the ObjectMapper

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -1,10 +1,9 @@
 package io.quarkus.jackson.runtime;
 
 import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot
 public class JacksonBuildTimeConfig {
 
     /**

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
@@ -1,0 +1,14 @@
+package io.quarkus.jackson.runtime;
+
+public class JacksonConfigSupport {
+
+    private boolean failOnUnknownProperties;
+
+    public JacksonConfigSupport(boolean failOnUnknownProperties) {
+        this.failOnUnknownProperties = failOnUnknownProperties;
+    }
+
+    public boolean isFailOnUnknownProperties() {
+        return failOnUnknownProperties;
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
@@ -1,0 +1,19 @@
+package io.quarkus.jackson.runtime;
+
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class JacksonRecorder {
+
+    public Supplier<JacksonConfigSupport> jacksonConfigSupport(JacksonBuildTimeConfig jacksonBuildTimeConfig) {
+        return new Supplier<JacksonConfigSupport>() {
+
+            @Override
+            public JacksonConfigSupport get() {
+                return new JacksonConfigSupport(jacksonBuildTimeConfig.failOnUnknownProperties);
+            }
+        };
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -22,9 +22,9 @@ public class ObjectMapperProducer {
     @Singleton
     @Produces
     public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers,
-            JacksonBuildTimeConfig jacksonBuildTimeConfig) {
+            JacksonConfigSupport jacksonConfigSupport) {
         ObjectMapper objectMapper = new ObjectMapper();
-        if (!jacksonBuildTimeConfig.failOnUnknownProperties) {
+        if (!jacksonConfigSupport.isFailOnUnknownProperties()) {
             // this feature is enabled by default, so we disable it
             objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         }

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -25,10 +25,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
@@ -120,19 +116,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Reverts quarkusio/quarkus#14588

It seems like this is causing problems to application that use the `quarkus-kubernetes` extension.
Until I have time to find the root cause of that problem, we need to revert