### PR TITLE
Scan super classes for config items

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
@@ -5,7 +5,6 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.comp
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.deriveConfigRootName;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,15 +31,17 @@ final public class ConfigDocItemScanner {
     private final Map<String, TypeElement> configGroupsToTypeElement = new HashMap<>();
 
     private final FsMap allExtensionGeneratedDocs;
-    private final Path allConfigurationGroupsDir = Constants.GENERATED_DOCS_PATH
-            .resolve("all-configuration-groups-generated-doc");
+    private final FsMap allConfigGroupGeneratedDocs;
     private final FsMultiMap configurationRootsParExtensionFileName;
 
     public ConfigDocItemScanner() {
         this.allExtensionGeneratedDocs = new FsMap(Constants.GENERATED_DOCS_PATH
                 .resolve("all-configuration-roots-generated-doc"));
+        this.allConfigGroupGeneratedDocs = new FsMap(Constants.GENERATED_DOCS_PATH
+                .resolve("all-configuration-groups-generated-doc"));
         this.configurationRootsParExtensionFileName = new FsMultiMap(Constants.GENERATED_DOCS_PATH
                 .resolve("extensions-configuration-roots-list"));
+
     }
 
     /**
@@ -108,7 +109,7 @@ final public class ConfigDocItemScanner {
 
         Set<ConfigDocGeneratedOutput> configDocGeneratedOutputs = new HashSet<>();
         final ConfigDoItemFinder configDoItemFinder = new ConfigDoItemFinder(configRoots, configGroupsToTypeElement,
-                javaDocProperties, allConfigurationGroupsDir);
+                javaDocProperties, allConfigGroupGeneratedDocs, allExtensionGeneratedDocs);
         final ScannedConfigDocsItemHolder inMemoryScannedItemsHolder = configDoItemFinder.findInMemoryConfigurationItems();
 
         if (!inMemoryScannedItemsHolder.isEmpty()) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -6,12 +6,13 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
+@ConfigGroup
 public class OidcCommonConfig {
     /**
-     * The base URL of the OpenID Connect (OIDC) server, for example, 'https://host:port/auth'.
+     * The base URL of the OpenID Connect (OIDC) server, for example, `https://host:port/auth`.
      * OIDC discovery endpoint will be called by default by appending a '.well-known/openid-configuration' path to this URL.
      * Note if you work with Keycloak OIDC server, make sure the base URL is in the following format:
-     * 'https://host:port/auth/realms/{realm}' where '{realm}' has to be replaced by the name of the Keycloak realm.
+     * `https://host:port/auth/realms/{realm}` where `{realm}` has to be replaced by the name of the Keycloak realm.
      */
     @ConfigItem
     public Optional<String> authServerUrl = Optional.empty();
@@ -39,9 +40,9 @@ public class OidcCommonConfig {
     /**
      * The maximum amount of time connecting to the currently unavailable OIDC server will be attempted for.
      * The number of times the connection request will be repeated is calculated by dividing the value of this property by 2.
-     * For example, setting it to '20S' will allow for requesting the connection up to 10 times with a 2 seconds delay between
+     * For example, setting it to `20S` will allow for requesting the connection up to 10 times with a 2 seconds delay between
      * the retries.
-     * Note the 'connection-timeout' property does not affect this amount of time.
+     * Note the `connection-timeout` property does not affect this amount of time.
      */
     @ConfigItem
     public Optional<Duration> connectionDelay = Optional.empty();
@@ -74,16 +75,16 @@ public class OidcCommonConfig {
     public static class Credentials {
 
         /**
-         * Client secret which is used for a 'client_secret_basic' authentication method.
+         * Client secret which is used for a `client_secret_basic` authentication method.
          * Note that a 'client-secret.value' can be used instead but both properties are mutually exclusive.
          */
         @ConfigItem
         public Optional<String> secret = Optional.empty();
 
         /**
-         * Client secret which can be used for the 'client_secret_basic' (default) and 'client_secret_post'
+         * Client secret which can be used for the `client_secret_basic` (default) and `client_secret_post`
          * and 'client_secret_jwt' authentication methods.
-         * Note that a 'secret.value' property can be used instead to support the 'client_secret_basic' method
+         * Note that a `secret.value` property can be used instead to support the `client_secret_basic` method
          * but both properties are mutually exclusive.
          */
         @ConfigItem


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/14626

Verify that the generated `quarkus-oidc.adoc` file now contains `auth-server-url` and other config items defined in [OidcCommonConfig](https://github.com/quarkusio/quarkus/blob/df5f7d27916db069d2bcc0744ced7e79d2b79584/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java)

/cc @sberyozkin for verification. 

/cc @miguelsorianod 