### PR TITLE
Add quarkus-smallrye-opentracing to an integration test without Undertow

### DIFF
--- a/integration-tests/smallrye-config/pom.xml
+++ b/integration-tests/smallrye-config/pom.xml
@@ -23,6 +23,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
+    <!-- Add opentracing to ensure that it works in native when undertow isn't present -->
+    <!-- See https://github.com/quarkusio/quarkus/issues/14966 -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-opentracing</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -53,6 +59,19 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
       <version>${project.version}</version>
       <type>pom</type>
       <scope>test</scope>


### PR DESCRIPTION
This is done in order to ensure that OpenTracing works in native
when a servlet container is not present

Related to: https://github.com/quarkusio/quarkus/issues/14966