### PR TITLE
Switch to java.specification.version in JavaVersionUtil, covers XY-ea version of Early Access builds

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class JavaVersionUtil {
 
-    private static final Pattern PATTERN = Pattern.compile("(?:1\\.)?(\\d+)(?:\\..*)?");
+    private static final Pattern PATTERN = Pattern.compile("(?:1\\.)?(\\d+)");
 
     private static boolean IS_JAVA_11_OR_NEWER;
     private static boolean IS_JAVA_13_OR_NEWER;
@@ -16,7 +16,7 @@ public class JavaVersionUtil {
 
     // visible for testing
     static void performChecks() {
-        Matcher matcher = PATTERN.matcher(System.getProperty("java.version", ""));
+        Matcher matcher = PATTERN.matcher(System.getProperty("java.specification.version", ""));
         if (matcher.matches()) {
             int first = Integer.parseInt(matcher.group(1));
             IS_JAVA_11_OR_NEWER = (first >= 11);

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test;
 
 class JavaVersionUtilTest {
 
-    private static final String JAVA_VERSION = "java.version";
+    private static final String JAVA_SPECIFICATION_VERSION = "java.specification.version";
 
     @Test
     void testJava8() {
-        testWithVersion("1.8.0_242", () -> {
+        testWithVersion("1.8", () -> {
             assertFalse(JavaVersionUtil.isJava11OrHigher());
             assertFalse(JavaVersionUtil.isJava13OrHigher());
         });
@@ -19,7 +19,7 @@ class JavaVersionUtilTest {
 
     @Test
     void testJava11() {
-        testWithVersion("11.0.7", () -> {
+        testWithVersion("11", () -> {
             assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertFalse(JavaVersionUtil.isJava13OrHigher());
         });
@@ -27,20 +27,36 @@ class JavaVersionUtilTest {
 
     @Test
     void testJava14() {
-        testWithVersion("14.0.1", () -> {
+        testWithVersion("14", () -> {
             assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertTrue(JavaVersionUtil.isJava13OrHigher());
         });
     }
 
-    private void testWithVersion(String javaVersion, Runnable test) {
-        String previous = System.getProperty(JAVA_VERSION);
-        System.setProperty(JAVA_VERSION, javaVersion);
+    @Test
+    void testJava17() {
+        testWithVersion("17", () -> {
+            assertTrue(JavaVersionUtil.isJava11OrHigher());
+            assertTrue(JavaVersionUtil.isJava13OrHigher());
+        });
+    }
+
+    @Test
+    void testJava21() {
+        testWithVersion("21", () -> {
+            assertTrue(JavaVersionUtil.isJava11OrHigher());
+            assertTrue(JavaVersionUtil.isJava13OrHigher());
+        });
+    }
+
+    private void testWithVersion(String javaSpecificationVersion, Runnable test) {
+        String previous = System.getProperty(JAVA_SPECIFICATION_VERSION);
+        System.setProperty(JAVA_SPECIFICATION_VERSION, javaSpecificationVersion);
         JavaVersionUtil.performChecks();
         try {
             test.run();
         } finally {
-            System.setProperty(JAVA_VERSION, previous);
+            System.setProperty(JAVA_SPECIFICATION_VERSION, previous);
             JavaVersionUtil.performChecks();
         }
 


### PR DESCRIPTION
Switch to java.specification.version in JavaVersionUtil, covers XY-ea version of Early Access builds

Fixes https://github.com/quarkusio/quarkus/issues/15062

An alternative solution for the issue is https://github.com/quarkusio/quarkus/compare/master...rsvoboda:JavaVersionUtil.java.version?expand=1

I think it's better to go with `java.specification.version`, continue with `java.version` might have some benefits which I missed