### PR TITLE
Also add the rest-client-jackson extension in the REST Client doc

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -41,23 +41,21 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-client-quickstart \
     -DclassName="org.acme.rest.client.CountriesResource" \
     -Dpath="/country" \
-    -Dextensions="resteasy,rest-client,resteasy-jackson"
+    -Dextensions="resteasy,resteasy-jackson,rest-client,rest-client-jackson"
 cd rest-client-quickstart
 ----
 
-This command generates the Maven project with a REST endpoint and imports the `rest-client` and `resteasy-jackson` extensions.
+This command generates the Maven project with a REST endpoint and imports:
 
-[NOTE]
-====
-If your application does not expose any JAX-RS endpoints (eg. a link:command-mode-reference[command mode application]), use the `rest-client-jackson` or the `rest-client-jackson` extension instead.
-====
+* the `resteasy` and `resteasy-jackson` extensions for the REST server support;
+* the `rest-client` and `rest-client-jackson` extensions for the REST client support.
 
 If you already have your Quarkus project configured, you can add the `rest-client` and the `rest-client-jackson` extensions
 to your project by running the following command in your project base directory:
 
 [source,bash]
 ----
-./mvnw quarkus:add-extension -Dextensions="rest-client,resteasy-jackson"
+./mvnw quarkus:add-extension -Dextensions="rest-client,rest-client-jackson"
 ----
 
 This will add the following to your `pom.xml`:
@@ -70,7 +68,7 @@ This will add the following to your `pom.xml`:
 </dependency>
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
+    <artifactId>quarkus-rest-client-jackson</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
We had users trying this guide/quickstart with RESTEasy Reactive and if
switching to RESTEasy Reactive, the RESTEasy classic Jackson support is
missing.