### PR TITLE
Remove uberJar Maven/Gradle param & quarkus.package.uber-jar property

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -31,15 +31,6 @@ public class PackageConfig {
     public String type;
 
     /**
-     * If the java runner should be packed as an uberjar
-     *
-     * This is deprecated, you should use quarkus.package.type=uber-jar instead
-     */
-    @Deprecated
-    @ConfigItem(defaultValue = "false")
-    public boolean uberJar;
-
-    /**
      * Manifest configuration of the runner jar.
      */
     @ConfigItem

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -181,19 +181,13 @@ public class JarResultBuildStep {
         if (appCDS.isPresent()) {
             handleAppCDSSupportFileGeneration(transformedClasses, generatedClasses, appCDS.get());
         }
-        if (!(packageConfig.type.equalsIgnoreCase(PackageConfig.JAR) ||
-                packageConfig.type.equalsIgnoreCase(PackageConfig.UBER_JAR))
-                && packageConfig.uberJar) {
-            throw new RuntimeException(
-                    "Cannot set quarkus.package.uber-jar=true and quarkus.package.type, if you want an uber-jar set quarkus.package.type=uber-jar.");
-        }
 
         if (!uberJarRequired.isEmpty() && !legacyJarRequired.isEmpty()) {
             throw new RuntimeException(
                     "Extensions with conflicting package types. One extension requires uber-jar another requires legacy format");
         }
 
-        if (legacyJarRequired.isEmpty() && (!uberJarRequired.isEmpty() || packageConfig.uberJar
+        if (legacyJarRequired.isEmpty() && (!uberJarRequired.isEmpty()
                 || packageConfig.type.equalsIgnoreCase(PackageConfig.UBER_JAR))) {
             return buildUberJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses, applicationArchivesBuildItem,
                     packageConfig, applicationInfo, generatedClasses, generatedResources, closeablesBuildItem,

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -32,8 +32,6 @@ public class QuarkusBuild extends QuarkusTask {
 
     private static final String NATIVE_PROPERTY_NAMESPACE = "quarkus.native";
 
-    private boolean uberJar;
-
     private List<String> ignoredEntries = new ArrayList<>();
 
     public QuarkusBuild() {
@@ -47,21 +45,6 @@ public class QuarkusBuild extends QuarkusTask {
             System.setProperty(expandConfigurationKey(nativeArg.getKey()), nativeArg.getValue().toString());
         }
         return this;
-    }
-
-    @Input
-    public boolean isUberJar() {
-        return uberJar;
-    }
-
-    /**
-     * @param uberJar Set to true if the build task should build an uberjar
-     * @deprecated use {@code quarkus.package.type} instead
-     */
-    @Option(description = "Set to true if the build task should build an uberjar", option = "uber-jar")
-    @Deprecated
-    public void setUberJar(boolean uberJar) {
-        this.uberJar = uberJar;
     }
 
     @Optional
@@ -135,13 +118,6 @@ public class QuarkusBuild extends QuarkusTask {
             String joinedEntries = String.join(",", ignoredEntries);
             effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);
         }
-        boolean clear = false;
-        if (isUberJar() && System.getProperty("quarkus.package.uber-jar") == null) {
-            getLogger().lifecycle(
-                    "The uberJar option is deprecated, and will be removed in a future version. To build an uber-jar set the config property quarkus.package.type=uber-jar. For more info see https://quarkus.io/guides/gradle-tooling#building-uber-jars");
-            System.setProperty("quarkus.package.uber-jar", "true");
-            clear = true;
-        }
         try (CuratedApplication appCreationContext = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setAppModelResolver(modelResolver)
@@ -164,10 +140,6 @@ public class QuarkusBuild extends QuarkusTask {
 
         } catch (BootstrapException e) {
             throw new GradleException("Failed to build a runnable JAR", e);
-        } finally {
-            if (clear) {
-                System.clearProperty("quarkus.package.uber-jar");
-            }
         }
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -32,7 +32,6 @@ import io.quarkus.bootstrap.util.IoUtils;
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class BuildMojo extends QuarkusBootstrapMojo {
 
-    public static final String QUARKUS_PACKAGE_UBER_JAR = "quarkus.package.uber-jar";
     private static final String PACKAGE_TYPE_PROP = "quarkus.package.type";
     private static final String NATIVE_PROFILE_NAME = "native";
     private static final String NATIVE_PACKAGE_TYPE = "native";

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -54,14 +54,7 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
     private String finalName;
 
     /**
-     * @deprecated use {@code quarkus.package.type} instead
-     */
-    @Parameter(property = "uberJar", defaultValue = "false")
-    @Deprecated
-    private boolean uberJar;
-
-    /**
-     * When using the uberJar option, this array specifies entries that should
+     * When building an uber-jar, this array specifies entries that should
      * be excluded from the final jar. The entries are relative to the root of
      * the file. An example of this configuration could be:
      * <code><pre>
@@ -146,14 +139,6 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
 
     protected String[] ignoredEntries() {
         return ignoredEntries;
-    }
-
-    protected boolean uberJar() {
-        if (uberJar) {
-            getLog().warn(
-                    "The parameter uberJar is deprecated, and will be removed in a future version. To build an uber-jar set the config property quarkus.package.type=uber-jar. For more info see https://quarkus.io/guides/maven-tooling#uber-jar-maven");
-        }
-        return uberJar;
     }
 
     protected AppArtifactKey projectId() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -159,9 +159,6 @@ public class QuarkusBootstrapProvider implements Closeable {
                     effectiveProperties.setProperty(name, projectProperties.getProperty(name));
                 }
             }
-            if (mojo.uberJar() && System.getProperty(BuildMojo.QUARKUS_PACKAGE_UBER_JAR) == null) {
-                effectiveProperties.setProperty(BuildMojo.QUARKUS_PACKAGE_UBER_JAR, "true");
-            }
 
             effectiveProperties.putIfAbsent("quarkus.application.name", mojo.mavenProject().getArtifactId());
             effectiveProperties.putIfAbsent("quarkus.application.version", mojo.mavenProject().getVersion());

--- a/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/CloudFunctionsDeploymentBuildStep.java
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/CloudFunctionsDeploymentBuildStep.java
@@ -31,7 +31,7 @@ public class CloudFunctionsDeploymentBuildStep {
             throws BuildException, IOException {
         if (!jar.isUberJar()) {
             throw new BuildException("Google Cloud Function deployment need to use a uberjar, " +
-                    "please set 'quarkus.package.uber-jar=true' inside your application.properties",
+                    "please set 'quarkus.package.type=uber-jar' inside your application.properties",
                     Collections.EMPTY_LIST);
         }
 

--- a/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/CloudFunctionsDeploymentBuildStep.java
+++ b/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/CloudFunctionsDeploymentBuildStep.java
@@ -30,7 +30,7 @@ public class CloudFunctionsDeploymentBuildStep {
             throws BuildException, IOException {
         if (!jar.isUberJar()) {
             throw new BuildException("Google Cloud Function deployment need to use a uberjar, " +
-                    "please set 'quarkus.package.uber-jar=true' inside your application.properties",
+                    "please set 'quarkus.package.type=uber-jar' inside your application.properties",
                     Collections.EMPTY_LIST);
         }
 

--- a/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/CloudFunctionDeploymentBuildStep.java
+++ b/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/CloudFunctionDeploymentBuildStep.java
@@ -30,7 +30,7 @@ public class CloudFunctionDeploymentBuildStep {
             throws BuildException, IOException {
         if (!jar.isUberJar()) {
             throw new BuildException("Google Cloud Function deployment need to use a uberjar, " +
-                    "please set 'quarkus.package.uber-jar=true' inside your application.properties",
+                    "please set 'quarkus.package.type=uber-jar' inside your application.properties",
                     Collections.EMPTY_LIST);
         }
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
@@ -43,23 +43,6 @@ public class PackageIT extends MojoTestBase {
         verifyUberJar();
     }
 
-    @Test
-    public void testPackageWorksWhenUberjarIsFalse()
-            throws MavenInvocationException, IOException, InterruptedException {
-        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-false");
-
-        running = new RunningInvoker(testDir, false);
-        final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"),
-                Collections.singletonMap("QUARKUS_PACKAGE_UBER_JAR", "false"));
-
-        assertThat(result.getProcess().waitFor()).isEqualTo(0);
-
-        File runnerJar = getTargetDir().toPath().resolve("quarkus-app").resolve("quarkus-run.jar").toFile();
-
-        // make sure the jar can be read by JarInputStream
-        ensureManifestOfJarIsReadableByJarInputStream(runnerJar);
-    }
-
     private void ensureManifestOfJarIsReadableByJarInputStream(File jar) throws IOException {
         try (InputStream fileInputStream = new FileInputStream(jar)) {
             try (JarInputStream stream = new JarInputStream(fileInputStream)) {
@@ -116,7 +99,7 @@ public class PackageIT extends MojoTestBase {
     @Test
     public void testPackageWorksWhenUberjarIsTrue()
             throws MavenInvocationException, IOException, InterruptedException {
-        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-true");
+        testDir = initProject("projects/uberjar-check");
 
         createAndVerifyUberJar();
         // ensure that subsequent package without clean also works
@@ -125,7 +108,7 @@ public class PackageIT extends MojoTestBase {
 
     private void createAndVerifyUberJar() throws IOException, MavenInvocationException, InterruptedException {
         Properties p = new Properties();
-        p.setProperty("quarkus.package.uber-jar", "true");
+        p.setProperty("quarkus.package.type", "uber-jar");
 
         running = new RunningInvoker(testDir, false);
         final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"),
@@ -183,12 +166,12 @@ public class PackageIT extends MojoTestBase {
      */
     @Test
     public void testRunnerUberJarHasValidCRC() throws Exception {
-        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-true2");
+        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-crc");
 
         running = new RunningInvoker(testDir, false);
 
         Properties p = new Properties();
-        p.setProperty("quarkus.package.uber-jar", "true");
+        p.setProperty("quarkus.package.type", "uber-jar");
         final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"),
                 Collections.emptyMap(), p);
         assertThat(result.getProcess().waitFor()).isEqualTo(0);
@@ -212,7 +195,7 @@ public class PackageIT extends MojoTestBase {
      */
     @Test
     public void testLegacyJarHasValidCRC() throws Exception {
-        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-false2");
+        testDir = initProject("projects/uberjar-check", "projects/project-legacyjar-crc");
 
         running = new RunningInvoker(testDir, false);
         final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"),
@@ -238,7 +221,7 @@ public class PackageIT extends MojoTestBase {
      */
     @Test
     public void testFastJarHasValidCRC() throws Exception {
-        testDir = initProject("projects/uberjar-check", "projects/project-uberjar-false2");
+        testDir = initProject("projects/uberjar-check", "projects/project-fastjar-crc");
 
         running = new RunningInvoker(testDir, false);
         final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"),

--- a/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestSectionsUberJarTest.java
+++ b/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestSectionsUberJarTest.java
@@ -48,7 +48,7 @@ public class CustomManifestSectionsUberJarTest {
                 Assertions.assertEquals("Test Value 1", testAttributes.getValue(testKey1),
                         "Custom Manifest Entry for Test-Key-1 value is not correct");
                 Assertions.assertTrue(testAttributes.containsKey(new Attributes.Name("Test-Key-2")),
-                        "Custom Manifest Emntry for Test-Key-2 is missing");
+                        "Custom Manifest Entry for Test-Key-2 is missing");
             }
         }
     }

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-manifest-thin.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-manifest-thin.properties
@@ -1,4 +1,3 @@
 quarkus.package.type=jar
-quarkus.package.uber-jar=false
 quarkus.package.manifest.manifest-sections.Test-Information.Test-Key-1=Test Value 1
 quarkus.package.manifest.manifest-sections.Test-Information.Test-Key-2=Test Value 2

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-manifest-uber.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-manifest-uber.properties
@@ -1,4 +1,3 @@
-quarkus.package.type=jar
-quarkus.package.uber-jar=true
+quarkus.package.type=uber-jar
 quarkus.package.manifest.manifest-sections.Test-Information.Test-Key-1=Test Value 1
 quarkus.package.manifest.manifest-sections.Test-Information.Test-Key-2=Test Value 2

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/no-custom-manifest-thin.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/no-custom-manifest-thin.properties
@@ -1,2 +1,1 @@
 quarkus.package.type=jar
-quarkus.package.uber-jar=false

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/no-custom-manifest-uber.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/no-custom-manifest-uber.properties
@@ -1,2 +1,1 @@
-quarkus.package.type=jar
-quarkus.package.uber-jar=true
+quarkus.package.type=uber-jar


### PR DESCRIPTION
Resolves #14878

/cc @glefloch

@aloubyansky Not sure what to do with `QuarkusBootstrapMojo.ignoredEntries`. It says:
> When using the uberJar option, this array specifies entries that should be excluded from the final jar.

but looking at the usage, it seems it's always evaluated, not only for uber-jar?