### PR TITLE
Change ordinal from 150 to 270 in Vault config source

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
@@ -18,6 +18,7 @@ public class VaultConfigSourceProvider implements ConfigSourceProvider {
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
-        return Arrays.asList(new VaultConfigSource(150, vaultBootstrapConfig));
+        // 270 is higher than the file system or jar ordinals, but lower than env vars
+        return Arrays.asList(new VaultConfigSource(270, vaultBootstrapConfig));
     }
 }


### PR DESCRIPTION
Use `270` for the vault config source, which is consistent with the consul config source and the kubernetes config (base value for the config map).
Fixes https://github.com/quarkusio/quarkus/issues/14743
/cc @radcortez @geoand 