### PR TITLE
Propagate ApplicationConfig in test

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -51,7 +51,7 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
                 .addFinal(ApplicationClassNameBuildItem.class)
                 .setTargetDir(quarkusBootstrap.getTargetDirectory())
                 .setDeploymentClassLoader(curatedApplication.createDeploymentClassLoader())
-                .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
+                .setBuildSystemProperties(curatedApplication.getAppModel().getBuildSystemProperties())
                 .setEffectiveModel(curatedApplication.getAppModel());
         if (quarkusBootstrap.getBaseName() != null) {
             builder.setBaseName(quarkusBootstrap.getBaseName());

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -271,7 +271,7 @@ public class AugmentActionImpl implements AugmentAction {
                     .addFinal(ApplicationClassNameBuildItem.class)
                     .setTargetDir(quarkusBootstrap.getTargetDirectory())
                     .setDeploymentClassLoader(deploymentClassLoader)
-                    .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
+                    .setBuildSystemProperties(curatedApplication.getAppModel().getBuildSystemProperties())
                     .setEffectiveModel(curatedApplication.getAppModel());
             if (quarkusBootstrap.getBaseName() != null) {
                 builder.setBaseName(quarkusBootstrap.getBaseName());

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -3,6 +3,7 @@ package io.quarkus.gradle;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import org.gradle.api.Project;
@@ -115,6 +116,7 @@ public class AppModelGradleResolver implements AppModelResolver {
             }
         }
         appModel = QuarkusModelHelper.convert(model, appArtifact);
+        appModel.getBuildSystemProperties().putAll(buildSystemProperties(appArtifact));
         return appModel;
     }
 
@@ -128,6 +130,13 @@ public class AppModelGradleResolver implements AppModelResolver {
             Set<AppArtifactKey> localProjects)
             throws AppModelResolverException {
         return resolveModel(appArtifact);
+    }
+
+    private Properties buildSystemProperties(AppArtifact appArtifact) {
+        Properties buildSystemProperties = new Properties();
+        buildSystemProperties.put("quarkus.application.name", appArtifact.getArtifactId());
+        buildSystemProperties.put("quarkus.application.version", appArtifact.getVersion());
+        return buildSystemProperties;
     }
 
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -125,7 +125,7 @@ public class QuarkusBuild extends QuarkusTask {
         appArtifact.setPaths(QuarkusGradleUtils.getOutputPaths(getProject()));
         final AppModelResolver modelResolver = extension().getAppModelResolver();
 
-        final Properties effectiveProperties = getBuildSystemProperties(appArtifact);
+        final Properties effectiveProperties = getBuildSystemProperties();
         if (ignoredEntries != null && ignoredEntries.size() > 0) {
             String joinedEntries = String.join(",", ignoredEntries);
             effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -49,7 +49,7 @@ public class QuarkusGenerateCode extends QuarkusTask {
         appArtifact.setPaths(QuarkusGradleUtils.getOutputPaths(getProject()));
 
         final AppModelResolver modelResolver = extension().getAppModelResolver();
-        final Properties realProperties = getBuildSystemProperties(appArtifact);
+        final Properties realProperties = getBuildSystemProperties();
 
         Path buildDir = getProject().getBuildDir().toPath();
         try (CuratedApplication appCreationContext = QuarkusBootstrap.builder()

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -26,7 +26,7 @@ public abstract class QuarkusTask extends DefaultTask {
         return extension;
     }
 
-    protected Properties getBuildSystemProperties(AppArtifact appArtifact) {
+    protected Properties getBuildSystemProperties() {
         final Map<String, ?> properties = getProject().getProperties();
         final Properties realProperties = new Properties();
         for (Map.Entry<String, ?> entry : properties.entrySet()) {
@@ -36,8 +36,6 @@ public abstract class QuarkusTask extends DefaultTask {
                 realProperties.setProperty(key, (String) value);
             }
         }
-        realProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
-        realProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
         return realProperties;
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
@@ -62,20 +62,22 @@ public class AppModel implements Serializable {
 
     private final Map<String, String> platformProperties;
 
+    private final Properties buildSystemProperties;
+
     private AppModel(AppArtifact appArtifact, List<AppDependency> runtimeDeps, List<AppDependency> deploymentDeps,
             List<AppDependency> fullDeploymentDeps, Set<AppArtifactKey> parentFirstArtifacts,
             Set<AppArtifactKey> runnerParentFirstArtifacts, Set<AppArtifactKey> lesserPriorityArtifacts,
             Set<AppArtifactKey> localProjectArtifacts) {
         this(appArtifact, runtimeDeps, deploymentDeps, fullDeploymentDeps, parentFirstArtifacts, runnerParentFirstArtifacts,
                 lesserPriorityArtifacts,
-                localProjectArtifacts, Collections.emptyMap());
+                localProjectArtifacts, Collections.emptyMap(), new Properties());
     }
 
     private AppModel(AppArtifact appArtifact, List<AppDependency> runtimeDeps, List<AppDependency> deploymentDeps,
             List<AppDependency> fullDeploymentDeps, Set<AppArtifactKey> parentFirstArtifacts,
             Set<AppArtifactKey> runnerParentFirstArtifacts, Set<AppArtifactKey> lesserPriorityArtifacts,
             Set<AppArtifactKey> localProjectArtifacts,
-            Map<String, String> platformProperties) {
+            Map<String, String> platformProperties, Properties buildSystemProperties) {
         this.appArtifact = appArtifact;
         this.runtimeDeps = runtimeDeps;
         this.deploymentDeps = deploymentDeps;
@@ -85,6 +87,7 @@ public class AppModel implements Serializable {
         this.lesserPriorityArtifacts = lesserPriorityArtifacts;
         this.localProjectArtifacts = localProjectArtifacts;
         this.platformProperties = platformProperties;
+        this.buildSystemProperties = buildSystemProperties;
     }
 
     public Map<String, String> getPlatformProperties() {
@@ -131,6 +134,10 @@ public class AppModel implements Serializable {
         return localProjectArtifacts;
     }
 
+    public Properties getBuildSystemProperties() {
+        return buildSystemProperties;
+    }
+
     @Override
     public String toString() {
         return "AppModel{" +
@@ -156,6 +163,7 @@ public class AppModel implements Serializable {
         private final Set<AppArtifactKey> lesserPriorityArtifacts = new HashSet<>();
         private final Set<AppArtifactKey> localProjectArtifacts = new HashSet<>();
         private Map<String, String> platformProperties = Collections.emptyMap();
+        private Properties buildSystemProperties = new Properties();
 
         public Builder setAppArtifact(AppArtifact appArtifact) {
             this.appArtifact = appArtifact;
@@ -251,6 +259,11 @@ public class AppModel implements Serializable {
             return this;
         }
 
+        public Builder addBuildSystemProperties(Properties buildSystemProperties) {
+            this.buildSystemProperties.putAll(buildSystemProperties);
+            return this;
+        }
+
         /**
          * Sets the parent first and excluded artifacts from a descriptor properties file
          *
@@ -305,7 +318,7 @@ public class AppModel implements Serializable {
                     .collect(Collectors.toList());
             AppModel appModel = new AppModel(appArtifact, runtimeDeps, deploymentDeps, fullDeploymentDeps,
                     parentFirstArtifacts, runnerParentFirstArtifacts, lesserPriorityArtifacts, localProjectArtifacts,
-                    platformProperties);
+                    platformProperties, buildSystemProperties);
             log.debugf("Created AppModel %s", appModel);
             return appModel;
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -64,7 +64,6 @@ public class QuarkusBootstrap implements Serializable {
      */
     private final List<Path> excludeFromClassPath;
 
-    private final Properties buildSystemProperties;
     private final String baseName;
     private final Path targetDirectory;
 
@@ -95,7 +94,6 @@ public class QuarkusBootstrap implements Serializable {
         this.additionalApplicationArchives = new ArrayList<>(builder.additionalApplicationArchives);
         this.excludeFromClassPath = new ArrayList<>(builder.excludeFromClassPath);
         this.projectRoot = builder.projectRoot != null ? builder.projectRoot.normalize() : null;
-        this.buildSystemProperties = builder.buildSystemProperties;
         this.mode = builder.mode;
         this.offline = builder.offline;
         this.test = builder.test;
@@ -224,10 +222,6 @@ public class QuarkusBootstrap implements Serializable {
         return Collections.unmodifiableList(excludeFromClassPath);
     }
 
-    public Properties getBuildSystemProperties() {
-        return buildSystemProperties;
-    }
-
     public Path getProjectRoot() {
         return projectRoot;
     }
@@ -274,7 +268,6 @@ public class QuarkusBootstrap implements Serializable {
                 .setBaseName(baseName)
                 .setProjectRoot(projectRoot)
                 .setBaseClassLoader(baseClassLoader)
-                .setBuildSystemProperties(buildSystemProperties)
                 .setMode(mode)
                 .setTest(test)
                 .setLocalProjectDiscovery(localProjectDiscovery)

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -288,6 +288,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
                 .setAppArtifact(appArtifact)
                 .addFullDeploymentDeps(fullDeploymentDeps)
                 .addRuntimeDeps(userDeps)
+                .addBuildSystemProperties(collectBuildSystemProperties(appArtifact))
                 .build();
     }
 
@@ -343,6 +344,13 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             throw new AppModelResolverException(buf.toString());
         }
         appBuilder.addPlatformProperties(collectedProps);
+    }
+
+    private Properties collectBuildSystemProperties(AppArtifact appArtifact) {
+        Properties buildSystemProperties = new Properties();
+        buildSystemProperties.put("quarkus.application.name", appArtifact.getArtifactId());
+        buildSystemProperties.put("quarkus.application.version", appArtifact.getVersion());
+        return buildSystemProperties;
     }
 
     @Override

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -72,6 +72,7 @@ import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
+import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.resolver.model.QuarkusModel;
 import io.quarkus.bootstrap.runner.Timing;
@@ -113,6 +114,9 @@ public class QuarkusTestExtension
     protected static final String TEST_LOCATION = "test-location";
     protected static final String TEST_CLASS = "test-class";
     public static final String QUARKUS_TEST_HANG_DETECTION_TIMEOUT = "quarkus.test.hang-detection-timeout";
+
+    private static final String QUARKUS_APPLICATION_NAME = "quarkus.application.name";
+    private static final String QUARKUS_APPLICATION_VERSION = "quarkus.application.version";
 
     private static boolean failedBoot;
 
@@ -235,8 +239,8 @@ public class QuarkusTestExtension
                 if (profileInstance.getConfigProfile() != null) {
                     System.setProperty(ProfileManager.QUARKUS_TEST_PROFILE_PROP, profileInstance.getConfigProfile());
                 }
-                //we just use system properties for now
-                //its a lot simpler
+                // we just use system properties for now
+                // its a lot simpler
                 for (Map.Entry<String, String> i : additional.entrySet()) {
                     sysPropRestore.put(i.getKey(), System.getProperty(i.getKey()));
                 }


### PR DESCRIPTION
As discussed yesterday, it is not possible to use `quarkus.application.name` and `quarkus.application.version` properties in tests. 

This branch register `quarkus.application.name` and `quarkus.application.version` as system property just before the application start. 