### PR TITLE
Replacing deprecated constants from jackson-databind

### DIFF
--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
@@ -50,11 +50,12 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -439,11 +440,14 @@ public class GenerateExtensionsJsonMojo extends AbstractMojo {
         if (yaml) {
             YAMLFactory yf = new YAMLFactory();
             return new ObjectMapper(yf)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+                    .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         } else {
-            return new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
-                    .enable(JsonParser.Feature.ALLOW_COMMENTS).enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+            return JsonMapper.builder()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                    .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                    .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                    .build();
         }
     }
 

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
@@ -2,10 +2,11 @@ package io.quarkus.platform.descriptor.loader.json.impl;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import io.quarkus.platform.descriptor.loader.json.QuarkusJsonPlatformDescriptorLoader;
 import io.quarkus.platform.descriptor.loader.json.QuarkusJsonPlatformDescriptorLoaderContext;
@@ -19,11 +20,12 @@ public class QuarkusJsonPlatformDescriptorLoaderImpl
         final QuarkusJsonPlatformDescriptor platform = context
                 .parseJson(is -> {
                     try {
-                        ObjectMapper mapper = new ObjectMapper()
-                                .enable(JsonParser.Feature.ALLOW_COMMENTS)
-                                .enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS)
+                        ObjectMapper mapper = JsonMapper.builder()
+                                .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                                .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
                                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                                .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+                                .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                                .build();
                         return mapper.readValue(is, QuarkusJsonPlatformDescriptor.class);
                     } catch (IOException e) {
                         throw new RuntimeException("Failed to parse JSON stream", e);

--- a/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
@@ -21,9 +21,10 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import io.quarkus.annotation.processor.generate_doc.ConfigDocGeneratedOutput;
 import io.quarkus.annotation.processor.generate_doc.ConfigDocItem;
@@ -51,10 +52,11 @@ public class AllConfigGenerator {
             // exit 0 will break Maven
             return;
         }
-        ObjectMapper mapper = new ObjectMapper()
-                .enable(JsonParser.Feature.ALLOW_COMMENTS)
-                .enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS)
-                .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                .build();
         MavenArtifactResolver resolver = MavenArtifactResolver.builder().setWorkspaceDiscovery(false).build();
 
         // let's read it (and ignore the fields we don't need)

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -1,12 +1,13 @@
 package io.quarkus.maven;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.quarkus.bootstrap.BootstrapConstants;
@@ -530,11 +531,14 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (yaml) {
             YAMLFactory yf = new YAMLFactory();
             return new ObjectMapper(yf)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+                    .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         } else {
-            return new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
-                    .enable(JsonParser.Feature.ALLOW_COMMENTS).enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+            return JsonMapper.builder()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                    .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                    .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                    .build();
         }
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/URLRegistryBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/URLRegistryBuilder.java
@@ -2,7 +2,7 @@ package io.quarkus.registry.builder;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.quarkus.registry.model.ImmutableRegistry;
 import io.quarkus.registry.model.Registry;
 import java.io.IOException;
@@ -31,7 +31,7 @@ public class URLRegistryBuilder {
         }
         ObjectMapper mapper = new ObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+                .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         if (urls.size() == 1) {
             // Just one
             return mapper.readValue(urls.get(0), Registry.class);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/catalog/model/Repository.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/catalog/model/Repository.java
@@ -2,7 +2,7 @@ package io.quarkus.registry.catalog.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import java.io.IOException;
@@ -29,7 +29,7 @@ public abstract class Repository {
      */
     public static Repository parse(Path rootPath, ObjectMapper mapper) {
         ObjectReader reader = mapper.reader()
-                .with(mapper.getDeserializationConfig().with(PropertyNamingStrategy.KEBAB_CASE));
+                .with(mapper.getDeserializationConfig().with(PropertyNamingStrategies.KEBAB_CASE));
         return ImmutableRepository.builder()
                 .addAllPlatforms(parse(rootPath.resolve("platforms.json"), Platform.class, reader))
                 .addAllIndividualExtensions(parse(rootPath.resolve("extensions"), Extension.class, reader))

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/DefaultExtensionRegistryTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/DefaultExtensionRegistryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.extensions.ExtensionInstallPlan;
 import io.quarkus.registry.builder.RegistryBuilder;
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.io.TempDir;
 class DefaultExtensionRegistryTest {
 
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     static DefaultExtensionRegistry extensionRegistry;
 

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/builder/RegistryBuilderTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/builder/RegistryBuilderTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.quarkus.registry.RepositoryIndexer;
 import io.quarkus.registry.TestArtifactResolver;
 import io.quarkus.registry.catalog.model.Repository;
@@ -38,7 +38,7 @@ class RegistryBuilderTest {
         if (Boolean.getBoolean("generateTmpRegistry")) {
             ObjectMapper mapper = new ObjectMapper()
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+                    .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
             mapper.writeValue(new java.io.File("/tmp/registry.json"), registry);
         }
     }

--- a/integration-tests/jackson/src/main/java/io/quarkus/it/jackson/model/SampleResponse.java
+++ b/integration-tests/jackson/src/main/java/io/quarkus/it/jackson/model/SampleResponse.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jackson.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @RegisterForReflection
 public class SampleResponse {
 


### PR DESCRIPTION
Replacing deprecated constants from jackson-databind

 - `PropertyNamingStrategy.KEBAB_CASE => PropertyNamingStrategies.KEBAB_CASE`
 - `JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS => JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS`
 - `JsonParser.Feature.ALLOW_COMMENTS => JsonReadFeature.ALLOW_JAVA_COMMENTS` (while not technically deprecated, since 2.10 recommended to use JsonReadFeature.ALLOW_JAVA_COMMENTS instead)
 - `new ObjectMapper() => JsonMapper.builder() ... .build()` for JsonReadFeature support
