### PR TITLE
Quartz + Scheduler: Allow to use config in Identity field

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -99,6 +99,15 @@ Sometimes a possibility to specify an explicit id may come in handy.
 void myMethod() { }
 ----
 
+If a value starts with `{` and ends with `}` then the scheduler attempts to find a corresponding config property and use the configured value instead.
+
+.Interval Config Property Example
+[source,java]
+----
+@Scheduled(identity = "{myMethod.identity.expr}")
+void myMethod() { }
+----
+
 === Delayed Execution
 
 `@Scheduled` provides two ways to delay the time a trigger should start firing at.

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicateIdentityExpressionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicateIdentityExpressionTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.quartz.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdentityExpressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdentityExpressionTest.InvalidBean.class)
+                    .addAsResource(new StringAsset("my.identity=my_name"),
+                            "application.properties"));
+
+    @Test
+    public void test() {
+    }
+
+    static class InvalidBean {
+
+        @Scheduled(every = "1s", identity = "{my.identity}")
+        @Scheduled(every = "1s", identity = "my_name")
+        void wrong() {
+        }
+
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/MissingConfigIdentityExpressionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/MissingConfigIdentityExpressionTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.quartz.test;
+
+import java.util.NoSuchElementException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MissingConfigIdentityExpressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(NoSuchElementException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MissingConfigIdentityExpressionTest.InvalidBean.class));
+
+    @Test
+    public void test() {
+    }
+
+    static class InvalidBean {
+
+        @Scheduled(every = "1s", identity = "{my.identity}")
+        void wrong() {
+        }
+
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/SimpleIdentityTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/SimpleIdentityTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.quartz.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SimpleIdentityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset("jobs.identity=every_1s_another_name"),
+                            "application.properties"));
+
+    @Test
+    public void testJobsWithIdentity() throws InterruptedException {
+        // Only assert that the scheduled method is working fine
+        assertTrue(Jobs.LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+    public static class Jobs {
+
+        static final CountDownLatch LATCH = new CountDownLatch(2);
+
+        @Scheduled(every = "1s", identity = "every_1s_name")
+        @Scheduled(every = "1s", identity = "{jobs.identity}")
+        void ping() {
+            LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -71,6 +71,7 @@ import io.quarkus.scheduler.runtime.SchedulerContext;
 import io.quarkus.scheduler.runtime.SchedulerRecorder;
 import io.quarkus.scheduler.runtime.SimpleScheduler;
 import io.quarkus.scheduler.runtime.devconsole.SchedulerDevConsoleRecorder;
+import io.quarkus.scheduler.runtime.util.SchedulerUtils;
 
 /**
  * @author Martin Kouba
@@ -306,7 +307,7 @@ public class SchedulerProcessor {
         AnnotationValue everyValue = schedule.value("every");
         if (cronValue != null && !cronValue.asString().trim().isEmpty()) {
             String cron = cronValue.asString().trim();
-            if (SchedulerContext.isConfigValue(cron)) {
+            if (SchedulerUtils.isConfigValue(cron)) {
                 // Don't validate config property
                 return null;
             }
@@ -323,7 +324,7 @@ public class SchedulerProcessor {
         } else {
             if (everyValue != null && !everyValue.asString().trim().isEmpty()) {
                 String every = everyValue.asString().trim();
-                if (SchedulerContext.isConfigValue(every)) {
+                if (SchedulerUtils.isConfigValue(every)) {
                     return null;
                 }
                 if (Character.isDigit(every.charAt(0))) {
@@ -343,7 +344,7 @@ public class SchedulerProcessor {
         if (delay == null || delay.asLong() <= 0) {
             if (delayedValue != null && !delayedValue.asString().trim().isEmpty()) {
                 String delayed = delayedValue.asString().trim();
-                if (SchedulerContext.isConfigValue(delayed)) {
+                if (SchedulerUtils.isConfigValue(delayed)) {
                     return null;
                 }
                 if (Character.isDigit(delayed.charAt(0))) {
@@ -365,7 +366,7 @@ public class SchedulerProcessor {
 
         AnnotationValue identityValue = schedule.value("identity");
         if (identityValue != null) {
-            String identity = identityValue.asString().trim();
+            String identity = SchedulerUtils.lookUpPropertyValue(identityValue.asString());
             AnnotationInstance previousInstanceWithSameIdentity = encounteredIdentities.get(identity);
             if (previousInstanceWithSameIdentity != null) {
                 String message = String.format("The identity: \"%s\" on: %s is not unique and it has already bean used by : %s",

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicateIdentityExpressionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicateIdentityExpressionTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.scheduler.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdentityExpressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdentityExpressionTest.InvalidBean.class)
+                    .addAsResource(new StringAsset("my.identity=my_name"),
+                            "application.properties"));
+
+    @Test
+    public void test() {
+    }
+
+    static class InvalidBean {
+
+        @Scheduled(every = "1s", identity = "{my.identity}")
+        @Scheduled(every = "1s", identity = "my_name")
+        void wrong() {
+        }
+
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/MissingConfigIdentityExpressionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/MissingConfigIdentityExpressionTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.scheduler.test;
+
+import java.util.NoSuchElementException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MissingConfigIdentityExpressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(NoSuchElementException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MissingConfigIdentityExpressionTest.InvalidBean.class));
+
+    @Test
+    public void test() {
+    }
+
+    static class InvalidBean {
+
+        @Scheduled(every = "1s", identity = "{my.identity}")
+        void wrong() {
+        }
+
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/SimpleIdentityTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/SimpleIdentityTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.scheduler.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SimpleIdentityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset("jobs.identity=every_1s_another_name"),
+                            "application.properties"));
+
+    @Test
+    public void testJobsWithIdentity() throws InterruptedException {
+        // Only assert that the scheduled method is working fine
+        assertTrue(Jobs.LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+    public static class Jobs {
+
+        static final CountDownLatch LATCH = new CountDownLatch(2);
+
+        @Scheduled(every = "1s", identity = "every_1s_name")
+        @Scheduled(every = "1s", identity = "{jobs.identity}")
+        void ping() {
+            LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -43,6 +43,10 @@ public @interface Scheduled {
     /**
      * Optionally defines a unique identifier for this job.
      * <p>
+     * If the value starts with "&#123;" and ends with "&#125;" the scheduler attempts to find a corresponding config property
+     * and use the configured value instead: {@code &#64;Scheduled(identity = "{myservice.check.identity.expr}")}.
+     *
+     * <p>
      * If the value is not given, Quarkus will generate a unique id.
      * <p>
      * 

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerContext.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerContext.java
@@ -26,13 +26,4 @@ public interface SchedulerContext {
             throw new IllegalStateException("Unable to create invoker: " + invokerClassName, e);
         }
     }
-
-    static String getConfigProperty(String val) {
-        return val.substring(1, val.length() - 1);
-    }
-
-    static boolean isConfigValue(String val) {
-        val = val.trim();
-        return val.startsWith("{") && val.endsWith("}");
-    }
 }

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
@@ -21,8 +21,6 @@ import javax.enterprise.inject.Typed;
 import javax.inject.Singleton;
 import javax.interceptor.Interceptor;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.logging.Logger;
 import org.jboss.threads.JBossScheduledThreadPoolExecutor;
 
@@ -39,6 +37,7 @@ import io.quarkus.scheduler.ScheduledExecution;
 import io.quarkus.scheduler.Scheduler;
 import io.quarkus.scheduler.SkippedExecution;
 import io.quarkus.scheduler.Trigger;
+import io.quarkus.scheduler.runtime.util.SchedulerUtils;
 
 @Typed(Scheduler.class)
 @Singleton
@@ -55,7 +54,7 @@ public class SimpleScheduler implements Scheduler {
     private final List<ScheduledTask> scheduledTasks;
     private final boolean enabled;
 
-    public SimpleScheduler(SchedulerContext context, Config config, SchedulerRuntimeConfig schedulerRuntimeConfig,
+    public SimpleScheduler(SchedulerContext context, SchedulerRuntimeConfig schedulerRuntimeConfig,
             Event<SkippedExecution> skippedExecutionEvent) {
         this.running = true;
         this.enabled = schedulerRuntimeConfig.enabled;
@@ -83,8 +82,7 @@ public class SimpleScheduler implements Scheduler {
                 int nameSequence = 0;
                 for (Scheduled scheduled : method.getSchedules()) {
                     nameSequence++;
-                    SimpleTrigger trigger = createTrigger(method.getInvokerClassName(), parser, scheduled, nameSequence,
-                            config);
+                    SimpleTrigger trigger = createTrigger(method.getInvokerClassName(), parser, scheduled, nameSequence);
                     ScheduledInvoker invoker = context.createInvoker(method.getInvokerClassName());
                     if (scheduled.concurrentExecution() == ConcurrentExecution.SKIP) {
                         invoker = new SkipConcurrentExecutionInvoker(invoker, skippedExecutionEvent);
@@ -153,8 +151,8 @@ public class SimpleScheduler implements Scheduler {
         return enabled && running;
     }
 
-    SimpleTrigger createTrigger(String invokerClass, CronParser parser, Scheduled scheduled, int nameSequence, Config config) {
-        String id = scheduled.identity().trim();
+    SimpleTrigger createTrigger(String invokerClass, CronParser parser, Scheduled scheduled, int nameSequence) {
+        String id = SchedulerUtils.lookUpPropertyValue(scheduled.identity());
         if (id.isEmpty()) {
             id = nameSequence + "_" + invokerClass;
         }
@@ -163,17 +161,14 @@ public class SimpleScheduler implements Scheduler {
         if (scheduled.delay() > 0) {
             millisToAdd = scheduled.delayUnit().toMillis(scheduled.delay());
         } else if (!scheduled.delayed().isEmpty()) {
-            millisToAdd = Math.abs(parseDuration(scheduled, scheduled.delayed(), "delayed").toMillis());
+            millisToAdd = SchedulerUtils.parseDelayedAsMillis(scheduled);
         }
         if (millisToAdd != null) {
             start = start.toInstant().plusMillis(millisToAdd).atZone(start.getZone());
         }
 
-        String cron = scheduled.cron().trim();
+        String cron = SchedulerUtils.lookUpPropertyValue(scheduled.cron());
         if (!cron.isEmpty()) {
-            if (SchedulerContext.isConfigValue(cron)) {
-                cron = config.getValue(SchedulerContext.getConfigProperty(cron), String.class);
-            }
             Cron cronExpr;
             try {
                 cronExpr = parser.parse(cron);
@@ -182,27 +177,9 @@ public class SimpleScheduler implements Scheduler {
             }
             return new CronTrigger(id, start, cronExpr);
         } else if (!scheduled.every().isEmpty()) {
-            return new IntervalTrigger(id, start, Math.abs(parseDuration(scheduled, scheduled.every(), "every").toMillis()));
+            return new IntervalTrigger(id, start, SchedulerUtils.parseEveryAsMillis(scheduled));
         } else {
             throw new IllegalArgumentException("Invalid schedule configuration: " + scheduled);
-        }
-    }
-
-    // Keep it public so that we can reuse the logic in the quartz extension
-    public static Duration parseDuration(Scheduled scheduled, String value, String memberName) {
-        value = value.trim();
-        if (SchedulerContext.isConfigValue(value)) {
-            value = ConfigProviderResolver.instance().getConfig().getValue(SchedulerContext.getConfigProperty(value),
-                    String.class);
-        }
-        if (Character.isDigit(value.charAt(0))) {
-            value = "PT" + value;
-        }
-        try {
-            return Duration.parse(value);
-        } catch (Exception e) {
-            // This could only happen for config-based expressions
-            throw new IllegalStateException("Invalid " + memberName + "() expression on: " + scheduled, e);
         }
     }
 

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/util/SchedulerUtils.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/util/SchedulerUtils.java
@@ -1,0 +1,83 @@
+package io.quarkus.scheduler.runtime.util;
+
+import java.time.Duration;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+import io.quarkus.scheduler.Scheduled;
+
+/**
+ * Utilities class for scheduler extensions.
+ *
+ */
+public class SchedulerUtils {
+
+    private static final String DELAYED = "delayed";
+    private static final String EVERY = "every";
+
+    private SchedulerUtils() {
+
+    }
+
+    /**
+     * Parse the `@Scheduled(delayed = "")` field into milliseconds.
+     *
+     * @param scheduled annotation
+     * @return returns the duration in milliseconds.
+     */
+    public static long parseDelayedAsMillis(Scheduled scheduled) {
+        return parseDurationAsMillis(scheduled, scheduled.delayed(), DELAYED);
+    }
+
+    /**
+     * Parse the `@Scheduled(every = "")` field into milliseconds.
+     *
+     * @param scheduled annotation
+     * @return returns the duration in milliseconds.
+     */
+    public static long parseEveryAsMillis(Scheduled scheduled) {
+        return parseDurationAsMillis(scheduled, scheduled.every(), EVERY);
+    }
+
+    /**
+     * Looks up the property value by checking whether the value is a configuration key and resolves it if so.
+     *
+     * @param propertyValue property value to look up.
+     * @return the resolved property value.
+     */
+    public static String lookUpPropertyValue(String propertyValue) {
+        String value = propertyValue.trim();
+        if (!value.isEmpty() && isConfigValue(value)) {
+            value = ConfigProviderResolver.instance().getConfig().getValue(getConfigProperty(value), String.class);
+        }
+
+        return value;
+    }
+
+    public static boolean isConfigValue(String val) {
+        val = val.trim();
+        return val.startsWith("{") && val.endsWith("}");
+    }
+
+    private static String getConfigProperty(String val) {
+        return val.substring(1, val.length() - 1);
+    }
+
+    private static long parseDurationAsMillis(Scheduled scheduled, String value, String memberName) {
+        return Math.abs(parseDuration(scheduled, value, memberName).toMillis());
+    }
+
+    private static Duration parseDuration(Scheduled scheduled, String value, String memberName) {
+        value = lookUpPropertyValue(value);
+        if (Character.isDigit(value.charAt(0))) {
+            value = "PT" + value;
+        }
+
+        try {
+            return Duration.parse(value);
+        } catch (Exception e) {
+            // This could only happen for config-based expressions
+            throw new IllegalStateException("Invalid " + memberName + "() expression on: " + scheduled, e);
+        }
+    }
+}

--- a/extensions/spring-scheduled/deployment/src/main/java/io/quarkus/spring/scheduled/deployment/SpringScheduledProcessor.java
+++ b/extensions/spring-scheduled/deployment/src/main/java/io/quarkus/spring/scheduled/deployment/SpringScheduledProcessor.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -26,7 +25,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.scheduler.deployment.ScheduledBusinessMethodItem;
-import io.quarkus.scheduler.runtime.SchedulerContext;
+import io.quarkus.scheduler.runtime.util.SchedulerUtils;
 
 /**
  * A simple processor that search for Spring Scheduled annotations in Beans and produce
@@ -166,9 +165,7 @@ public class SpringScheduledProcessor {
         long paramValue;
         if (paramValueString.startsWith("${")) {
             paramValueString = paramValueString.replace("${", "{").trim();
-            paramValueString = ConfigProviderResolver.instance().getConfig().getValue(
-                    SchedulerContext.getConfigProperty(paramValueString),
-                    String.class);
+            paramValueString = SchedulerUtils.lookUpPropertyValue(paramValueString);
         }
         try {
             paramValue = Long.valueOf(paramValueString);


### PR DESCRIPTION
These changes allow to use config properties in the `identity` field:

```
@Scheduled(identity = "{job.id}")
```

Fix #14967