### PR TITLE
Ensure that ServerStringMessageBodyHandler doesn't affect build time resolution of builders

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyWriter.java
@@ -1,6 +1,6 @@
 package io.quarkus.resteasy.reactive.jackson.runtime.serialisers;
 
-import static org.jboss.resteasy.reactive.server.vertx.providers.serialisers.json.JsonMessageBodyWriterUtil.*;
+import static org.jboss.resteasy.reactive.server.vertx.providers.serialisers.json.JsonMessageBodyWriterUtil.setContentTypeIfNecessary;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
 
-public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object> {
+public class JacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
     private static final String JSON_VIEW_NAME = JsonView.class.getName();
     private static final String CUSTOM_SERIALIZATION = CustomSerialization.class.getName();
@@ -63,11 +63,6 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return true;
-    }
-
-    @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         setContentTypeIfNecessary(httpHeaders);
@@ -85,11 +80,6 @@ public class JacksonMessageBodyWriter implements ServerMessageBodyWriter<Object>
             }
             entityStream.write(defaultWriter.writeValueAsBytes(o));
         }
-    }
-
-    @Override
-    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
-        return true;
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/java/io/quarkus/resteasy/reactive/jsonb/runtime/serialisers/JsonbMessageBodyWriter.java
@@ -13,22 +13,16 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
-import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-public class JsonbMessageBodyWriter implements ServerMessageBodyWriter<Object> {
+public class JsonbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
     private final Jsonb json;
 
     @Inject
     public JsonbMessageBodyWriter(Jsonb json) {
         this.json = json;
-    }
-
-    @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return true;
     }
 
     @Override
@@ -40,11 +34,6 @@ public class JsonbMessageBodyWriter implements ServerMessageBodyWriter<Object> {
         } else {
             json.toJson(o, type, entityStream);
         }
-    }
-
-    @Override
-    public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
-        return true;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.spi;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -15,4 +16,24 @@ public interface ServerMessageBodyWriter<T> extends MessageBodyWriter<T> {
 
     void writeResponse(T o, Type genericType, ServerRequestContext context) throws WebApplicationException, IOException;
 
+    /**
+     * A special super-class of MessageBodyWriters that accepts all types of input.
+     * The main purpose of this class is to allow runtime code
+     * to optimize for the case when there are multiple providers determined at build time
+     * but the first one will always be used
+     */
+    abstract class AllWriteableMessageBodyWriter implements ServerMessageBodyWriter<Object> {
+
+        @Override
+        public final boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target,
+                MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public final boolean isWriteable(Class<?> type, Type genericType,
+                Annotation[] annotations, MediaType mediaType) {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
By making certain writers extend AllWriteableMessageBodyWriter we can be certain that even in the presense
of multiple writers, RESTEasy Reactive can optimize itself to use only the first one

Fixes: #14720