### PR TITLE
Create Extension with Quarkus CLI

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -153,7 +153,6 @@
         <kotlin.version>1.4.20</kotlin.version>
         <dekorate.version>0.14.2</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
-        <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.0.3</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
@@ -4677,11 +4676,6 @@
                         <artifactId>maven-artifact</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>jline</groupId>
-                <artifactId>jline</artifactId>
-                <version>${jline.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>

--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -132,9 +132,9 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
                 return CommandLine.ExitCode.SOFTWARE;
             }
         } catch (Exception e) {
+            err().println("Project creation failed, " + e.getMessage());
             if (parent.showErrors)
                 e.printStackTrace(err());
-            err().println("Project creation failed, " + e.getMessage());
             return CommandLine.ExitCode.SOFTWARE;
         }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -1,0 +1,170 @@
+package io.quarkus.cli;
+
+import static io.quarkus.devtools.commands.CreateExtension.extractQuarkiverseExtensionId;
+import static io.quarkus.devtools.commands.CreateExtension.isQuarkiverseGroupId;
+import static io.quarkus.devtools.commands.CreateExtension.resolveModel;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
+
+import org.apache.maven.model.Model;
+
+import io.quarkus.cli.core.BaseSubCommand;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.utils.Prompter;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "create-extension", sortOptions = false, usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Creates the base of a Quarkus extension in different layout depending of the options and environment.")
+public class CreateExtension extends BaseSubCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = { "-g",
+            "--group-id" }, order = 1, paramLabel = "GROUP-ID", description = "The groupId for project.")
+    String groupId;
+
+    @CommandLine.Option(names = { "-i",
+            "--extension-id" }, order = 0, paramLabel = "EXTENSION-ID", description = "The extension id.")
+    String extensionId;
+
+    @CommandLine.Option(names = { "-v",
+            "--version" }, order = 3, paramLabel = "VERSION", description = "The version for the extension.")
+    String version = "1.0.0-SNAPSHOT";
+
+    @CommandLine.Option(names = { "-q",
+            "--quarkus-version" }, order = 4, paramLabel = "QUARKUS-VERSION", description = "The quarkus version for the extension.")
+    String quarkusVersion;
+
+    @CommandLine.Option(names = { "-N",
+            "--namespace-id" }, order = 5, paramLabel = "NAMESPACE-ID", description = "A prefix common to all extension modules artifactIds.")
+    String namespaceId;
+
+    @CommandLine.Option(names = { "-p",
+            "--package-name" }, order = 6, paramLabel = "PACKAGE-NAME", description = "Base package under which classes should be created in Runtime and Deployment modules.. When specified, use a custom package name instead of auto generating it from other parameters.")
+    String packageName;
+
+    @CommandLine.Option(names = {
+            "--extension-name" }, order = 7, paramLabel = "EXTENSION-NAME", description = "When specified, use a custom extension name instead of generating it from the extension id.")
+    String extensionName;
+
+    @CommandLine.Option(names = {
+            "--namespace-name" }, order = 8, paramLabel = "NAMESPACE-NAME", description = "A prefix common to all extension modules names. When specified, use a custom namespace name instead of generating it from the namespace id.")
+    String namespaceName;
+
+    @CommandLine.Option(names = {
+            "--bom-group-id" }, order = 9, paramLabel = "BOM-GROUP-ID", description = "The group id of the Quarkus platform BOM.")
+    String quarkusBomGroupId;
+
+    @CommandLine.Option(names = {
+            "--bom-artifact-id" }, order = 10, paramLabel = "BOM-ARTIFACT-ID", description = "The artifact id of the Quarkus platform BOM.")
+    String quarkusBomArtifactId;
+
+    @CommandLine.Option(names = {
+            "--bom-version" }, order = 11, paramLabel = "BOM-VERSION", description = "The version id of the Quarkus platform BOM.")
+    String quarkusBomVersion;
+
+    @CommandLine.Option(names = {
+            "--without-unit-test" }, order = 12, description = "Indicates whether to generate a unit test class for the extension.")
+    boolean withoutUnitTest;
+
+    @CommandLine.Option(names = {
+            "--without-it-tests" }, order = 13, description = "Indicates whether to generate a integration tests for the extension.")
+    boolean withoutIntegrationTests;
+
+    @CommandLine.Option(names = {
+            "--without-devmode-test" }, order = 14, description = "Indicates whether to generate a dev mode test class for the extension.")
+    boolean withoutDevModeTest;
+
+    @CommandLine.Option(names = {
+            "--without-tests" }, order = 15, description = "Indicates whether to generate any test for the extension.")
+    boolean withoutTests;
+
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec spec; //
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            Path dir = Paths.get(System.getProperty("user.dir"));
+
+            promptValues(dir);
+            autoComputeQuarkiverseExtensionId();
+
+            final io.quarkus.devtools.commands.CreateExtension createExtension = new io.quarkus.devtools.commands.CreateExtension(
+                    dir)
+                            .extensionId(extensionId)
+                            .extensionName(extensionName)
+                            .groupId(groupId)
+                            .version(version)
+                            .packageName(packageName)
+                            .namespaceId(namespaceId)
+                            .namespaceName(namespaceName)
+                            .quarkusVersion(quarkusVersion)
+                            .quarkusBomGroupId(quarkusBomGroupId)
+                            .quarkusBomArtifactId(quarkusBomArtifactId)
+                            .quarkusBomGroupId(quarkusBomVersion)
+                            .withoutUnitTest(withoutTests || withoutUnitTest)
+                            .withoutDevModeTest(withoutTests || withoutDevModeTest)
+                            .withoutIntegrationTests(withoutTests || withoutIntegrationTests);
+
+            try {
+                boolean success = createExtension.execute().isSuccess();
+                if (!success) {
+                    err().println("Failed to generate Extension");
+                    return CommandLine.ExitCode.SOFTWARE;
+                }
+            } catch (QuarkusCommandException e) {
+                err().println("Failed to generate Extension, " + e.getMessage());
+                if (parent.showErrors) {
+                    e.printStackTrace(err());
+                }
+                return CommandLine.ExitCode.SOFTWARE;
+            }
+
+        } catch (Exception e) {
+            err().println("Failed to generate Extension, " + e.getMessage());
+            if (parent.showErrors) {
+                e.printStackTrace(err());
+            }
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+
+        return CommandLine.ExitCode.OK;
+    }
+
+    private void autoComputeQuarkiverseExtensionId() {
+        if (isQuarkiverseGroupId(groupId) && isEmpty(extensionId)) {
+            extensionId = extractQuarkiverseExtensionId(groupId);
+        }
+    }
+
+    private void promptValues(Path dir) throws QuarkusCommandException {
+        if (batchMode) {
+            if (isBlank(extensionId)) {
+                throw new CommandLine.MissingParameterException(spec.commandLine(), spec.optionsMap().get("-id"),
+                        "Missing required option: '--extension-id=EXTENSION-ID'");
+            }
+            return;
+        }
+        try {
+            final Prompter prompter = new Prompter();
+            final Model model = resolveModel(dir);
+            if (model == null || !model.getArtifactId().endsWith("quarkus-parent")) {
+                if (isBlank(quarkusVersion)) {
+                    quarkusVersion = prompter.prompt("Set the Quarkus version");
+                }
+                if (isBlank(groupId)) {
+                    groupId = prompter.promptWithDefaultValue("Set the extension groupId", "org.acme");
+                }
+            }
+            autoComputeQuarkiverseExtensionId();
+            if (isBlank(extensionId)) {
+                extensionId = prompter.prompt("Set the extension id");
+            }
+        } catch (IOException e) {
+            throw new QuarkusCommandException("Unable to get user input", e);
+        }
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateJBang.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateJBang.java
@@ -50,9 +50,9 @@ public class CreateJBang extends BaseSubCommand implements Callable<Integer> {
                 return CommandLine.ExitCode.SOFTWARE;
             }
         } catch (Exception e) {
+            err().println("JBang project creation failed, " + e.getMessage());
             if (parent.showErrors)
                 e.printStackTrace(err());
-            err().println("JBang project creation failed, " + e.getMessage());
             return CommandLine.ExitCode.SOFTWARE;
         }
         return CommandLine.ExitCode.OK;

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -21,7 +21,8 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "quarkus", aliases = {
         "qs" }, versionProvider = QuarkusVersion.class, usageHelpAutoWidth = true, subcommandsRepeatable = true, mixinStandardHelpOptions = true, subcommands = {
                 Build.class,
-                Clean.class, Create.class, CreateJBang.class, List.class, Add.class, Remove.class, Dev.class })
+                Clean.class, Create.class, CreateJBang.class, List.class, Add.class, Remove.class, Dev.class,
+                CreateExtension.class })
 public class QuarkusCli implements QuarkusApplication {
 
     public void usage() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/core/BaseSubCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/core/BaseSubCommand.java
@@ -6,7 +6,11 @@ import io.quarkus.cli.QuarkusCli;
 import picocli.CommandLine;
 
 public abstract class BaseSubCommand {
-    @CommandLine.Option(names = { "-h", "--help" }, order = 0, usageHelp = true, description = "display this help message")
+
+    @CommandLine.Option(names = { "-B", "--batch-mode" }, order = 100, description = "run command in batch mode")
+    protected boolean batchMode;
+
+    @CommandLine.Option(names = { "-h", "--help" }, order = 101, usageHelp = true, description = "display this help message")
     protected boolean help;
 
     @CommandLine.ParentCommand

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -116,12 +116,6 @@
             </exclusions>
         </dependency>
 
-        <!-- user prompt -->
-        <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
@@ -3,12 +3,8 @@ package io.quarkus.maven.components;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.codehaus.plexus.component.annotations.Component;
-
-import jline.console.ConsoleReader;
 
 /**
  * Prompt implementation.
@@ -16,52 +12,12 @@ import jline.console.ConsoleReader;
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
 @Component(role = Prompter.class, instantiationStrategy = "per-lookup")
-public class Prompter {
-
-    private final ConsoleReader console;
-
+public class Prompter extends io.quarkus.devtools.utils.Prompter {
     public Prompter() throws IOException {
-        this.console = new ConsoleReader();
-        console.setHistoryEnabled(false);
-        console.setExpandEvents(false);
+        super();
     }
 
     public Prompter(InputStream in, OutputStream out) throws IOException {
-        this.console = new ConsoleReader(in, out);
-        console.setHistoryEnabled(false);
-        console.setExpandEvents(false);
+        super(in, out);
     }
-
-    public ConsoleReader getConsole() {
-        return console;
-    }
-
-    public String prompt(final String message, final Character mask) throws IOException {
-        Objects.requireNonNull(message);
-
-        final String prompt = String.format("%s: ", message);
-        String value;
-        do {
-            value = console.readLine(prompt, mask);
-        } while (StringUtils.isBlank(value));
-        return value;
-    }
-
-    public String prompt(final String message) throws IOException {
-        Objects.requireNonNull(message);
-        return prompt(message, null);
-    }
-
-    public String promptWithDefaultValue(final String message, final String defaultValue) throws IOException {
-        Objects.requireNonNull(message);
-        Objects.requireNonNull(defaultValue);
-
-        final String prompt = String.format("%s [%s]: ", message, defaultValue);
-        String value = console.readLine(prompt);
-        if (StringUtils.isBlank(value)) {
-            return defaultValue;
-        }
-        return value;
-    }
-
 }

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -46,6 +46,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-platform-descriptor-api</artifactId>
         </dependency>
+        <!-- user prompt -->
+        <dependency>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -189,8 +189,8 @@ public class CreateExtension {
     public QuarkusCommandOutcome execute() throws QuarkusCommandException {
         final String extensionId = data.getRequiredStringValue(EXTENSION_ID);
 
-        final Path workingDir = resolveWorkingDir();
-        final Model baseModel = resolveBaseModel(workingDir);
+        final Path workingDir = resolveWorkingDir(baseDir);
+        final Model baseModel = resolveModel(baseDir);
         final LayoutType layoutType = detectLayoutType(baseModel, data.getStringValue(GROUP_ID).orElse(null));
 
         data.putIfAbsent(EXTENSION_NAME, toCapWords(extensionId));
@@ -287,7 +287,8 @@ public class CreateExtension {
         return toCapWords(namespaceId) + " - ";
     }
 
-    private Model resolveBaseModel(Path workingDir) throws QuarkusCommandException {
+    public static Model resolveModel(Path dir) throws QuarkusCommandException {
+        final Path workingDir = resolveWorkingDir(dir);
         final Path basePom = workingDir.resolve("pom.xml");
         if (!Files.isRegularFile(basePom)) {
             return null;
@@ -313,8 +314,8 @@ public class CreateExtension {
                 + data.getRequiredStringValue(EXTENSION_ID);
     }
 
-    private Path resolveWorkingDir() {
-        return baseDir.endsWith("extensions/") ? baseDir.resolve("..") : baseDir;
+    private static Path resolveWorkingDir(Path dir) {
+        return dir.endsWith("extensions/") ? dir.resolve("..") : dir;
     }
 
     public static LayoutType detectLayoutType(Model basePom, String groupId) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateExtensionCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateExtensionCommandHandler.java
@@ -73,7 +73,7 @@ public class CreateExtensionCommandHandler {
 
             return QuarkusCommandOutcome.success();
         } catch (IOException e) {
-            throw new QuarkusCommandException("Error while creating Quarkus extension", e);
+            throw new QuarkusCommandException("Error while creating Quarkus extension: " + e.getMessage(), e);
         }
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateJBangProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateJBangProjectCommandHandler.java
@@ -52,7 +52,7 @@ public class CreateJBangProjectCommandHandler implements QuarkusCommandHandler {
                             + " jbang project has been successfully generated in:\n--> "
                             + invocation.getQuarkusProject().getProjectDirPath().toString() + "\n-----------");
         } catch (IOException e) {
-            throw new QuarkusCommandException("Failed to create JBang project", e);
+            throw new QuarkusCommandException("Failed to create JBang project: " + e.getMessage(), e);
         }
         return QuarkusCommandOutcome.success();
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -116,7 +116,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                             + invocation.getQuarkusProject().getProjectDirPath().toString() + "\n-----------");
 
         } catch (IOException e) {
-            throw new QuarkusCommandException("Failed to create project", e);
+            throw new QuarkusCommandException("Failed to create project: " + e.getMessage(), e);
         }
         return QuarkusCommandOutcome.success();
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/Prompter.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/Prompter.java
@@ -1,0 +1,63 @@
+package io.quarkus.devtools.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
+import jline.console.ConsoleReader;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Prompt implementation.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class Prompter {
+
+    private final ConsoleReader console;
+
+    public Prompter() throws IOException {
+        this.console = new ConsoleReader();
+        console.setHistoryEnabled(false);
+        console.setExpandEvents(false);
+    }
+
+    public Prompter(InputStream in, OutputStream out) throws IOException {
+        this.console = new ConsoleReader(in, out);
+        console.setHistoryEnabled(false);
+        console.setExpandEvents(false);
+    }
+
+    public ConsoleReader getConsole() {
+        return console;
+    }
+
+    public String prompt(final String message, final Character mask) throws IOException {
+        Objects.requireNonNull(message);
+
+        final String prompt = String.format("%s: ", message);
+        String value;
+        do {
+            value = console.readLine(prompt, mask);
+        } while (StringUtils.isBlank(value));
+        return value;
+    }
+
+    public String prompt(final String message) throws IOException {
+        Objects.requireNonNull(message);
+        return prompt(message, null);
+    }
+
+    public String promptWithDefaultValue(final String message, final String defaultValue) throws IOException {
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(defaultValue);
+
+        final String prompt = String.format("%s [%s]: ", message, defaultValue);
+        String value = console.readLine(prompt);
+        if (StringUtils.isBlank(value)) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+}

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -37,6 +37,7 @@
         <scala-plugin.version>4.1.1</scala-plugin.version>
 
         <!-- Versions -->
+        <jline.version>2.14.6</jline.version>
         <assertj.version>3.19.0</assertj.version>
         <jackson.version>2.12.1</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
@@ -126,6 +127,11 @@
                         <artifactId>jboss-annotations-api_1.2_spec</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>jline</groupId>
+                <artifactId>jline</artifactId>
+                <version>${jline.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
Closes #14727


```shell

### STANDALONE

java -jar quarkus-cli-999-SNAPSHOT-runner.jar create-extension                                                                    
create-extension-cli
Set the Quarkus version: 999-SNAPSHOT
Set the extension groupId [org.acme]: 
Set the extension id: aloha

Detected layout type is 'standalone' 
Generated runtime artifactId is 'aloha'


applying codestarts...
🔠 java
🧰 maven
🗃 quarkus-extension
🐒 devmode-test
🐒 extension-base
🐒 integration-tests
🐒 unit-test

-----------
👍 extension has been successfully generated in:
--> /Users/ia3andy/workspace/redhat/quarkus/quarkus/devtools/cli/target/aloha
-----------
```
```SHELL
### QUARKIVERSE

$ java -jar quarkus-cli-999-SNAPSHOT-runner.jar create-extension -g io.quarkiverse.alohaq                                       

Set the Quarkus version: 999-SNAPSHOT

Detected layout type is 'quarkiverse' 
Generated runtime artifactId is 'quarkus-alohaq'


applying codestarts...
🔠 java
🧰 maven
🗃 quarkus-extension
🛠 git
🐒 devmode-test
🐒 extension-base
🐒 integration-tests
🐒 quarkiverse
🐒 unit-test

-----------
👍 extension has been successfully generated in:
--> /Users/ia3andy/workspace/redhat/quarkus/quarkus/devtools/cli/target/quarkus-alohaq
-----------


```

## HELP

```shell

$ java -jar quarkus-cli-999-SNAPSHOT-runner.jar create-extension --help                                                           

Usage: quarkus create-extension [-Bh] [--without-devmode-test] [--without-it-tests] [--without-tests] [--without-unit-test] [--bom-artifact-id=BOM-ARTIFACT-ID]
                                [--bom-group-id=BOM-GROUP-ID] [--bom-version=BOM-VERSION] [--extension-name=EXTENSION-NAME] [-g=GROUP-ID] [-i=EXTENSION-ID]
                                [-N=NAMESPACE-ID] [--namespace-name=NAMESPACE-NAME] [-p=PACKAGE-NAME] [-q=QUARKUS-VERSION] [-v=VERSION]
Creates the base of a Quarkus extension in different layout depending of the options and environment.
  -i, --extension-id=EXTENSION-ID   The extension id.
  -g, --group-id=GROUP-ID           The groupId for project.
  -v, --version=VERSION             The version for the extension.
  -q, --quarkus-version=QUARKUS-VERSION
                                    The quarkus version for the extension.
  -N, --namespace-id=NAMESPACE-ID   A prefix common to all extension modules artifactIds.
  -p, --package-name=PACKAGE-NAME   Base package under which classes should be created in Runtime and Deployment modules.. When specified, use a custom package name instead
                                      of auto generating it from other parameters.
      --extension-name=EXTENSION-NAME
                                    When specified, use a custom extension name instead of generating it from the extension id.
      --namespace-name=NAMESPACE-NAME
                                    A prefix common to all extension modules names. When specified, use a custom namespace name instead of generating it from the namespace
                                      id.
      --bom-group-id=BOM-GROUP-ID   The group id of the Quarkus platform BOM.
      --bom-artifact-id=BOM-ARTIFACT-ID
                                    The artifact id of the Quarkus platform BOM.
      --bom-version=BOM-VERSION     The version id of the Quarkus platform BOM.
      --without-unit-test           Indicates whether to generate a unit test class for the extension.
      --without-it-tests            Indicates whether to generate a integration tests for the extension.
      --without-devmode-test        Indicates whether to generate a dev mode test class for the extension.
      --without-tests               Indicates whether to generate any test for the extension.
  -B, --batch-mode                  run command in batch mode
  -h, --help                        display this help message

```


