### PR TITLE
Fix Jackson Not available at runtime for Dev UI Logstream

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
@@ -451,7 +451,7 @@ public class WebJarUtil {
         }
     }
 
-    private static Path createResourcesDirectory(AppArtifact userApplication, AppArtifact resourcesArtifact) {
+    public static Path createResourcesDirectory(AppArtifact userApplication, AppArtifact resourcesArtifact) {
         try {
             Path path = Paths.get(TMP_DIR, "quarkus", userApplication.getGroupId(), userApplication.getArtifactId(),
                     resourcesArtifact.getGroupId(), resourcesArtifact.getArtifactId(), resourcesArtifact.getVersion());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
@@ -178,6 +178,13 @@ public final class Json {
             return this;
         }
 
+        public JsonArrayBuilder addAll(List<JsonObjectBuilder> value) {
+            if (value != null && !value.isEmpty()) {
+                values.addAll(value);
+            }
+            return this;
+        }
+
         private void addInternal(Object value) {
             if (value != null) {
                 values.add(value);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/JsonFormatter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/JsonFormatter.java
@@ -9,8 +9,7 @@ import java.util.List;
 import org.jboss.logmanager.ExtFormatter;
 import org.jboss.logmanager.ExtLogRecord;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
+import io.quarkus.vertx.http.runtime.devmode.Json;
 
 /**
  * Formatting log records into a json format
@@ -19,13 +18,14 @@ public class JsonFormatter extends ExtFormatter {
 
     @Override
     public String format(final ExtLogRecord logRecord) {
-        return toJsonObject(logRecord).toString();
+        return toJsonObject(logRecord).build();
     }
 
-    private JsonObject toJsonObject(ExtLogRecord logRecord) {
+    private Json.JsonObjectBuilder toJsonObject(ExtLogRecord logRecord) {
         String formattedMessage = formatMessage(logRecord);
 
-        JsonObject jsonObject = new JsonObject();
+        Json.JsonObjectBuilder jsonObject = Json.object();
+
         jsonObject.put(TYPE, LOG_LINE);
         if (logRecord.getLoggerName() != null) {
             jsonObject.put(LOGGER_NAME_SHORT, getShortFullClassName(logRecord.getLoggerName(), ""));
@@ -71,11 +71,11 @@ public class JsonFormatter extends ExtFormatter {
         return jsonObject;
     }
 
-    private JsonArray getStacktraces(Throwable t) {
+    private Json.JsonArrayBuilder getStacktraces(Throwable t) {
         List<String> traces = new LinkedList<>();
         addStacktrace(traces, t);
 
-        JsonArray jsonArray = new JsonArray();
+        Json.JsonArrayBuilder jsonArray = Json.array();
 
         traces.forEach((trace) -> {
             jsonArray.add(trace);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogController.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogController.java
@@ -1,65 +1,72 @@
 package io.quarkus.vertx.http.runtime.logstream;
 
-import static java.util.logging.Level.ALL;
-import static java.util.logging.Level.CONFIG;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.FINER;
-import static java.util.logging.Level.FINEST;
-import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.OFF;
-import static java.util.logging.Level.SEVERE;
-import static java.util.logging.Level.WARNING;
+import static org.jboss.logmanager.Level.ALL;
+import static org.jboss.logmanager.Level.CONFIG;
+import static org.jboss.logmanager.Level.DEBUG;
+import static org.jboss.logmanager.Level.ERROR;
+import static org.jboss.logmanager.Level.FATAL;
+import static org.jboss.logmanager.Level.FINE;
+import static org.jboss.logmanager.Level.FINER;
+import static org.jboss.logmanager.Level.FINEST;
+import static org.jboss.logmanager.Level.INFO;
+import static org.jboss.logmanager.Level.OFF;
+import static org.jboss.logmanager.Level.SEVERE;
+import static org.jboss.logmanager.Level.TRACE;
+import static org.jboss.logmanager.Level.WARN;
+import static org.jboss.logmanager.Level.WARNING;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
+import org.jboss.logmanager.Level;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+
+import io.quarkus.vertx.http.runtime.devmode.Json;
 
 /**
  * Allow controlling to the log levels
  */
 public class LogController {
+    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(LogController.class);
 
-    public JsonArray getLevels() {
-        return new JsonArray()
-                .add(OFF.getName())
-                .add(SEVERE.getName())
-                .add(WARNING.getName())
-                .add(INFO.getName())
-                .add(CONFIG.getName())
-                .add(FINE.getName())
-                .add(FINER.getName())
-                .add(FINEST.getName())
-                .add(ALL.getName());
+    private LogController() {
     }
 
-    public JsonArray getLoggers() {
-        TreeMap<String, JsonObject> loggerMap = new TreeMap<>();
-        LogManager manager = LogManager.getLogManager();
-        Enumeration<String> loggerNames = manager.getLoggerNames();
+    public static Json.JsonArrayBuilder getLevels() {
+        Json.JsonArrayBuilder array = Json.array();
+        for (String level : LEVELS) {
+            array.add(level);
+        }
+        return array;
+    }
+
+    public static Json.JsonArrayBuilder getLoggers() {
+        LogContext logContext = LogContext.getLogContext();
+        TreeMap<String, Json.JsonObjectBuilder> loggerMap = new TreeMap<>();
+
+        Enumeration<String> loggerNames = logContext.getLoggerNames();
         while (loggerNames.hasMoreElements()) {
             String loggerName = loggerNames.nextElement();
-            JsonObject jsonObject = getLogger(loggerName);
+            Json.JsonObjectBuilder jsonObject = getLogger(loggerName);
             if (jsonObject != null) {
                 loggerMap.put(loggerName, jsonObject);
             }
         }
 
-        List<JsonObject> orderedLoggers = new ArrayList<>(loggerMap.values());
-        JsonArray jsonArray = new JsonArray(orderedLoggers);
+        List<Json.JsonObjectBuilder> orderedLoggers = new ArrayList<>(loggerMap.values());
+        Json.JsonArrayBuilder jsonArray = Json.array();
+        jsonArray.addAll(orderedLoggers);
         return jsonArray;
     }
 
-    public JsonObject getLogger(String loggerName) {
+    public static Json.JsonObjectBuilder getLogger(String loggerName) {
+        LogContext logContext = LogContext.getLogContext();
         if (loggerName != null && !loggerName.isEmpty()) {
-            Logger logger = Logger.getLogger(loggerName);
-            JsonObject jsonObject = new JsonObject();
+            Logger logger = logContext.getLogger(loggerName);
+            Json.JsonObjectBuilder jsonObject = Json.object();
             jsonObject.put("name", loggerName);
             jsonObject.put("effectiveLevel", getEffectiveLogLevel(logger));
             jsonObject.put("configuredLevel", getConfiguredLogLevel(logger));
@@ -68,20 +75,22 @@ public class LogController {
         return null;
     }
 
-    public void updateLogLevel(String loggerName, String levelVal) {
-        Logger logger = Logger.getLogger(loggerName);
+    public static void updateLogLevel(String loggerName, String levelValue) {
+        LogContext logContext = LogContext.getLogContext();
+        Logger logger = logContext.getLogger(loggerName);
         if (logger != null) {
-            Level level = Level.parse(levelVal);
+            java.util.logging.Level level = Level.parse(levelValue);
             logger.setLevel(level);
+            LOG.info("Log level updated [" + loggerName + "] changed to [" + levelValue + "]");
         }
     }
 
-    private String getConfiguredLogLevel(Logger logger) {
-        Level level = logger.getLevel();
+    private static String getConfiguredLogLevel(Logger logger) {
+        java.util.logging.Level level = logger.getLevel();
         return level != null ? level.getName() : null;
     }
 
-    private String getEffectiveLogLevel(Logger logger) {
+    private static String getEffectiveLogLevel(Logger logger) {
         if (logger == null) {
             return null;
         }
@@ -89,5 +98,24 @@ public class LogController {
             return logger.getLevel().getName();
         }
         return getEffectiveLogLevel(logger.getParent());
+    }
+
+    public static final List<String> LEVELS = new ArrayList<>();
+
+    static {
+        LEVELS.add(OFF.getName());
+        LEVELS.add(SEVERE.getName());
+        LEVELS.add(ERROR.getName());
+        LEVELS.add(FATAL.getName());
+        LEVELS.add(WARNING.getName());
+        LEVELS.add(WARN.getName());
+        LEVELS.add(INFO.getName());
+        LEVELS.add(DEBUG.getName());
+        LEVELS.add(TRACE.getName());
+        LEVELS.add(CONFIG.getName());
+        LEVELS.add(FINE.getName());
+        LEVELS.add(FINER.getName());
+        LEVELS.add(FINEST.getName());
+        LEVELS.add(ALL.getName());
     }
 }


### PR DESCRIPTION
Vertx Json depends on Jackson, that is not avaialble on runtime. This removes usage of vertx json and use `io.quarkus.vertx.http.runtime.devmode.Json`

This PR also contain more small changes needed so that Logger Manager in Quarkiverse can reuse the Log stream UI in Dev UI. (missed in #15024) This was discovered while preparing https://github.com/quarkiverse/quarkus-logging-manager/pull/53


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>