### PR TITLE
Micrometer: rename vertx options to http-server

### DIFF
--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
+import javax.inject.Singleton;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -23,6 +25,7 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.DotNames;
@@ -47,7 +50,11 @@ import io.quarkus.micrometer.runtime.MicrometerCountedInterceptor;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.MicrometerTimed;
 import io.quarkus.micrometer.runtime.MicrometerTimedInterceptor;
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
+import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.metrics.MetricsFactory;
 
@@ -69,6 +76,31 @@ public class MicrometerProcessor {
 
         public boolean getAsBoolean() {
             return mConfig.enabled;
+        }
+    }
+
+    public static class HttpBinderEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+
+        public boolean getAsBoolean() {
+            return mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpServer) ||
+                    mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpClient);
+        }
+    }
+
+    public static class HttpServerBinderEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+
+        public boolean getAsBoolean() {
+            return mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpServer);
+        }
+    }
+
+    public static class HttpClientBinderEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+
+        public boolean getAsBoolean() {
+            return mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpClient);
         }
     }
 
@@ -183,6 +215,24 @@ public class MicrometerProcessor {
     void processAnnotatedMetrics(BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformers) {
         annotationsTransformers.produce(createAnnotationTransformer(COUNTED_ANNOTATION, COUNTED_BINDING));
         annotationsTransformers.produce(createAnnotationTransformer(TIMED_ANNOTATION, TIMED_BINDING));
+    }
+
+    @BuildStep(onlyIf = { MicrometerEnabled.class })
+    @Record(ExecutionTime.RUNTIME_INIT)
+    SyntheticBeanBuildItem enableHttpBinders(MicrometerRecorder recorder,
+            HttpServerConfig serverConfig,
+            HttpClientConfig clientConfig,
+            VertxConfig vertxConfig) {
+        return SyntheticBeanBuildItem
+                .configure(HttpBinderConfiguration.class)
+                .scope(Singleton.class)
+                .setRuntimeInit()
+                .unremovable()
+                .runtimeValue(recorder.configureHttpMetrics(
+                        mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpServer),
+                        mConfig.checkBinderEnabledWithDefault(mConfig.binder.httpClient),
+                        serverConfig, clientConfig, vertxConfig))
+                .done();
     }
 
     @BuildStep(onlyIf = MicrometerEnabled.class)

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/RestClientProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/RestClientProcessor.java
@@ -7,10 +7,11 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.micrometer.deployment.MicrometerProcessor;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 
-public class HttpClientProcessor {
+public class RestClientProcessor {
     // Avoid referencing optional dependencies
 
     // Rest client listener SPI
@@ -23,7 +24,7 @@ public class HttpClientProcessor {
     // Http Client runtime config (injected programmatically)
     private static final String REST_CLIENT_HTTP_CONFIG = "io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig";
 
-    static class HttpClientEnabled implements BooleanSupplier {
+    static class RestClientEnabled implements BooleanSupplier {
         MicrometerConfig mConfig;
 
         public boolean getAsBoolean() {
@@ -31,7 +32,7 @@ public class HttpClientProcessor {
         }
     }
 
-    @BuildStep(onlyIf = HttpClientEnabled.class)
+    @BuildStep(onlyIf = { RestClientEnabled.class, MicrometerProcessor.HttpClientBinderEnabled.class })
     UnremovableBeanBuildItem registerRestClientListener(BuildProducer<NativeImageResourceBuildItem> resource,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         resource.produce(new NativeImageResourceBuildItem(

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -12,7 +12,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
-import io.quarkus.micrometer.runtime.config.PrometheusConfig;
+import io.quarkus.micrometer.runtime.config.PrometheusConfigGroup;
 import io.quarkus.micrometer.runtime.export.PrometheusMeterRegistryProvider;
 import io.quarkus.micrometer.runtime.export.PrometheusRecorder;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
@@ -55,7 +55,7 @@ public class PrometheusRegistryProcessor {
             MicrometerConfig mConfig,
             PrometheusRecorder recorder) {
 
-        PrometheusConfig pConfig = mConfig.export.prometheus;
+        PrometheusConfigGroup pConfig = mConfig.export.prometheus;
         log.debug("PROMETHEUS CONFIG: " + pConfig);
 
         // Exact match for resources matched to the root path

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpDisabledTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
+import io.quarkus.micrometer.runtime.binder.vertx.VertxMeterBinderAdapter;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.SocketAddress;
+
+public class VertxWithHttpDisabledTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Instance<VertxMeterBinderAdapter> vertxMeterBinderAdapterInstance;
+
+    @Inject
+    HttpBinderConfiguration httpBinderConfiguration;
+
+    @Test
+    public void testVertxMetricsWithoutHttp() throws Exception {
+        Assertions.assertTrue(vertxMeterBinderAdapterInstance.isResolvable());
+        VertxMeterBinderAdapter adapter = vertxMeterBinderAdapterInstance.get();
+
+        // HttpServerMetrics should not be created (null returned) because
+        // Http server metrics are disabled
+        Assertions.assertNull(adapter.createHttpServerMetrics(new HttpServerOptions(), new SocketAddress() {
+            @Override
+            public String host() {
+                return "a.b.c";
+            }
+
+            @Override
+            public int port() {
+                return 0;
+            }
+
+            @Override
+            public String path() {
+                return null;
+            }
+        }));
+
+        Assertions.assertFalse(httpBinderConfiguration.isServerEnabled());
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxWithHttpEnabledTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
+import io.quarkus.micrometer.runtime.binder.vertx.VertxMeterBinderAdapter;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+
+public class VertxWithHttpEnabledTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.ignore-patterns", "/http")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.match-patterns", "/one=/two")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.ignore-patterns", "/two")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Instance<VertxMeterBinderAdapter> vertxMeterBinderAdapterInstance;
+
+    @Inject
+    HttpBinderConfiguration httpBinderConfiguration;
+
+    @Test
+    public void testMetricFactoryCreatedMetrics() throws Exception {
+        Assertions.assertTrue(vertxMeterBinderAdapterInstance.isResolvable());
+        VertxMeterBinderAdapter adapter = vertxMeterBinderAdapterInstance.get();
+
+        HttpServerMetrics metrics = adapter.createHttpServerMetrics(new HttpServerOptions(), new SocketAddress() {
+            @Override
+            public String host() {
+                return "a.b.c";
+            }
+
+            @Override
+            public int port() {
+                return 0;
+            }
+
+            @Override
+            public String path() {
+                return null;
+            }
+        });
+
+        Assertions.assertNotNull(metrics);
+        Assertions.assertTrue(httpBinderConfiguration.isServerEnabled());
+
+        // prefer http-server.ignore-patterns
+        Assertions.assertEquals(1, httpBinderConfiguration.getServerIgnorePatterns().size());
+        Pattern p = httpBinderConfiguration.getServerIgnorePatterns().get(0);
+        Assertions.assertTrue(p.matcher("/http").matches());
+
+        // Use vertx.match-patterns (http-server version is missing)
+        Assertions.assertEquals(1, httpBinderConfiguration.getServerMatchPatterns().size());
+        Map.Entry<Pattern, String> entry = httpBinderConfiguration.getServerMatchPatterns().entrySet().iterator().next();
+        Assertions.assertTrue(entry.getKey().matcher("/one").matches());
+        Assertions.assertEquals("/two", entry.getValue());
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/AllRegistriesDisabledTest.java
@@ -39,6 +39,6 @@ public class AllRegistriesDisabledTest {
     @Test
     public void testNoPrometheusEndpoint() {
         // Micrometer is enabled, prometheus is not.
-        RestAssured.when().get("/prometheus").then().statusCode(404);
+        RestAssured.when().get("/q/metrics").then().statusCode(404);
     }
 }

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -34,6 +34,10 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+        </dependency>
 
         <!-- Needed for the JSON meter registry -->
         <dependency>

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
@@ -31,9 +31,13 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.quarkus.arc.Arc;
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.binder.JVMInfoBinder;
 import io.quarkus.micrometer.runtime.binder.vertx.VertxMeterBinderAdapter;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
+import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -170,5 +174,18 @@ public class MicrometerRecorder {
             return throwable.getClass().getSimpleName();
         }
         return throwable.getCause().getClass().getSimpleName();
+    }
+
+    /* RUNTIME_INIT */
+    public RuntimeValue<HttpBinderConfiguration> configureHttpMetrics(
+            boolean httpServerMetricsEnabled,
+            boolean httpClientMetricsEnabled,
+            HttpServerConfig serverConfig,
+            HttpClientConfig clientConfig,
+            VertxConfig vertxConfig) {
+        return new RuntimeValue<HttpBinderConfiguration>(
+                new HttpBinderConfiguration(httpServerMetricsEnabled,
+                        httpClientMetricsEnabled,
+                        serverConfig, clientConfig, vertxConfig));
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpBinderConfiguration.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpBinderConfiguration.java
@@ -1,0 +1,116 @@
+package io.quarkus.micrometer.runtime.binder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
+import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
+
+/**
+ * Digest configuration options for http metrics once, so they can
+ * be used by different binders emitting http metrics (depending on
+ * other extension configuration).
+ *
+ * This is a synthetic bean created at runtime init (see MicrometerRecorder),
+ * so references to this bean must be deferred until runtime.
+ */
+public class HttpBinderConfiguration {
+    private static final Logger log = Logger.getLogger(HttpBinderConfiguration.class);
+
+    boolean serverEnabled = true;
+    boolean clientEnabled = true;
+
+    List<Pattern> serverIgnorePatterns = Collections.emptyList();
+    Map<Pattern, String> serverMatchPatterns = Collections.emptyMap();
+
+    List<Pattern> clientIgnorePatterns = Collections.emptyList();
+    Map<Pattern, String> clientMatchPatterns = Collections.emptyMap();
+
+    public HttpBinderConfiguration(boolean httpServerMetrics, boolean httpClientMetrics,
+            HttpServerConfig serverConfig, HttpClientConfig clientConfig, VertxConfig vertxConfig) {
+
+        serverEnabled = httpServerMetrics;
+        clientEnabled = httpClientMetrics;
+
+        if (serverEnabled) {
+            // Handle deprecated/previous vertx properties as well
+            serverIgnorePatterns = getIgnorePatterns(
+                    serverConfig.ignorePatterns.isPresent() ? serverConfig.ignorePatterns : vertxConfig.ignorePatterns);
+            serverMatchPatterns = getMatchPatterns(
+                    serverConfig.matchPatterns.isPresent() ? serverConfig.matchPatterns : vertxConfig.matchPatterns);
+        }
+
+        if (clientEnabled) {
+            clientIgnorePatterns = getIgnorePatterns(clientConfig.ignorePatterns);
+            clientMatchPatterns = getMatchPatterns(clientConfig.matchPatterns);
+        }
+    }
+
+    public boolean isServerEnabled() {
+        return serverEnabled;
+    }
+
+    public List<Pattern> getServerIgnorePatterns() {
+        return serverIgnorePatterns;
+    }
+
+    public Map<Pattern, String> getServerMatchPatterns() {
+        return serverMatchPatterns;
+    }
+
+    public boolean isClientEnabled() {
+        return clientEnabled;
+    }
+
+    public List<Pattern> getClientIgnorePatterns() {
+        return clientIgnorePatterns;
+    }
+
+    public Map<Pattern, String> getClientMatchPatterns() {
+        return clientMatchPatterns;
+    }
+
+    List<Pattern> getIgnorePatterns(Optional<List<String>> configInput) {
+        if (configInput.isPresent()) {
+            List<String> input = configInput.get();
+            List<Pattern> ignorePatterns = new ArrayList<>(input.size());
+            for (String s : input) {
+                ignorePatterns.add(Pattern.compile(s));
+            }
+            return ignorePatterns;
+        }
+        return Collections.emptyList();
+    }
+
+    Map<Pattern, String> getMatchPatterns(Optional<List<String>> configInput) {
+        if (configInput.isPresent()) {
+            List<String> input = configInput.get();
+            Map<Pattern, String> matchPatterns = new HashMap<>(input.size());
+            for (String s : input) {
+                int pos = s.indexOf("=");
+                if (pos > 0 && s.length() > 2) {
+                    String pattern = s.substring(0, pos);
+                    String replacement = s.substring(pos + 1);
+                    try {
+                        matchPatterns.put(Pattern.compile(pattern), replacement);
+                    } catch (PatternSyntaxException pse) {
+                        log.errorf("Invalid pattern in replacement string (%s=%s): %s", pattern, replacement, pse);
+                    }
+                } else {
+                    log.errorf("Invalid pattern in replacement string (%s). Should be pattern=replacement", s);
+                }
+            }
+            return matchPatterns;
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpMetricsCommon.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpMetricsCommon.java
@@ -1,22 +1,11 @@
 package io.quarkus.micrometer.runtime.binder;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
-import org.jboss.logging.Logger;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.http.Outcome;
 
 public class HttpMetricsCommon {
-    private static final Logger log = Logger.getLogger(HttpMetricsCommon.class);
-
     public static final Tag URI_NOT_FOUND = Tag.of("uri", "NOT_FOUND");
     public static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
     public static final Tag URI_ROOT = Tag.of("uri", "root");
@@ -88,40 +77,5 @@ public class HttpMetricsCommon {
 
         // Use first segment of request path
         return Tag.of("uri", pathInfo);
-    }
-
-    public static List<Pattern> getIgnorePatterns(Optional<List<String>> configInput) {
-        if (configInput.isPresent()) {
-            List<String> input = configInput.get();
-            List<Pattern> ignorePatterns = new ArrayList<>(input.size());
-            for (String s : input) {
-                ignorePatterns.add(Pattern.compile(s));
-            }
-            return ignorePatterns;
-        }
-        return Collections.emptyList();
-    }
-
-    public static Map<Pattern, String> getMatchPatterns(Optional<List<String>> configInput) {
-        if (configInput.isPresent()) {
-            List<String> input = configInput.get();
-            Map<Pattern, String> matchPatterns = new HashMap<>(input.size());
-            for (String s : input) {
-                int pos = s.indexOf("=");
-                if (pos > 0 && s.length() > 2) {
-                    String pattern = s.substring(0, pos);
-                    String replacement = s.substring(pos + 1);
-                    try {
-                        matchPatterns.put(Pattern.compile(pattern), replacement);
-                    } catch (PatternSyntaxException pse) {
-                        log.errorf("Invalid pattern in replacement string (%s=%s): %s", pattern, replacement, pse);
-                    }
-                } else {
-                    log.errorf("Invalid pattern in replacement string (%s). Should be pattern=replacement", s);
-                }
-            }
-            return matchPatterns;
-        }
-        return Collections.emptyMap();
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
@@ -11,9 +11,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.http.Outcome;
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.binder.HttpMetricsCommon;
 import io.quarkus.micrometer.runtime.binder.HttpRequestMetric;
-import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -42,14 +42,14 @@ public class VertxHttpServerMetrics extends VertxTcpMetrics
     final String nameHttpServerPush;
     final String nameHttpServerRequests;
 
-    VertxHttpServerMetrics(MeterRegistry registry, VertxConfig config) {
+    VertxHttpServerMetrics(MeterRegistry registry, HttpBinderConfiguration config) {
         super(registry, "http.server");
         nameWebsocketConnections = "http.server.websocket.connections";
         nameHttpServerPush = "http.server.push";
         nameHttpServerRequests = "http.server.requests";
 
-        ignorePatterns = HttpMetricsCommon.getIgnorePatterns(config.ignorePatterns);
-        matchPatterns = HttpMetricsCommon.getMatchPatterns(config.matchPatterns);
+        ignorePatterns = config.getServerIgnorePatterns();
+        matchPatterns = config.getServerMatchPatterns();
     }
 
     /**

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMeterBinderRecorder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMeterBinderRecorder.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.VertxOptions;
@@ -28,6 +29,7 @@ public class VertxMeterBinderRecorder {
     /* RUNTIME_INIT */
     public void setVertxConfig(VertxConfig config) {
         VertxMeterBinderAdapter binder = Arc.container().instance(VertxMeterBinderAdapter.class).get();
-        binder.setVertxConfig(config);
+        HttpBinderConfiguration httpConfig = Arc.container().instance(HttpBinderConfiguration.class).get();
+        binder.setVertxConfig(config, httpConfig);
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpClientConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpClientConfigGroup.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Build / static runtime config for outbound HTTP requests
+ */
+@ConfigGroup
+public class HttpClientConfigGroup implements MicrometerConfig.CapabilityEnabled {
+    /**
+     * Outbound HTTP request metrics support.
+     * <p>
+     * Support for HTTP client metrics will be enabled if Micrometer
+     * support is enabled, the REST client feature is enabled,
+     * and either this value is true, or this value is unset and
+     * {@code quarkus.micrometer.binder-enabled-default} is true.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled;
+
+    @Override
+    public Optional<Boolean> getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName()
+                + "{enabled=" + enabled
+                + '}';
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpServerConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpServerConfigGroup.java
@@ -6,15 +6,15 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
- * Build / static runtime config for the Vert.x Binder
+ * Build / static runtime config for inbound HTTP traffic
  */
 @ConfigGroup
-public class VertxConfig implements MicrometerConfig.CapabilityEnabled {
+public class HttpServerConfigGroup implements MicrometerConfig.CapabilityEnabled {
     /**
-     * Vert.x metrics support.
+     * Inbound HTTP metrics support.
      * <p>
-     * Support for Vert.x metrics will be enabled if Micrometer
-     * support is enabled, Vert.x MetricsOptions is on the classpath
+     * Support for HTTP server metrics will be enabled if Micrometer
+     * support is enabled, an extension serving HTTP traffic is enabled,
      * and either this value is true, or this value is unset and
      * {@code quarkus.micrometer.binder-enabled-default} is true.
      */

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/JsonConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/JsonConfigGroup.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class JsonConfig implements MicrometerConfig.CapabilityEnabled {
+public class JsonConfigGroup implements MicrometerConfig.CapabilityEnabled {
     /**
      * Support for export to JSON format. Off by default.
      */

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/KafkaConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/KafkaConfigGroup.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Build / static runtime config for Kafka Binders
  */
 @ConfigGroup
-public class KafkaConfig implements MicrometerConfig.CapabilityEnabled {
+public class KafkaConfigGroup implements MicrometerConfig.CapabilityEnabled {
     /**
      * Kafka metrics support.
      * <p>

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MPMetricsConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MPMetricsConfigGroup.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Build / static runtime config for the Microprofile Metrics Binder
  */
 @ConfigGroup
-public class MicroprofileMetricsConfig implements MicrometerConfig.CapabilityEnabled {
+public class MPMetricsConfigGroup implements MicrometerConfig.CapabilityEnabled {
     // @formatter:off
     /**
      * Eclipse MicroProfile Metrics support.

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
@@ -91,7 +91,8 @@ public final class MicrometerConfig {
     /** Build / static runtime config for binders */
     @ConfigGroup
     public static class BinderConfig {
-        public HttpClientConfig httpClient;
+        public HttpClientConfigGroup httpClient;
+        public HttpServerConfigGroup httpServer;
 
         /**
          * Micrometer JVM metrics support.
@@ -101,8 +102,8 @@ public final class MicrometerConfig {
         @ConfigItem(defaultValue = "true")
         public boolean jvm;
 
-        public KafkaConfig kafka;
-        public MicroprofileMetricsConfig mpMetrics;
+        public KafkaConfigGroup kafka;
+        public MPMetricsConfigGroup mpMetrics;
 
         /**
          * Micrometer System metrics support.
@@ -112,14 +113,14 @@ public final class MicrometerConfig {
         @ConfigItem(defaultValue = "true")
         public boolean system;
 
-        public VertxConfig vertx;
+        public VertxConfigGroup vertx;
     }
 
     /** Build / static runtime config for exporters */
     @ConfigGroup
     public static class ExportConfig {
-        public JsonConfig json;
-        public PrometheusConfig prometheus;
+        public JsonConfigGroup json;
+        public PrometheusConfigGroup prometheus;
     }
 
     public static interface CapabilityEnabled {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
@@ -6,7 +6,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class PrometheusConfig implements MicrometerConfig.CapabilityEnabled {
+public class PrometheusConfigGroup implements MicrometerConfig.CapabilityEnabled {
     /**
      * Support for export to Prometheus.
      * <p>

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/VertxConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/VertxConfigGroup.java
@@ -6,17 +6,18 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
- * Build / static runtime config for outbound HTTP requests
+ * Build / static runtime config for the Vert.x Binder
  */
 @ConfigGroup
-public class HttpClientConfig implements MicrometerConfig.CapabilityEnabled {
+public class VertxConfigGroup implements MicrometerConfig.CapabilityEnabled {
     /**
-     * Outbound HTTP request metrics support.
+     * Vert.x metrics support.
      * <p>
-     * Support for HTTP client metrics will be enabled if Micrometer
-     * support is enabled, the REST client feature is enabled,
+     * Support for Vert.x metrics will be enabled if Micrometer
+     * support is enabled, Vert.x MetricsOptions is on the classpath
      * and either this value is true, or this value is unset and
      * {@code quarkus.micrometer.binder-enabled-default} is true.
+     *
      */
     @ConfigItem
     public Optional<Boolean> enabled;

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/HttpServerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/HttpServerConfig.java
@@ -1,0 +1,53 @@
+package io.quarkus.micrometer.runtime.config.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "micrometer.binder.http-server", phase = ConfigPhase.RUN_TIME)
+public class HttpServerConfig {
+    /**
+     * Comma-separated list of regular expressions used to specify uri
+     * labels in http metrics.
+     *
+     * Vertx instrumentation will attempt to transform parameterized
+     * resource paths, `/item/123`, into a generic form, `/item/{id}`,
+     * to reduce the cardinality of uri label values.
+     *
+     * Patterns specified here will take precedence over those computed
+     * values.
+     *
+     * For example, if `/item/\\d+=/item/custom` is specified in this list,
+     * a request to a matching path (`/item/123`) will use the specified
+     * replacement value (`/item/custom`) as the value for the uri label.
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    public Optional<List<String>> matchPatterns = Optional.empty();
+
+    /**
+     * Comma-separated list of regular expressions defining uri paths
+     * that should be ignored (not measured).
+     */
+    @ConfigItem
+    public Optional<List<String>> ignorePatterns = Optional.empty();
+
+    public void mergeDeprecatedConfig(VertxConfig config) {
+        System.out.println("BEFORE");
+        System.out.println(ignorePatterns);
+        System.out.println(matchPatterns);
+        if (!ignorePatterns.isPresent()) {
+            ignorePatterns = config.ignorePatterns;
+        }
+        if (!matchPatterns.isPresent()) {
+            matchPatterns = config.matchPatterns;
+        }
+        System.out.println("AFTER");
+        System.out.println(ignorePatterns);
+        System.out.println(matchPatterns);
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/PrometheusConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/PrometheusConfig.java
@@ -10,8 +10,8 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * Runtime configuration for Micrometer meter registries.
  */
 @SuppressWarnings("unused")
-@ConfigRoot(name = "micrometer.export", phase = ConfigPhase.RUN_TIME)
-public class ExportConfig {
+@ConfigRoot(name = "micrometer.export.prometheus", phase = ConfigPhase.RUN_TIME)
+public class PrometheusConfig {
     // @formatter:off
     /**
      * Prometheus registry configuration properties.
@@ -22,6 +22,6 @@ public class ExportConfig {
      * @asciidoclet
      */
     // @formatter:on
-    @ConfigItem
+    @ConfigItem(name = ConfigItem.PARENT)
     Map<String, String> prometheus;
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/VertxConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/VertxConfig.java
@@ -10,29 +10,19 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "micrometer.binder.vertx", phase = ConfigPhase.RUN_TIME)
 public class VertxConfig {
     /**
-     * Comma-separated list of regular expressions used to specify uri
-     * labels in http metrics.
-     *
-     * Vertx instrumentation will attempt to transform parameterized
-     * resource paths, `/item/123`, into a generic form, `/item/{id}`,
-     * to reduce the cardinality of uri label values.
-     *
-     * Patterns specified here will take precedence over those computed
-     * values.
-     *
-     * For example, if `/item/\\d+=/item/custom` is specified in this list,
-     * a request to a matching path (`/item/123`) will use the specified
-     * replacement value (`/item/custom`) as the value for the uri label.
-     *
-     * @asciidoclet
+     * @deprecated use {@code quarkus.micrometer.binder.http-server.match-patterns}
      */
+    @Deprecated
     @ConfigItem
     public Optional<List<String>> matchPatterns = Optional.empty();
 
     /**
      * Comma-separated list of regular expressions defining uri paths
      * that should be ignored (not measured).
+     * 
+     * @deprecated use {@code quarkus.micrometer.binder.http-server.ignore-patterns}
      */
+    @Deprecated
     @ConfigItem
     public Optional<List<String>> ignorePatterns = Optional.empty();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/registry/json/JsonExporter.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/registry/json/JsonExporter.java
@@ -88,8 +88,9 @@ public class JsonExporter {
     private Map<String, JsonValue> exportGauges(Collection<Gauge> gauges) {
         Map<String, JsonValue> result = new HashMap<String, JsonValue>(gauges.size());
         for (Gauge g : gauges) {
-            if (Double.isFinite(g.value())) {
-                result.put(createExportKey(g.getId()), JSON_PROVIDER.createValue(g.value()));
+            double value = g.value();
+            if (Double.isFinite(value)) {
+                result.put(createExportKey(g.getId()), JSON_PROVIDER.createValue(value));
             }
         }
         return result;
@@ -98,8 +99,9 @@ public class JsonExporter {
     private Map<String, JsonValue> exportTimeGauges(Collection<TimeGauge> timeGauges) {
         Map<String, JsonValue> result = new HashMap<String, JsonValue>(timeGauges.size());
         for (TimeGauge g : timeGauges) {
-            if (Double.isFinite(g.value())) {
-                result.put(createExportKey(g.getId()), JSON_PROVIDER.createValue(g.value()));
+            double value = g.value();
+            if (Double.isFinite(value)) {
+                result.put(createExportKey(g.getId()), JSON_PROVIDER.createValue(value));
             }
         }
         return result;

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
@@ -10,16 +10,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
+import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
+import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
 import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 
 public class VertxHttpServerMetricsTest {
 
     @Test
     public void testHttpServerMetricsIgnorePatterns() {
-        VertxConfig runtimeConfig = new VertxConfig();
-        runtimeConfig.ignorePatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/.*")));
-        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), runtimeConfig);
+        HttpServerConfig serverConfig = new HttpServerConfig();
+        serverConfig.ignorePatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/.*")));
 
+        HttpBinderConfiguration binderConfig = new HttpBinderConfiguration(
+                true, false,
+                serverConfig, new HttpClientConfig(), new VertxConfig());
+
+        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), binderConfig);
         Assertions.assertFalse(metrics.ignorePatterns.isEmpty());
         Pattern p = metrics.ignorePatterns.get(0);
         Assertions.assertEquals("/item/.*", p.pattern());
@@ -28,9 +35,14 @@ public class VertxHttpServerMetricsTest {
 
     @Test
     public void testHttpServerMetricsMatchPatterns() {
-        VertxConfig runtimeConfig = new VertxConfig();
-        runtimeConfig.matchPatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/\\d+=/item/{id}")));
-        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), runtimeConfig);
+        HttpServerConfig serverConfig = new HttpServerConfig();
+        serverConfig.matchPatterns = Optional.of(new ArrayList<>(Arrays.asList("/item/\\d+=/item/{id}")));
+
+        HttpBinderConfiguration binderConfig = new HttpBinderConfiguration(
+                true, false,
+                serverConfig, new HttpClientConfig(), new VertxConfig());
+
+        VertxHttpServerMetrics metrics = new VertxHttpServerMetrics(new SimpleMeterRegistry(), binderConfig);
 
         Assertions.assertFalse(metrics.matchPatterns.isEmpty());
         Map.Entry<Pattern, String> entry = metrics.matchPatterns.entrySet().iterator().next();

--- a/integration-tests/micrometer-mp-metrics/src/main/java/io/quarkus/it/micrometer/mpmetrics/MessageResource.java
+++ b/integration-tests/micrometer-mp-metrics/src/main/java/io/quarkus/it/micrometer/mpmetrics/MessageResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.micrometer.mpmetrics;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/message")
+public class MessageResource {
+
+    private final MeterRegistry registry;
+
+    public MessageResource(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @GET
+    public String message() {
+        return registry.getClass().getName();
+    }
+
+    @GET
+    @Path("fail")
+    public String fail() {
+        throw new NullPointerException("Failed on purpose");
+    }
+
+    @GET
+    @Path("item/{id}")
+    public String item(@PathParam("id") String id) {
+        return "return message with id " + id;
+    }
+}

--- a/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
+++ b/integration-tests/micrometer-mp-metrics/src/main/resources/application.properties
@@ -13,3 +13,5 @@ quarkus.log.category."org.jboss.resteasy".level=INFO
 
 quarkus.micrometer.binder.mp-metrics.enabled=true
 quarkus.micrometer.export.json.enabled=true
+
+quarkus.micrometer.binder.vertx.ignore-patterns=/message

--- a/integration-tests/micrometer-mp-metrics/src/test/java/io/quarkus/it/micrometer/mpmetrics/MPMetricsTest.java
+++ b/integration-tests/micrometer-mp-metrics/src/test/java/io/quarkus/it/micrometer/mpmetrics/MPMetricsTest.java
@@ -81,12 +81,20 @@ class MPMetricsTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
+    void callMessage() {
+        given()
+                .when().get("/message")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(9)
     void validateMetricsOutput_2() {
         given()
                 .when().get("/q/metrics")
                 .then()
-                .log().body()
                 .statusCode(200)
 
                 // Prometheus body has ALL THE THINGS in no particular order
@@ -95,17 +103,17 @@ class MPMetricsTest {
                 .body(containsString(
                         "highestPrimeNumberSoFar 887.0"))
                 .body(containsString(
-                        "io_quarkus_it_micrometer_mpmetrics_InjectedInstance_notPrime_total{scope=\"application\",}"));
+                        "io_quarkus_it_micrometer_mpmetrics_InjectedInstance_notPrime_total{scope=\"application\",}"))
+                .body(not(containsString("/message")));
     }
 
     @Test
-    @Order(7)
+    @Order(10)
     void validateJsonOutput() {
         given()
                 .header("Accept", "application/json")
                 .when().get("/q/metrics")
                 .then()
-                .log().body()
                 .statusCode(200)
                 .body("'io.quarkus.it.micrometer.mpmetrics.CountedInstance.countPrimes;scope=application'",
                         Matchers.equalTo(2.0f))

--- a/integration-tests/micrometer-prometheus/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus/src/main/resources/application.properties
@@ -15,6 +15,9 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.jdbc.max-size=8
 
+# This is the old property, should still be used
 quarkus.micrometer.binder.vertx.ignore-patterns=/fruit/create
+# Add a property to verify match pattern behavior
+quarkus.micrometer.binder.http-server.match-patterns=/message/match/\\d+/\\d+=/match/{id}/{sub}
 
 deployment.env=test

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -49,7 +49,7 @@ class PrometheusMetricsRegistryTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void testPathParameter() {
         given()
                 .when().get("/message/item/123")
@@ -58,7 +58,7 @@ class PrometheusMetricsRegistryTest {
     }
 
     @Test
-    @Order(4)
+    @Order(6)
     void testPanacheCalls() {
         given()
                 .when().get("/fruit/create")
@@ -72,7 +72,7 @@ class PrometheusMetricsRegistryTest {
     }
 
     @Test
-    @Order(5)
+    @Order(7)
     void testPrimeEndpointCalls() {
         given()
                 .when().get("/prime/7")
@@ -82,7 +82,7 @@ class PrometheusMetricsRegistryTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     void testAllTheThings() {
         given()
                 .when().get("/all-the-things")


### PR DESCRIPTION
Resolves #14745 
Resolves #14887

This is a better fit after the addition of similar options for http-client