### PR TITLE
Set keycloak-authorization proxy url

### DIFF
--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -114,6 +114,10 @@ public class KeycloakPolicyEnforcerAuthorizer
             adapterConfig.setAllowAnyHostname(true);
         }
 
+        if (oidcConfig.defaultTenant.proxy.host.isPresent()) {
+            adapterConfig.setProxyUrl(oidcConfig.defaultTenant.proxy.host.get() + ":" + oidcConfig.defaultTenant.proxy.port);
+        }
+
         PolicyEnforcerConfig enforcerConfig = getPolicyEnforcerConfig(config, adapterConfig);
 
         if (enforcerConfig == null) {


### PR DESCRIPTION
Fixes #14733

This PR sets it as for example `localhost:80`.

Keycloak adapter code checks it like this:
```
URI uri = URI.create(adapterConfig.getProxyUrl());
this.proxyHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
```

where the scheme is defaulted to `http` which users can override by setting the host to `https://localhost` etc