### PR TITLE
Safer Annotations

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,6 +54,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-utils.version>2.5.1</smallrye-reactive-utils.version>
         <smallrye-reactive-messaging.version>3.2.0</smallrye-reactive-messaging.version>
+        <smallrye-safer-annotations.version>1.0.3</smallrye-safer-annotations.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
@@ -4046,6 +4047,11 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-transaction-spi</artifactId>
                 <version>${jboss-transaction-spi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-safer-annotations</artifactId>
+                <version>${smallrye-safer-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus.arc</groupId>

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -915,6 +915,47 @@ It is important to note that this customization is only performed for the serial
 Here are some more advanced topics that you may not need to know about initially, but
 could prove useful for more complex use cases.
 
+=== Better error messages in your source files
+
+In order to get better type safety and error messages directly in your IDE, RESTEasy Reactive uses the
+https://github.com/smallrye/smallrye-safer-annotations[SmallRye Safer Annotations] compiler plugin, which
+you will get automatically as soon as you import the `quarkus-resteasy-reactive` extension.
+
+If you are using the Eclipse IDE, you may want to install the https://marketplace.eclipse.org/content/m2e-apt[M2E APT]
+plugin and enable it by adding this property to your `pom.xml`:
+
+[source,xml]
+----
+<properties>
+    <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+</properties>
+----
+
+Note that if you configure any compiler plugin manually via `annotationProcessorPaths` you
+will need to list `smallrye-safer-annotations` explicitely as it will not be picked up
+from the transitive classpath anymore:
+
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${compiler-plugin.version}</version>
+            <configuration>
+                <annotationProcessorPaths>
+                    <annotationProcessorPath>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-safer-annotations</artifactId>
+                        <version>1.0.2</version>
+                    </annotationProcessorPath>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----
+
 === Execution model, blocking, non-blocking
 
 [[execution-model]]

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/pom.xml
@@ -111,6 +111,24 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id></id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>io.smallrye</groupId>
+                                    <artifactId>smallrye-safer-annotations</artifactId>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
@@ -48,6 +48,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-safer-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerExceptionMapperOverride.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerExceptionMapperOverride.java
@@ -1,0 +1,37 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.safer.annotations.DefinitionOverride;
+import io.smallrye.safer.annotations.OverrideTarget;
+import io.smallrye.safer.annotations.TargetMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Adds the following allowed parameters to the Safer-Annotations type checking
+ * - RoutingContext
+ * - HttpServerRequest
+ */
+@OverrideTarget(ServerExceptionMapper.class)
+@TargetMethod(returnTypes = { Response.class, UniResponse.class }, parameterTypes = {
+        ContainerRequestContext.class, UriInfo.class, HttpHeaders.class, Request.class,
+        ResourceInfo.class, SimpleResourceInfo.class, RoutingContext.class, ThrowableSubtype.class, HttpServerRequest.class })
+public class ServerExceptionMapperOverride implements DefinitionOverride {
+
+}
+
+class UniResponse extends TargetMethod.GenericType<Uni<Response>> {
+}
+
+class ThrowableSubtype extends TargetMethod.Subtype<Throwable> {
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerRequestFilterOverride.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerRequestFilterOverride.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import java.util.Optional;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.safer.annotations.DefinitionOverride;
+import io.smallrye.safer.annotations.OverrideTarget;
+import io.smallrye.safer.annotations.TargetMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Adds the following allowed parameters to the Safer-Annotations type checking
+ * - RoutingContext
+ * - HttpServerRequest
+ */
+@OverrideTarget(ServerRequestFilter.class)
+@TargetMethod(returnTypes = { void.class, Response.class, UniResponse.class, UniVoid.class,
+        OptionalResponse.class }, parameterTypes = {
+                ContainerRequestContext.class, UriInfo.class, HttpHeaders.class, Request.class,
+                ResourceInfo.class, SimpleResourceInfo.class, ResteasyReactiveContainerRequestContext.class,
+                RoutingContext.class,
+                HttpServerRequest.class })
+public class ServerRequestFilterOverride implements DefinitionOverride {
+
+}
+
+class UniVoid extends TargetMethod.GenericType<Uni<Void>> {
+}
+
+class OptionalResponse extends TargetMethod.GenericType<Optional<Response>> {
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerResponseFilterOverride.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ServerResponseFilterOverride.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
+
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
+
+import io.smallrye.safer.annotations.DefinitionOverride;
+import io.smallrye.safer.annotations.OverrideTarget;
+import io.smallrye.safer.annotations.TargetMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Adds the following allowed parameters to the Safer-Annotations type checking
+ * - RoutingContext
+ * - HttpServerRequest
+ */
+@OverrideTarget(ServerResponseFilter.class)
+@TargetMethod(returnTypes = { void.class, UniVoid.class }, parameterTypes = {
+        ContainerRequestContext.class,
+        ContainerResponseContext.class,
+        ResteasyReactiveContainerRequestContext.class,
+        ResourceInfo.class, SimpleResourceInfo.class, Throwable.class, RoutingContext.class,
+        HttpServerRequest.class })
+public class ServerResponseFilterOverride implements DefinitionOverride {
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/resources/META-INF/services/io.smallrye.safer.annotations.DefinitionOverride
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/resources/META-INF/services/io.smallrye.safer.annotations.DefinitionOverride
@@ -1,0 +1,3 @@
+io.quarkus.resteasy.reactive.server.runtime.ServerExceptionMapperOverride
+io.quarkus.resteasy.reactive.server.runtime.ServerRequestFilterOverride
+io.quarkus.resteasy.reactive.server.runtime.ServerResponseFilterOverride

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -52,6 +52,7 @@
         <jakarta.json.version>1.1.6</jakarta.json.version>
         <mutiny.version>0.17.0</mutiny.version>
         <smallrye-common.version>1.6.0</smallrye-common.version>
+        <smallrye-safer-annotations.version>1.0.3</smallrye-safer-annotations.version>
         <vertx.version>4.0.3</vertx.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
@@ -162,6 +163,12 @@
                 <version>${smallrye-common.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-safer-annotations</artifactId>
+                <version>${smallrye-safer-annotations.version}</version>
             </dependency>
 
             <!-- JUnit 5 dependencies, imported as a BOM -->

--- a/independent-projects/resteasy-reactive/server/runtime/pom.xml
+++ b/independent-projects/resteasy-reactive/server/runtime/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-safer-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.resteasy.reactive</groupId>
             <artifactId>resteasy-reactive-common</artifactId>
         </dependency>

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.server;
 
+import io.smallrye.safer.annotations.TargetMethod;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,6 +10,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -34,6 +36,8 @@ import javax.ws.rs.core.UriInfo;
  * <li>{@link Request}
  * <li>{@link ResourceInfo}
  * <li>{@link SimpleResourceInfo}
+ * <li><tt>io.vertx.ext.web.RoutingContext</tt>
+ * <li><tt>io.vertx.core.http.HttpServerRequest</tt>
  * </ul>
  *
  * When {@code value} is not set, then the handled Exception type is deduced by the Exception type used in the method parameters
@@ -43,6 +47,9 @@ import javax.ws.rs.core.UriInfo;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@TargetMethod(returnTypes = { Response.class, UniResponse.class }, parameterTypes = {
+        ContainerRequestContext.class, UriInfo.class, HttpHeaders.class, Request.class,
+        ResourceInfo.class, SimpleResourceInfo.class, ThrowableSubtype.class })
 public @interface ServerExceptionMapper {
 
     Class<? extends Throwable>[] value() default {};
@@ -51,4 +58,7 @@ public @interface ServerExceptionMapper {
      * The priority with which the exception mapper will be executed
      */
     int priority() default Priorities.USER;
+}
+
+class ThrowableSubtype extends TargetMethod.Subtype<Throwable> {
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server;
 
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.safer.annotations.TargetMethod;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,7 +12,9 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
 
 /**
  * When used on a method, then an implementation of {@link javax.ws.rs.container.ContainerRequestFilter} is generated
@@ -48,6 +51,9 @@ import javax.ws.rs.core.UriInfo;
  * <li>{@link Request}
  * <li>{@link ResourceInfo}
  * <li>{@link SimpleResourceInfo}
+ * <li>{@link ResteasyReactiveContainerRequestContext}
+ * <li><tt>io.vertx.ext.web.RoutingContext</tt>
+ * <li><tt>io.vertx.core.http.HttpServerRequest</tt>
  * </ul>
  *
  * The return type of the method must be either be of type {@code void}, {@code Response}, {@code Optional<Response>},
@@ -74,6 +80,10 @@ import javax.ws.rs.core.UriInfo;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@TargetMethod(returnTypes = { void.class, Response.class, UniResponse.class, UniVoid.class,
+        OptionalResponse.class }, parameterTypes = {
+                ContainerRequestContext.class, UriInfo.class, HttpHeaders.class, Request.class,
+                ResourceInfo.class, SimpleResourceInfo.class, ResteasyReactiveContainerRequestContext.class })
 public @interface ServerRequestFilter {
 
     /**

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerResponseFilter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerResponseFilter.java
@@ -1,13 +1,18 @@
 package org.jboss.resteasy.reactive.server;
 
+import io.smallrye.mutiny.Uni;
+import io.smallrye.safer.annotations.TargetMethod;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
 
 /**
  * When used on a method, then an implementation of {@link javax.ws.rs.container.ContainerResponseContext} is generated
@@ -43,9 +48,12 @@ import javax.ws.rs.container.ResourceInfo;
  * <li>{@link ResourceInfo}
  * <li>{@link SimpleResourceInfo}
  * <li>{@link Throwable} - The thrown exception - or {@code null} if no exception was thrown
+ * <li>{@link ResteasyReactiveContainerRequestContext}
+ * <li><tt>io.vertx.ext.web.RoutingContext</tt>
+ * <li><tt>io.vertx.core.http.HttpServerRequest</tt>
  * </ul>
  *
- * The return type of the method must be either be of type {@code void} or {@code Uni<Void>}.
+ * The return type of the method must either be of type {@code void} or {@code Uni<Void>}.
  * <ul>
  * <li>{@code void} should be used when filtering does not need to perform any blocking operations.
  * <li>{@code Uni<Void>} should be used when filtering needs to perform a blocking operations.
@@ -57,10 +65,24 @@ import javax.ws.rs.container.ResourceInfo;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@TargetMethod(returnTypes = { void.class, UniVoid.class }, parameterTypes = {
+        ContainerRequestContext.class,
+        ContainerResponseContext.class,
+        ResteasyReactiveContainerRequestContext.class,
+        ResourceInfo.class, SimpleResourceInfo.class, Throwable.class })
 public @interface ServerResponseFilter {
 
     /**
      * The priority with which this response filter will be executed
      */
     int priority() default Priorities.USER;
+}
+
+class UniResponse extends TargetMethod.GenericType<Uni<Response>> {
+}
+
+class UniVoid extends TargetMethod.GenericType<Uni<Void>> {
+}
+
+class OptionalResponse extends TargetMethod.GenericType<Optional<Response>> {
 }


### PR DESCRIPTION
This PR introduces the io.quarkus.safer:safer-annotations module which allows for fine-grained annotation constraints, as an independent-project. And starts making RESTEasy Reactive use it.

Don't hesitate to provide feedback on module/package names, or anything else.