### PR TITLE
Fix for scala codestart unit test

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/test-resource-template.ftl
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class ${class_name}Test {
 
     @Test
-    def testHelloEndpoint() = {
+    def testHelloEndpoint(): Unit = {
         given()
           .`when`().get("${path}")
           .then()


### PR DESCRIPTION
The unit test for the Scala Codestart is not running. The reason is related to the return type that is coming through the type interference of the test method body. But is should be Scala ```Unit```