### PR TITLE
CI: Fix cancel-previous-runs in ci-fork-mvn-cache

### DIFF
--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci-fork-mvn-cache.yml
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Set up JDK 11


### PR DESCRIPTION
Fixes: `Error: Workflow must be specified for schedule event type`
E.g.: https://github.com/famod/quarkus/runs/1805656486?check_suite_focus=true