### PR TITLE
Propagate the `IllegalArgumentException` that can be produced by `org.jboss.jandex.Indexer#index` when the given input-stream is `null`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -82,7 +82,7 @@ public class IndexingUtil {
             try (InputStream stream = IoUtil.readClass(classLoader, beanClass)) {
                 beanInfo = indexer.index(stream);
                 additionalIndex.add(beanInfo.name());
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new IllegalStateException("Failed to index: " + beanClass, e);
             }
         } else {


### PR DESCRIPTION
Propagate the `IllegalArgumentException` that can be produced by `org.jboss.jandex.Indexer#index` when the given input-stream is `null`