### PR TITLE
Bump kubernetes-client-bom from 5.0.1 to 5.0.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -174,7 +174,7 @@
         <sentry.version>3.2.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.0.1</kubernetes-client.version>
+        <kubernetes-client.version>5.0.2</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
- Fix for CVE-2021-20218
  https://github.com/fabric8io/kubernetes-client/issues/2715