### PR TITLE
Add support for Multipart requests in RESTEasy Reactive

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -373,6 +373,77 @@ link:{jsonpapi}/javax/json/JsonArray.html[`JsonStructure`], link:{jsonpapi}/java
 
 NOTE: You can add support for more <<readers-writers,body parameter types>>.
 
+=== Handling Multipart Form data
+
+To handle HTTP requests that have `multipart/form-data` as their content type, RESTEasy Reactive introduces the `@org.jboss.resteasy.reactive.MultipartForm` annotation.
+Let us look at an example of its use.
+
+Assuming an HTTP request containing a file upload and a form value containing a string description need to be handled, we could write a POJO
+that will hold this information like so:
+
+[source,java]
+----
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+public class FormData {
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public String description;
+
+    @RestForm("image")
+    public FileUpload file;
+}
+----
+
+The `name` field will contain the data contained in the part of HTTP request called `description` (because `@RestForm` does not define a value, the field name is used),
+while the `file` field will contain data about the uploaded file in the `image` part of HTTP request.
+
+NOTE: `FileUpload` provides access to various metadata of the uploaded file. If however all you need is a handle to the uploaded file, `java.nio.file.Path` or `java.io.File` could be used.
+
+NOTE: `@PartType` is used to aid in deserialization of the corresponding part of the request into the desired Java type. It is very useful when for example the corresponding body part is JSON
+and needs to be converted to a POJO.
+
+This POJO could be used in a Resource method like so:
+
+[source,java]
+----
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+
+@Path("multipart")
+public class Endpoint {
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("form")
+    public String form(@MultipartForm FormData formData) {
+        // return something
+    }
+}
+----
+
+The use of `@MultipartForm` as method parameter makes RESTEasy Reactive handle the request as a multipart form request.
+
+WARNING: When handling file uploads, it is very important to move the file to permanent storage (like a database, a dedicated file system or a cloud storage) in your code that handles the POJO.
+Otherwise, the file will no longer be accessible when the request terminates.
+Moreoever if `quarkus.http.body.delete-uploaded-files-on-end` is set to true, Quarkus will delete the uploaded file when the HTTP response is sent. If the setting is disabled,
+the file will reside on the file system of the server (in the directory defined by the `quarkus.http.body.uploads-directory` configuration option), but as the uploaded files are saved
+with a UUID file name and no additional metadata is saved, these files are essentially a random dump of files.
+
+
 === Returning a response body
 
 In order to return an HTTP response, simply return the resource you want from your method. The method

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+public class FormData {
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public Map<String, Object> map;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public Person person;
+
+    @RestForm("htmlFile")
+    private FileUpload htmlPart;
+
+    public FileUpload getHtmlPart() {
+        return htmlPart;
+    }
+
+    public void setHtmlPart(FileUpload htmlPart) {
+        this.htmlPart = htmlPart;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+
+import io.smallrye.common.annotation.Blocking;
+
+@Path("/multipart")
+public class MultipartResource {
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Blocking
+    @Path("/json")
+    public Map<String, Object> greeting(@MultipartForm FormData formData) {
+        Map<String, Object> result = new HashMap<>(formData.map);
+        result.put("person", formData.person);
+        result.put("htmlFileSize", formData.getHtmlPart().size());
+        result.put("htmlFilePath", formData.getHtmlPart().uploadedFile().toAbsolutePath().toString());
+        result.put("htmlFileContentType", formData.getHtmlPart().contentType());
+        return result;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MultipartTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FormData.class, Person.class, MultipartResource.class)
+                            .addAsResource(new StringAsset("quarkus.http.body.delete-uploaded-files-on-end=true\n"),
+                                    "application.properties");
+                }
+
+            });
+
+    private final File HTML_FILE = new File("./src/test/resources/test.html");
+
+    @Test
+    public void test() throws IOException {
+        RestAssured.given()
+                .multiPart("map",
+                        "{\n" +
+                                "  \"foo\": \"bar\",\n" +
+                                "  \"sub\": {\n" +
+                                "    \"foo2\": \"bar2\"\n" +
+                                "  }\n" +
+                                "}")
+                .multiPart("person", "{\"first\": \"Bob\", \"last\": \"Builder\"}", "application/json")
+                .multiPart("htmlFile", HTML_FILE, "text/html")
+                .accept("application/json")
+                .when()
+                .post("/multipart/json")
+                .then()
+                .statusCode(200)
+                .body("foo", equalTo("bar"))
+                .body("sub.foo2", equalTo("bar2"))
+                .body("person.first", equalTo("Bob"))
+                .body("person.last", equalTo("Builder"))
+                .body("htmlFileSize", equalTo(Files.readAllBytes(HTML_FILE.toPath()).length))
+                .body("htmlFilePath", not(equalTo(HTML_FILE.toPath().toAbsolutePath().toString())))
+                .body("htmlFileContentType", equalTo("text/html"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/resources/test.html
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/resources/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- head definitions go here -->
+</head>
+<body>
+<!-- the content goes here -->
+</body>
+</html>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+
+import org.jboss.jandex.DotName;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+final class DotNames {
+
+    static final String POPULATE_METHOD_NAME = "populate";
+    static final DotName OBJECT_NAME = DotName.createSimple(Object.class.getName());
+    static final DotName STRING_NAME = DotName.createSimple(String.class.getName());
+    static final DotName INPUT_STREAM_NAME = DotName.createSimple(InputStream.class.getName());
+    static final DotName INPUT_STREAM_READER_NAME = DotName.createSimple(InputStreamReader.class.getName());
+    static final DotName FIELD_UPLOAD_NAME = DotName.createSimple(FileUpload.class.getName());
+    static final DotName PATH_NAME = DotName.createSimple(Path.class.getName());
+    static final DotName FILE_NAME = DotName.createSimple(File.class.getName());
+    static final DotName PART_TYPE_NAME = DotName.createSimple(PartType.class.getName());
+
+    private DotNames() {
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartPopulatorGenerator.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartPopulatorGenerator.java
@@ -1,0 +1,392 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.*;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.processor.AsmUtil;
+import org.jboss.resteasy.reactive.common.processor.TypeArgMapper;
+import org.jboss.resteasy.reactive.common.util.DeploymentUtils;
+import org.jboss.resteasy.reactive.common.util.types.TypeSignatureParser;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.injection.ResteasyReactiveInjectionContext;
+import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
+
+import io.quarkus.deployment.bean.JavaBeanUtil;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.server.runtime.multipart.MultipartSupport;
+import io.quarkus.resteasy.reactive.server.runtime.multipart.QuarkusFileUpload;
+
+final class MultipartPopulatorGenerator {
+
+    private static final Logger LOGGER = Logger.getLogger(MultipartPopulatorGenerator.class);
+
+    private MultipartPopulatorGenerator() {
+    }
+
+    /**
+     * Generates a class that populates a Pojo that is used as a @MultipartForm parameter in a resource method.
+     * The generated class is called at runtime by the {@code __quarkus_rest_inject} method of the class
+     * (which is added by {@link MultipartTransformer}).
+     *
+     * <p>
+     * For example for a pojo like:
+     *
+     * <pre>
+     * public class FormData {
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.TEXT_PLAIN)
+     *     private String foo;
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.APPLICATION_JSON)
+     *     public Map<String, String> map;
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.APPLICATION_JSON)
+     *     public Person person;
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.TEXT_PLAIN)
+     *     private Status status;
+     *
+     *     &#64;RestForm("htmlFile")
+     *     private FileUpload htmlPart;
+     *
+     *     &#64;RestForm("htmlFile")
+     *     public Path xmlPart;
+     *
+     *     &#64;RestForm
+     *     public File txtFile;
+     *
+     *     public String getFoo() {
+     *         return foo;
+     *     }
+     *
+     *     public void setFoo(String foo) {
+     *         this.foo = foo;
+     *     }
+     *
+     *     public Status getStatus() {
+     *         return status;
+     *     }
+     *
+     *     public void setStatus(Status status) {
+     *         this.status = status;
+     *     }
+     *
+     *     public FileUpload getHtmlPart() {
+     *         return htmlPart;
+     *     }
+     *
+     *     public void setHtmlPart(FileUpload htmlPart) {
+     *         this.htmlPart = htmlPart;
+     *     }
+     * }
+     * </pre>
+     *
+     * <p>
+     * the generated populator would look like:
+     *
+     * <pre>
+     * public class FormData_generated_populator {
+     *     private static Class map_type;
+     *     private static Type map_genericType;
+     *     private static MediaType map_mediaType;
+     *     private static Class person_type;
+     *     private static Type person_genericType;
+     *     private static MediaType person_mediaType;
+     *     private static Class status_type;
+     *     private static Type status_genericType;
+     *     private static MediaType status_mediaType;
+     *
+     *     static {
+     *         map_type = DeploymentUtils.loadClass("java.util.Map");
+     *         map_genericType = TypeSignatureParser.parse("Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;");
+     *         map_mediaType = MediaType.valueOf("application/json");
+     *         Class var0 = DeploymentUtils.loadClass("org.acme.getting.started.Person");
+     *         person_type = var0;
+     *         person_genericType = var0;
+     *         person_mediaType = MediaType.valueOf("application/json");
+     *         Class var1 = DeploymentUtils.loadClass("org.acme.getting.started.Status");
+     *         status_type = var1;
+     *         status_genericType = var1;
+     *         status_mediaType = MediaType.valueOf("text/plain");
+     *     }
+     *
+     *     public static void populate(FormData var0, ResteasyReactiveInjectionContext var1) {
+     *         ResteasyReactiveRequestContext var3 = (ResteasyReactiveRequestContext) var1;
+     *         ServerHttpRequest var5 = var3.serverRequest();
+     *         String var2 = var5.getFormAttribute("foo");
+     *         var0.setFoo((String) var2);
+     *         QuarkusFileUpload var4 = MultipartSupport.getFileUpload("htmlFile", var3);
+     *         var0.setHtmlPart((FileUpload) var4);
+     *         String var6 = var5.getFormAttribute("map");
+     *         Class var7 = map_type;
+     *         Type var8 = map_genericType;
+     *         MediaType var9 = map_mediaType;
+     *         Object var10 = MultipartSupport.convertFormAttribute(var6, var7, var8, var9, var3);
+     *         var0.map = (Map) var10;
+     *         String var11 = var5.getFormAttribute("person");
+     *         Class var12 = person_type;
+     *         Type var13 = person_genericType;
+     *         MediaType var14 = person_mediaType;
+     *         Object var15 = MultipartSupport.convertFormAttribute(var11, var12, var13, var14, var3);
+     *         var0.person = (Person) var15;
+     *         String var16 = var5.getFormAttribute("status");
+     *         Class var17 = status_type;
+     *         Type var18 = status_genericType;
+     *         MediaType var19 = status_mediaType;
+     *         Object var20 = MultipartSupport.convertFormAttribute(var16, var17, var18, var19, var3);
+     *         var0.setStatus((Status) var20);
+     *         QuarkusFileUpload var21 = MultipartSupport.getFileUpload("txtFile", var3);
+     *         File var22;
+     *         if (var21 != null) {
+     *             var22 = var21.uploadedFile().toFile();
+     *         } else {
+     *             var22 = null;
+     *         }
+     *
+     *         var0.txtFile = (File) var22;
+     *         QuarkusFileUpload var23 = MultipartSupport.getFileUpload("htmlFile", var3);
+     *         Path var24;
+     *         if (var23 != null) {
+     *             var24 = var23.uploadedFile();
+     *         } else {
+     *             var24 = null;
+     *         }
+     *
+     *         var0.xmlPart = (Path) var24;
+     *     }
+     * }
+     * </pre>
+     *
+     */
+    static String generate(ClassInfo multipartClassInfo, ClassOutput classOutput, IndexView index) {
+        if (!multipartClassInfo.hasNoArgsConstructor()) {
+            throw new IllegalArgumentException("Classes annotated with '@MultipartForm' must contain a no-args constructor");
+        }
+
+        String multipartClassName = multipartClassInfo.name().toString();
+        String generateClassName = multipartClassName + "_generated_populator";
+        try (ClassCreator cc = new ClassCreator(classOutput, generateClassName, null, Object.class.getName())) {
+            MethodCreator populate = cc.getMethodCreator(DotNames.POPULATE_METHOD_NAME, void.class.getName(),
+                    multipartClassName,
+                    ResteasyReactiveInjectionContext.class.getName());
+            populate.setModifiers(Modifier.PUBLIC | Modifier.STATIC);
+
+            MethodCreator clinit = cc.getMethodCreator("<clinit>", void.class);
+            clinit.setModifiers(Modifier.PUBLIC | Modifier.STATIC);
+
+            ResultHandle instanceHandle = populate.getMethodParam(0);
+            ResultHandle rrCtxHandle = populate.checkCast(populate.getMethodParam(1), ResteasyReactiveRequestContext.class);
+            ResultHandle serverReqHandle = populate.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(ResteasyReactiveRequestContext.class, "serverRequest", ServerHttpRequest.class),
+                    rrCtxHandle);
+
+            // go up the class hierarchy until we reach Object
+            ClassInfo currentClassInHierarchy = multipartClassInfo;
+            while (true) {
+                List<FieldInfo> fields = currentClassInHierarchy.fields();
+                for (FieldInfo field : fields) {
+                    if (Modifier.isStatic(field.flags())) { // nothing we need to do about static fields
+                        continue;
+                    }
+
+                    AnnotationInstance formParamInstance = field.annotation(REST_FORM_PARAM);
+                    if (formParamInstance == null) {
+                        formParamInstance = field.annotation(FORM_PARAM);
+                    }
+                    if (formParamInstance == null) { // fields not annotated with @RestForm or @FormParam are completely ignored
+                        continue;
+                    }
+
+                    boolean useFieldAccess = false;
+                    String setterName = JavaBeanUtil.getSetterName(field.name());
+                    Type fieldType = field.type();
+                    DotName fieldDotName = fieldType.name();
+                    MethodInfo setter = currentClassInHierarchy.method(setterName, fieldType);
+                    if (setter == null) {
+                        // even if the field is private, it will be transformed to be made public
+                        useFieldAccess = true;
+                    }
+                    if (!useFieldAccess && !Modifier.isPublic(setter.flags())) {
+                        throw new IllegalArgumentException(
+                                "Setter '" + setterName + "' of class '" + multipartClassInfo + "' must be public");
+                    }
+
+                    if (fieldDotName.equals(DotNames.INPUT_STREAM_NAME)
+                            || fieldDotName.equals(DotNames.INPUT_STREAM_READER_NAME)) {
+                        // don't support InputStream as it's too easy to get into trouble
+                        throw new IllegalArgumentException(
+                                "InputStream and InputStreamReader are not support as a field type of a Multipart POJO class. Offending field is '"
+                                        + field.name() + "' of class '" + multipartClassName + "'");
+                    }
+
+                    String formAttrName = field.name();
+                    AnnotationValue formParamValue = formParamInstance.value();
+                    if (formParamValue != null) {
+                        formAttrName = formParamValue.asString();
+                    }
+
+                    // TODO: not sure this is correct, but it seems to be what RESTEasy does and it also makes most sense in the context of a POJO
+                    String partType = MediaType.TEXT_PLAIN;
+                    AnnotationInstance partTypeInstance = field.annotation(DotNames.PART_TYPE_NAME);
+                    if (partTypeInstance != null) {
+                        AnnotationValue partTypeValue = partTypeInstance.value();
+                        if (partTypeValue != null) {
+                            partType = partTypeValue.asString();
+                        }
+                    }
+
+                    boolean isFileRelatedField = fieldDotName.equals(DotNames.FIELD_UPLOAD_NAME)
+                            || fieldDotName.equals(DotNames.PATH_NAME)
+                            || fieldDotName.equals(DotNames.FILE_NAME);
+                    ResultHandle formAttrNameHandle = populate.load(formAttrName);
+                    AssignableResultHandle resultHandle = populate.createVariable(Object.class);
+
+                    if (isFileRelatedField) {
+                        // uploaded file are present in the RoutingContext and are extracted using MultipartSupport#getFileUpload
+
+                        ResultHandle fileUploadHandle = populate.invokeStaticMethod(
+                                MethodDescriptor.ofMethod(MultipartSupport.class, "getFileUpload", QuarkusFileUpload.class,
+                                        String.class, ResteasyReactiveRequestContext.class),
+                                formAttrNameHandle, rrCtxHandle);
+                        if (fieldDotName.equals(DotNames.FIELD_UPLOAD_NAME)) {
+                            populate.assign(resultHandle, fileUploadHandle);
+                        } else if (fieldDotName.equals(DotNames.PATH_NAME) || fieldDotName.equals(DotNames.FILE_NAME)) {
+                            BranchResult fileUploadNullBranch = populate.ifNull(fileUploadHandle);
+                            BytecodeCreator fileUploadNullTrue = fileUploadNullBranch.trueBranch();
+                            fileUploadNullTrue.assign(resultHandle, populate.loadNull());
+                            fileUploadNullTrue.breakScope();
+                            BytecodeCreator fileUploadFalse = fileUploadNullBranch.falseBranch();
+                            ResultHandle pathHandle = fileUploadFalse.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(QuarkusFileUpload.class, "uploadedFile", Path.class),
+                                    fileUploadHandle);
+                            if (fieldDotName.equals(DotNames.PATH_NAME)) {
+                                fileUploadFalse.assign(resultHandle, pathHandle);
+                            } else {
+                                fileUploadFalse.assign(resultHandle, fileUploadFalse.invokeInterfaceMethod(
+                                        MethodDescriptor.ofMethod(Path.class, "toFile", File.class), pathHandle));
+                            }
+                            fileUploadFalse.breakScope();
+                        }
+                    } else {
+                        if (fieldDotName.equals(DotNames.STRING_NAME) && partType.equals(MediaType.TEXT_PLAIN)) {
+                            // in this case all we need to do is read the value of the form attribute
+
+                            populate.assign(resultHandle,
+                                    populate.invokeInterfaceMethod(MethodDescriptor.ofMethod(ServerHttpRequest.class,
+                                            "getFormAttribute", String.class, String.class), serverReqHandle,
+                                            formAttrNameHandle));
+                        } else {
+                            // we need to use the field type and the media type to locate a MessageBodyReader
+
+                            FieldDescriptor typeField = cc.getFieldCreator(field.name() + "_type", Class.class)
+                                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC).getFieldDescriptor();
+                            FieldDescriptor genericTypeField = cc
+                                    .getFieldCreator(field.name() + "_genericType", java.lang.reflect.Type.class)
+                                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC).getFieldDescriptor();
+                            FieldDescriptor mediaTypeField = cc.getFieldCreator(field.name() + "_mediaType", MediaType.class)
+                                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC).getFieldDescriptor();
+
+                            ResultHandle typeHandle = clinit.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(DeploymentUtils.class, "loadClass", Class.class, String.class),
+                                    clinit.load(fieldDotName.toString()));
+                            clinit.writeStaticField(typeField, typeHandle);
+                            if ((fieldType.kind() != Type.Kind.CLASS) && (fieldType.kind() != Type.Kind.PRIMITIVE)) {
+                                // in order to pass the generic type we use the same trick with capturing and at runtime
+                                // parsing the signature
+                                TypeArgMapper typeArgMapper = new TypeArgMapper(field.declaringClass(), index);
+                                ResultHandle genericTypeHandle = clinit.invokeStaticMethod(
+                                        MethodDescriptor.ofMethod(TypeSignatureParser.class, "parse",
+                                                java.lang.reflect.Type.class, String.class),
+                                        clinit.load(AsmUtil.getSignature(fieldType, typeArgMapper)));
+                                clinit.writeStaticField(genericTypeField, genericTypeHandle);
+                            } else {
+                                clinit.writeStaticField(genericTypeField, typeHandle);
+                            }
+                            clinit.writeStaticField(mediaTypeField, clinit.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(MediaType.class, "valueOf", MediaType.class, String.class),
+                                    clinit.load(partType)));
+
+                            ResultHandle formStrValueHandle = populate.invokeInterfaceMethod(
+                                    MethodDescriptor.ofMethod(ServerHttpRequest.class,
+                                            "getFormAttribute", String.class, String.class),
+                                    serverReqHandle,
+                                    formAttrNameHandle);
+
+                            populate.assign(resultHandle, populate.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(MultipartSupport.class, "convertFormAttribute", Object.class,
+                                            String.class,
+                                            Class.class,
+                                            java.lang.reflect.Type.class, MediaType.class,
+                                            ResteasyReactiveRequestContext.class),
+                                    formStrValueHandle, populate.readStaticField(typeField),
+                                    populate.readStaticField(genericTypeField),
+                                    populate.readStaticField(mediaTypeField),
+                                    rrCtxHandle));
+                        }
+                    }
+
+                    if (useFieldAccess) {
+                        BytecodeCreator bc = populate;
+                        if (fieldType.kind() == Type.Kind.PRIMITIVE) {
+                            bc = populate.ifNull(resultHandle).falseBranch();
+                        }
+                        bc.writeInstanceField(FieldDescriptor.of(currentClassInHierarchy.name().toString(), field.name(),
+                                fieldDotName.toString()), instanceHandle, resultHandle);
+                    } else {
+                        BytecodeCreator bc = populate;
+                        if (fieldType.kind() == Type.Kind.PRIMITIVE) {
+                            bc = populate.ifNull(resultHandle).falseBranch();
+                        }
+                        bc.invokeVirtualMethod(MethodDescriptor.ofMethod(currentClassInHierarchy.name().toString(),
+                                setterName, void.class, fieldDotName.toString()), instanceHandle, resultHandle);
+                    }
+                }
+
+                DotName superClassDotName = currentClassInHierarchy.superName();
+                if (superClassDotName.equals(DotNames.OBJECT_NAME)) {
+                    break;
+                }
+                ClassInfo newCurrentClassInHierarchy = index.getClassByName(superClassDotName);
+                if (newCurrentClassInHierarchy == null) {
+                    if (!superClassDotName.toString().startsWith("java.")) {
+                        LOGGER.warn("Class '" + superClassDotName + "' which is a parent class of '"
+                                + currentClassInHierarchy.name()
+                                + "' is not part of the Jandex index so its fields will be ignored. If you intended to include these fields, consider making the dependency part of the Jandex index by following the advice at: https://quarkus.io/guides/cdi-reference#bean_discovery");
+                    }
+                    break;
+                }
+                currentClassInHierarchy = newCurrentClassInHierarchy;
+            }
+            clinit.returnValue(null);
+            populate.returnValue(null);
+        }
+        return generateClassName;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartTransformer.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartTransformer.java
@@ -1,0 +1,90 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import java.util.function.BiFunction;
+
+import org.jboss.resteasy.reactive.server.injection.ResteasyReactiveInjectionContext;
+import org.jboss.resteasy.reactive.server.injection.ResteasyReactiveInjectionTarget;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+class MultipartTransformer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    private static final String INJECTION_TARGET_BINARY_NAME = ResteasyReactiveInjectionTarget.class.getName()
+            .replace('.', '/');
+    private static final String INJECTION_CONTEXT_BINARY_NAME = ResteasyReactiveInjectionContext.class.getName()
+            .replace('.', '/');
+    private static final String INJECTION_CONTEXT_DESCRIPTOR = "L" + INJECTION_CONTEXT_BINARY_NAME + ";";
+
+    private static final String INJECT_METHOD_NAME = "__quarkus_rest_inject";
+    private static final String INJECT_METHOD_DESCRIPTOR = "(" + INJECTION_CONTEXT_DESCRIPTOR + ")V";
+
+    private final String populatorName;
+
+    public MultipartTransformer(String populatorName) {
+        this.populatorName = populatorName;
+    }
+
+    @Override
+    public ClassVisitor apply(String s, ClassVisitor visitor) {
+        return new MultipartClassVisitor(Opcodes.ASM8, visitor, populatorName);
+    }
+
+    static class MultipartClassVisitor extends ClassVisitor {
+
+        private String thisDescriptor;
+        private final String populatorName;
+
+        public MultipartClassVisitor(int api, ClassVisitor classVisitor, String populatorName) {
+            super(api, classVisitor);
+            this.populatorName = populatorName;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            thisDescriptor = "L" + name + ";";
+
+            // make the class public
+            access &= ~(Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED);
+            access |= Opcodes.ACC_PUBLIC;
+
+            String[] newInterfaces = new String[interfaces.length + 1];
+            newInterfaces[0] = INJECTION_TARGET_BINARY_NAME;
+            System.arraycopy(interfaces, 0, newInterfaces, 1, interfaces.length);
+            super.visit(version, access, name, signature, superName, newInterfaces);
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            if (((access & Opcodes.ACC_FINAL) == 0) && ((access & Opcodes.ACC_STATIC) == 0)) {
+                // convert non-final, non-static fields to public so our generated code can always access it
+                access &= ~(Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED);
+                access |= Opcodes.ACC_PUBLIC;
+            }
+            return super.visitField(access, name, descriptor, signature, value);
+        }
+
+        @Override
+        public void visitEnd() {
+            MethodVisitor injectMethod = visitMethod(Opcodes.ACC_PUBLIC, INJECT_METHOD_NAME, INJECT_METHOD_DESCRIPTOR, null,
+                    null);
+            injectMethod.visitParameter("ctx", 0 /* modifiers */);
+            injectMethod.visitCode();
+
+            // this
+            injectMethod.visitIntInsn(Opcodes.ALOAD, 0);
+            // ctx param
+            injectMethod.visitIntInsn(Opcodes.ALOAD, 1);
+
+            // call the populator
+            injectMethod.visitMethodInsn(Opcodes.INVOKESTATIC, populatorName.replace('.', '/'),
+                    DotNames.POPULATE_METHOD_NAME,
+                    String.format("(%s%s)V", thisDescriptor, INJECTION_CONTEXT_DESCRIPTOR), false);
+
+            injectMethod.visitInsn(Opcodes.RETURN);
+            injectMethod.visitEnd();
+            injectMethod.visitMaxs(0, 0);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormData.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormData.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+public class FormData extends FormDataBase {
+
+    @RestForm
+    // don't set a part type, use the default
+    private String name;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    private Status status;
+
+    @RestForm("htmlFile")
+    private FileUpload htmlPart;
+
+    @RestForm("xmlFile")
+    public Path xmlPart;
+
+    @RestForm
+    public File txtFile;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public FileUpload getHtmlPart() {
+        return htmlPart;
+    }
+
+    public void setHtmlPart(FileUpload htmlPart) {
+        this.htmlPart = htmlPart;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormDataBase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormDataBase.java
@@ -1,0 +1,14 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+import io.quarkus.resteasy.reactive.server.test.multipart.other.OtherPackageFormDataBase;
+
+abstract class FormDataBase extends OtherPackageFormDataBase {
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    boolean active;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.multipart.other.OtherPackageFormDataBase;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MultipartInputTest {
+
+    private static final File uploadDir = new File("./file-uploads"); // the default used by Quarkus
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FormDataBase.class, OtherPackageFormDataBase.class, FormData.class, Status.class,
+                                    OtherFormData.class,
+                                    OtherFormDataBase.class,
+                                    MultipartResource.class, OtherMultipartResource.class);
+                }
+
+            });
+
+    private final File HTML_FILE = new File("./src/test/resources/test.html");
+    private final File XML_FILE = new File("./src/test/resources/test.html");
+    private final File TXT_FILE = new File("./src/test/resources/lorem.txt");
+
+    @BeforeEach
+    public void assertEmptyUploads() {
+        Assertions.assertEquals(0, uploadDir.listFiles().length);
+    }
+
+    @AfterEach
+    public void clearDirectory() {
+        for (File file : uploadDir.listFiles()) {
+            if (!file.isDirectory()) {
+                file.delete();
+            }
+        }
+    }
+
+    @Test
+    public void testSimple() {
+        RestAssured.given()
+                .multiPart("name", "Alice")
+                .multiPart("active", "true")
+                .multiPart("num", "25")
+                .multiPart("status", "WORKING")
+                .multiPart("htmlFile", HTML_FILE, "text/html")
+                .multiPart("xmlFile", XML_FILE, "text/xml")
+                .multiPart("txtFile", TXT_FILE, "text/plain")
+                .accept("text/plain")
+                .when()
+                .post("/multipart/simple/2")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Alice - true - 50 - WORKING - text/html - true - true"));
+
+        // ensure that the 3 uploaded files where created on disk
+        Assertions.assertEquals(3, uploadDir.listFiles().length);
+    }
+
+    @Test
+    public void testBlocking() throws IOException {
+        RestAssured.given()
+                .multiPart("name", "Trudy")
+                .multiPart("num", "20")
+                .multiPart("status", "SLEEPING")
+                .multiPart("htmlFile", HTML_FILE, "text/html")
+                .multiPart("xmlFile", XML_FILE, "text/xml")
+                .multiPart("txtFile", TXT_FILE, "text/plain")
+                .accept("text/plain")
+                .when()
+                .post("/multipart/blocking?times=2")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Trudy - 40 - SLEEPING"))
+                .header("html-size", equalTo(fileSizeAsStr(HTML_FILE)))
+                // test that file was actually upload and that the web application isn't sharing the file with the test...
+                .header("html-path", not(equalTo(filePath(HTML_FILE))))
+                .header("xml-size", equalTo(fileSizeAsStr(XML_FILE)))
+                .header("xml-path", not(equalTo(filePath(XML_FILE))))
+                .header("txt-size", equalTo(fileSizeAsStr(TXT_FILE)))
+                .header("txt-path", not(equalTo(filePath(TXT_FILE))));
+
+        // ensure that the 3 uploaded files where created on disk
+        Assertions.assertEquals(3, uploadDir.listFiles().length);
+    }
+
+    @Test
+    public void testOther() {
+        RestAssured.given()
+                .multiPart("first", "foo")
+                .multiPart("last", "bar")
+                .accept("text/plain")
+                .when()
+                .post("/otherMultipart/simple")
+                .then()
+                .statusCode(200)
+                .body(equalTo("foo - bar - final - static"));
+
+        Assertions.assertEquals(0, uploadDir.listFiles().length);
+    }
+
+    private String filePath(File file) {
+        return file.toPath().toAbsolutePath().toString();
+    }
+
+    private String fileSizeAsStr(File file) throws IOException {
+        return "" + Files.readAllBytes(file.toPath()).length;
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.smallrye.common.annotation.Blocking;
+
+@Path("/multipart")
+public class MultipartResource {
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("/simple/{times}")
+    public String simple(@MultipartForm FormData formData, Integer times) {
+        if (BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        return formData.getName() + " - " + formData.active + " - " + times * formData.getNum() + " - " + formData.getStatus()
+                + " - "
+                + formData.getHtmlPart().contentType() + " - " + Files.exists(formData.xmlPart) + " - "
+                + formData.txtFile.exists();
+    }
+
+    @POST
+    @Blocking
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("/blocking")
+    public Response blocking(@DefaultValue("1") @RestQuery Integer times, @MultipartForm FormData formData) throws IOException {
+        if (!BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        return Response.ok(formData.getName() + " - " + times * formData.getNum() + " - " + formData.getStatus())
+                .header("html-size", formData.getHtmlPart().size())
+                .header("html-path", formData.getHtmlPart().uploadedFile().toAbsolutePath().toString())
+                .header("xml-size", Files.readAllBytes(formData.xmlPart).length)
+                .header("xml-path", formData.xmlPart.toAbsolutePath().toString())
+                .header("txt-size", Files.readAllBytes(formData.txtFile.toPath()).length)
+                .header("txt-path", formData.txtFile.toPath().toAbsolutePath().toString())
+                .build();
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherFormData.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherFormData.java
@@ -1,0 +1,13 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import org.jboss.resteasy.reactive.RestForm;
+
+public class OtherFormData extends OtherFormDataBase {
+
+    public static String staticField = "static";
+
+    public final String finalField = "final";
+
+    @RestForm
+    public String last;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherFormDataBase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherFormDataBase.java
@@ -1,0 +1,9 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import javax.ws.rs.FormParam;
+
+public class OtherFormDataBase {
+
+    @FormParam("first")
+    public String first;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherMultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/OtherMultipartResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+
+@Path("/otherMultipart")
+public class OtherMultipartResource {
+
+    @Path("simple")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @POST
+    public String simple(@MultipartForm OtherFormData formData) {
+        return formData.first + " - " + formData.last + " - " + formData.finalField + " - " + OtherFormData.staticField;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/Status.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/Status.java
@@ -1,0 +1,7 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+public enum Status {
+    SLEEPING,
+    WORKING,
+    EATING;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/other/OtherPackageFormDataBase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/other/OtherPackageFormDataBase.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.server.test.multipart.other;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class OtherPackageFormDataBase {
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    private int num;
+
+    public int getNum() {
+        return num;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/resources/test.html
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/resources/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- head definitions go here -->
+</head>
+<body>
+<!-- the content goes here -->
+</body>
+</html>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/resources/test.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/resources/test.xml
@@ -1,0 +1,4 @@
+<note>
+    <heading>Reminder</heading>
+    <body>Remind me of...</body>
+</note>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/BlockingInputHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/BlockingInputHandler.java
@@ -1,10 +1,13 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
+import java.time.Duration;
+
 import javax.ws.rs.HttpMethod;
 
 import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
-import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
 import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestContext;
 
 import io.quarkus.vertx.http.runtime.VertxInputStream;
@@ -14,12 +17,13 @@ import io.vertx.ext.web.RoutingContext;
  * Handler that reads data and sets up the input stream and blocks until the data has been read.
  * This is meant to be used only when the request processing has already been offloaded to a worker thread.
  */
-public class BlockingInputHandler implements ServerRestHandler {
+public class BlockingInputHandler implements RuntimeConfigurableServerRestHandler {
 
-    private final long timeout;
+    private volatile Duration timeout;
 
-    public BlockingInputHandler(long timeout) {
-        this.timeout = timeout;
+    @Override
+    public void configure(RuntimeConfiguration configuration) {
+        timeout = configuration.readTimeout();
     }
 
     @Override
@@ -38,8 +42,7 @@ public class BlockingInputHandler implements ServerRestHandler {
             //TODO: this should not be installed for servlet
             VertxResteasyReactiveRequestContext vertxContext = (VertxResteasyReactiveRequestContext) context;
             RoutingContext routingContext = vertxContext.getContext();
-            vertxContext.setInputStream(new VertxInputStream(routingContext, timeout));
+            vertxContext.setInputStream(new VertxInputStream(routingContext, timeout.toMillis()));
         }
     }
-
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/MultipartFormHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/MultipartFormHandler.java
@@ -1,0 +1,225 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.http.HttpServerFileUpload;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.FileUploadImpl;
+
+/**
+ * ServerRestHandler implementation that handles the {@code multipart/form-data} media type.
+ *
+ * The code has been adapted from {@link io.vertx.ext.web.handler.impl.BodyHandlerImpl}
+ * and its main functionality is to populate {@code RoutingContext}'s fileUploads
+ */
+public class MultipartFormHandler implements RuntimeConfigurableServerRestHandler {
+
+    private static final Logger LOG = Logger.getLogger(MultipartFormHandler.class);
+
+    // in multipart requests, the body should not be available as a stream
+    private static final ByteArrayInputStream NO_BYTES_INPUT_STREAM = new ByteArrayInputStream(new byte[0]);
+
+    private volatile String uploadsDirectory;
+    private volatile boolean deleteUploadedFilesOnEnd;
+    private volatile Optional<Long> maxBodySize;
+
+    @Override
+    public void configure(RuntimeConfiguration configuration) {
+        uploadsDirectory = configuration.body().uploadsDirectory();
+        deleteUploadedFilesOnEnd = configuration.body().deleteUploadedFilesOnEnd();
+        maxBodySize = configuration.limits().maxBodySize();
+
+        try {
+            Files.createDirectories(Paths.get(uploadsDirectory));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext context) throws Exception {
+        // in some cases, with sub-resource locators or via request filters,
+        // it's possible we've already read the entity
+        if (context.hasInputStream()) {
+            // let's not set it twice
+            return;
+        }
+        if (context.serverRequest().getRequestMethod().equals(HttpMethod.GET) ||
+                context.serverRequest().getRequestMethod().equals(HttpMethod.HEAD)) {
+            return;
+        }
+        HttpServerRequest httpServerRequest = context.serverRequest().unwrap(HttpServerRequest.class);
+        if (httpServerRequest.isEnded()) {
+            context.setInputStream(NO_BYTES_INPUT_STREAM);
+        } else {
+            httpServerRequest.setExpectMultipart(true);
+            httpServerRequest.pause();
+            context.suspend();
+            MultipartFormVertxHandler handler = new MultipartFormVertxHandler(context, uploadsDirectory,
+                    deleteUploadedFilesOnEnd, maxBodySize);
+            httpServerRequest.handler(handler);
+            httpServerRequest.endHandler(new Handler<Void>() {
+                @Override
+                public void handle(Void event) {
+                    handler.end();
+                }
+            });
+            httpServerRequest.resume();
+        }
+    }
+
+    private static class MultipartFormVertxHandler implements Handler<Buffer> {
+        private final ResteasyReactiveRequestContext rrContext;
+        private final RoutingContext context;
+
+        private final String uploadsDirectory;
+        private final boolean deleteUploadedFilesOnEnd;
+        private final Optional<Long> maxBodySize;
+
+        boolean failed;
+        AtomicInteger uploadCount = new AtomicInteger();
+        AtomicBoolean cleanup = new AtomicBoolean(false);
+        boolean ended;
+        long uploadSize = 0L;
+
+        public MultipartFormVertxHandler(ResteasyReactiveRequestContext rrContext, String uploadsDirectory,
+                boolean deleteUploadedFilesOnEnd, Optional<Long> maxBodySize) {
+            this.rrContext = rrContext;
+            this.context = rrContext.serverRequest().unwrap(RoutingContext.class);
+            this.uploadsDirectory = uploadsDirectory;
+            this.deleteUploadedFilesOnEnd = deleteUploadedFilesOnEnd;
+            this.maxBodySize = maxBodySize;
+            Set<FileUpload> fileUploads = context.fileUploads();
+
+            context.request().setExpectMultipart(true);
+            context.request().uploadHandler(new Handler<HttpServerFileUpload>() {
+                @Override
+                public void handle(HttpServerFileUpload upload) {
+                    if (maxBodySize.isPresent() && upload.isSizeAvailable()) {
+                        // we can try to abort even before the upload starts
+                        long size = uploadSize + upload.size();
+                        if (size > MultipartFormVertxHandler.this.maxBodySize.get()) {
+                            failed = true;
+                            rrContext.resume(new WebApplicationException(Response.Status.REQUEST_ENTITY_TOO_LARGE));
+                            return;
+                        }
+                    }
+                    // we actually upload to a file with a generated filename
+                    uploadCount.incrementAndGet();
+                    String uploadedFileName = new File(MultipartFormVertxHandler.this.uploadsDirectory,
+                            UUID.randomUUID().toString()).getPath();
+                    upload.streamToFileSystem(uploadedFileName);
+                    FileUploadImpl fileUpload = new FileUploadImpl(uploadedFileName, upload);
+                    fileUploads.add(fileUpload);
+                    upload.exceptionHandler(new Handler<Throwable>() {
+                        @Override
+                        public void handle(Throwable t) {
+                            MultipartFormVertxHandler.this.deleteFileUploads();
+                            rrContext.resume(new WebApplicationException(t, Response.Status.INTERNAL_SERVER_ERROR));
+                        }
+                    });
+                    upload.endHandler(new Handler<Void>() {
+                        @Override
+                        public void handle(Void event) {
+                            uploadEnded();
+                        }
+                    });
+                }
+            });
+        }
+
+        @Override
+        public void handle(Buffer buff) {
+            if (failed) {
+                return;
+            }
+            uploadSize += buff.length();
+            if (maxBodySize.isPresent() && uploadSize > maxBodySize.get()) {
+                failed = true;
+                // enqueue a delete for the error uploads
+                context.vertx().runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void v) {
+                        MultipartFormVertxHandler.this.deleteFileUploads();
+                    }
+                });
+                rrContext.resume(new WebApplicationException(Response.Status.REQUEST_ENTITY_TOO_LARGE));
+            }
+        }
+
+        void uploadEnded() {
+            int count = uploadCount.decrementAndGet();
+            // only if parsing is done and count is 0 then all files have been processed
+            if (ended && count == 0) {
+                doEnd();
+            }
+        }
+
+        void end() {
+            // this marks the end of body parsing, calling doEnd should
+            // only be possible from this moment onwards
+            ended = true;
+            // only if parsing is done and count is 0 then all files have been processed
+            if (uploadCount.get() == 0) {
+                doEnd();
+            }
+        }
+
+        void doEnd() {
+            if (failed) {
+                deleteFileUploads();
+                return;
+            }
+            if (deleteUploadedFilesOnEnd) {
+                context.addBodyEndHandler(x -> deleteFileUploads());
+            }
+            rrContext.setInputStream(NO_BYTES_INPUT_STREAM);
+            rrContext.resume();
+        }
+
+        private void deleteFileUploads() {
+            if (cleanup.compareAndSet(false, true)) {
+                for (FileUpload fileUpload : context.fileUploads()) {
+                    FileSystem fileSystem = context.vertx().fileSystem();
+                    String uploadedFileName = fileUpload.uploadedFileName();
+                    fileSystem.exists(uploadedFileName, existResult -> {
+                        if (existResult.failed()) {
+                            LOG.warn("Could not detect if uploaded file exists, not deleting: " + uploadedFileName,
+                                    existResult.cause());
+                        } else if (existResult.result()) {
+                            fileSystem.delete(uploadedFileName, deleteResult -> {
+                                if (deleteResult.failed()) {
+                                    LOG.warn("Delete of uploaded file failed: " + uploadedFileName, deleteResult.cause());
+                                }
+                            });
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -1,0 +1,59 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.resteasy.reactive.server.core.Deployment;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
+
+@Recorder
+public class ResteasyReactiveRuntimeRecorder {
+
+    public void configure(RuntimeValue<Deployment> deployment, HttpConfiguration configuration) {
+        List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers = deployment.getValue()
+                .getRuntimeConfigurableServerRestHandlers();
+        for (RuntimeConfigurableServerRestHandler handler : runtimeConfigurableServerRestHandlers) {
+            handler.configure(new RuntimeConfiguration() {
+                @Override
+                public Duration readTimeout() {
+                    return configuration.readTimeout;
+                }
+
+                @Override
+                public Body body() {
+                    return new Body() {
+                        @Override
+                        public boolean deleteUploadedFilesOnEnd() {
+                            return configuration.body.deleteUploadedFilesOnEnd;
+                        }
+
+                        @Override
+                        public String uploadsDirectory() {
+                            return configuration.body.uploadsDirectory;
+                        }
+                    };
+                }
+
+                @Override
+                public Limits limits() {
+                    return new Limits() {
+                        @Override
+                        public Optional<Long> maxBodySize() {
+                            if (configuration.limits.maxBodySize.isPresent()) {
+                                return Optional.of(configuration.limits.maxBodySize.get().asLongValue());
+                            } else {
+                                return Optional.empty();
+                            }
+                        }
+                    };
+                }
+            });
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartSupport.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartSupport.java
@@ -1,0 +1,102 @@
+package io.quarkus.resteasy.reactive.server.runtime.multipart;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.MessageBodyReader;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
+import org.jboss.resteasy.reactive.server.handlers.RequestDeserializeHandler;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * This class isn't used directly, it is however used by generated code meant to deal with multipart forms.
+ */
+public final class MultipartSupport {
+
+    private static final Logger log = Logger.getLogger(RequestDeserializeHandler.class);
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
+
+    private MultipartSupport() {
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static Object convertFormAttribute(String value, Class type, Type genericType, MediaType mediaType,
+            ResteasyReactiveRequestContext context) {
+        if (value == null) {
+            return null;
+        }
+
+        ServerSerialisers serialisers = context.getDeployment().getSerialisers();
+        List<MessageBodyReader<?>> readers = serialisers.findReaders(null, type, mediaType, RuntimeType.SERVER);
+        if (readers.isEmpty()) {
+            throw new NotSupportedException();
+        }
+
+        for (MessageBodyReader<?> reader : readers) {
+            if (reader instanceof ServerMessageBodyReader) {
+                ServerMessageBodyReader<?> serverMessageBodyReader = (ServerMessageBodyReader<?>) reader;
+                if (serverMessageBodyReader.isReadable(type, genericType, context.getTarget().getLazyMethod(), mediaType)) {
+                    // this should always be an empty stream as multipart doesn't set the request body
+                    InputStream originalInputStream = context.getInputStream();
+                    try {
+                        // we need to set a fake input stream in order to trick the readers into thinking they are reading from the body
+                        context.setInputStream(formAttributeValueToInputStream(value));
+                        return serverMessageBodyReader.readFrom(type, genericType, mediaType, context);
+                    } catch (IOException e) {
+                        log.debug("Error occurred during deserialization of input", e);
+                        throw new InternalServerErrorException(e);
+                    } finally {
+                        context.setInputStream(originalInputStream);
+                    }
+
+                }
+            } else {
+                // TODO: should we be passing in the annotations?
+                if (reader.isReadable(type, genericType, EMPTY_ANNOTATIONS, mediaType)) {
+                    try {
+                        return reader.readFrom((Class) type, genericType, EMPTY_ANNOTATIONS, mediaType,
+                                context.getHttpHeaders().getRequestHeaders(),
+                                formAttributeValueToInputStream(value));
+                    } catch (IOException e) {
+                        log.debug("Error occurred during deserialization of input", e);
+                        throw new InternalServerErrorException(e);
+                    }
+                }
+            }
+        }
+        throw new NotSupportedException("Media type '" + mediaType + "' in multipart request is not supported");
+    }
+
+    public static QuarkusFileUpload getFileUpload(String formName, ResteasyReactiveRequestContext context) {
+        RoutingContext routingContext = context.unwrap(RoutingContext.class);
+        Set<FileUpload> fileUploads = routingContext.fileUploads();
+        for (FileUpload fileUpload : fileUploads) {
+            if (fileUpload.name().equals(formName)) {
+                return new QuarkusFileUpload(fileUpload);
+            }
+        }
+        return null;
+    }
+
+    private static ByteArrayInputStream formAttributeValueToInputStream(String formAttributeValue) {
+        return new ByteArrayInputStream(formAttributeValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/QuarkusFileUpload.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/QuarkusFileUpload.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.server.runtime.multipart;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+public class QuarkusFileUpload implements FileUpload {
+
+    private final io.vertx.ext.web.FileUpload vertxFileUpload;
+
+    public QuarkusFileUpload(io.vertx.ext.web.FileUpload vertxFileUpload) {
+        this.vertxFileUpload = vertxFileUpload;
+    }
+
+    @Override
+    public String name() {
+        return vertxFileUpload.name();
+    }
+
+    @Override
+    public Path uploadedFile() {
+        return Paths.get(vertxFileUpload.uploadedFileName());
+    }
+
+    @Override
+    public String fileName() {
+        return vertxFileUpload.fileName();
+    }
+
+    @Override
+    public long size() {
+        return vertxFileUpload.size();
+    }
+
+    @Override
+    public String contentType() {
+        return vertxFileUpload.contentType();
+    }
+
+    @Override
+    public String charSet() {
+        return vertxFileUpload.charSet();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
@@ -26,7 +26,7 @@ public class BodyConfig {
      * <p>
      * Either an absolute path or a path relative to the current directory of the application process.
      */
-    @ConfigItem(defaultValue = "file-uploads")
+    @ConfigItem(defaultValue = "${java.io.tmpdir}/uploads")
     public String uploadsDirectory;
 
     /**
@@ -44,7 +44,7 @@ public class BodyConfig {
      * If {@code true} the uploaded files stored in {@code quarkus.http.body-handler.uploads-directory} will be removed
      * after handling the request. Otherwise the files will be left there forever.
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "true")
     public boolean deleteUploadedFilesOnEnd;
 
     /**

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/UploadsDirectoryTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/UploadsDirectoryTest.java
@@ -40,7 +40,8 @@ public class UploadsDirectoryTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Routes.class)
                     .addAsResource(new StringAsset(
-                            "quarkus.http.body.uploads-directory = " + UPLOADS_DIR + "\n"),
+                            "quarkus.http.body.uploads-directory = " + UPLOADS_DIR
+                                    + "\nquarkus.http.body.delete-uploaded-files-on-end=false\n"),
                             "application.properties"));
 
     @Test

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -71,6 +71,7 @@ import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 import org.jboss.jandex.DotName;
+import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.RestCookie;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestHeader;
@@ -111,6 +112,7 @@ public final class ResteasyReactiveDotNames {
     public static final DotName REST_QUERY_PARAM = DotName.createSimple(RestQuery.class.getName());
     public static final DotName REST_HEADER_PARAM = DotName.createSimple(RestHeader.class.getName());
     public static final DotName REST_FORM_PARAM = DotName.createSimple(RestForm.class.getName());
+    public static final DotName MULTI_PART_FORM_PARAM = DotName.createSimple(MultipartForm.class.getName());
     public static final DotName REST_MATRIX_PARAM = DotName.createSimple(RestMatrix.class.getName());
     public static final DotName REST_COOKIE_PARAM = DotName.createSimple(RestCookie.class.getName());
     public static final DotName GET = DotName.createSimple(javax.ws.rs.GET.class.getName());

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TypeArgMapper.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TypeArgMapper.java
@@ -1,0 +1,53 @@
+package org.jboss.resteasy.reactive.common.processor;
+
+import java.util.List;
+import java.util.function.Function;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+
+public class TypeArgMapper implements Function<String, String> {
+    private final ClassInfo declaringClass;
+    private final IndexView index;
+
+    public TypeArgMapper(ClassInfo declaringClass, IndexView index) {
+        this.declaringClass = declaringClass;
+        this.index = index;
+    }
+
+    @Override
+    public String apply(String v) {
+        //we attempt to resolve type variables
+        ClassInfo declarer = declaringClass;
+        int pos = -1;
+        for (;;) {
+            if (declarer == null) {
+                return null;
+            }
+            List<TypeVariable> typeParameters = declarer.typeParameters();
+            for (int i = 0; i < typeParameters.size(); i++) {
+                TypeVariable tv = typeParameters.get(i);
+                if (tv.identifier().equals(v)) {
+                    pos = i;
+                }
+            }
+            if (pos != -1) {
+                break;
+            }
+            declarer = index.getClassByName(declarer.superName());
+        }
+        Type type = JandexUtil
+                .resolveTypeParameters(declaringClass.name(), declarer.name(), index)
+                .get(pos);
+        if (type.kind() == Type.Kind.TYPE_VARIABLE && type.asTypeVariable().identifier().equals(v)) {
+            List<Type> bounds = type.asTypeVariable().bounds();
+            if (bounds.isEmpty()) {
+                return "Ljava/lang/Object;";
+            }
+            return AsmUtil.getSignature(bounds.get(0), this);
+        } else {
+            return AsmUtil.getSignature(type, this);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/MultipartForm.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/MultipartForm.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used on POJOs meant to map to the various parts of
+ * of {@code multipart/form-data} HTTP bodies.
+ * Each part of the POJO that should be mapped to a part of the body should be annotated with {@link RestForm}.
+ * In order to facilitate conversion to the field's body type, {@link PartType} should be used to determine the media
+ * type of the corresponding body part.
+ *
+ * It's important to take caution when using such POJOs to read via {@link org.jboss.resteasy.reactive.multipart.FileUpload},
+ * {@code java.io.File} or {@code java.nio.file.Path} uploaded files in a blocking manner, that the resource method should be
+ * annotated with {@link io.smallrye.common.annotation.Blocking}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER })
+public @interface MultipartForm {
+    String value() default "";
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/PartType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/PartType.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used on fields of {@link MultipartForm} POJOs to designate the media type the corresponding body part maps to.
+ */
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PartType {
+    String value();
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
@@ -6,6 +6,7 @@ public enum ParameterType {
     QUERY,
     HEADER,
     FORM,
+    MULTI_PART_FORM,
     BODY,
     MATRIX,
     CONTEXT,

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
@@ -59,6 +59,8 @@ public class ResourceMethod {
 
     private boolean isFormParamRequired;
 
+    private boolean isMultipart;
+
     public boolean isResourceLocator() {
         return httpMethod == null;
     }
@@ -177,6 +179,15 @@ public class ResourceMethod {
 
     public ResourceMethod setFormParamRequired(boolean isFormParamRequired) {
         this.isFormParamRequired = isFormParamRequired;
+        return this;
+    }
+
+    public boolean isMultipart() {
+        return isMultipart;
+    }
+
+    public ResourceMethod setMultipart(boolean isMultipart) {
+        this.isMultipart = isMultipart;
         return this;
     }
 

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/multipart/FileUpload.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/multipart/FileUpload.java
@@ -1,0 +1,39 @@
+package org.jboss.resteasy.reactive.multipart;
+
+import java.nio.file.Path;
+
+/**
+ * Represents a file-upload from an HTTP multipart form submission.
+ */
+public interface FileUpload {
+
+    /**
+     * @return the name of the upload as provided in the form submission.
+     */
+    String name();
+
+    /**
+     * @return the actual temporary file name on the server where the file was uploaded to.
+     */
+    Path uploadedFile();
+
+    /**
+     * @return the file name of the upload as provided in the form submission.
+     */
+    String fileName();
+
+    /**
+     * @return the size of the upload, in bytes
+     */
+    long size();
+
+    /**
+     * @return the content type (MIME type) of the upload.
+     */
+    String contentType();
+
+    /**
+     * @return the charset of the upload.
+     */
+    String charSet();
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -20,6 +20,7 @@ import org.jboss.resteasy.reactive.server.handlers.RestInitialHandler;
 import org.jboss.resteasy.reactive.server.mapping.RequestMapper;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.BeanFactory.BeanInstance;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -38,6 +39,7 @@ public class Deployment {
     private final RequestContextFactory requestContextFactory;
     private final List<ServerRestHandler> preMatchHandlers;
     private final List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
+    private final List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers;
 
     public Deployment(ExceptionMapping exceptionMapping, ContextResolvers contextResolvers,
             ServerSerialisers serialisers,
@@ -46,7 +48,8 @@ public class Deployment {
             ConfigurationImpl configuration, Supplier<Application> applicationSupplier,
             ThreadSetupAction threadSetupAction, RequestContextFactory requestContextFactory,
             List<ServerRestHandler> preMatchHandlers,
-            List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers) {
+            List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers,
+            List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers) {
         this.exceptionMapping = exceptionMapping;
         this.contextResolvers = contextResolvers;
         this.serialisers = serialisers;
@@ -60,6 +63,7 @@ public class Deployment {
         this.requestContextFactory = requestContextFactory;
         this.preMatchHandlers = preMatchHandlers;
         this.classMappers = classMappers;
+        this.runtimeConfigurableServerRestHandlers = runtimeConfigurableServerRestHandlers;
     }
 
     public Supplier<Application> getApplicationSupplier() {
@@ -157,5 +161,9 @@ public class Deployment {
 
     public RequestContextFactory getRequestContextFactory() {
         return requestContextFactory;
+    }
+
+    public List<RuntimeConfigurableServerRestHandler> getRuntimeConfigurableServerRestHandlers() {
+        return runtimeConfigurableServerRestHandlers;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/InjectParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/InjectParamExtractor.java
@@ -5,11 +5,11 @@ import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.injection.ResteasyReactiveInjectionTarget;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
-public class BeanParamExtractor implements ParameterExtractor {
+public class InjectParamExtractor implements ParameterExtractor {
 
     private final BeanFactory<Object> factory;
 
-    public BeanParamExtractor(BeanFactory<Object> factory) {
+    public InjectParamExtractor(BeanFactory<Object> factory) {
         this.factory = factory;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/CustomServerRestHandlers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/CustomServerRestHandlers.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.reactive.server.core.startup;
+
+import java.util.function.Supplier;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public final class CustomServerRestHandlers {
+
+    private final Supplier<ServerRestHandler> blockingInputHandlerSupplier;
+    private final Supplier<ServerRestHandler> multipartHandlerSupplier;
+
+    public CustomServerRestHandlers(Supplier<ServerRestHandler> blockingInputHandlerSupplier,
+            Supplier<ServerRestHandler> multipartHandlerSupplier) {
+        this.blockingInputHandlerSupplier = blockingInputHandlerSupplier;
+        this.multipartHandlerSupplier = multipartHandlerSupplier;
+    }
+
+    public Supplier<ServerRestHandler> getBlockingInputHandlerSupplier() {
+        return blockingInputHandlerSupplier;
+    }
+
+    public Supplier<ServerRestHandler> getMultipartHandlerSupplier() {
+        return multipartHandlerSupplier;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -42,6 +42,7 @@ import org.jboss.resteasy.reactive.server.model.Features;
 import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -50,7 +51,7 @@ public class RuntimeDeploymentManager {
     public static final ServerRestHandler[] EMPTY_REST_HANDLER_ARRAY = new ServerRestHandler[0];
     private final DeploymentInfo info;
     private final Supplier<Executor> executorSupplier;
-    private final Supplier<ServerRestHandler> blockingInputHandlerSupplier;
+    private final CustomServerRestHandlers customServerRestHandlers;
     private final Consumer<Closeable> closeTaskHandler;
     private final RequestContextFactory requestContextFactory;
     private final ThreadSetupAction threadSetupAction;
@@ -58,12 +59,12 @@ public class RuntimeDeploymentManager {
 
     public RuntimeDeploymentManager(DeploymentInfo info,
             Supplier<Executor> executorSupplier,
-            Supplier<ServerRestHandler> blockingInputHandlerSupplier,
+            CustomServerRestHandlers customServerRestHandlers,
             Consumer<Closeable> closeTaskHandler,
             RequestContextFactory requestContextFactory, ThreadSetupAction threadSetupAction, String rootPath) {
         this.info = info;
         this.executorSupplier = executorSupplier;
-        this.blockingInputHandlerSupplier = blockingInputHandlerSupplier;
+        this.customServerRestHandlers = customServerRestHandlers;
         this.closeTaskHandler = closeTaskHandler;
         this.requestContextFactory = requestContextFactory;
         this.threadSetupAction = threadSetupAction;
@@ -94,8 +95,9 @@ public class RuntimeDeploymentManager {
                         return info.getFactoryCreator().apply(aClass).createInstance();
                     }
                 });
+        List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers = new ArrayList<>();
         RuntimeResourceDeployment runtimeResourceDeployment = new RuntimeResourceDeployment(info, executorSupplier,
-                blockingInputHandlerSupplier,
+                customServerRestHandlers,
                 interceptorDeployment, dynamicEntityWriter, resourceLocatorHandler, requestContextFactory.isDefaultBlocking());
         List<ResourceClass> possibleSubResource = new ArrayList<>(locatableResourceClasses);
         possibleSubResource.addAll(resourceClasses); //the TCK uses normal resources also as sub resources
@@ -103,10 +105,9 @@ public class RuntimeDeploymentManager {
             Map<String, TreeMap<URITemplate, List<RequestMapper.RequestPath<RuntimeResource>>>> templates = new HashMap<>();
             URITemplate classPathTemplate = clazz.getPath() == null ? null : new URITemplate(clazz.getPath(), true);
             for (ResourceMethod method : clazz.getMethods()) {
-                //TODO: add DynamicFeature for these
-                //TODO: remove the cast
                 RuntimeResource runtimeResource = runtimeResourceDeployment.buildResourceMethod(
                         clazz, (ServerResourceMethod) method, true, classPathTemplate, info);
+                addRuntimeConfigurableHandlers(runtimeResource, runtimeConfigurableServerRestHandlers);
 
                 RuntimeMappingDeployment.buildMethodMapper(templates, method, runtimeResource);
             }
@@ -128,6 +129,7 @@ public class RuntimeDeploymentManager {
             for (ResourceMethod method : clazz.getMethods()) {
                 RuntimeResource runtimeResource = runtimeResourceDeployment.buildResourceMethod(
                         clazz, (ServerResourceMethod) method, false, classTemplate, info);
+                addRuntimeConfigurableHandlers(runtimeResource, runtimeConfigurableServerRestHandlers);
 
                 RuntimeMappingDeployment.buildMethodMapper(perClassMappers, method, runtimeResource);
             }
@@ -199,7 +201,17 @@ public class RuntimeDeploymentManager {
         return new Deployment(exceptionMapping, info.getCtxResolvers(), serialisers,
                 abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY), dynamicEntityWriter,
                 prefix, paramConverterProviders, configurationImpl, applicationSupplier,
-                threadSetupAction, requestContextFactory, preMatchHandlers, classMappers);
+                threadSetupAction, requestContextFactory, preMatchHandlers, classMappers,
+                runtimeConfigurableServerRestHandlers);
+    }
+
+    private void addRuntimeConfigurableHandlers(RuntimeResource runtimeResource,
+            List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers) {
+        for (ServerRestHandler serverRestHandler : runtimeResource.getHandlerChain()) {
+            if (serverRestHandler instanceof RuntimeConfigurableServerRestHandler) {
+                runtimeConfigurableServerRestHandlers.add((RuntimeConfigurableServerRestHandler) serverRestHandler);
+            }
+        }
     }
 
     //TODO: this needs plenty more work to support all possible types and provide all information the FeatureContext allows

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
@@ -12,4 +12,6 @@ public interface ResteasyReactiveInjectionContext {
     String getCookieParameter(String name);
 
     Object getFormParameter(String name, boolean single, boolean encoded);
+
+    <T> T unwrap(Class<T> theType);
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionTarget.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionTarget.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.injection;
 
 public interface ResteasyReactiveInjectionTarget {
-    public default void __quarkus_rest_inject(ResteasyReactiveInjectionContext ctx) {
+
+    default void __quarkus_rest_inject(ResteasyReactiveInjectionContext ctx) {
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfigurableServerRestHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfigurableServerRestHandler.java
@@ -1,0 +1,6 @@
+package org.jboss.resteasy.reactive.server.spi;
+
+public interface RuntimeConfigurableServerRestHandler extends ServerRestHandler {
+
+    void configure(RuntimeConfiguration configuration);
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.reactive.server.spi;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface RuntimeConfiguration {
+
+    Duration readTimeout();
+
+    Body body();
+
+    Limits limits();
+
+    interface Body {
+
+        boolean deleteUploadedFilesOnEnd();
+
+        String uploadsDirectory();
+    }
+
+    interface Limits {
+        Optional<Long> maxBodySize();
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -236,6 +236,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T unwrap(Class<T> theType) {
         if (theType == RoutingContext.class) {
@@ -244,6 +245,8 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
             return (T) request;
         } else if (theType == HttpServerResponse.class) {
             return (T) response;
+        } else if (theType == ResteasyReactiveRequestContext.class) {
+            return (T) this;
         }
         return null;
     }


### PR DESCRIPTION
Fixes: #14601

As mentioned in the title, this only adds support for reading multipart form data - which seems to be the most common case.

The idea here is to use code similar to what Vert.x uses with its `BodyHandlerImpl` to populate the `RoutingContext` and `HttpServerRequest` with the appropriate data from the multipart body, and then use the `__quarkus_rest_inject` mechanism available to parameter handling, in order to call a generated piece of code that populates the POJO by pulling data from the context.
The user facing API (`@Multipart` and `@PartType`) is pretty much the same as what is available in RESTEasy Classic.

One thing this PR does not do is provide an abstraction for the file upload handling that will work for non Vert.x enviroments