### PR TITLE
Allow to configure file.encoding and user.language for native image building

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -8,6 +8,8 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class NativeConfig {
@@ -42,6 +44,18 @@ public class NativeConfig {
     @Deprecated
     @ConfigItem(defaultValue = "true")
     public boolean enableJni;
+
+    /**
+     * Defines the file encoding as in -Dfile.encoding=...
+     *
+     * Native image runtime uses the host's (i.e. build time) value of file.encoding
+     * system property. We intentionally default this to UTF-8 to avoid platform specific
+     * defaults to be picked up which can then result in inconsistent behavior in the
+     * generated native executable.
+     */
+    @ConfigItem(defaultValue = "UTF-8")
+    @ConvertWith(TrimmedStringConverter.class)
+    public String fileEncoding;
 
     /**
      * If all character sets should be added to the native image. This increases image size

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -46,6 +46,15 @@ public class NativeConfig {
     public boolean enableJni;
 
     /**
+     * Defines the user language used for building the native executable.
+     * <p>
+     * Defaults to the system one.
+     */
+    @ConfigItem(defaultValue = "${user.language:}")
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<String> userLanguage;
+
+    /**
      * Defines the file encoding as in -Dfile.encoding=...
      *
      * Native image runtime uses the host's (i.e. build time) value of file.encoding

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -55,6 +55,15 @@ public class NativeConfig {
     public Optional<String> userLanguage;
 
     /**
+     * Defines the user country used for building the native executable.
+     * <p>
+     * Defaults to the system one.
+     */
+    @ConfigItem(defaultValue = "${user.country:}")
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<String> userCountry;
+
+    /**
      * Defines the file encoding as in -Dfile.encoding=...
      *
      * Native image runtime uses the host's (i.e. build time) value of file.encoding

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -153,6 +153,9 @@ public class NativeImageBuildStep {
             if (nativeConfig.userLanguage.isPresent()) {
                 command.add("-J-Duser.language=" + nativeConfig.userLanguage.get());
             }
+            if (nativeConfig.userCountry.isPresent()) {
+                command.add("-J-Duser.country=" + nativeConfig.userCountry.get());
+            }
             command.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding);
 
             if (enableSslNative) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -150,7 +150,9 @@ public class NativeImageBuildStep {
                     }
                 }
             }
-            command.add("-J-Duser.language=" + System.getProperty("user.language"));
+            if (nativeConfig.userLanguage.isPresent()) {
+                command.add("-J-Duser.language=" + nativeConfig.userLanguage.get());
+            }
             command.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding);
 
             if (enableSslNative) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -151,11 +151,7 @@ public class NativeImageBuildStep {
                 }
             }
             command.add("-J-Duser.language=" + System.getProperty("user.language"));
-            // Native image runtime uses the host's (i.e. build time) value of file.encoding
-            // system property. We intentionally default this to UTF-8 to avoid platform specific
-            // defaults to be picked up which can then result in inconsistent behaviour in the
-            // generated native application
-            command.add("-J-Dfile.encoding=UTF-8");
+            command.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding);
 
             if (enableSslNative) {
                 nativeConfig.enableHttpsUrlHandler = true;


### PR DESCRIPTION
Follow up of https://github.com/quarkusio/quarkus/pull/10527 .

/cc @jaikiran @blinkfox