### PR TITLE
OIDC: Create Cookies Secure if cookieForceSecure is enabled

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -445,6 +445,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Map<String, String> extraParams;
 
         /**
+         * If enabled the state, session and post logout cookies will have their 'secure' parameter set to 'true'
+         * when HTTP is used. It may be necessary when running behind an SSL terminating reverse proxy.
+         * The cookies will always be secure if HTTPS is used even if this property is set to false.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean cookieForceSecure;
+
+        /**
          * Cookie path parameter value which, if set, will be used to set a path parameter for the session, state and post
          * logout cookies.
          * The `cookie-path-header` property, if set, will be checked first.
@@ -541,6 +549,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setRestorePathAfterRedirect(boolean restorePathAfterRedirect) {
             this.restorePathAfterRedirect = restorePathAfterRedirect;
+        }
+
+        public boolean isCookieForceSecure() {
+            return cookieForceSecure;
+        }
+
+        public void setCookieForceSecure(boolean cookieForceSecure) {
+            this.cookieForceSecure = cookieForceSecure;
         }
 
         public Optional<String> getCookiePath() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -423,7 +423,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             String name, String value, long maxAge) {
         ServerCookie cookie = new CookieImpl(name, value);
         cookie.setHttpOnly(true);
-        cookie.setSecure(context.request().isSSL());
+        cookie.setSecure(oidcConfig.authentication.cookieForceSecure || context.request().isSSL());
         cookie.setMaxAge(maxAge);
         LOG.debugf(name + " cookie 'max-age' parameter is set to %d", maxAge);
         Authentication auth = oidcConfig.getAuthentication();


### PR DESCRIPTION
As discussed with @sberyozkin in zulip cookies should be created secure=true if forceRedirectHttpsScheme is enabled.

Fixes #14856.