### PR TITLE
Support KubernetesServer test resource for CRUD operations

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -987,10 +987,67 @@ A very common need is to start some services on which your Quarkus application d
 By simply annotating any test in the test suite with `@QuarkusTestResource`, Quarkus will run the corresponding `QuarkusTestResourceLifecycleManager` before any tests are run.
 A test suite is also free to utilize multiple `@QuarkusTestResource` annotations, in which case all the corresponding `QuarkusTestResourceLifecycleManager` objects will be run before the tests. When using multiple test resources they can be started concurrently. For that you need to set `@QuarkusTestResource(parallel = true)`.
 
+NOTE: test resources are global, even if they are defined on a test class, which means they will all be activated for all tests, even though we do
+remove duplicates. If you want to only enable a test resource on a single test class, you can use `@QuarkusTestResource(restrictToAnnotatedTest = true)`.
+
 Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesMockServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
 Common cases include starting docker containers using https://www.testcontainers.org/[Testcontainers] (an example of which can be found https://github.com/quarkusio/quarkus-quickstarts/blob/master/kafka-quickstart/src/test/java/org/acme/kafka/KafkaResource.java[here]),
 or starting a mock HTTP server using http://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/master/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).
+
+=== Annotation-based test resources
+
+It is possible to write test resources that are enabled and configured using annotations. This is enabled by placing the `@QuarkusTestResource`
+on an annotation which will be used to enable and configure the test resource.
+
+For example, this defines the `@WithKubernetesTestServer` annotation, which you can use on your tests to activate the `KubernetesServerTestResource`,
+but only for the annotated test class.
+
+[source,java]
+----
+@QuarkusTestResource(KubernetesServerTestResource.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface WithKubernetesTestServer {
+    /**
+     * Start it with HTTPS
+     */
+    boolean https() default false;
+
+    /**
+     * Start it in CRUD mode
+     */
+    boolean crud() default true;
+
+    /**
+     * Port to use, defaults to any available port
+     */
+    int port() default 0;
+}
+----
+
+The `KubernetesServerTestResource` class has to implement the
+`QuarkusTestResourceConfigurableLifecycleManager` interface in order to be configured using the previous annotation:
+
+[source,java]
+----
+public class KubernetesServerTestResource
+        implements QuarkusTestResourceConfigurableLifecycleManager<WithKubernetesTestServer> {
+
+    private boolean https = false;
+    private boolean crud = true;
+    private int port = 0;
+
+    @Override
+    public void init(WithKubernetesTestServer annotation) {
+        this.https = annotation.https();
+        this.crud = annotation.crud();
+        this.port = annotation.port();
+    }
+
+    // ...
+}
+----
 
 == Hang Detection
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -987,8 +987,8 @@ A very common need is to start some services on which your Quarkus application d
 By simply annotating any test in the test suite with `@QuarkusTestResource`, Quarkus will run the corresponding `QuarkusTestResourceLifecycleManager` before any tests are run.
 A test suite is also free to utilize multiple `@QuarkusTestResource` annotations, in which case all the corresponding `QuarkusTestResourceLifecycleManager` objects will be run before the tests. When using multiple test resources they can be started concurrently. For that you need to set `@QuarkusTestResource(parallel = true)`.
 
-NOTE: test resources are global, even if they are defined on a test class, which means they will all be activated for all tests, even though we do
-remove duplicates. If you want to only enable a test resource on a single test class, you can use `@QuarkusTestResource(restrictToAnnotatedTest = true)`.
+NOTE: test resources are global, even if they are defined on a test class or custom profile, which means they will all be activated for all tests, even though we do
+remove duplicates. If you want to only enable a test resource on a single test class or test profile, you can use `@QuarkusTestResource(restrictToAnnotatedClass = true)`.
 
 Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesMockServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
@@ -1001,7 +1001,7 @@ It is possible to write test resources that are enabled and configured using ann
 on an annotation which will be used to enable and configure the test resource.
 
 For example, this defines the `@WithKubernetesTestServer` annotation, which you can use on your tests to activate the `KubernetesServerTestResource`,
-but only for the annotated test class.
+but only for the annotated test class. You can also place them on your `QuarkusTestProfile` test profiles.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -71,9 +71,9 @@ public class KubernetesClientProducer {
 
 == Testing
 
-To make testing against a mock Kubernetes API extremely simple, Quarkus provides the `KubernetesMockServerTestResource` which automatically launches
+To make testing against a mock Kubernetes API extremely simple, Quarkus provides the `WithKubernetesTestServer` annotation which automatically launches
 a mock of the Kubernetes API server and sets the proper environment variables needed so that the Kubernetes Client configures itself to use said mock.
-Tests can inject the mock and set it up in any way necessary for the particular testing using the `@MockServer` annotation.
+Tests can inject the mock server and set it up in any way necessary for the particular testing using the `@KubernetesTestServer` annotation.
 
 Let's assume we have a REST endpoint defined like so:
 
@@ -100,12 +100,13 @@ We could write a test for this endpoint very easily like so:
 
 [source%nowrap,java]
 ----
-@QuarkusTestResource(KubernetesMockServerTestResource.class)
+// you can even configure aspects like crud, https and port on this annotation
+@WithKubernetesTestServer
 @QuarkusTest
 public class KubernetesClientTest {
 
-    @MockServer
-    KubernetesMockServer mockServer;
+    @KubernetesTestServer
+    KubernetesServer mockServer;
 
     @BeforeEach
     public void before() {
@@ -139,14 +140,14 @@ Note that to take advantage of these features, the `quarkus-test-kubernetes-clie
 </dependency>
 ----
 
-You can create a `CustomKubernetesMockServerTestResource.java` to ensure all your `@QuarkusTest` enabled test classes share the same mock server setup:
+Alternately, you can create a `CustomKubernetesMockServerTestResource.java` to ensure all your `@QuarkusTest` enabled test classes share the same mock server setup:
 
 [source%nowrap,java]
 ----
-public class CustomKubernetesMockServerTestResource extends KubernetesMockServerTestResource {
+public class CustomKubernetesMockServerTestResource extends KubernetesServerTestResource {
 
     @Override
-    public void configureMockServer(KubernetesMockServer mockServer) {
+    public void configureMockServer(KubernetesServer mockServer) {
         mockServer.expect().get().withPath("/api/v1/namespaces/test/pods")
                 .andReturn(200, new PodList())
                 .always();

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -93,6 +93,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
                 <executions>
                     <!--
                     The prod mode tests need to be part of a different execution to ensure that they don't mess with the standard tests.

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
@@ -52,7 +52,8 @@ public class Pods {
         final Pod pod = pods.get(0);
         final String podName = pod.getMetadata().getName();
         // would normally do some kind of meaningful update here
-        Pod updatedPod = new PodBuilder().withNewMetadata().withName(podName).withNewResourceVersion("12345").endMetadata()
+        Pod updatedPod = new PodBuilder().withNewMetadata().withName(podName).withNewResourceVersion("12345")
+                .addToLabels("key1", "value1").endMetadata()
                 .build();
 
         updatedPod = kubernetesClient.pods().withName(podName).createOrReplace(updatedPod);

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusProdModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
 public class AbsentConfigMapPropertiesPMT {
 
     @RegisterExtension

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusProdModeTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
 public class AbsentConfigMapPropertiesPMT {
 
     @RegisterExtension

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
 @QuarkusTest
 public class ConfigMapPropertiesTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
 @QuarkusTest
 public class ConfigMapPropertiesTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.kubernetes.client;
+
+import java.util.Base64;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+
+public class CustomKubernetesTestServerTestResource extends KubernetesServerTestResource {
+
+    // setup the ConfigMap objects that the application expects to lookup configuration from
+    @Override
+    protected void configureServer() {
+        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap1")
+                .addToData("dummy", "dummy")
+                .addToData("overridden.secret", "cm") // will be overridden since secrets have a higher priority
+                .addToData("some.prop1", "val1")
+                .addToData("some.prop2", "val2")
+                .addToData("some.prop4", "v4") // will be overridden since cmap2 has a higher priority
+                .addToData("some.prop5", "val5")
+                .addToData("application.properties", "some.prop3=val3")
+                .addToData("application.yaml", "some:\n  prop4: val4").build());
+
+        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap2")
+                .addToData("application.yaml", "some:\n  prop4: val4").build());
+
+        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap3")
+                .addToData("dummy", "dummyFromDemo")
+                .addToData("some.prop1", "val1FromDemo")
+                .addToData("some.prop2", "val2FromDemo")
+                .addToData("some.prop5", "val5FromDemo")
+                .addToData("application.properties", "some.prop3=val3FromDemo")
+                .addToData("application.yaml", "some:\n  prop4: val4FromDemo").build());
+
+        server.getClient().inNamespace("test").secrets().create(secretBuilder("s1")
+                .addToData("dummysecret", encodeValue("dummysecret"))
+                .addToData("overridden.secret", encodeValue("secret"))
+                .addToData("secret.prop1", encodeValue("val1"))
+                .addToData("secret.prop2", encodeValue("val2"))
+                .addToData("application.properties", encodeValue("secret.prop3=val3"))
+                .addToData("application.yaml", encodeValue("secret:\n  prop4: val4")).build());
+
+        server.getClient().inNamespace("test").secrets().create(secretBuilder("s1")
+                .addToData("dummysecret", encodeValue("dummysecretFromDemo"))
+                .addToData("overridden.secret", encodeValue("secretFromDemo"))
+                .addToData("secret.prop1", encodeValue("val1FromDemo"))
+                .addToData("secret.prop2", encodeValue("val2FromDemo"))
+                .addToData("application.properties", encodeValue("secret.prop3=val3FromDemo"))
+                .addToData("application.yaml", encodeValue("secret:\n  prop4: val4FromDemo")).build());
+    }
+
+    private ConfigMapBuilder configMapBuilder(String name) {
+        return new ConfigMapBuilder().withNewMetadata()
+                .withName(name).endMetadata();
+    }
+
+    private SecretBuilder secretBuilder(String name) {
+        return new SecretBuilder().withNewMetadata()
+                .withName(name).endMetadata();
+    }
+
+    private String encodeValue(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes());
+    }
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -19,7 +19,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
 @QuarkusTest
 public class KubernetesClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -19,7 +19,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
 @QuarkusTest
 public class KubernetesClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -17,7 +17,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(value = CustomKubernetesTestServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesTestServerTestResource.class, restrictToAnnotatedClass = true)
 @QuarkusTest
 public class KubernetesNewClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -17,7 +17,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(CustomKubernetesTestServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesTestServerTestResource.class, restrictToAnnotatedTest = true)
 @QuarkusTest
 public class KubernetesNewClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.kubernetes.client;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.restassured.RestAssured;
+
+/*
+ * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
+ * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
+ */
+@QuarkusTestResource(CustomKubernetesTestServerTestResource.class)
+@QuarkusTest
+public class KubernetesNewClientTest {
+
+    @KubernetesTestServer
+    private KubernetesServer mockServer;
+
+    @Test
+    public void testInteractionWithAPIServer() throws InterruptedException {
+        setupMockServerForTest();
+
+        RestAssured.when().get("/pod/test").then()
+                .body("size()", is(2)).body(containsString("pod1"), containsString("pod2"));
+
+        RestAssured.when().delete("/pod/test").then()
+                .statusCode(204);
+
+        RestAssured.when().put("/pod/test").then()
+                .body(containsString("value1"));
+
+        RestAssured.when().post("/pod/test").then()
+                .body(containsString("12345"));
+    }
+
+    private void setupMockServerForTest() {
+        Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+        Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
+
+        mockServer.getClient().inNamespace("test").pods().create(pod1);
+        mockServer.getClient().inNamespace("test").pods().create(pod2);
+    }
+
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTestIT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.kubernetes.client;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class KubernetesNewClientTestIT extends KubernetesNewClientTest {
+
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerOnProfileTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerOnProfileTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.it.kubernetes.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+/*
+ * This class has no native-image test because it relies on setting config overrides that clash
+ * with native image build config.
+ * This is the same test as KubernetesTestServerTest but with the test resource annotation on the profile
+ */
+@TestProfile(KubernetesTestServerOnProfileTest.MyProfile.class)
+@QuarkusTest
+public class KubernetesTestServerOnProfileTest {
+
+    private static KubernetesServer setupServer;
+
+    public static class Setup implements Consumer<KubernetesServer> {
+
+        @Override
+        public void accept(KubernetesServer t) {
+            setupServer = t;
+        }
+
+    }
+
+    @KubernetesTestServer
+    private KubernetesServer mockServer;
+
+    @Test
+    public void testConfiguration() throws InterruptedException {
+        // we can't really test CRUD, and HTTPS doesn't work
+        Assertions.assertEquals(10001, mockServer.getMockServer().getPort());
+        Assertions.assertSame(mockServer, setupServer);
+    }
+
+    @WithKubernetesTestServer(https = false, crud = true, port = 10001, setup = KubernetesTestServerOnProfileTest.Setup.class)
+    public static class MyProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> overrides = new HashMap<>();
+            // do not fetch config from kubernetes
+            overrides.put("quarkus.kubernetes-config.enabled", "false");
+            overrides.put("quarkus.kubernetes-config.secrets.enabled", "false");
+            // get rid of errors due to us not populating config from kubernetes
+            overrides.put("dummy", "asd");
+            overrides.put("some.prop1", "asd");
+            overrides.put("some.prop2", "asd");
+            overrides.put("some.prop3", "asd");
+            overrides.put("some.prop4", "asd");
+            overrides.put("some.prop5", "asd");
+            overrides.put("secret.prop1", "asd");
+            overrides.put("secret.prop2", "asd");
+            overrides.put("secret.prop3", "asd");
+            overrides.put("secret.prop4", "asd");
+            overrides.put("overridden.secret", "asd");
+            overrides.put("dummysecret", "asd");
+            return overrides;
+        }
+    }
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
@@ -14,6 +14,10 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 
+/*
+ * This class has no native-image test because it relies on setting config overrides that clash
+ * with native image build config.
+ */
 @TestProfile(KubernetesTestServerTest.MyProfile.class)
 @WithKubernetesTestServer(https = false, crud = true, port = 10001, setup = KubernetesTestServerTest.Setup.class)
 @QuarkusTest

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.it.kubernetes.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+
+@TestProfile(KubernetesTestServerTest.MyProfile.class)
+@QuarkusTestResource(value = KubernetesServerTestResource.class, initArgs = {
+        @ResourceArg(name = KubernetesServerTestResource.HTTPS, value = "false"),
+        @ResourceArg(name = KubernetesServerTestResource.CRUD, value = "false"),
+        @ResourceArg(name = KubernetesServerTestResource.PORT, value = "10001"),
+})
+@QuarkusTest
+public class KubernetesTestServerTest {
+
+    @KubernetesTestServer
+    private KubernetesServer mockServer;
+
+    @Test
+    public void testConfiguration() throws InterruptedException {
+        // we can't really test CRUD, and HTTPS doesn't work
+        Assertions.assertEquals(mockServer.getMockServer().getPort(), 10001);
+    }
+
+    public static class MyProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> overrides = new HashMap<>();
+            // do not fetch config from kubernetes
+            overrides.put("quarkus.kubernetes-config.enabled", "false");
+            overrides.put("quarkus.kubernetes-config.secrets.enabled", "false");
+            // get rid of errors due to us not populating config from kubernetes
+            overrides.put("dummy", "asd");
+            overrides.put("some.prop1", "asd");
+            overrides.put("some.prop2", "asd");
+            overrides.put("some.prop3", "asd");
+            overrides.put("some.prop4", "asd");
+            overrides.put("some.prop5", "asd");
+            overrides.put("secret.prop1", "asd");
+            overrides.put("secret.prop2", "asd");
+            overrides.put("secret.prop3", "asd");
+            overrides.put("secret.prop4", "asd");
+            overrides.put("overridden.secret", "asd");
+            overrides.put("dummysecret", "asd");
+            return overrides;
+        }
+    }
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
@@ -7,20 +7,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 
 @TestProfile(KubernetesTestServerTest.MyProfile.class)
-@QuarkusTestResource(value = KubernetesServerTestResource.class, initArgs = {
-        @ResourceArg(name = KubernetesServerTestResource.HTTPS, value = "false"),
-        @ResourceArg(name = KubernetesServerTestResource.CRUD, value = "false"),
-        @ResourceArg(name = KubernetesServerTestResource.PORT, value = "10001"),
-})
+@WithKubernetesTestServer(https = false, crud = true, port = 10001)
 @QuarkusTest
 public class KubernetesTestServerTest {
 
@@ -30,7 +24,7 @@ public class KubernetesTestServerTest {
     @Test
     public void testConfiguration() throws InterruptedException {
         // we can't really test CRUD, and HTTPS doesn't work
-        Assertions.assertEquals(mockServer.getMockServer().getPort(), 10001);
+        Assertions.assertEquals(10001, mockServer.getMockServer().getPort());
     }
 
     public static class MyProfile implements QuarkusTestProfile {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.kubernetes.client;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,20 @@ import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 
 @TestProfile(KubernetesTestServerTest.MyProfile.class)
-@WithKubernetesTestServer(https = false, crud = true, port = 10001)
+@WithKubernetesTestServer(https = false, crud = true, port = 10001, setup = KubernetesTestServerTest.Setup.class)
 @QuarkusTest
 public class KubernetesTestServerTest {
+
+    private static KubernetesServer setupServer;
+
+    public static class Setup implements Consumer<KubernetesServer> {
+
+        @Override
+        public void accept(KubernetesServer t) {
+            setupServer = t;
+        }
+
+    }
 
     @KubernetesTestServer
     private KubernetesServer mockServer;
@@ -25,6 +37,7 @@ public class KubernetesTestServerTest {
     public void testConfiguration() throws InterruptedException {
         // we can't really test CRUD, and HTTPS doesn't work
         Assertions.assertEquals(10001, mockServer.getMockServer().getPort());
+        Assertions.assertSame(mockServer, setupServer);
     }
 
     public static class MyProfile implements QuarkusTestProfile {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
@@ -10,7 +10,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
 @TestProfile(NamespacedConfigMapPropertiesTest.MyProfile.class)
 @QuarkusTest
 public class NamespacedConfigMapPropertiesTest {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
@@ -10,7 +10,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
 @TestProfile(NamespacedConfigMapPropertiesTest.MyProfile.class)
 @QuarkusTest
 public class NamespacedConfigMapPropertiesTest {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
 @QuarkusTest
 public class SecretPropertiesTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
 @QuarkusTest
 public class SecretPropertiesTest {
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
@@ -42,6 +42,13 @@ public @interface QuarkusTestResource {
      */
     boolean parallel() default false;
 
+    /**
+     * Whether this annotation should only be enabled if it is placed on the currently running test class.
+     * Note that this defaults to true for meta-annotations since meta-annotations are only considered
+     * for the current test class.
+     */
+    boolean restrictToAnnotatedTest() default false;
+
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.RUNTIME)
     @Documented

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
@@ -43,11 +43,11 @@ public @interface QuarkusTestResource {
     boolean parallel() default false;
 
     /**
-     * Whether this annotation should only be enabled if it is placed on the currently running test class.
+     * Whether this annotation should only be enabled if it is placed on the currently running test class or test profile.
      * Note that this defaults to true for meta-annotations since meta-annotations are only considered
-     * for the current test class.
+     * for the current test class or test profile.
      */
-    boolean restrictToAnnotatedTest() default false;
+    boolean restrictToAnnotatedClass() default false;
 
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.RUNTIME)

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceConfigurableLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceConfigurableLifecycleManager.java
@@ -1,0 +1,9 @@
+package io.quarkus.test.common;
+
+import java.lang.annotation.Annotation;
+
+public interface QuarkusTestResourceConfigurableLifecycleManager<ConfigAnnotation extends Annotation>
+        extends QuarkusTestResourceLifecycleManager {
+    default void init(ConfigAnnotation annotation) {
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -37,6 +37,7 @@ public class TestResourceManager implements Closeable {
     private final List<TestResourceEntry> allTestResourceEntries;
     private Map<String, String> oldSystemProps;
     private boolean started = false;
+    private boolean hasPerTestResources = false;
 
     public TestResourceManager(Class<?> testClass) {
         this(testClass, Collections.emptyList(), false);
@@ -284,6 +285,7 @@ public class TestResourceManager implements Closeable {
 
                     boolean isParallel = testResource.parallel();
 
+                    hasPerTestResources = true;
                     uniqueEntries.add(new TestResourceClassEntry(testResourceClass, args, reflAnnotation, isParallel));
 
                     break;
@@ -311,6 +313,11 @@ public class TestResourceManager implements Closeable {
                 AnnotationValue parallelAnnotationValue = annotation.value("parallel");
                 if (parallelAnnotationValue != null) {
                     isParallel = parallelAnnotationValue.asBoolean();
+                }
+
+                AnnotationValue restrict = annotation.value("restrictToAnnotatedTest");
+                if (restrict != null && restrict.asBoolean()) {
+                    hasPerTestResources = true;
                 }
 
                 uniqueEntries.add(new TestResourceClassEntry(testResourceClass, args, null, isParallel));
@@ -351,6 +358,11 @@ public class TestResourceManager implements Closeable {
             }
         }
         return testResourceAnnotations;
+    }
+
+    // NOTE: called by reflection in QuarkusTestExtension
+    public boolean hasPerTestResources() {
+        return hasPerTestResources;
     }
 
     private boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass, Class<?> testClass) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -266,6 +266,9 @@ public class TestResourceManager implements Closeable {
             for (Annotation annotationAnnotation : reflAnnotation.annotationType().getAnnotations()) {
                 if (annotationAnnotation.annotationType() == QuarkusTestResource.class) {
                     QuarkusTestResource testResource = (QuarkusTestResource) annotationAnnotation;
+
+                    // NOTE: we don't need to check restrictToAnnotatedTest because by design config-based annotations
+                    // are not discovered outside the test class, so they're restricted
                     Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass = testResource.value();
 
                     ResourceArg[] argsAnnotationValue = testResource.initArgs();
@@ -287,7 +290,7 @@ public class TestResourceManager implements Closeable {
                 }
             }
         }
-        for (AnnotationInstance annotation : findQuarkusTestResourceInstances(index)) {
+        for (AnnotationInstance annotation : findQuarkusTestResourceInstances(testClass, index)) {
             try {
                 Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass = loadTestResourceClassFromTCCL(
                         annotation.value().asString());
@@ -330,14 +333,32 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    private Collection<AnnotationInstance> findQuarkusTestResourceInstances(IndexView index) {
-        Set<AnnotationInstance> testResourceAnnotations = new HashSet<>(
-                index.getAnnotations(DotName.createSimple(QuarkusTestResource.class.getName())));
+    private Collection<AnnotationInstance> findQuarkusTestResourceInstances(Class<?> testClass, IndexView index) {
+        Set<AnnotationInstance> testResourceAnnotations = new HashSet<>();
+        for (AnnotationInstance annotation : index.getAnnotations(DotName.createSimple(QuarkusTestResource.class.getName()))) {
+            if (keepTestResourceAnnotation(annotation, annotation.target().asClass(), testClass)) {
+                testResourceAnnotations.add(annotation);
+            }
+        }
+
         for (AnnotationInstance annotation : index
                 .getAnnotations(DotName.createSimple(QuarkusTestResource.List.class.getName()))) {
-            Collections.addAll(testResourceAnnotations, annotation.value().asNestedArray());
+            for (AnnotationInstance nestedAnnotation : annotation.value().asNestedArray()) {
+                // keep the list target
+                if (keepTestResourceAnnotation(nestedAnnotation, annotation.target().asClass(), testClass)) {
+                    testResourceAnnotations.add(nestedAnnotation);
+                }
+            }
         }
         return testResourceAnnotations;
+    }
+
+    private boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass, Class<?> testClass) {
+        AnnotationValue restrict = annotation.value("restrictToAnnotatedTest");
+        if (restrict != null && restrict.asBoolean()) {
+            return testClass.getName().equals(targetClass.name().toString('.'));
+        }
+        return true;
     }
 
     public static class TestResourceClassEntry {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -3,6 +3,7 @@ package io.quarkus.test.junit;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -173,7 +174,8 @@ public class NativeTestExtension
                 }
             }
 
-            testResourceManager = new TestResourceManager(requiredTestClass);
+            testResourceManager = new TestResourceManager(requiredTestClass, quarkusTestProfile,
+                    Collections.emptyList(), profileInstance != null ? profileInstance.disableGlobalTestResources() : false);
             testResourceManager.init();
             hasPerTestResources = testResourceManager.hasPerTestResources();
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -93,11 +93,7 @@ public class NativeTestExtension
         ExtensionContext root = extensionContext.getRoot();
         ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
         ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
-        TestProfile annotation = testClass.getAnnotation(TestProfile.class);
-        Class<? extends QuarkusTestProfile> selectedProfile = null;
-        if (annotation != null) {
-            selectedProfile = annotation.value();
-        }
+        Class<? extends QuarkusTestProfile> selectedProfile = findProfile(testClass);
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
         // we reload the test resources if we changed test class and if we had or will have per-test test resources
         boolean reloadTestResources = !Objects.equals(extensionContext.getRequiredTestClass(), currentJUnitTestClass)
@@ -123,6 +119,17 @@ public class NativeTestExtension
             }
         }
         return state;
+    }
+
+    private Class<? extends QuarkusTestProfile> findProfile(Class<?> testClass) {
+        while (testClass != Object.class) {
+            TestProfile annotation = testClass.getAnnotation(TestProfile.class);
+            if (annotation != null) {
+                return annotation.value();
+            }
+            testClass = testClass.getSuperclass();
+        }
+        return null;
     }
 
     private ExtensionState doNativeStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -313,8 +313,9 @@ public class QuarkusTestExtension
 
             //must be done after the TCCL has been set
             testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
-                    .getConstructor(Class.class, List.class, boolean.class)
+                    .getConstructor(Class.class, Class.class, List.class, boolean.class)
                     .newInstance(requiredTestClass,
+                            profile != null ? profile : null,
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources());
             testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
@@ -1192,7 +1193,7 @@ public class QuarkusTestExtension
     public static boolean hasPerTestResources(Class<?> requiredTestClass) {
         while (requiredTestClass != Object.class) {
             for (QuarkusTestResource testResource : requiredTestClass.getAnnotationsByType(QuarkusTestResource.class)) {
-                if (testResource.restrictToAnnotatedTest()) {
+                if (testResource.restrictToAnnotatedClass()) {
                     return true;
                 }
             }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -6,6 +6,7 @@ import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.reflect.Constructor;
@@ -400,14 +401,14 @@ public class QuarkusTestExtension
         try {
             Constructor<?> testResourceClassEntryConstructor = Class
                     .forName(TestResourceManager.TestResourceClassEntry.class.getName(), true, classLoader)
-                    .getConstructor(Class.class, Map.class, boolean.class);
+                    .getConstructor(Class.class, Map.class, Annotation.class, boolean.class);
 
             List<QuarkusTestProfile.TestResourceEntry> testResources = profileInstance.testResources();
             List<Object> result = new ArrayList<>(testResources.size());
             for (QuarkusTestProfile.TestResourceEntry testResource : testResources) {
                 Object instance = testResourceClassEntryConstructor.newInstance(
                         Class.forName(testResource.getClazz().getName(), true, classLoader), testResource.getArgs(),
-                        testResource.isParallel());
+                        null, testResource.isParallel());
                 result.add(instance);
             }
 

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
@@ -1,0 +1,83 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public abstract class AbstractKubernetesTestResource<T> implements QuarkusTestResourceLifecycleManager {
+    protected T server;
+
+    @Override
+    public Map<String, String> start() {
+        final Map<String, String> systemProps = new HashMap<>();
+        systemProps.put(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+        systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+        systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+        systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+        systemProps.put(Config.KUBERNETES_HTTP2_DISABLE, "true");
+
+        server = createServer();
+        initServer();
+
+        try (GenericKubernetesClient<?> client = getClient()) {
+            systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, client.getConfiguration().getMasterUrl());
+        }
+
+        configureServer();
+
+        return systemProps;
+    }
+
+    protected abstract GenericKubernetesClient<?> getClient();
+
+    /**
+     * Can be used by subclasses in order to
+     * setup the mock server before the Quarkus application starts
+     */
+    protected void configureServer() {
+    }
+
+    protected void initServer() {
+    }
+
+    protected abstract T createServer();
+
+    protected boolean useHttps() {
+        return Boolean.getBoolean("quarkus.kubernetes-client.test.https");
+    }
+
+    @Override
+    public void inject(Object testInstance) {
+        Class<?> c = testInstance.getClass();
+        Class<? extends Annotation> annotation = getInjectionAnnotation();
+        Class<?> injectedClass = getInjectedClass();
+        while (c != Object.class) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.getAnnotation(annotation) != null) {
+                    if (!injectedClass.isAssignableFrom(f.getType())) {
+                        throw new RuntimeException(annotation + " can only be used on fields of type " + injectedClass);
+                    }
+
+                    f.setAccessible(true);
+                    try {
+                        f.set(testInstance, server);
+                        return;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            c = c.getSuperclass();
+        }
+    }
+
+    protected abstract Class<?> getInjectedClass();
+
+    protected abstract Class<? extends Annotation> getInjectionAnnotation();
+
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Annotation;
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 
+/**
+ * @deprecated use {@link KubernetesServerTestResource}
+ */
+@Deprecated
 public class KubernetesMockServerTestResource extends AbstractKubernetesTestResource<KubernetesMockServer> {
 
     @Override

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -1,81 +1,62 @@
 package io.quarkus.test.kubernetes.client;
 
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
+import java.lang.annotation.Annotation;
 
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-public class KubernetesMockServerTestResource implements QuarkusTestResourceLifecycleManager {
-
-    private KubernetesMockServer mockServer;
+public class KubernetesMockServerTestResource extends AbstractKubernetesTestResource<KubernetesMockServer> {
 
     @Override
-    public Map<String, String> start() {
-        final Map<String, String> systemProps = new HashMap<>();
-        systemProps.put(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
-        systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
-        systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
-        systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
-        systemProps.put(Config.KUBERNETES_HTTP2_DISABLE, "true");
-
-        mockServer = createMockServer();
-        mockServer.init();
-        try (NamespacedKubernetesClient client = mockServer.createClient()) {
-            systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, client.getConfiguration().getMasterUrl());
-        }
-
-        configureMockServer(mockServer);
-
-        return systemProps;
+    protected GenericKubernetesClient<?> getClient() {
+        return server.createClient();
     }
 
+    @Override
+    protected void initServer() {
+        server.init();
+    }
+
+    @Override
+    protected KubernetesMockServer createServer() {
+        return createMockServer();
+    }
+
+    /**
+     * @deprecated use {@link #createServer()}
+     */
+    @Deprecated
     protected KubernetesMockServer createMockServer() {
         return new KubernetesMockServer(useHttps());
     }
 
-    /**
-     * Can be used by subclasses of {@code KubernetesMockServerTestResource} in order to
-     * setup the mock server before the Quarkus application starts
-     */
-    public void configureMockServer(KubernetesMockServer mockServer) {
+    @Override
+    protected void configureServer() {
+        configureMockServer(server);
+    }
 
+    /**
+     * @deprecated use {@link #configureServer()}
+     */
+    @Deprecated
+    public void configureMockServer(KubernetesMockServer mockServer) {
     }
 
     @Override
     public void stop() {
-        if (mockServer != null) {
-            mockServer.destroy();
+        if (server != null) {
+            server.destroy();
+            server = null;
         }
     }
 
     @Override
-    public void inject(Object testInstance) {
-        Class<?> c = testInstance.getClass();
-        while (c != Object.class) {
-            for (Field f : c.getDeclaredFields()) {
-                if (f.getAnnotation(MockServer.class) != null) {
-                    if (!KubernetesMockServer.class.isAssignableFrom(f.getType())) {
-                        throw new RuntimeException("@MockServer can only be used on fields of type KubernetesMockServer");
-                    }
-
-                    f.setAccessible(true);
-                    try {
-                        f.set(testInstance, mockServer);
-                        return;
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-            c = c.getSuperclass();
-        }
+    protected Class<?> getInjectedClass() {
+        return KubernetesMockServer.class;
     }
 
-    protected boolean useHttps() {
-        return Boolean.getBoolean("quarkus.kubernetes-client.test.https");
+    @Override
+    protected Class<? extends Annotation> getInjectionAnnotation() {
+        return MockServer.class;
     }
 }

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
@@ -1,11 +1,47 @@
 package io.quarkus.test.kubernetes.client;
 
 import java.lang.annotation.Annotation;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Map;
 
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
 public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer> {
+
+    /**
+     * Configure HTTPS usage, defaults to false
+     */
+    public final static String HTTPS = "https";
+    /**
+     * Configure CRUD usage, defaults to true
+     */
+    public final static String CRUD = "crud";
+    /**
+     * Configure the port to use, defaults to 0, for the first available port
+     */
+    public final static String PORT = "port";
+
+    private boolean https = false;
+    private boolean crud = true;
+    private int port = 0;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        String val = initArgs.get(HTTPS);
+        if (val != null) {
+            this.https = Boolean.parseBoolean(val);
+        }
+        val = initArgs.get(CRUD);
+        if (val != null) {
+            this.crud = Boolean.parseBoolean(val);
+        }
+        val = initArgs.get(PORT);
+        if (val != null) {
+            this.port = Integer.parseInt(val);
+        }
+    }
 
     @Override
     protected GenericKubernetesClient<?> getClient() {
@@ -19,7 +55,7 @@ public class KubernetesServerTestResource extends AbstractKubernetesTestResource
 
     @Override
     protected KubernetesServer createServer() {
-        return new KubernetesServer(useHttps(), true);
+        return new KubernetesServer(https, crud, InetAddress.getLoopbackAddress(), port, Collections.emptyList());
     }
 
     @Override
@@ -37,6 +73,6 @@ public class KubernetesServerTestResource extends AbstractKubernetesTestResource
 
     @Override
     protected Class<? extends Annotation> getInjectionAnnotation() {
-        return Server.class;
+        return KubernetesTestServer.class;
     }
 }

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.Annotation;
+
+import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+
+public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer> {
+
+    @Override
+    protected GenericKubernetesClient<?> getClient() {
+        return server.getClient();
+    }
+
+    @Override
+    protected void initServer() {
+        server.before();
+    }
+
+    @Override
+    protected KubernetesServer createServer() {
+        return new KubernetesServer(useHttps(), true);
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.after();
+            server = null;
+        }
+    }
+
+    @Override
+    protected Class<?> getInjectedClass() {
+        return KubernetesServer.class;
+    }
+
+    @Override
+    protected Class<? extends Annotation> getInjectionAnnotation() {
+        return Server.class;
+    }
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
@@ -3,44 +3,23 @@ package io.quarkus.test.kubernetes.client;
 import java.lang.annotation.Annotation;
 import java.net.InetAddress;
 import java.util.Collections;
-import java.util.Map;
 
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 
-public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer> {
-
-    /**
-     * Configure HTTPS usage, defaults to false
-     */
-    public final static String HTTPS = "https";
-    /**
-     * Configure CRUD usage, defaults to true
-     */
-    public final static String CRUD = "crud";
-    /**
-     * Configure the port to use, defaults to 0, for the first available port
-     */
-    public final static String PORT = "port";
+public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer>
+        implements QuarkusTestResourceConfigurableLifecycleManager<WithKubernetesTestServer> {
 
     private boolean https = false;
     private boolean crud = true;
     private int port = 0;
 
     @Override
-    public void init(Map<String, String> initArgs) {
-        String val = initArgs.get(HTTPS);
-        if (val != null) {
-            this.https = Boolean.parseBoolean(val);
-        }
-        val = initArgs.get(CRUD);
-        if (val != null) {
-            this.crud = Boolean.parseBoolean(val);
-        }
-        val = initArgs.get(PORT);
-        if (val != null) {
-            this.port = Integer.parseInt(val);
-        }
+    public void init(WithKubernetesTestServer annotation) {
+        this.https = annotation.https();
+        this.crud = annotation.crud();
+        this.port = annotation.port();
     }
 
     @Override

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesTestServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesTestServer.java
@@ -13,6 +13,6 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface Server {
+public @interface KubernetesTestServer {
 
 }

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/Server.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/Server.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+
+/**
+ * Used to specify that the field should be injected with the mock Kubernetes API server
+ * Can only be used on type {@link KubernetesServer}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Server {
+
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Consumer;
 
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -32,4 +33,14 @@ public @interface WithKubernetesTestServer {
      */
     int port() default 0;
 
+    /**
+     * Setup class to call after the mock server is created, for custom setup.
+     */
+    Class<? extends Consumer<KubernetesServer>> setup() default NO_SETUP.class;
+
+    static class NO_SETUP implements Consumer<KubernetesServer> {
+        @Override
+        public void accept(KubernetesServer t) {
+        }
+    };
 }

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
@@ -1,0 +1,35 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.common.QuarkusTestResource;
+
+/**
+ * Use on your test resource to get a mock {@link KubernetesServer} spawn up, and injectable with {@link KubernetesTestServer}.
+ * This annotation is only active when used on a test class, and only for this test class.
+ */
+@QuarkusTestResource(value = KubernetesServerTestResource.class, restrictToAnnotatedTest = true)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface WithKubernetesTestServer {
+
+    /**
+     * Start it with HTTPS
+     */
+    boolean https() default false;
+
+    /**
+     * Start it in CRUD mode
+     */
+    boolean crud() default true;
+
+    /**
+     * Port to use, defaults to any available port
+     */
+    int port() default 0;
+
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
@@ -13,7 +13,7 @@ import io.quarkus.test.common.QuarkusTestResource;
  * Use on your test resource to get a mock {@link KubernetesServer} spawn up, and injectable with {@link KubernetesTestServer}.
  * This annotation is only active when used on a test class, and only for this test class.
  */
-@QuarkusTestResource(value = KubernetesServerTestResource.class, restrictToAnnotatedTest = true)
+@QuarkusTestResource(value = KubernetesServerTestResource.class, restrictToAnnotatedClass = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithKubernetesTestServer {


### PR DESCRIPTION
Can you check @shawkins if this would work for you?

It's a bit over-engineered, but I didn't want for future fixes on one class to miss the other.
I'm also unsure about the annotation for injecting the crud server, but the target server type doesn't have a good name including `mock` like the other… I don't you don't need it ATM but it's more regular to support injection anyway.

@geoand could you double-check if this is binary-compatible? I think it should be. Do you know if we have tests/docs?

Fixes #14744.

Late edit: Also fixes #14823.