### PR TITLE
[WIP] Use Vertx Json codec in Vault extension

### DIFF
--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/VaultModel.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/VaultModel.java
@@ -1,4 +1,7 @@
 package io.quarkus.vault.runtime.client.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface VaultModel {
 }


### PR DESCRIPTION
Remove the Jackson `ObjectMapper` in `VertxVaultClient` and rely solely on the json mapping capabilitées offered by `vertx`:

 - https://vertx.io/docs/vertx-web-client/java/#_json_bodies
 -  https://vertx.io/docs/vertx-web-client/java/#_decoding_responses

cf https://github.com/vert-x3/vertx-config/blob/master/vertx-config-vault/src/main/java/io/vertx/config/vault/client/SlimVaultClient.java