### PR TITLE
Activate annotation processors again for panache

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PanacheEntityMetaModelTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PanacheEntityMetaModelTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.orm.panache.deployment.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity_;
+
+public class PanacheEntityMetaModelTest {
+    @Test
+    public void testMetaModelExistence() {
+        Assertions.assertEquals("id", PanacheEntity_.ID);
+    }
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -85,7 +85,9 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerArgument>-proc:none</compilerArgument>
+                    <annotationProcessors>
+                        <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                    </annotationProcessors>
                 </configuration>
             </plugin>
             <plugin>

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/PanacheEntityMetaModelTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/PanacheEntityMetaModelTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntity_;
+
+public class PanacheEntityMetaModelTest {
+    @Test
+    public void testMetaModelExistence() {
+        Assertions.assertEquals("id", PanacheEntity_.ID);
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -89,7 +89,9 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerArgument>-proc:none</compilerArgument>
+                    <annotationProcessors>
+                        <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                    </annotationProcessors>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
We depend on the jpamodelgen annotation processor in the panache modules, to create the Meta Model for e.g. the PanacheEntity class.

closes #14926