### PR TITLE
Mark Resteasy Qute with code starter

### DIFF
--- a/extensions/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,3 +9,4 @@ metadata:
   categories:
   - "web"
   status: "experimental"
+  codestart: "qute"


### PR DESCRIPTION
The extension Quarkus Qute is marked with the "provides-example" tag and the example is internally using Quarkus Resteasy Qute extension.

Therefore, Quarkus Resteasy Qute extension should be marked with "provides-example" and provides the same example as in Quarkus Qute extension.