### PR TITLE
Liquibase: fix missing relative csv, sql, procedure & view files in native

### DIFF
--- a/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
@@ -7,4 +7,6 @@
     <include relativeToChangelogFile="true" file="create-tables.xml" />
 
     <include relativeToChangelogFile="true" file="test/test.xml" />
+
+    <include relativeToChangelogFile="true" file="create-views.xml" />
 </databaseChangeLog>

--- a/integration-tests/liquibase/src/main/resources/db/xml/create-views.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/create-views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd">
+
+    <preConditions>
+        <dbms type="h2"/>
+    </preConditions>
+
+    <changeSet author="dev (generated)" id="create-view-inline">
+        <createView viewName="v_inline">select id, name from liquibase where id > 1</createView>
+    </changeSet>
+
+    <changeSet author="dev (generated)" id="create-view-file-abs">
+        <createView viewName="v_file_abs"
+                    path="db/xml/views/view-abs.sql"
+                    relativeToChangelogFile="false"/>
+    </changeSet>
+
+    <changeSet author="dev (generated)" id="create-view-file-rel">
+        <createView viewName="v_file_rel"
+                    path="views/view-rel.sql"
+                    relativeToChangelogFile="true"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/integration-tests/liquibase/src/main/resources/db/xml/views/view-abs.sql
+++ b/integration-tests/liquibase/src/main/resources/db/xml/views/view-abs.sql
@@ -1,0 +1,1 @@
+select id, name from liquibase where id > 1

--- a/integration-tests/liquibase/src/main/resources/db/xml/views/view-rel.sql
+++ b/integration-tests/liquibase/src/main/resources/db/xml/views/view-rel.sql
@@ -1,0 +1,1 @@
+select id, name from liquibase where id > 1

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
@@ -19,7 +19,11 @@ public class LiquibaseFunctionalityTest {
                 .get("/liquibase/update")
                 .then()
                 .body(is(
-                        "create-tables-1,test-1,json-create-tables-1,json-test-1,sql-create-tables-1,sql-test-1,yaml-create-tables-1,yaml-test-1,00000000000000,00000000000001,00000000000002"));
+                        "create-tables-1,test-1,create-view-inline,create-view-file-abs,create-view-file-rel,"
+                                + "json-create-tables-1,json-test-1,"
+                                + "sql-create-tables-1,sql-test-1,"
+                                + "yaml-create-tables-1,yaml-test-1,"
+                                + "00000000000000,00000000000001,00000000000002"));
     }
 
 }


### PR DESCRIPTION
Originally, I just wanted to extend the IT as a follow up to https://github.com/quarkusio/quarkus/pull/14741#issuecomment-770879659.
But during testing I realized that `relativeToChangelogFile` is not handled at all, resulting in missing files in native.

In the long run, we might be better off just adding _all_ resources under a user-configurable path, instead of trying to parse everything piece by piece. E.g. when `includeAll` is fixed in Liquibase (#14751), we would otherwise need to cover that as well...