### PR TITLE
Fix test in sample gradle projects

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
@@ -39,7 +39,8 @@ public class AddExtensionToSingleModuleKtsProjectTest extends QuarkusGradleWrapp
 
         final File projectDir = getProjectDir("add-remove-extension-single-module-kts");
 
-        runGradleWrapper(projectDir, "clean", "build");
+        BuildResult buildResult = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
 
         final Path buildKts = projectDir.toPath().resolve("build.gradle.kts");
         assertThat(buildKts).exists();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
@@ -36,7 +36,8 @@ public class AddExtensionToSingleModuleProjectTest extends QuarkusGradleWrapperT
 
         final File projectDir = getProjectDir("add-remove-extension-single-module");
 
-        runGradleWrapper(projectDir, "clean", "build");
+        BuildResult buildResult = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
 
         final Path build = projectDir.toPath().resolve("build.gradle");
         assertThat(build).exists();

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/main/java/org/acme/ExampleResource.java
@@ -6,19 +6,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 @Path("/hello")
 public class ExampleResource {
-
-    @ConfigProperty(name = "my-app-name")
-    String appName;
-    @ConfigProperty(name = "quarkus.application.version")
-    String appVersion;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return appName + " " + appVersion;
+        return "Hello from Test";
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 # Configuration file
 # key = value
-my-app-name=${quarkus.application.name}

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/test/java/org/acme/ExampleResourceTest.java
@@ -17,13 +17,4 @@ public class ExampleResourceTest {
              .statusCode(200)
              .body(is("Hello from Test"));
     }
-
-    @Test
-    public void testTestOnly() {
-      given()
-          .when().get("test-only")
-          .then()
-              .statusCode(200)
-              .body(is("Test only"));
-    }
 }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module-kts/src/test/resources/application.properties
@@ -1,5 +1,3 @@
 # Configuration file
 # key = value
-example.message=Hello from Test
-test-only=Test only
 

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/main/java/org/acme/ExampleResource.java
@@ -6,19 +6,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 @Path("/hello")
 public class ExampleResource {
-
-    @ConfigProperty(name = "my-app-name")
-    String appName;
-    @ConfigProperty(name = "quarkus.application.version")
-    String appVersion;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return appName + " " + appVersion;
+        return "Hello from Test";
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 # Configuration file
 # key = value
-my-app-name=${quarkus.application.name}

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/test/java/org/acme/ExampleResourceTest.java
@@ -17,13 +17,4 @@ public class ExampleResourceTest {
              .statusCode(200)
              .body(is("Hello from Test"));
     }
-
-    @Test
-    public void testTestOnly() {
-      given()
-          .when().get("test-only")
-          .then()
-              .statusCode(200)
-              .body(is("Test only"));
-    }
 }

--- a/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/add-remove-extension-single-module/src/test/resources/application.properties
@@ -1,5 +1,3 @@
 # Configuration file
 # key = value
-example.message=Hello from Test
-test-only=Test only
 


### PR DESCRIPTION
This branch fix sample gradle projects used by integration-test.
I also added an assertion on the command result to make sure we detect this ASAP, even if logs are off. 

Also, this config injection works in dev mode, but fails on test. As these tests are only testing `add`/`remove` extension, I simply removed the property injection. @geoand is a normal behaviour?

    @ConfigProperty(name = "quarkus.application.version")
    String appVersion;


close #14799 