### PR TITLE
Deprecate uberJar mojo parameter and log a warning when used

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -53,7 +53,11 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.finalName}")
     private String finalName;
 
+    /**
+     * @deprecated use {@code quarkus.package.type} instead
+     */
     @Parameter(property = "uberJar", defaultValue = "false")
+    @Deprecated
     private boolean uberJar;
 
     /**
@@ -145,6 +149,10 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
     }
 
     protected boolean uberJar() {
+        if (uberJar) {
+            getLog().warn(
+                    "The parameter uberJar is deprecated, and will be removed in a future version. To build an uber-jar set the config property quarkus.package.type=uber-jar. For more info see https://quarkus.io/guides/maven-tooling#uber-jar-maven");
+        }
         return uberJar;
     }
 

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/base/pom.tpl.qute.xml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/quarkus/core/buildtool/maven/base/pom.tpl.qute.xml
@@ -18,6 +18,9 @@
         <quarkus-plugin.version>{quarkus.maven-plugin.version}</quarkus-plugin.version>
         <compiler-plugin.version>{maven-compiler-plugin.version}</compiler-plugin.version>
         <surefire-plugin.version>{maven-surefire-plugin.version}</surefire-plugin.version>
+        {#if uberjar}
+        <quarkus.package.type>uber-jar</quarkus.package.type>
+        {/if}
     </properties>
 
     <dependencyManagement>
@@ -102,11 +105,6 @@
                 <artifactId>{quarkus.maven-plugin.artifact-id}</artifactId>
                 <version>$\{quarkus-plugin.version}</version>
                 <extensions>true</extensions>
-                {#if uberjar}
-                <configuration>
-                    <uberJar>true</uberJar>
-                </configuration>
-                {/if}
                 <executions>
                     <execution>
                         <goals>

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -506,7 +506,8 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 [[uber-jar-maven]]
 === Uber-Jar Creation
 
-Quarkus Maven plugin supports the generation of Uber-Jars by specifying a `quarkus.package.type=uber-jar` configuration option in your `application.properties`.
+Quarkus Maven plugin supports the generation of Uber-Jars by specifying a `quarkus.package.type=uber-jar` configuration option in your `application.properties`
+(or `<quarkus.package.type>uber-jar</quarkus.package.type>` in your `pom.xml`).
 
 The original jar will still be present in the `target` directory but it will be renamed to contain the `.original` suffix.
 

--- a/extensions/azure-functions-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/azure-functions-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,7 @@
     <functionResourceGroup>${resourceGroup}</functionResourceGroup>
     <function>${function}</function>
     <stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
+    <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -79,9 +80,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus-plugin.version}</version>
-        <configuration>
-          <uberJar>true</uberJar>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/maven/src/test/resources/projects/command-mode-app-args-plugin-config/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/command-mode-app-args-plugin-config/pom.xml
@@ -13,6 +13,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -54,7 +55,6 @@
         </executions>
         <configuration>
           <argsString>plugin pom config</argsString> <!-- dev goal parameter -->
-          <uberJar>true</uberJar> <!-- build goal parameter -->
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources/projects/ignore-entries-uber-jar/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/ignore-entries-uber-jar/pom.xml
@@ -13,6 +13,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -44,7 +45,6 @@
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus-plugin.version}</version>
         <configuration>
-          <uberJar>true</uberJar>
           <ignoredEntries>
             <ignoredEntry>META-INF/swagger-ui-files/swagger-ui-bundle.js.map</ignoredEntry>
             <ignoredEntry>META-INF/swagger-ui-files/swagger-ui-standalone-preset.js.map</ignoredEntry>

--- a/integration-tests/maven/src/test/resources/projects/uberjar-maven-plugin-config/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/uberjar-maven-plugin-config/pom.xml
@@ -13,6 +13,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -58,9 +59,6 @@
               <goal>generate-code-tests</goal>
               <goal>build</goal>
             </goals>
-            <configuration>
-              <uberJar>true</uberJar>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Relates to #14878.

Notes:
- I replaced the remaining usages with Maven properties, not with application properties, because I prefer to keep build related stuff out of application.properties/.yaml, but I have no hard feelings if you want it the other way.
- I stole the pattern for the warning from here: #14634