### PR TITLE
Add QuarkusProdModeTest start/stop methods and fix restassured random port

### DIFF
--- a/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestTest.java
+++ b/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class QuarkusProdModeTestTest {
+    @RegisterExtension
+    static final QuarkusProdModeTest simpleApp = new QuarkusProdModeTest()
+            .setApplicationName("simple-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setRun(true);
+
+    @Test
+    public void shouldStartAndStopInnerProcess() {
+        thenAppIsRunning();
+
+        whenStopApp();
+        thenAppIsNotRunning();
+
+        whenStartApp();
+        thenAppIsRunning();
+    }
+
+    private void whenStopApp() {
+        simpleApp.stop();
+    }
+
+    private void whenStartApp() {
+        simpleApp.start();
+    }
+
+    private void thenAppIsNotRunning() {
+        assertNotNull(simpleApp.getExitCode(), "App is running");
+    }
+
+    private void thenAppIsRunning() {
+        assertNull(simpleApp.getExitCode(), "App is not running");
+    }
+}


### PR DESCRIPTION
These changes allow to use QuarkusProdModeTest to cope with more complex test scenarios like failover cases. Example:

```
@RegisterExtension
static final QuarkusProdModeTest nodeApp = new QuartzNodeApplicationResource();

@RegisterExtension
static final QuarkusProdModeTest masterApp = new QuartzMasterApplicationResource();

@Test
public void testFailover() {
    assertMasterIsConnectedWithNode();

    // simulate node failover
    nodeApp.stop();
    assertMasterIsNotConnectedWithNode();

    nodeApp.start();
    assertMasterIsConnectedWithNode();
}
```

Also, about the rest assured, when we want to start our Quarkus application using a random port (`quarkus.http.port=0`), the QuarkusProdModeTest is setting `RestAssured.defaultPort = 0` which is invalid (if you try to do `given()` in your test case, you will get an exception. 

Fix https://github.com/quarkusio/quarkus/issues/14961