### PR TITLE
Ensure that resume from a worker pool thread doesn't resume on event loop

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/NewParamsRestResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/NewParamsRestResource.java
@@ -28,6 +28,8 @@ import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 import org.junit.jupiter.api.Assertions;
 
+import io.quarkus.runtime.BlockingOperationControl;
+import io.smallrye.common.annotation.Blocking;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 
@@ -52,6 +54,16 @@ public class NewParamsRestResource {
             @RestCookie String c) {
         return "params: p: " + p + ", q: " + q + ", h: " + h + ", f: " + f + ", m: " + m + ", c: " + c + ", q2: "
                 + q2.orElse("empty") + ", q3: " + q3.orElse(-1);
+    }
+
+    @Blocking
+    @POST
+    @Path("form-blocking")
+    public String formBlocking(@RestForm String f) {
+        if (!BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should not have dispatched");
+        }
+        return f;
     }
 
     @GET

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -390,6 +390,12 @@ public class SimpleQuarkusRestTestCase {
                 .then()
                 .log().ifError()
                 .body(Matchers.equalTo("data:OK\n\n"));
+        RestAssured.with()
+                .urlEncodingEnabled(false)
+                .formParam("f", "fv")
+                .post("/new-params/myklass;m=mv/myregex/form-blocking")
+                .then()
+                .body(Matchers.equalTo("fv"));
     }
 
     @Test


### PR DESCRIPTION
Fixes: #14875

This basically takes the first commit from #14852 and adds a test.
The idea is that we will want to backport this change, but we don't 
want to backport the entirety of #14852