### PR TITLE
Update OKHTTP3 to v4.9.0 (v3.x -> v4.x)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -170,7 +170,7 @@
         <mongo-crypt.version>1.0.1</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
         <proton-j.version>0.33.8</proton-j.version>
-        <okhttp.version>3.14.9</okhttp.version>
+        <okhttp.version>4.9.0</okhttp.version>
         <sentry.version>3.2.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>


### PR DESCRIPTION
OkHTTP is referenced by the Quarkus BOM and is on a legacy v3 Java version. OkHTTP migrated fully to Kotlin in v4 with full backward compatibility to Java and v3.

https://square.github.io/okhttp/upgrading_to_okhttp_4/
