### PR TITLE
Disable JTA in Hibernate Reactive

### DIFF
--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -56,9 +56,40 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -72,6 +103,117 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>test-postgresql</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>docker-postgresql</id>
+            <activation>
+                <property>
+                    <name>start-containers</name>
+                </property>
+            </activation>
+            <properties>
+                <postgres.image>postgres:13.1</postgres.image>
+                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${postgres.image}</name>
+                                    <alias>postgresql</alias>
+                                    <run>
+                                        <env>
+                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
+                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
+                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
+                                        </env>
+                                        <ports>
+                                            <port>5431:5432</port>
+                                        </ports>
+                                        <wait>
+                                            <tcp>
+                                                <mode>mapped</mode>
+                                                <ports>
+                                                    <port>5432</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>10000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                            <!--Stops all postgres images currently running, not just those we just started.
+                              Useful to stop processes still running from a previously failed integration test run -->
+                            <allContainers>true</allContainers>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>docker-prune</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${docker-prune.location}</executable>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -208,7 +208,7 @@ public final class HibernateReactiveProcessor {
         // we found one
         ParsedPersistenceXmlDescriptor desc = new ParsedPersistenceXmlDescriptor(null); //todo URL
         desc.setName("default-reactive");
-        desc.setTransactionType(PersistenceUnitTransactionType.JTA);
+        desc.setTransactionType(PersistenceUnitTransactionType.RESOURCE_LOCAL);
         desc.getProperties().setProperty(AvailableSettings.DIALECT, dialectClassName);
         desc.setExcludeUnlistedClasses(true);
         desc.addClasses(new ArrayList<>(domainObjects.getAllModelClassNames()));

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoEntitiesTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoEntitiesTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.reactive;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoEntitiesTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void testNoEntities() {
+        // When having no entities, we should still be able to start the application.
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoJtaTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoJtaTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.hibernate.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoJtaTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    SessionFactory sessionFactory; // This is an ORM SessionFactory, but it's backing Hibernate Reactive.
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    @ActivateRequestContext
+    public void test() {
+        ServiceRegistryImplementor serviceRegistry = sessionFactory.unwrap(SessionFactoryImplementor.class)
+                .getServiceRegistry();
+
+        // Two assertions are necessary, because these values are influenced by separate configuration
+        assertThat(serviceRegistry.getService(JtaPlatform.class).retrieveTransactionManager()).isNull();
+        assertThat(serviceRegistry.getService(TransactionCoordinatorBuilder.class).isJta()).isFalse();
+
+        // Quick test to make sure HRX works
+        MyEntity entity = new MyEntity("default");
+        MyEntity retrievedEntity = session.withTransaction(tx -> session.persist(entity))
+                .chain(() -> session.withTransaction(tx -> session.clear().find(MyEntity.class, entity.getId())))
+                .await().indefinitely();
+        assertThat(retrievedEntity)
+                .isNotSameAs(entity)
+                .returns(entity.getName(), MyEntity::getName);
+    }
+
+    @Entity
+    public static class MyEntity {
+
+        private long id;
+
+        private String name;
+
+        public MyEntity() {
+        }
+
+        public MyEntity(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + ":" + name;
+        }
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "defaultSeq")
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/DefaultEntity.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/DefaultEntity.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class DefaultEntity {
+
+    private long id;
+
+    private String name;
+
+    public DefaultEntity() {
+    }
+
+    public DefaultEntity(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + name;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "defaultSeq")
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiMutinySessionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    @ActivateRequestContext
+    public void test() {
+        DefaultEntity entity = new DefaultEntity("default");
+
+        DefaultEntity retrievedEntity = session.persist(entity)
+                .chain(() -> session.flush())
+                .invoke(() -> session.clear())
+                .chain(() -> session.find(DefaultEntity.class, entity.getId()))
+                .await().indefinitely();
+
+        assertThat(retrievedEntity)
+                .isNotSameAs(entity)
+                .returns(entity.getName(), DefaultEntity::getName);
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
@@ -29,10 +29,8 @@ public class SinglePersistenceUnitCdiMutinySessionTest {
     public void test() {
         DefaultEntity entity = new DefaultEntity("default");
 
-        DefaultEntity retrievedEntity = session.persist(entity)
-                .chain(() -> session.flush())
-                .invoke(() -> session.clear())
-                .chain(() -> session.find(DefaultEntity.class, entity.getId()))
+        DefaultEntity retrievedEntity = session.withTransaction(tx -> session.persist(entity))
+                .chain(() -> session.withTransaction(tx -> session.clear().find(DefaultEntity.class, entity.getId())))
                 .await().indefinitely();
 
         assertThat(retrievedEntity)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+
+import org.hibernate.reactive.stage.Stage;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiStageSessionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    Stage.Session session;
+
+    @Test
+    @ActivateRequestContext
+    public void test() {
+        DefaultEntity entity = new DefaultEntity("default");
+
+        DefaultEntity retrievedEntity = session.persist(entity)
+                .thenCompose($ -> session.flush())
+                .thenApply($ -> session.clear())
+                .thenCompose($ -> session.find(DefaultEntity.class, entity.getId()))
+                .toCompletableFuture().join();
+
+        assertThat(retrievedEntity)
+                .isNotSameAs(entity)
+                .returns(entity.getName(), DefaultEntity::getName);
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
@@ -29,10 +29,8 @@ public class SinglePersistenceUnitCdiStageSessionTest {
     public void test() {
         DefaultEntity entity = new DefaultEntity("default");
 
-        DefaultEntity retrievedEntity = session.persist(entity)
-                .thenCompose($ -> session.flush())
-                .thenApply($ -> session.clear())
-                .thenCompose($ -> session.find(DefaultEntity.class, entity.getId()))
+        DefaultEntity retrievedEntity = session.withTransaction(tx -> session.persist(entity))
+                .thenCompose($ -> session.withTransaction(tx -> session.clear().find(DefaultEntity.class, entity.getId())))
                 .toCompletableFuture().join();
 
         assertThat(retrievedEntity)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.hibernate.reactive.stage.Stage;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,6 +26,7 @@ public class SinglePersistenceUnitCdiStageSessionTest {
     Stage.Session session;
 
     @Test
+    @Disabled("#14812: We're getting a ContextNotActiveException for some (unknown) reason")
     @ActivateRequestContext
     public void test() {
         DefaultEntity entity = new DefaultEntity("default");

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive=true
+quarkus.datasource.reactive.url=${postgres.reactive.url}
+
+# Hibernate config
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -21,7 +21,6 @@ import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.id.impl.ReactiveIdentifierGeneratorFactoryInitiator;
-import org.hibernate.reactive.provider.service.NoJdbcConnectionProviderInitiator;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
 import org.hibernate.reactive.provider.service.ReactivePersisterClassResolverInitiator;
@@ -43,6 +42,7 @@ import io.quarkus.hibernate.orm.runtime.service.CfgXmlAccessServiceInitiatorQuar
 import io.quarkus.hibernate.orm.runtime.service.DisabledJMXInitiator;
 import io.quarkus.hibernate.orm.runtime.service.FlatClassLoaderService;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
+import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcEnvironmentInitiator;
 
 /**
@@ -178,8 +178,7 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
         serviceInitiators.add(PersisterFactoryInitiator.INSTANCE);
 
         //Custom for Hibernate Reactive:
-        serviceInitiators.add(NoJdbcConnectionProviderInitiator.INSTANCE);
-        //serviceInitiators.add(QuarkusConnectionProviderInitiator.INSTANCE);
+        serviceInitiators.add(QuarkusNoJdbcConnectionProviderInitiator.INSTANCE);
         serviceInitiators.add(MultiTenantConnectionProviderInitiator.INSTANCE);
 
         // Disabled: Dialect is injected explicitly

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -16,7 +16,6 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.id.impl.ReactiveIdentifierGeneratorFactoryInitiator;
-import org.hibernate.reactive.provider.service.NoJdbcConnectionProviderInitiator;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
 import org.hibernate.reactive.provider.service.ReactivePersisterClassResolverInitiator;
@@ -36,6 +35,7 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusImportSqlCommandExtractor
 import io.quarkus.hibernate.orm.runtime.service.QuarkusMutableIdentifierGeneratorFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.StandardHibernateORMInitiatorListProvider;
+import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 
 /**
  * Defines the initial list of StandardServiceInitiator instances used to initialize the
@@ -80,8 +80,7 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
         serviceInitiators.add(PersisterFactoryInitiator.INSTANCE);
 
         //Custom for Hibernate Reactive:
-        serviceInitiators.add(NoJdbcConnectionProviderInitiator.INSTANCE);
-        //serviceInitiators.add(QuarkusConnectionProviderInitiator.INSTANCE);
+        serviceInitiators.add(QuarkusNoJdbcConnectionProviderInitiator.INSTANCE);
         serviceInitiators.add(MultiTenantConnectionProviderInitiator.INSTANCE);
         serviceInitiators.add(DialectResolverInitiator.INSTANCE);
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusNoJdbcConnectionProviderInitiator.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusNoJdbcConnectionProviderInitiator.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.reactive.provider.service.NoJdbcConnectionProvider;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public class QuarkusNoJdbcConnectionProviderInitiator implements StandardServiceInitiator<ConnectionProvider> {
+    public static final QuarkusNoJdbcConnectionProviderInitiator INSTANCE = new QuarkusNoJdbcConnectionProviderInitiator();
+
+    private QuarkusNoJdbcConnectionProviderInitiator() {
+    }
+
+    @Override
+    public ConnectionProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        return NoJdbcConnectionProvider.INSTANCE;
+    }
+
+    @Override
+    public Class<ConnectionProvider> getServiceInitiated() {
+        return ConnectionProvider.class;
+    }
+}


### PR DESCRIPTION
Because Hibernate Reactive only supports resource-local transactions. JTA is ignored in most cases, and when it's not it just makes error messages confusing (see #14264).

The first few commits just add basic unit tests to `quarkus-hibernate-reactive-deployment`.
Next we actually disable JTA and test it. 

The final commit is somewhat unrelated to JTA, but it has the same purpose as disabling JTA: making error messages clearer when something wrong happens. In this case, the error message when encountering #14264 will change from "The application must supply JDBC connections" to "Not using JDBC". Not great, but IMO better.