### PR TITLE
Fixed non-working delay for oidc-client

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -93,6 +93,10 @@ public class OidcCommonUtils {
                 : 0;
     }
 
+    public static long getConnectionDelayInMillis(OidcCommonConfig oidcConfig) {
+        return getConnectionDelay(oidcConfig) * 1000;
+    }
+
     public static Optional<ProxyOptions> toProxyOptions(OidcCommonConfig.Proxy proxyConfig) {
         // Proxy is enabled if (at least) "host" is configured.
         if (!proxyConfig.host.isPresent()) {


### PR DESCRIPTION
Fixes  #14959

I also removed the wrong log info that stated "Connecting to IDP for up to %d times every 2 seconds" in fact according to the original idea, the code should have worked in such a way that after each unsuccessful request there should be a delay of 2 seconds.