### PR TITLE
Use 127.0.0.1 as MongoDB hosts

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
@@ -77,7 +77,7 @@ public class MongoMetricsTest extends MongoTestBase {
 
     private Tag[] getTags() {
         return new Tag[] {
-                new Tag("host", "localhost"),
+                new Tag("host", "127.0.0.1"),
                 new Tag("port", "27018"),
         };
     }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -16,7 +16,6 @@ import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.runtime.Network;
 
 public class MongoTestBase {
 
@@ -56,7 +55,7 @@ public class MongoTestBase {
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
             IMongodConfig config = new MongodConfigBuilder()
                     .version(version)
-                    .net(new Net(port, Network.localhostIsIPv6()))
+                    .net(new Net("127.0.0.1", port, false))
                     .build();
             MONGO = getMongodExecutable(config);
             try {

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -31,7 +31,6 @@ import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.runtime.Network;
 
 public class MongoWithReplicasTestBase {
 
@@ -46,7 +45,7 @@ public class MongoWithReplicasTestBase {
             List<IMongodConfig> configs = new ArrayList<>();
             for (int i = 0; i < 2; i++) {
                 int port = 27018 + i;
-                configs.add(buildMongodConfiguration("localhost", port, true));
+                configs.add(buildMongodConfiguration("127.0.0.1", port, true));
             }
             configs.forEach(config -> {
                 MongodExecutable exec = getMongodExecutable(config);
@@ -184,7 +183,7 @@ public class MongoWithReplicasTestBase {
         }
         final MongodConfigBuilder builder = new MongodConfigBuilder()
                 .version(Version.Main.V4_0)
-                .net(new Net(url, port, Network.localhostIsIPv6()));
+                .net(new Net(url, port, false));
         if (configureReplicaSet) {
             builder.withLaunchArgument("--replSet", "test001");
             builder.cmdOptions(new MongoCmdOptionsBuilder()

--- a/extensions/mongodb-client/deployment/src/test/resources/application-default-and-named-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-default-and-named-mongoclient.properties
@@ -1,2 +1,2 @@
-quarkus.mongodb.connection-string=mongodb://localhost:27018
-quarkus.mongodb.cluster2.connection-string=mongodb://localhost:27019
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.cluster2.connection-string=mongodb://127.0.0.1:27019

--- a/extensions/mongodb-client/deployment/src/test/resources/application-metrics-mongo.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-metrics-mongo.properties
@@ -1,2 +1,2 @@
-quarkus.mongodb.connection-string=mongodb://localhost:27018
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
 quarkus.mongodb.metrics.enabled=true

--- a/extensions/mongodb-client/deployment/src/test/resources/application-named-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-named-mongoclient.properties
@@ -1,2 +1,2 @@
-quarkus.mongodb.cluster1.connection-string=mongodb://localhost:27018
-quarkus.mongodb.cluster2.connection-string=mongodb://localhost:27019
+quarkus.mongodb.cluster1.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.cluster2.connection-string=mongodb://127.0.0.1:27019

--- a/extensions/mongodb-client/deployment/src/test/resources/default-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/default-mongoclient.properties
@@ -1,1 +1,1 @@
-quarkus.mongodb.connection-string=mongodb://localhost:27018
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018

--- a/extensions/mongodb-client/deployment/src/test/resources/named-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/named-mongoclient.properties
@@ -1,2 +1,2 @@
-quarkus.mongodb.connection-string=mongodb://localhost:27018
-quarkus.mongodb.second.connection-string=mongodb://localhost:27018
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.second.connection-string=mongodb://127.0.0.1:27018


### PR DESCRIPTION
I don't know what's going on but I have some of the tests not connecting
properly using localhost and using 127.0.0.1 fixes it.

It's probably related to a weird issue with IPv6 but I think it's a
simple enough fix and it should work everywhere.