### PR TITLE
Ensure MetadataImplementor#validate is not run twice

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -70,7 +70,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
         try {
             final SessionFactoryOptionsBuilder optionsBuilder = metadata.buildSessionFactoryOptionsBuilder();
             populate(persistenceUnitName, optionsBuilder, standardServiceRegistry, multiTenancyStrategy);
-            return new SessionFactoryImpl(metadata.getOriginalMetadata(), optionsBuilder.buildOptions(), HQLQueryPlan::new);
+            return new SessionFactoryImpl(metadata, optionsBuilder.buildOptions(), HQLQueryPlan::new);
         } catch (Exception e) {
             throw persistenceException("Unable to build Hibernate SessionFactory", e);
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -63,7 +63,7 @@ public class PreconfiguredServiceRegistryBuilder {
         checkIsNotReactive(rs);
         this.initiators = buildQuarkusServiceInitiatorList(rs);
         this.integrators = rs.getIntegrators();
-        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata().getOriginalMetadata()
+        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata()
                 .getMetadataBuildingOptions()
                 .getServiceRegistry();
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.runtime.recording;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.hibernate.MappingException;
@@ -13,6 +14,7 @@ import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.model.TypeDefinition;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.annotations.NamedEntityGraphDefinition;
 import org.hibernate.cfg.annotations.NamedProcedureCallDefinition;
@@ -21,11 +23,17 @@ import org.hibernate.engine.ResultSetMappingDefinition;
 import org.hibernate.engine.spi.FilterDefinition;
 import org.hibernate.engine.spi.NamedQueryDefinition;
 import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
+import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.mapping.FetchProfile;
+import org.hibernate.mapping.MappedSuperclass;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
+import org.hibernate.query.spi.NamedQueryRepository;
 import org.hibernate.type.Type;
+import org.hibernate.type.TypeResolver;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * This is a Quarkus custom implementation of Metadata wrapping the original
@@ -39,7 +47,7 @@ import org.hibernate.type.Type;
  * are unavailable, as these would normally trigger an additional validation phase:
  * we can actually boot Quarkus in a simpler way.
  */
-public final class PrevalidatedQuarkusMetadata implements Metadata {
+public final class PrevalidatedQuarkusMetadata implements MetadataImplementor {
 
     private final MetadataImpl metadata;
 
@@ -61,10 +69,6 @@ public final class PrevalidatedQuarkusMetadata implements Metadata {
                 metadata.getBootstrapContext());
     }
 
-    public MetadataImplementor getOriginalMetadata() {
-        return metadata;
-    }
-
     //Relevant overrides:
 
     @Override
@@ -77,6 +81,11 @@ public final class PrevalidatedQuarkusMetadata implements Metadata {
     public SessionFactory buildSessionFactory() {
         //Ensure we don't boot Hibernate using this, but rather use the #buildSessionFactoryOptionsBuilder above.
         throw new IllegalStateException("This method is not supposed to be used in Quarkus");
+    }
+
+    @Override
+    public void validate() throws MappingException {
+        //Intentional no-op
     }
 
     //All other contracts from Metadata delegating:
@@ -222,6 +231,38 @@ public final class PrevalidatedQuarkusMetadata implements Metadata {
     @Override
     public Type getReferencedPropertyType(final String className, final String propertyName) throws MappingException {
         return metadata.getReferencedPropertyType(className, propertyName);
+    }
+
+    // Delegates for MetadataImplementor:
+
+    @Override
+    public MetadataBuildingOptions getMetadataBuildingOptions() {
+        return metadata.getMetadataBuildingOptions();
+    }
+
+    @Override
+    public TypeConfiguration getTypeConfiguration() {
+        return metadata.getTypeConfiguration();
+    }
+
+    @Override
+    public TypeResolver getTypeResolver() {
+        return metadata.getTypeResolver();
+    }
+
+    @Override
+    public NamedQueryRepository buildNamedQueryRepository(SessionFactoryImpl sessionFactory) {
+        return metadata.buildNamedQueryRepository(sessionFactory);
+    }
+
+    @Override
+    public Set<MappedSuperclass> getMappedSuperclassMappingsCopy() {
+        return metadata.getMappedSuperclassMappingsCopy();
+    }
+
+    @Override
+    public void initSessionFactory(SessionFactoryImplementor sessionFactoryImplementor) {
+        metadata.initSessionFactory(sessionFactoryImplementor);
     }
 
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
@@ -28,6 +28,6 @@ public final class FastBootReactiveEntityManagerFactoryBuilder extends FastBootE
         populate(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, optionsBuilder, standardServiceRegistry,
                 multiTenancyStrategy);
         SessionFactoryOptions options = optionsBuilder.buildOptions();
-        return new ReactiveSessionFactoryImpl(metadata.getOriginalMetadata(), options);
+        return new ReactiveSessionFactoryImpl(metadata, options);
     }
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -66,7 +66,7 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
         checkIsReactive(rs);
         this.initiators = buildQuarkusServiceInitiatorList(rs);
         this.integrators = rs.getIntegrators();
-        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata().getOriginalMetadata()
+        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata()
                 .getMetadataBuildingOptions()
                 .getServiceRegistry();
     }


### PR DESCRIPTION
This change might seem pointless refactoring, but w/o it the next release of Hibernate ORM will not compile to native.

Proposing the change already to make the transition easier.

See also discussion on:
 - https://github.com/hibernate/hibernate-orm/pull/3713
 