### PR TITLE
Exclude amazon-services runtime http-clients dependencies

### DIFF
--- a/extensions/amazon-services/dynamodb/runtime/pom.xml
+++ b/extensions/amazon-services/dynamodb/runtime/pom.xml
@@ -35,6 +35,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/iam/runtime/pom.xml
+++ b/extensions/amazon-services/iam/runtime/pom.xml
@@ -35,6 +35,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/kms/runtime/pom.xml
+++ b/extensions/amazon-services/kms/runtime/pom.xml
@@ -35,6 +35,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kms</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/s3/runtime/pom.xml
+++ b/extensions/amazon-services/s3/runtime/pom.xml
@@ -34,6 +34,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/ses/runtime/pom.xml
+++ b/extensions/amazon-services/ses/runtime/pom.xml
@@ -35,6 +35,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ses</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/sns/runtime/pom.xml
+++ b/extensions/amazon-services/sns/runtime/pom.xml
@@ -34,6 +34,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sns</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/extensions/amazon-services/sqs/runtime/pom.xml
+++ b/extensions/amazon-services/sqs/runtime/pom.xml
@@ -34,6 +34,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>software.amazon.awssdk</groupId>
+                  <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
Related: #15014 

The `apache-client` and `netty-nio-client` dependencies are marked with `runtime` scope from each amazon service, so even if the extensions mark them as `optional` they are pulled and end up in the final directory.

This PR excludes those dependencies so they are effectively `optional`.