### PR TITLE
Update Kafka to 2.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,10 +138,10 @@
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <mutiny.version>0.14.0</mutiny.version>
         <mutiny-vertx.version>1.5.0</mutiny-vertx.version>
-        <kafka2.version>2.6.0</kafka2.version>
+        <kafka2.version>2.7.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
-        <scala.version>2.12.9</scala.version>
+        <scala.version>2.12.13</scala.version>
         <tika.version>1.24.1</tika.version>
         <ooxml-schemas.version>1.4</ooxml-schemas.version>
         <aws-lambda-java.version>1.2.1</aws-lambda-java.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <mutiny.version>0.14.0</mutiny.version>
         <mutiny-vertx.version>1.5.0</mutiny-vertx.version>
-        <kafka2.version>2.5.0</kafka2.version>
+        <kafka2.version>2.6.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.12.9</scala.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,14 +20,15 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <!-- Maven plugin versions -->
-        <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.4.31</kotlin.version>
-        <scala.version>2.12.8</scala.version>
-        <scala-plugin.version>4.1.1</scala-plugin.version>
+        <scala.version>2.12.13</scala.version>
+        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+        <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->
+        <scala-plugin.version>${scala-maven-plugin.version}</scala-plugin.version>
 
         <!-- version.* properties are defined in jboss-parent and are overridden/updated here: -->
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle-kotlin-dsl/codestart.yml
@@ -24,4 +24,4 @@ language:
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8
   scala:
     dependencies:
-      - org.scala-lang:scala-library:2.12.8
+      - org.scala-lang:scala-library:2.12.13

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/gradle/codestart.yml
@@ -24,4 +24,4 @@ language:
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8
   scala:
     dependencies:
-      - org.scala-lang:scala-library:2.12.8
+      - org.scala-lang:scala-library:2.12.13

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -69,6 +69,12 @@ class KafkaStreamsProcessor {
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, DefaultPartitionGrouper.class));
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, DefaultProductionExceptionHandler.class));
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, FailOnInvalidTimestamp.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
+                org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
+                org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
+                org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor.class));
     }
 
     private void registerClassesThatClientMaySpecify(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -33,8 +33,8 @@
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.3.72</kotlin.version>
-        <scala.version>2.12.8</scala.version>
-        <scala-plugin.version>4.1.1</scala-plugin.version>
+        <scala.version>2.12.13</scala.version>
+        <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
         <jline.version>2.14.6</jline.version>

--- a/integration-tests/kafka-streams/pom.xml
+++ b/integration-tests/kafka-streams/pom.xml
@@ -189,6 +189,19 @@
                 <quarkus.native.enable-all-security-services>true</quarkus.native.enable-all-security-services>
             </properties>
         </profile>
+        <!-- Skip the tests on Windows due to https://issues.apache.org/jira/browse/KAFKA-12190 -->
+        <profile>
+            <id>skip-tests-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
+++ b/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
@@ -11,8 +11,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <scala.version>2.12.8</scala.version>
-        <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
+        <scala.version>2.12.13</scala.version>
+        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
PR based on #14706 but extend the Kafka Streams Processor to register the Task Assignors implementation.