### PR TITLE
When a change to startup related code is made disable dev mode instrumentation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevConfig.java
@@ -1,0 +1,18 @@
+package io.quarkus.deployment.dev;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public class DevConfig {
+
+    /**
+     * Whether or not Quarkus should disable it's ability to not do a full restart
+     * when changes to classes are compatible with JVM instrumentation.
+     * If this is set to true, Quarkus will always restart on changes and never perform class redefinition.
+     */
+    @ConfigItem(defaultValue = "true")
+    boolean instrumentation;
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -219,7 +220,8 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                                 classTransformers.apply(name, bytes));
                     }
                     Index current = indexer.complete();
-                    boolean ok = containsStartupCode(current);
+                    boolean ok = instrumentationEnabled()
+                            && !containsStartupCode(current);
                     if (ok) {
                         for (ClassInfo clazz : current.getKnownClasses()) {
                             ClassInfo old = lastStartIndex.getClassByName(clazz.name());
@@ -270,9 +272,20 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         return false;
     }
 
+    private Boolean instrumentationEnabled() {
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            return ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.dev.instrumentation", boolean.class).orElse(true);
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
     private boolean containsStartupCode(Index index) {
         if (!index.getAnnotations(STARTUP_NAME).isEmpty()) {
-            return false;
+            return true;
         }
         List<AnnotationInstance> observesInstances = index.getAnnotations(OBSERVES_NAME);
         if (!observesInstances.isEmpty()) {
@@ -281,12 +294,12 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     MethodParameterInfo methodParameterInfo = observesInstance.target().asMethodParameter();
                     short paramPos = methodParameterInfo.position();
                     if (STARTUP_EVENT_NAME.equals(methodParameterInfo.method().parameters().get(paramPos).name())) {
-                        return false;
+                        return true;
                     }
                 }
             }
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -271,6 +271,14 @@ public class DevMojo extends AbstractMojo {
     @Parameter(defaultValue = "${quarkus.enforceBuildGoal}")
     private boolean enforceBuildGoal = true;
 
+    /**
+     * Whether or not Quarkus should disable it's ability to not do a full restart
+     * when changes to classes are compatible with JVM instrumentation.
+     * If this is set to true, Quarkus will always restart on changes and never perform class redefinition.
+     */
+    @Parameter(defaultValue = "${disableInstrumentation}")
+    private boolean disableInstrumentation = false;
+
     @Component
     private WorkspaceReader wsReader;
 
@@ -823,7 +831,9 @@ public class DevMojo extends AbstractMojo {
                     && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
                 if (appDep.getArtifact().getGroupId().equals("io.quarkus")
                         && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
-                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                    if (!disableInstrumentation) {
+                        builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                    }
                 } else {
                     builder.classpathEntry(appDep.getArtifact().getFile());
                 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -271,14 +271,6 @@ public class DevMojo extends AbstractMojo {
     @Parameter(defaultValue = "${quarkus.enforceBuildGoal}")
     private boolean enforceBuildGoal = true;
 
-    /**
-     * Whether or not Quarkus should disable it's ability to not do a full restart
-     * when changes to classes are compatible with JVM instrumentation.
-     * If this is set to true, Quarkus will always restart on changes and never perform class redefinition.
-     */
-    @Parameter(defaultValue = "${disableInstrumentation}")
-    private boolean disableInstrumentation = false;
-
     @Component
     private WorkspaceReader wsReader;
 
@@ -831,9 +823,7 @@ public class DevMojo extends AbstractMojo {
                     && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
                 if (appDep.getArtifact().getGroupId().equals("io.quarkus")
                         && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
-                    if (!disableInstrumentation) {
-                        builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
-                    }
+                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
                 } else {
                     builder.classpathEntry(appDep.getArtifact().getFile());
                 }

--- a/integration-tests/maven/src/test/resources/projects/classic-inst/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources/projects/classic-inst/src/main/java/org/acme/HelloResource.java
@@ -43,4 +43,16 @@ public class HelloResource {
     public String uuid() {
         return uuid.toString();
     }
+
+    @GET
+    @Path("disable")
+    public void disable() {
+        System.setProperty("quarkus.dev.instrumentation", "false");
+    }
+
+    @GET
+    @Path("enable")
+    public void enable() {
+        System.setProperty("quarkus.dev.instrumentation","true");
+    }
 }

--- a/integration-tests/maven/src/test/resources/projects/classic-inst/src/main/java/org/acme/HelloService.java
+++ b/integration-tests/maven/src/test/resources/projects/classic-inst/src/main/java/org/acme/HelloService.java
@@ -1,9 +1,16 @@
 package org.acme;
 
+import io.quarkus.runtime.StartupEvent;
+
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 
 @ApplicationScoped
 public class HelloService {
+
+    public void start(@Observes StartupEvent startupEvent) {
+
+    }
 
     public String name() {
         return "Stuart";


### PR DESCRIPTION
This is done because such code is meant to be run at startup so when it changes,
users expect to see it be rerun

Furthermore, add the `-DdisableInstrumentation` which allows a user to explicitly turn of instrumentation