### PR TITLE
Document Reactive DataSource idle-timeout limitation

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -616,6 +616,39 @@ In `application.properties` add:
 quarkus.datasource.reactive.url=mysql:///quarkus_test?host=/var/run/mysqld/mysqld.sock
 ----
 
+== TCP Connection `idle-timeout`
+
+Reactive datasources can be configured with an `idle-timeout` (in milliseconds) that applies at the TCP connection level.
+
+NOTE: The `idle-timeout` is disabled by default.
+
+For example, you could expire idle connections after 60 minutes:
+
+[source,properties]
+----
+quarkus.datasource.reactive.idle-timeout=PT60M
+----
+
+[WARNING]
+====
+This timeout does not apply to the pool, but to the TCP connection.
+
+If it expires while the connection is idle in the pool, the connection is closed and removed from the pool.
+
+If it expires immediately after your borrowed the connection from the pool and before you execute a query, you will get an error.
+
+
+While this is unlikely to happen, you must be prepared for such eventuality:
+
+[source,java]
+----
+// Run a query, retry at most 3 times if it fails
+Uni<RowSet<Row>> rowSet = client.query("SELECT id, name FROM fruits ORDER BY name ASC")
+                            .execute()
+                            .onFailure().retry().atMost(3);
+----
+====
+
 == Configuration Reference
 
 === Common Datasource


### PR DESCRIPTION
Follows-up on #14737

See #14608