### PR TITLE
Disable flaky test on Windows

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -9,6 +9,8 @@ import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
@@ -183,6 +185,7 @@ public class SimpleQuarkusRestTestCase {
                 .then().body(Matchers.equalTo("VERTX-BUFFER"));
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testAsync() {
         RestAssured.get("/simple/async/cs/ok")
@@ -364,6 +367,7 @@ public class SimpleQuarkusRestTestCase {
                 .then().body(Matchers.equalTo("OK"));
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testNewParams() {
         RestAssured.get("/new-params/myklass/myregex/context")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamTestCase.java
@@ -19,6 +19,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
@@ -27,6 +29,7 @@ import io.restassured.RestAssured;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
 
+@DisabledOnOs(OS.WINDOWS)
 public class StreamTestCase {
 
     @TestHTTPResource


### PR DESCRIPTION
This test fails frequently on Windows.
Ideally we look into it more, but I have absolutely 0️⃣ time at the moment, so let's just disable it