### PR TITLE
Add support for Jib's alwaysCacheBaseImage

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -110,4 +110,15 @@ public class JibConfig {
      */
     @ConfigItem
     public Optional<String> user;
+
+    /**
+     * Controls the optimization which skips downloading base image layers that exist in a target
+     * registry. If the user does not set this property, then read as false.
+     *
+     * If {@code true}, base image layers are always pulled and cached. If
+     * {@code false}, base image layers will not be pulled/cached if they already exist on the
+     * target registry.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean alwaysCacheBaseImage;
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -134,7 +134,7 @@ public class JibProcessor {
         }
         setUser(jibConfig, jibContainerBuilder);
         handleExtraFiles(outputTarget, jibContainerBuilder);
-        JibContainer container = containerize(containerImageConfig, containerImage, jibContainerBuilder,
+        JibContainer container = containerize(containerImageConfig, jibConfig, containerImage, jibContainerBuilder,
                 pushRequest.isPresent());
 
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "jar-container",
@@ -165,7 +165,7 @@ public class JibProcessor {
                 nativeImage, containerImageLabels);
         setUser(jibConfig, jibContainerBuilder);
         handleExtraFiles(outputTarget, jibContainerBuilder);
-        JibContainer container = containerize(containerImageConfig, containerImage, jibContainerBuilder,
+        JibContainer container = containerize(containerImageConfig, jibConfig, containerImage, jibContainerBuilder,
                 pushRequest.isPresent());
 
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container",
@@ -173,8 +173,9 @@ public class JibProcessor {
     }
 
     private JibContainer containerize(ContainerImageConfig containerImageConfig,
-            ContainerImageInfoBuildItem containerImage, JibContainerBuilder jibContainerBuilder, boolean pushRequested) {
-        Containerizer containerizer = createContainerizer(containerImageConfig, containerImage, pushRequested);
+            JibConfig jibConfig, ContainerImageInfoBuildItem containerImage, JibContainerBuilder jibContainerBuilder,
+            boolean pushRequested) {
+        Containerizer containerizer = createContainerizer(containerImageConfig, jibConfig, containerImage, pushRequested);
         for (String additionalTag : containerImage.getAdditionalTags()) {
             containerizer.withAdditionalTag(additionalTag);
         }
@@ -192,7 +193,7 @@ public class JibProcessor {
     }
 
     private Containerizer createContainerizer(ContainerImageConfig containerImageConfig,
-            ContainerImageInfoBuildItem containerImage,
+            JibConfig jibConfig, ContainerImageInfoBuildItem containerImage,
             boolean pushRequested) {
         Containerizer containerizer;
         ImageReference imageReference = ImageReference.of(containerImage.getRegistry().orElse(null),
@@ -216,6 +217,7 @@ public class JibProcessor {
             }
         });
         containerizer.setAllowInsecureRegistries(containerImageConfig.insecure);
+        containerizer.setAlwaysCacheBaseImage(jibConfig.alwaysCacheBaseImage);
         return containerizer;
     }
 


### PR DESCRIPTION
The default value is the same as what Jib uses
(see https://github.com/GoogleContainerTools/jib/blob/v2.7.1-maven/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java#L138)

Fixes: #14861