### PR TITLE
Enable vertx providers only when Jackson is present

### DIFF
--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -48,8 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -31,6 +31,10 @@ import io.quarkus.resteasy.runtime.JaxRsSecurityConfig;
 import io.quarkus.resteasy.runtime.NotFoundExceptionMapper;
 import io.quarkus.resteasy.runtime.SecurityContextFilter;
 import io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper;
+import io.quarkus.resteasy.runtime.vertx.JsonArrayReader;
+import io.quarkus.resteasy.runtime.vertx.JsonArrayWriter;
+import io.quarkus.resteasy.runtime.vertx.JsonObjectReader;
+import io.quarkus.resteasy.runtime.vertx.JsonObjectWriter;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentBuildItem;
 import io.quarkus.security.spi.AdditionalSecuredClassesBuildIem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
@@ -83,6 +87,16 @@ public class ResteasyBuiltinsProcessor {
         if (capabilities.isPresent(Capability.SECURITY)) {
             providers.produce(new ResteasyJaxrsProviderBuildItem(SecurityContextFilter.class.getName()));
             additionalBeanBuildItem.produce(AdditionalBeanBuildItem.unremovableOf(SecurityContextFilter.class));
+        }
+    }
+
+    @BuildStep
+    void vertxProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, Capabilities capabilities) {
+        if (capabilities.isPresent(Capability.JACKSON)) {
+            providers.produce(new ResteasyJaxrsProviderBuildItem(JsonArrayReader.class.getName()));
+            providers.produce(new ResteasyJaxrsProviderBuildItem(JsonArrayWriter.class.getName()));
+            providers.produce(new ResteasyJaxrsProviderBuildItem(JsonObjectReader.class.getName()));
+            providers.produce(new ResteasyJaxrsProviderBuildItem(JsonObjectWriter.class.getName()));
         }
     }
 

--- a/extensions/resteasy/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/extensions/resteasy/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,4 +1,0 @@
-io.quarkus.resteasy.runtime.vertx.JsonObjectWriter
-io.quarkus.resteasy.runtime.vertx.JsonArrayWriter
-io.quarkus.resteasy.runtime.vertx.JsonObjectReader
-io.quarkus.resteasy.runtime.vertx.JsonArrayReader


### PR DESCRIPTION
These providers only work when Jackson databind is on the classpath
so we should not enable them otherwise