### PR TITLE
Make classes that are used as @BeanParam targets unremoveable

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -66,6 +66,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.ClientProxyUnwrapper;
 import io.quarkus.deployment.Capabilities;
@@ -199,6 +200,17 @@ public class ResteasyReactiveProcessor {
     void registerCustomExceptionMappers(BuildProducer<CustomExceptionMapperBuildItem> customExceptionMapper) {
         customExceptionMapper.produce(new CustomExceptionMapperBuildItem(AuthenticationFailedExceptionMapper.class.getName()));
         customExceptionMapper.produce(new CustomExceptionMapperBuildItem(UnauthorizedExceptionMapper.class.getName()));
+    }
+
+    @BuildStep
+    public void unremoveableBeans(Optional<ResourceScanningResultBuildItem> resourceScanningResultBuildItem,
+            BuildProducer<UnremovableBeanBuildItem> unremoveableBeans) {
+        if (!resourceScanningResultBuildItem.isPresent()) {
+            return;
+        }
+        Set<String> beanParams = resourceScanningResultBuildItem.get().getResult()
+                .getBeanParams();
+        unremoveableBeans.produce(UnremovableBeanBuildItem.beanClassNames(beanParams.toArray(new String[0])));
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -330,7 +330,7 @@ public class SimpleQuarkusRestTestCase {
                 .queryParam("queryList", "two")
                 .queryParam("int", "666")
                 .get("/injection/field")
-                .then().body(Matchers.equalTo("OK"));
+                .then().statusCode(200).body(Matchers.equalTo("OK"));
         RestAssured
                 .with()
                 .header("header", "one-header")
@@ -339,7 +339,7 @@ public class SimpleQuarkusRestTestCase {
                 .queryParam("queryList", "two")
                 .queryParam("int", "666")
                 .get("/injection/param")
-                .then().body(Matchers.equalTo("OK"));
+                .then().statusCode(200).body(Matchers.equalTo("OK"));
     }
 
     @Test

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -417,7 +417,7 @@ public class RuntimeResourceDeployment {
             case CUSTOM:
                 return customExtractor;
             default:
-                throw new RuntimeException("Unkown param type: " + type);
+                throw new RuntimeException("Unknown param type: " + type);
         }
     }
 


### PR DESCRIPTION
This is needed because these classes are looked up from CDI
programmatically.

Fixes: #14715