### PR TITLE
Fix quarkus websocket guide, failing test

### DIFF
--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -218,9 +218,6 @@ public class ChatTest {
         @OnOpen
         public void open(Session session) {
             MESSAGES.add("CONNECT");
-            // Send a message to indicate that we are ready,
-            // as the message handler may not be registered immediately after this callback.
-            session.getAsyncRemote().sendText("_ready_");
         }
 
         @OnMessage


### PR DESCRIPTION
The last assertion in the method `testWebsocketChat` was not working as it was receiving first the "_ready_" message instead of the server response.