### PR TITLE
Update to SmallRye Reactive Messaging 2.8.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-context-propagation.version>1.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.4.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.7.1</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.8.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>

--- a/extensions/reactive-messaging-http/deployment/src/test/java/io/quarkus/reactivemessaging/websocket/sink/app/WebSocketEmitter.java
+++ b/extensions/reactive-messaging-http/deployment/src/test/java/io/quarkus/reactivemessaging/websocket/sink/app/WebSocketEmitter.java
@@ -18,11 +18,11 @@ public class WebSocketEmitter {
 
     @Inject
     @Channel("my-ws-sink")
-    Emitter emitter;
+    Emitter<Object> emitter;
 
     @Inject
     @Channel("ws-sink-with-serializer")
-    Emitter emitterWithCustomSerializer;
+    Emitter<Object> emitterWithCustomSerializer;
 
     public void sendMessage(Message<?> message) {
         emitter.send(message);


### PR DESCRIPTION
Important stuff:

* @Incoming / @Outgoing methods don't have to be public anymore 
* New Kafka Readiness check that does not use an admin connection
* Allow Admin connection using `sasl` (Fix #14156)
* Fix the potential blocking when the Kafka client is closed
* Detect and throw a CDI DefinitionException when trying to inject an Emitter<Message<?>>
* @Channel injection are not automatically _merged_ and _brodcasted_
* High-load after Kafka broker connection drop - First part of the fix for #14366
