### PR TITLE
Less reflection in Hibernate Search extension

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchClasses.java
@@ -5,16 +5,11 @@ import java.util.List;
 
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonClasses;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMapping;
 import org.jboss.jandex.DotName;
 
 class HibernateSearchClasses {
 
     static final DotName INDEXED = DotName.createSimple(Indexed.class.getName());
-
-    static final DotName PROPERTY_MAPPING_META_ANNOTATION = DotName.createSimple(
-            org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping.class.getName());
-    static final DotName TYPE_MAPPING_META_ANNOTATION = DotName.createSimple(TypeMapping.class.getName());
 
     static final List<DotName> GSON_CLASSES = new ArrayList<>();
     static {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -24,7 +24,6 @@ import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateOrmIntegrationBoot
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.common.reflect.spi.ValueReadHandleFactory;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
@@ -136,7 +135,6 @@ public class HibernateSearchElasticsearchRecorder {
         public void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
                 BiConsumer<String, Object> propertyCollector) {
             HibernateOrmIntegrationBooter booter = HibernateOrmIntegrationBooter.builder(metadata, bootstrapContext)
-                    .valueReadHandleFactory(ValueReadHandleFactory.usingJavaLangReflect())
                     .build();
             booter.preBoot(propertyCollector);
         }


### PR DESCRIPTION
We don't need to enable runtime reflection on user classes, because:

1. We perform all reflection operations, except getting values from entities,
   at static init.
2. After static init, we hold references to all Methods/Fields that we
   will actually use at runtime. SubstrateVM is able to detect those and
   to properly build a native image that will handle calling invoke() on
   these Methods/Fields.

Also, now that we rely on GraalVM 21, we can move from Method/Field to MethodHandle.