### PR TITLE
Add new "examples" parameter to Create & CreateProjectMojo 

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -21,15 +21,19 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-a",
             "--artifact-id" }, order = 2, paramLabel = "ARTIFACT-ID", description = "The artifactId for project")
-    String artifactId = "my-project";
+    String artifactId = "code-with-quarkus";
 
     @CommandLine.Option(names = { "-v",
             "--version" }, order = 3, paramLabel = "VERSION", description = "The version for project")
-    String version = "1.0-SNAPSHOT";
+    String version = "1.0.0-SNAPSHOT";
 
     @CommandLine.Option(names = { "-0",
             "--no-examples" }, order = 4, description = "Generate without example code.")
     boolean noExamples = false;
+
+    @CommandLine.Option(names = { "-e",
+            "--examples" }, order = 4, description = "Choose which example(s) you want in the generated Quarkus application.")
+    Set<String> examples;
 
     @CommandLine.ArgGroup()
     TargetBuildTool targetBuildTool = new TargetBuildTool();
@@ -114,6 +118,7 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
                             .artifactId(artifactId)
                             .version(version)
                             .sourceType(sourceType)
+                            .overrideExamples(examples)
                             .extensions(extensions)
                             .noExamples(noExamples)
                             .execute().isSuccess();

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
@@ -42,23 +42,23 @@ public class CliTest {
 
     @Test
     public void testCreateMavenDefaults() throws Exception {
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
 
         execute("create");
 
         Assertions.assertEquals(CommandLine.ExitCode.OK, exitCode);
-        Assertions.assertTrue(screen.contains("Project my-project created"));
+        Assertions.assertTrue(screen.contains("Project code-with-quarkus created"));
 
         Assertions.assertTrue(project.resolve("pom.xml").toFile().exists());
         String pom = readString(project.resolve("pom.xml"));
         Assertions.assertTrue(pom.contains("<groupId>org.acme</groupId>"));
-        Assertions.assertTrue(pom.contains("<artifactId>my-project</artifactId>"));
-        Assertions.assertTrue(pom.contains("<version>1.0-SNAPSHOT</version>"));
+        Assertions.assertTrue(pom.contains("<artifactId>code-with-quarkus</artifactId>"));
+        Assertions.assertTrue(pom.contains("<version>1.0.0-SNAPSHOT</version>"));
     }
 
     @Test
     public void testAddListRemove() throws Exception {
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
         testCreateMavenDefaults();
 
         execute("add");
@@ -146,7 +146,7 @@ public class CliTest {
         // Gradle list command cannot be screen captured with the current implementation
         // so I will just test good return values
         //
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
         testCreateGradleDefaults();
 
         execute("add");
@@ -251,20 +251,20 @@ public class CliTest {
 
     @Test
     public void testCreateGradleDefaults() throws Exception {
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
 
         execute("create", "--gradle");
 
         Assertions.assertEquals(CommandLine.ExitCode.OK, exitCode);
-        Assertions.assertTrue(screen.contains("Project my-project created"));
+        Assertions.assertTrue(screen.contains("Project code-with-quarkus created"));
 
         Assertions.assertTrue(project.resolve("build.gradle").toFile().exists());
         String pom = readString(project.resolve("build.gradle"));
         Assertions.assertTrue(pom.contains("group 'org.acme'"));
-        Assertions.assertTrue(pom.contains("version '1.0-SNAPSHOT'"));
+        Assertions.assertTrue(pom.contains("version '1.0.0-SNAPSHOT'"));
         Assertions.assertTrue(project.resolve("settings.gradle").toFile().exists());
         String settings = readString(project.resolve("settings.gradle"));
-        Assertions.assertTrue(settings.contains("my-project"));
+        Assertions.assertTrue(settings.contains("code-with-quarkus"));
 
     }
 
@@ -273,7 +273,7 @@ public class CliTest {
 
         execute("create", "--gradle", "resteasy");
 
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
         System.setProperty("user.dir", project.toFile().getAbsolutePath());
         Assertions.assertEquals(CommandLine.ExitCode.OK, exitCode);
 
@@ -290,7 +290,7 @@ public class CliTest {
 
         execute("create", "resteasy");
 
-        Path project = workspace.resolve("my-project");
+        Path project = workspace.resolve("code-with-quarkus");
         System.setProperty("user.dir", project.toFile().getAbsolutePath());
         Assertions.assertEquals(CommandLine.ExitCode.OK, exitCode);
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -81,8 +81,17 @@ public class CreateProjectMojo extends AbstractMojo {
     @Parameter(property = "legacyCodegen", defaultValue = "false")
     private boolean legacyCodegen;
 
+    /**
+     * When true, do not include any example code in the generated Quarkus project.
+     */
     @Parameter(property = "noExamples", defaultValue = "false")
     private boolean noExamples;
+
+    /**
+     * Choose which example(s) you want in the generated Quarkus application.
+     */
+    @Parameter(property = "examples")
+    private Set<String> examples;
 
     /**
      * Group ID of the target platform BOM
@@ -272,6 +281,7 @@ public class CreateProjectMojo extends AbstractMojo {
                     .className(className)
                     .packageName(packageName)
                     .extensions(extensions)
+                    .overrideExamples(examples)
                     .legacyCodegen(legacyCodegen)
                     .noExamples(noExamples);
             if (path != null) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -92,12 +92,15 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
         // Add codestarts from extension and for tooling
         projectInput.getSelection().addNames(getExtensionCodestarts(projectInput));
         projectInput.getSelection().addNames(getToolingCodestarts(projectInput));
+        projectInput.getSelection().addNames(projectInput.getOverrideExamples());
 
         projectInput.getData().putAll(generateSelectedExtensionsData(projectInput));
 
         // Filter out examples if noExamples
         final List<Codestart> projectCodestarts = super.select(projectInput).stream()
                 .filter(c -> !isExample(c) || !projectInput.noExamples())
+                .filter(c -> !isExample(c) || projectInput.getOverrideExamples().isEmpty()
+                        || c.isSelected(projectInput.getOverrideExamples()))
                 .collect(Collectors.toCollection(ArrayList::new));
 
         // include default example codestarts if none selected

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInput.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInput.java
@@ -6,10 +6,12 @@ import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.codestarts.CodestartProjectInput;
 import io.quarkus.devtools.project.BuildTool;
 import java.util.Collection;
+import java.util.Set;
 
 public final class QuarkusCodestartProjectInput extends CodestartProjectInput {
     private final BuildTool buildTool;
     private final Collection<AppArtifactCoords> extensions;
+    private final Set<String> overrideExamples;
     private final boolean noExamples;
     private final boolean noDockerfiles;
     private final boolean noBuildToolWrapper;
@@ -17,6 +19,7 @@ public final class QuarkusCodestartProjectInput extends CodestartProjectInput {
     public QuarkusCodestartProjectInput(QuarkusCodestartProjectInputBuilder builder) {
         super(builder);
         this.extensions = builder.extensions;
+        this.overrideExamples = builder.overrideExamples;
         this.buildTool = requireNonNull(builder.buildTool, "buildTool is required");
         this.noExamples = builder.noExamples;
         this.noDockerfiles = builder.noDockerfiles;
@@ -29,6 +32,10 @@ public final class QuarkusCodestartProjectInput extends CodestartProjectInput {
 
     public Collection<AppArtifactCoords> getExtensions() {
         return extensions;
+    }
+
+    public Set<String> getOverrideExamples() {
+        return overrideExamples;
     }
 
     public boolean noExamples() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
@@ -11,11 +11,14 @@ import io.quarkus.devtools.project.extensions.Extensions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class QuarkusCodestartProjectInputBuilder extends CodestartProjectInputBuilder {
-    public Collection<AppArtifactCoords> extensions = new ArrayList<>();
+    Collection<AppArtifactCoords> extensions = new ArrayList<>();
+    Set<String> overrideExamples = new HashSet<>();
     boolean noExamples;
     boolean noDockerfiles;
     boolean noBuildToolWrapper;
@@ -37,6 +40,16 @@ public class QuarkusCodestartProjectInputBuilder extends CodestartProjectInputBu
 
     public QuarkusCodestartProjectInputBuilder addExtension(AppArtifactKey extension) {
         return this.addExtension(Extensions.toCoords(extension, null));
+    }
+
+    public QuarkusCodestartProjectInputBuilder addOverrideExamples(Collection<String> overrideExamples) {
+        this.overrideExamples.addAll(overrideExamples);
+        return this;
+    }
+
+    public QuarkusCodestartProjectInputBuilder addExample(String overrideExample) {
+        this.overrideExamples.add(overrideExample);
+        return this;
     }
 
     @Override

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -38,6 +38,7 @@ public class CreateProject {
     public static final String NO_BUILDTOOL_WRAPPER = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-buildtool-wrapper");
     public static final String NO_EXAMPLES = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-examples");
     public static final String CODESTARTS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "codestarts");
+    public static final String OVERRIDE_EXAMPLES = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "examples");
 
     private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("(?:1\\.)?(\\d+)(?:\\..*)?");
 
@@ -131,6 +132,11 @@ public class CreateProject {
 
     public CreateProject codestarts(Set<String> codestarts) {
         setValue(CODESTARTS, codestarts);
+        return this;
+    }
+
+    public CreateProject overrideExamples(Set<String> overrideExamples) {
+        setValue(OVERRIDE_EXAMPLES, overrideExamples);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -4,6 +4,7 @@ import static io.quarkus.devtools.commands.CreateProject.CODESTARTS;
 import static io.quarkus.devtools.commands.CreateProject.NO_BUILDTOOL_WRAPPER;
 import static io.quarkus.devtools.commands.CreateProject.NO_DOCKERFILES;
 import static io.quarkus.devtools.commands.CreateProject.NO_EXAMPLES;
+import static io.quarkus.devtools.commands.CreateProject.OVERRIDE_EXAMPLES;
 import static io.quarkus.devtools.commands.handlers.QuarkusCommandHandlers.computeCoordsFromQuery;
 import static io.quarkus.devtools.project.codegen.ProjectGenerator.BOM_ARTIFACT_ID;
 import static io.quarkus.devtools.project.codegen.ProjectGenerator.BOM_GROUP_ID;
@@ -88,6 +89,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
             final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                     .addExtensions(extensionsToAdd)
                     .buildTool(invocation.getQuarkusProject().getBuildTool())
+                    .addOverrideExamples(invocation.getValue(OVERRIDE_EXAMPLES, new HashSet<>()))
                     .addCodestarts(invocation.getValue(CODESTARTS, new HashSet<>()))
                     .noExamples(invocation.getValue(NO_EXAMPLES, false))
                     .noBuildToolWrapper(invocation.getValue(NO_BUILDTOOL_WRAPPER, false))


### PR DESCRIPTION
Closes #12957

This PR also change the defaults when creating a project with the Quarkus CLI (to follow other Quarkus tools):
- use `code-with-quarkus` as default project name
- use `1.0.0-SNAPSHOT` as default project version