### PR TITLE
Fix OidcClient expires_in check, add Wiremock test and quarkus-jackson

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -75,7 +75,7 @@
         {
             "category": "Security2",
             "timeout": 70,
-            "test-modules": "oidc oidc-code-flow oidc-tenancy keycloak-authorization oidc-client oidc-token-propagation oidc-wiremock"
+            "test-modules": "oidc oidc-code-flow oidc-tenancy keycloak-authorization oidc-client oidc-token-propagation oidc-wiremock oidc-client-wiremock"
         },
         {
             "category": "Security3",

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -91,7 +91,7 @@
 
         <unboundid-ldap.version>4.0.13</unboundid-ldap.version>
 
-        <wiremock-jre8.version>2.26.3</wiremock-jre8.version>
+        <wiremock-jre8.version>2.27.2</wiremock-jre8.version>
         <wiremock-maven-plugin.version>7.0.0</wiremock-maven-plugin.version>
 
         <!-- Code Coverage Properties-->
@@ -239,7 +239,11 @@
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>
-                   </exclusion>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -34,6 +34,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/oidc-client/runtime/pom.xml
+++ b/extensions/oidc-client/runtime/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>quarkus-oidc-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
           <groupId>io.smallrye.reactive</groupId>
           <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
         </dependency>

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -25,4 +25,6 @@ public final class OidcConstants {
     public static final String CODE_FLOW_CODE = "code";
     public static final String CODE_FLOW_STATE = "state";
     public static final String CODE_FLOW_REDIRECT_URI = "redirect_uri";
+
+    public static final String EXPIRES_IN = "expires_in";
 }

--- a/integration-tests/oidc-client-wiremock/pom.xml
+++ b/integration-tests/oidc-client-wiremock/pom.xml
@@ -6,36 +6,23 @@
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-integration-test-oidc-wiremock</artifactId>
-    <name>Quarkus - Integration Tests - OpenID Connect Adapter WireMock</name>
-    <description>Module that contains OpenID Connect related tests using WireMock</description>
+    <artifactId>quarkus-integration-test-oidc-client-wiremock</artifactId>
+    <name>Quarkus - Integration Tests - OpenID Connect Client Wiremock</name>
+    <description>Module that contains OpenID Connect Client tests using Wiremock</description>
 
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -48,10 +35,23 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc-deployment</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -64,7 +64,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-oidc-client-filter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client-filter-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -114,6 +118,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/frontend")
+public class FrontendResource {
+    @Inject
+    @RestClient
+    ProtectedResourceServiceOidcClient protectedResourceServiceOidcClient;
+
+    @GET
+    @Path("echoToken")
+    public String echoToken() {
+        return protectedResourceServiceOidcClient.echoToken();
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+@Path("/protected")
+public class ProtectedResource {
+
+    @GET
+    public String echoToken(@HeaderParam("Authorization") String authorization) {
+        return authorization.split(" ")[1];
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceOidcClient.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceOidcClient.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter
+@Path("/")
+public interface ProtectedResourceServiceOidcClient {
+
+    @GET
+    String echoToken();
+}

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+quarkus.oidc-client.auth-server-url=${keycloak.url}
+quarkus.oidc-client.discovery-enabled=false
+quarkus.oidc-client.token-path=/tokens
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=password
+quarkus.oidc-client.grant-options.password.username=alice
+quarkus.oidc-client.grant-options.password.password=alice
+
+io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
+
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
+quarkus.log.file.enable=true
+quarkus.log.file.format=%C - %s%n

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.keycloak;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.Options.ChunkedEncodingPolicy;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+
+    private static final Logger LOG = Logger.getLogger(KeycloakRealmResourceManager.class);
+
+    private WireMockServer server;
+
+    @Override
+    public Map<String, String> start() {
+
+        server = new WireMockServer(wireMockConfig().dynamicPort().useChunkedTransferEncoding(ChunkedEncodingPolicy.NEVER));
+        server.start();
+
+        server.stubFor(WireMock.post("/tokens")
+                .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+        server.stubFor(WireMock.post("/tokens")
+                .withRequestBody(matching("grant_type=refresh_token&refresh_token=refresh_token_1"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+
+        LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put("quarkus.oidc-client.auth-server-url", server.baseUrl());
+        conf.put("keycloak-url", server.baseUrl());
+        return conf;
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop();
+            LOG.info("Keycloak was shut down");
+            server = null;
+        }
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientInGraalITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.keycloak;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class OidcClientInGraalITCase extends OidcClientTest {
+}

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.it.keycloak;
+
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@QuarkusTestResource(KeycloakRealmResourceManager.class)
+public class OidcClientTest {
+
+    @Test
+    public void testEchoAndRefreshTokens() {
+        RestAssured.when().get("/frontend/echoToken")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_1"));
+
+        // Wait until the access token has expired
+        long expiredTokenTime = System.currentTimeMillis() + 5000;
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofSeconds(3))
+                .until(new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        return System.currentTimeMillis() > expiredTokenTime;
+                    }
+                });
+
+        RestAssured.when().get("/frontend/echoToken")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_2"));
+        checkLog();
+    }
+
+    private void checkLog() {
+        final Path logDirectory = Paths.get(".", "target");
+        given().await().pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        Path accessLogFilePath = logDirectory.resolve("quarkus.log");
+                        boolean fileExists = Files.exists(accessLogFilePath);
+                        if (!fileExists) {
+                            accessLogFilePath = logDirectory.resolve("target/quarkus.log");
+                            fileExists = Files.exists(accessLogFilePath);
+                        }
+                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                                "quarkus log file " + accessLogFilePath + " is missing");
+
+                        int tokenAcquisitionCount = 0;
+                        int tokenRefreshedCount = 0;
+
+                        try (BufferedReader reader = new BufferedReader(
+                                new InputStreamReader(new ByteArrayInputStream(Files.readAllBytes(accessLogFilePath)),
+                                        StandardCharsets.UTF_8))) {
+                            String line = null;
+                            while ((line = reader.readLine()) != null) {
+                                if (line.contains("Default OidcClient has refreshed the tokens")) {
+                                    tokenRefreshedCount++;
+                                } else if (line.contains("Default OidcClient has acquired the tokens")) {
+                                    tokenAcquisitionCount++;
+                                }
+
+                            }
+                        }
+                        assertEquals(1, tokenAcquisitionCount,
+                                "Log file must contain a single OidcClientImpl token acquisition confirmation");
+                        assertEquals(1, tokenRefreshedCount,
+                                "Log file must contain a single OidcClientImpl token refresh confirmation");
+                    }
+                });
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -79,6 +79,7 @@
         <module>liquibase</module>
         <module>oidc</module>
         <module>oidc-client</module>
+        <module>oidc-client-wiremock</module>
         <module>oidc-token-propagation</module>
         <module>oidc-code-flow</module>
         <module>oidc-tenancy</module>


### PR DESCRIPTION
Fixes #14759
Fixes #14796

This fixes the typo in checking the `expires_in` lifespan property and adds a Wiremock test - the tests dealing with Keycloak can't verify it since this property is not returned there - in which case the absolute expires at time is extracted from the JWT token.

The test also verifies a manual configuration of the token endpoint works - the existing tests rely on the auto-discovery

@pedroigor Hi Pedro - if you have a few secs - please also check