### PR TITLE
Deprecate --uber-jar option in quarkusBuild task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -54,7 +54,11 @@ public class QuarkusBuild extends QuarkusTask {
         return uberJar;
     }
 
+    /**
+     * @deprecated use {@code quarkus.package.type} instead
+     */
     @Option(description = "Set to true if the build task should build an uberjar", option = "uber-jar")
+    @Deprecated
     public void setUberJar(boolean uberJar) {
         this.uberJar = uberJar;
     }
@@ -131,7 +135,9 @@ public class QuarkusBuild extends QuarkusTask {
             effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);
         }
         boolean clear = false;
-        if (uberJar && System.getProperty("quarkus.package.uber-jar") == null) {
+        if (isUberJar() && System.getProperty("quarkus.package.uber-jar") == null) {
+            getLogger().lifecycle(
+                    "The uberJar option is deprecated, and will be removed in a future version. To build an uber-jar set the config property quarkus.package.type=uber-jar. For more info see https://quarkus.io/guides/gradle-tooling#building-uber-jars");
             System.setProperty("quarkus.package.uber-jar", "true");
             clear = true;
         }

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -402,18 +402,18 @@ This task depends on `quarkusBuild`, so it will generate the native image before
 
 == Building Uber-Jars
 
-Quarkus Gradle plugin supports the generation of Uber-Jars by specifying an `--uber-jar` argument as follows:
+Quarkus Gradle plugin supports the generation of Uber-Jars by specifying a `quarkus.package.type` argument as follows:
 
 [source,bash]
 ----
-./gradlew quarkusBuild --uber-jar
+./gradlew quarkusBuild -Dquarkus.package.type=uber-jar
 ----
 
 When building an Uber-Jar you can specify entries that you want to exclude from the generated jar by using the `--ignored-entry` argument:
 
 [source,bash]
 ----
-./gradlew quarkusBuild --uber-jar --ignored-entry=META-INF/file1.txt
+./gradlew quarkusBuild -Dquarkus.package.type=uber-jar --ignored-entry=META-INF/file1.txt
 ----
 
 The entries are relative to the root of the generated Uber-Jar. You can specify multiple entries by adding extra `--ignored-entry` arguments.


### PR DESCRIPTION
As in #14886 this branch deprecates the `--uber-jar` option from `quarkusBuild` task. 

Relates to #14878.

