### PR TITLE
Remove jcenter repository references in gradle projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,7 +297,6 @@ quarkusPlatformGroupId=io.quarkus
 pluginManagement {
     repositories {
         mavenLocal() // add mavenLocal() to first position
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -312,7 +311,6 @@ pluginManagement {
 ```
 repositories {
     mavenLocal() // add mavenLocal() to first position
-    jcenter()
     mavenCentral()
 }
 ```

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -6,7 +6,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -44,7 +43,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -44,7 +43,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -40,7 +39,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project-test-setup/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -37,7 +36,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-multi-module-project/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/custom-filesystem-provider/build.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-filesystem-provider/build.gradle
@@ -9,7 +9,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -41,7 +40,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/custom-filesystem-provider/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-filesystem-provider/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
@@ -12,7 +12,6 @@ repositories {
     } else {
         mavenLocal()
     }
-    jcenter()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/test/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-multi-module-project/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -39,7 +38,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/grpc-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-multi-module-project/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/implementation-files/build.gradle
+++ b/integration-tests/gradle/src/test/resources/implementation-files/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -39,7 +38,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/implementation-files/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/implementation-files/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -39,7 +38,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -34,7 +33,6 @@ subprojects {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -31,7 +30,6 @@ subprojects {
     }
 
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
     }

--- a/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
         } else {
             mavenLocal()
         }
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }


### PR DESCRIPTION
This branch remove `jcenter()` calls as the service will shut down later this year. 