### PR TITLE
Clarify the usage of quarkus.debug.print-startup-times

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1425,7 +1425,7 @@ convenience to avoid the need to explicitly load classes in the recorders.
 ==== Printing step execution time
 
 At times, it can be useful to know how the exact time each startup task (which is the result of each bytecode recording) takes when the application is run.
-The simplest way to determine this information is to set the `quarkus.debug.print-startup-times` property to `true` when running the application.
+The simplest way to determine this information is to launch the Quarkus application with the `-Dquarkus.debug.print-startup-times=true` system property.
 The output will look something like:
 
 [source%nowrap]


### PR DESCRIPTION
Related to: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/boot.20time/near/226627411