### PR TITLE
Remove dependency on quarkus-test-common in independent-projects/arc/tests

### DIFF
--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -41,19 +41,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-common</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.annotation.versioning</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
@@ -6,10 +6,10 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.wildfly.common.Assert.assertFalse;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/CircularInjectionNotSupportedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/CircularInjectionNotSupportedTest.java
@@ -1,12 +1,12 @@
 package io.quarkus.arc.test.injection.erroneous;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.wildfly.common.Assert;
 
 public class CircularInjectionNotSupportedTest {
 
@@ -17,8 +17,7 @@ public class CircularInjectionNotSupportedTest {
     @Test
     public void testExceptionThrown() {
         Throwable error = container.getFailure();
-        Assertions.assertNotNull(error);
-        Assert.assertTrue(error instanceof IllegalStateException);
+        assertThat(error).isInstanceOf(IllegalStateException.class);
     }
 
     static abstract class AbstractServiceImpl {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
@@ -1,10 +1,13 @@
 package io.quarkus.arc.test.stereotypes;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
-import io.quarkus.test.Mock;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -114,6 +117,19 @@ public class StereotypeAlternativeTest {
         public String ping() {
             return MockedFooWithExplicitPriority.class.getSimpleName();
         }
+    }
+
+    /**
+     * The built-in stereotype intended for use with mock beans injected in tests.
+     */
+    @Priority(1)
+    @Dependent
+    @Alternative
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    public @interface Mock {
+
     }
 
 }


### PR DESCRIPTION
This removes the dependency on quarkus-test-common as discussed in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/arc.2Ftests.20is.20not.20so.20independent/near/226379353