### PR TITLE
ArC - make it possible to turn any annotation into a qualifier

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -436,7 +436,7 @@ _Solution_: You can inject the `CustomScopeAnnotationsBuildItem` in a build step
 
 In rare cases it might be handy to programmatically register an existing annotation that is not annotated with `@javax.interceptor.InterceptorBinding` as an interceptor binding.
 This is similar to what CDI achieves through `BeforeBeanDiscovery#addInterceptorBinding()`.
-Though here we are going to use `InterceptorBindingRegistrarBuildItem` to get it done.
+We are going to use `InterceptorBindingRegistrarBuildItem` to get it done.
 
 .`InterceptorBindingRegistrarBuildItem` Example
 [source,java]
@@ -445,8 +445,29 @@ Though here we are going to use `InterceptorBindingRegistrarBuildItem` to get it
 InterceptorBindingRegistrarBuildItem addInterceptorBindings() {
     return new InterceptorBindingRegistrarBuildItem(new InterceptorBindingRegistrar() {
         @Override
-        public Map<DotName, Set<String>> registerAdditionalBindings() { <1>
+        public Map<DotName, Set<String>> registerAdditionalBindings() {
             return Collections.singletonMap(DotName.createSimple(NotAnInterceptorBinding.class.getName()),
+                                        Collections.emptySet());
+        }
+    });
+}
+----
+
+== Use Case - Additional Qualifiers
+
+Sometimes it might be useful to register an existing annotation that is not annotated with `@javax.inject.Qualifier` as a CDI qualifier.
+This is similar to what CDI achieves through `BeforeBeanDiscovery#addQualifier()`.
+We are going to use `QualifierRegistrarBuildItem` to get it done.
+
+.`QualifierRegistrarBuildItem` Example
+[source,java]
+----
+@BuildStep
+QualifierRegistrarBuildItem addQualifiers() {
+    return new QualifierRegistrarBuildItem(new QualifierRegistrar() {
+        @Override
+        public Map<DotName, Set<String>> getAdditionalQualifiers() {
+            return Collections.singletonMap(DotName.createSimple(NotAQualifier.class.getName()),
                                         Collections.emptySet());
         }
     });

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -137,7 +137,8 @@ public class ArcProcessor {
             List<AnnotationsTransformerBuildItem> annotationTransformers,
             List<InjectionPointTransformerBuildItem> injectionPointTransformers,
             List<ObserverTransformerBuildItem> observerTransformers,
-            List<InterceptorBindingRegistrarBuildItem> interceptorBindingRegistrarBuildItems,
+            List<InterceptorBindingRegistrarBuildItem> interceptorBindingRegistrars,
+            List<QualifierRegistrarBuildItem> qualifierRegistrars,
             List<AdditionalStereotypeBuildItem> additionalStereotypeBuildItems,
             List<ApplicationClassPredicateBuildItem> applicationClassPredicates,
             List<AdditionalBeanBuildItem> additionalBeans,
@@ -243,8 +244,12 @@ public class ArcProcessor {
             builder.addObserverTransformer(transformer.getInstance());
         }
         // register additional interceptor bindings
-        for (InterceptorBindingRegistrarBuildItem bindingRegistrar : interceptorBindingRegistrarBuildItems) {
-            builder.addInterceptorbindingRegistrar(bindingRegistrar.getInterceptorBindingRegistrar());
+        for (InterceptorBindingRegistrarBuildItem registrar : interceptorBindingRegistrars) {
+            builder.addInterceptorBindingRegistrar(registrar.getInterceptorBindingRegistrar());
+        }
+        // register additional qualifiers
+        for (QualifierRegistrarBuildItem registrar : qualifierRegistrars) {
+            builder.addQualifierRegistrar(registrar.getQualifierRegistrar());
         }
         for (BeanRegistrarBuildItem item : beanRegistrars) {
             builder.addBeanRegistrar(item.getBeanRegistrar());

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoInjectFieldProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoInjectFieldProcessor.java
@@ -24,10 +24,14 @@ public class AutoInjectFieldProcessor {
 
     @BuildStep
     void autoInjectQualifiers(BeanArchiveIndexBuildItem beanArchiveIndex,
-            BuildProducer<AutoInjectAnnotationBuildItem> autoInjectAnnotations) {
+            BuildProducer<AutoInjectAnnotationBuildItem> autoInjectAnnotations,
+            List<QualifierRegistrarBuildItem> qualifierRegistrars) {
         List<DotName> qualifiers = new ArrayList<>();
         for (AnnotationInstance qualifier : beanArchiveIndex.getIndex().getAnnotations(DotNames.QUALIFIER)) {
             qualifiers.add(qualifier.target().asClass().name());
+        }
+        for (QualifierRegistrarBuildItem registrar : qualifierRegistrars) {
+            qualifiers.addAll(registrar.getQualifierRegistrar().getAdditionalQualifiers().keySet());
         }
         autoInjectAnnotations.produce(new AutoInjectAnnotationBuildItem(qualifiers));
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/QualifierRegistrarBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/QualifierRegistrarBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Makes it possible to register annotations that should be considered qualifiers but are not annotated with
+ * {@code javax.inject.Qualifier}.
+ */
+public final class QualifierRegistrarBuildItem extends MultiBuildItem {
+
+    private final QualifierRegistrar registrar;
+
+    public QualifierRegistrarBuildItem(QualifierRegistrar registrar) {
+        this.registrar = registrar;
+    }
+
+    public QualifierRegistrar getQualifierRegistrar() {
+        return registrar;
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/qualifiers/QualifierRegistrarTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/qualifiers/QualifierRegistrarTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.arc.test.qualifiers;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.jandex.DotName;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.deployment.QualifierRegistrarBuildItem;
+import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QualifierRegistrarTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(NotAQualifier.class, SimpleBean.class, Client.class))
+            .addBuildChainCustomizer(b -> {
+                b.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new QualifierRegistrarBuildItem(new QualifierRegistrar() {
+                            @Override
+                            public Map<DotName, Set<String>> getAdditionalQualifiers() {
+                                return Collections.singletonMap(DotName.createSimple(NotAQualifier.class.getName()), null);
+                            }
+                        }));
+                    }
+                }).produces(QualifierRegistrarBuildItem.class).build();
+            });
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testQualifier() {
+        assertTrue(client.instance.isUnsatisfied());
+        assertEquals("PONG", client.simpleBean.ping());
+    }
+
+    @Dependent
+    static class Client {
+
+        @NotAQualifier
+        SimpleBean simpleBean;
+
+        @Inject
+        Instance<SimpleBean> instance;
+
+    }
+
+    @NotAQualifier
+    @Singleton
+    static class SimpleBean {
+
+        public String ping() {
+            return "PONG";
+        }
+
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface NotAQualifier {
+
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -269,7 +269,8 @@ public class BeanProcessor {
         final List<BeanRegistrar> beanRegistrars;
         final List<ObserverRegistrar> observerRegistrars;
         final List<ContextRegistrar> contextRegistrars;
-        final List<InterceptorBindingRegistrar> additionalInterceptorBindingRegistrars;
+        final List<QualifierRegistrar> qualifierRegistrars;
+        final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
         final List<BeanDeploymentValidator> beanDeploymentValidators;
 
         boolean removeUnusedBeans = false;
@@ -298,7 +299,8 @@ public class BeanProcessor {
             beanRegistrars = new ArrayList<>();
             observerRegistrars = new ArrayList<>();
             contextRegistrars = new ArrayList<>();
-            additionalInterceptorBindingRegistrars = new ArrayList<>();
+            qualifierRegistrars = new ArrayList<>();
+            interceptorBindingRegistrars = new ArrayList<>();
             beanDeploymentValidators = new ArrayList<>();
 
             removeUnusedBeans = false;
@@ -357,8 +359,13 @@ public class BeanProcessor {
             return this;
         }
 
-        public Builder addInterceptorbindingRegistrar(InterceptorBindingRegistrar bindingRegistrar) {
-            this.additionalInterceptorBindingRegistrars.add(bindingRegistrar);
+        public Builder addQualifierRegistrar(QualifierRegistrar qualifierRegistrar) {
+            this.qualifierRegistrars.add(qualifierRegistrar);
+            return this;
+        }
+
+        public Builder addInterceptorBindingRegistrar(InterceptorBindingRegistrar bindingRegistrar) {
+            this.interceptorBindingRegistrars.add(bindingRegistrar);
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
@@ -82,7 +82,7 @@ public final class InterceptorResolver {
         if (candidate.name().equals(interceptorBinding.name())) {
             // Must have the same annotation member value for each member which is not annotated @Nonbinding
             boolean matches = true;
-            Set<String> nonBindingFields = beanDeployment.getNonBindingFields(interceptorBinding.name());
+            Set<String> nonBindingFields = beanDeployment.getInterceptorNonbindingMembers(interceptorBinding.name());
             for (AnnotationValue value : candidate.valuesWithDefaults(beanDeployment.getBeanArchiveIndex())) {
                 String annotationField = value.name();
                 if (!interceptorBindingClass.method(annotationField).hasAnnotation(DotNames.NONBINDING)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierRegistrar.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierRegistrar.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc.processor;
+
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Qualifier;
+import org.jboss.jandex.DotName;
+
+/**
+ * Makes it possible to turn an annotation into a qualifier without adding a {@link Qualifier} annotation to it.
+ */
+public interface QualifierRegistrar extends BuildExtension {
+
+    /**
+     * Returns a map of additional qualifers where the key represents the annotation type and the value is an optional set of
+     * non-binding members.
+     */
+    Map<DotName, Set<String>> getAdditionalQualifiers();
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
@@ -13,22 +13,24 @@ public final class Components {
     private final Collection<InjectableObserverMethod<?>> observers;
     private final Collection<InjectableContext> contexts;
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
+    private final Map<String, Set<String>> qualifierNonbindingMembers;
 
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings) {
-        this(beans, observers, contexts, transitiveInterceptorBindings, Collections.emptyList());
+        this(beans, observers, contexts, transitiveInterceptorBindings, Collections.emptyList(), Collections.emptyMap());
     }
 
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings,
-            Collection<RemovedBean> removedBeans) {
+            Collection<RemovedBean> removedBeans, Map<String, Set<String>> qualifierNonbindingMembers) {
         this.beans = beans;
         this.observers = observers;
         this.contexts = contexts;
         this.transitiveInterceptorBindings = transitiveInterceptorBindings;
         this.removedBeans = removedBeans;
+        this.qualifierNonbindingMembers = qualifierNonbindingMembers;
     }
 
     public Collection<InjectableBean<?>> getBeans() {
@@ -49,6 +51,10 @@ public final class Components {
 
     public Collection<RemovedBean> getRemovedBeans() {
         return removedBeans;
+    }
+
+    public Map<String, Set<String>> getQualifierNonbindingMembers() {
+        return qualifierNonbindingMembers;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ComponentsProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ComponentsProvider.java
@@ -1,8 +1,7 @@
 package io.quarkus.arc;
 
 /**
- *
- * @author Martin Kouba
+ * Service provider interface used to colllect the runtime components.
  */
 public interface ComponentsProvider {
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -15,6 +15,7 @@ import io.quarkus.arc.processor.InjectionPointsTransformer;
 import io.quarkus.arc.processor.InterceptorBindingRegistrar;
 import io.quarkus.arc.processor.ObserverRegistrar;
 import io.quarkus.arc.processor.ObserverTransformer;
+import io.quarkus.arc.processor.QualifierRegistrar;
 import io.quarkus.arc.processor.ResourceOutput;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -71,6 +72,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         private final List<BeanRegistrar> beanRegistrars;
         private final List<ObserverRegistrar> observerRegistrars;
         private final List<ContextRegistrar> contextRegistrars;
+        private final List<QualifierRegistrar> qualifierRegistrars;
         private final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
         private final List<AnnotationsTransformer> annotationsTransformers;
         private final List<InjectionPointsTransformer> injectionsPointsTransformers;
@@ -89,6 +91,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             beanRegistrars = new ArrayList<>();
             observerRegistrars = new ArrayList<>();
             contextRegistrars = new ArrayList<>();
+            qualifierRegistrars = new ArrayList<>();
             interceptorBindingRegistrars = new ArrayList<>();
             annotationsTransformers = new ArrayList<>();
             injectionsPointsTransformers = new ArrayList<>();
@@ -148,6 +151,11 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             return this;
         }
 
+        public Builder qualifierRegistrars(QualifierRegistrar... registrars) {
+            Collections.addAll(this.qualifierRegistrars, registrars);
+            return this;
+        }
+
         public Builder interceptorBindingRegistrars(InterceptorBindingRegistrar... registrars) {
             Collections.addAll(this.interceptorBindingRegistrars, registrars);
             return this;
@@ -192,19 +200,13 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
     private final List<Class<? extends Annotation>> resourceAnnotations;
 
     private final List<BeanRegistrar> beanRegistrars;
-
     private final List<ObserverRegistrar> observerRegistrars;
-
     private final List<ContextRegistrar> contextRegistrars;
-
-    List<InterceptorBindingRegistrar> bindingRegistrars;
-
+    private final List<QualifierRegistrar> qualifierRegistrars;
+    private final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
     private final List<AnnotationsTransformer> annotationsTransformers;
-
     private final List<InjectionPointsTransformer> injectionPointsTransformers;
-
     private final List<ObserverTransformer> observerTransformers;
-
     private final List<BeanDeploymentValidator> beanDeploymentValidators;
 
     private final boolean shouldFail;
@@ -223,7 +225,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.beanRegistrars = Collections.emptyList();
         this.observerRegistrars = Collections.emptyList();
         this.contextRegistrars = Collections.emptyList();
-        this.bindingRegistrars = Collections.emptyList();
+        this.interceptorBindingRegistrars = Collections.emptyList();
+        this.qualifierRegistrars = Collections.emptyList();
         this.annotationsTransformers = Collections.emptyList();
         this.injectionPointsTransformers = Collections.emptyList();
         this.observerTransformers = Collections.emptyList();
@@ -243,7 +246,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.beanRegistrars = builder.beanRegistrars;
         this.observerRegistrars = builder.observerRegistrars;
         this.contextRegistrars = builder.contextRegistrars;
-        this.bindingRegistrars = builder.interceptorBindingRegistrars;
+        this.qualifierRegistrars = builder.qualifierRegistrars;
+        this.interceptorBindingRegistrars = builder.interceptorBindingRegistrars;
         this.annotationsTransformers = builder.annotationsTransformers;
         this.injectionPointsTransformers = builder.injectionsPointsTransformers;
         this.observerTransformers = builder.observerTransformers;
@@ -364,7 +368,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             beanRegistrars.forEach(builder::addBeanRegistrar);
             observerRegistrars.forEach(builder::addObserverRegistrar);
             contextRegistrars.forEach(builder::addContextRegistrar);
-            bindingRegistrars.forEach(builder::addInterceptorbindingRegistrar);
+            qualifierRegistrars.forEach(builder::addQualifierRegistrar);
+            interceptorBindingRegistrars.forEach(builder::addInterceptorBindingRegistrar);
             annotationsTransformers.forEach(builder::addAnnotationTransformer);
             injectionPointsTransformers.forEach(builder::addInjectionPointTransformer);
             observerTransformers.forEach(builder::addObserverTransformer);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/qualifiers/AdditionalQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/qualifiers/AdditionalQualifiersTest.java
@@ -1,0 +1,157 @@
+package io.quarkus.arc.test.buildextension.qualifiers;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Singleton;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AdditionalQualifiersTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ToBeQualifier.class,
+                    ToBeQualifierWithBindingField.class,
+                    ToBeQualifierWithNonBindingField.class, Alpha.class, Bravo.class, Charlie.class)
+            .qualifierRegistrars(new QualifierRegistrar() {
+
+                @Override
+                public Map<DotName, Set<String>> getAdditionalQualifiers() {
+                    Map<DotName, Set<String>> qualifiers = new HashMap<>();
+                    qualifiers.put(DotName.createSimple(ToBeQualifier.class.getName()), Collections.emptySet());
+                    qualifiers.put(DotName.createSimple(ToBeQualifierWithNonBindingField.class.getName()),
+                            Collections.singleton("foo"));
+                    qualifiers.put(DotName.createSimple(ToBeQualifierWithBindingField.class.getName()),
+                            Collections.singleton("value"));
+                    return qualifiers;
+                }
+            })
+            .build();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testQualifierWasRegistered() {
+        ArcContainer container = Arc.container();
+        assertTrue(container.select(Alpha.class).isUnsatisfied());
+        assertTrue(container.select(Alpha.class, new ToBeQualifierLiteral() {
+        }).isResolvable());
+        assertTrue(container.select(Bravo.class).isUnsatisfied());
+        assertTrue(container.select(Bravo.class, new ToBeQualifierWithNonBindingFieldLiteral() {
+            @Override
+            public String foo() {
+                return "blik";
+            }
+
+        }).isResolvable());
+        assertTrue(container.select(Charlie.class).isUnsatisfied());
+        assertTrue(container.select(Charlie.class, new ToBeQualifierWithBindingFieldLiteral() {
+            @Override
+            public String value() {
+                return "ignored";
+            }
+
+            @Override
+            public int age() {
+                return 10;
+            }
+
+        }).isResolvable());
+        assertTrue(container.select(Charlie.class, new ToBeQualifierWithBindingFieldLiteral() {
+            @Override
+            public String value() {
+                return "ignored";
+            }
+
+            @Override
+            public int age() {
+                // this should be binding!
+                return 1;
+            }
+
+        }).isUnsatisfied());
+    }
+
+    @ToBeQualifier
+    @Singleton
+    static class Alpha {
+
+    }
+
+    @ToBeQualifierWithNonBindingField(foo = "bzzzz")
+    @Singleton
+    static class Bravo {
+
+    }
+
+    // value should be ignore but age is used during resolution
+    @ToBeQualifierWithBindingField(value = "bzzzz", age = 20)
+    @ToBeQualifierWithBindingField(value = "nok", age = 10)
+    @Singleton
+    static class Charlie {
+
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface ToBeQualifier {
+
+    }
+
+    @SuppressWarnings("serial")
+    public abstract class ToBeQualifierLiteral extends AnnotationLiteral<ToBeQualifier> implements ToBeQualifier {
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface ToBeQualifierWithNonBindingField {
+        String foo();
+    }
+
+    @SuppressWarnings("serial")
+    public abstract class ToBeQualifierWithNonBindingFieldLiteral extends AnnotationLiteral<ToBeQualifierWithNonBindingField>
+            implements ToBeQualifierWithNonBindingField {
+    }
+
+    @Repeatable(ToBeQualifierWithBindingField.Container.class)
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface ToBeQualifierWithBindingField {
+
+        String value();
+
+        int age();
+
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target({ TYPE, METHOD, FIELD, PARAMETER })
+        public @interface Container {
+
+            ToBeQualifierWithBindingField[] value();
+
+        }
+    }
+
+    @SuppressWarnings("serial")
+    public abstract class ToBeQualifierWithBindingFieldLiteral extends AnnotationLiteral<ToBeQualifierWithBindingField>
+            implements ToBeQualifierWithBindingField {
+    }
+
+}


### PR DESCRIPTION
- resolves #14822

IMPL. NOTE: because of qualifiers are needed for resolution at runtime we have to record the qualifiers -> non-binding members map (in contrast with interceptor bindings).