### PR TITLE
ArC intercepted subclasses - fix bridge methods processing

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/AbstractResource.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/AbstractResource.java
@@ -1,0 +1,8 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+public abstract class AbstractResource<T> {
+
+    public String create(T dto) {
+        return dto.toString();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/ExampleApi.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/ExampleApi.java
@@ -1,0 +1,6 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+public interface ExampleApi {
+
+    String create(String dto);
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/ExampleResource.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/ExampleResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+import java.util.List;
+import javax.inject.Singleton;
+
+@Singleton
+@Simple
+public class ExampleResource extends AbstractResource<String> implements ExampleApi {
+
+    // Just to try to confuse our bridge method impl. algorithm 
+    public String create(List<Object> dtos) {
+        return dtos.toString();
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/Simple.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/Simple.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.interceptor.InterceptorBinding;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface Simple {
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/SimpleInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bridge/SimpleInterceptor.java
@@ -1,0 +1,23 @@
+package io.quarkus.arc.test.interceptors.bridge;
+
+import io.quarkus.arc.test.interceptors.Counter;
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Simple
+@Priority(1)
+@Interceptor
+public class SimpleInterceptor {
+
+    @Inject
+    Counter counter;
+
+    @AroundInvoke
+    Object mySuperCoolAroundInvoke(InvocationContext ctx) throws Exception {
+        counter.incrementAndGet();
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION
- skip methods overriden by bridge methods
- do not skip a bridge method for which an "impl. method" is not
declared on the class

Co-authored-by: Matej Novotny <manovotn@redhat.com>