### PR TITLE
Enable Java serialization only for GraalVM 21+

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
@@ -1,0 +1,25 @@
+package io.quarkus.runtime.graal;
+
+import java.io.ObjectStreamClass;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(java.io.ObjectStreamClass.class)
+@SuppressWarnings({ "unused" })
+final class Target_java_io_ObjectStreamClass {
+
+    @Substitute
+    private static ObjectStreamClass lookup(Class<?> cl, boolean all) {
+        throw new UnsupportedOperationException("Serialization of class definitions not supported");
+    }
+
+    private Target_java_io_ObjectStreamClass(final Class<?> cl) {
+        throw new UnsupportedOperationException("Serialization of class definitions not supported");
+    }
+
+    private Target_java_io_ObjectStreamClass() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
@@ -1,11 +1,16 @@
 package io.quarkus.runtime.graal;
 
 import java.io.ObjectStreamClass;
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.home.Version;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(java.io.ObjectStreamClass.class)
+import io.quarkus.runtime.graal.Target_java_io_ObjectStreamClass.GraalVM20OrEarlier;
+
+@TargetClass(value = java.io.ObjectStreamClass.class, onlyWith = GraalVM20OrEarlier.class)
 @SuppressWarnings({ "unused" })
 final class Target_java_io_ObjectStreamClass {
 
@@ -22,4 +27,11 @@ final class Target_java_io_ObjectStreamClass {
         throw new UnsupportedOperationException("Not supported");
     }
 
+    static class GraalVM20OrEarlier implements BooleanSupplier {
+
+        @Override
+        public boolean getAsBoolean() {
+            return Version.getCurrent().compareTo(21) < 0;
+        }
+    }
 }


### PR DESCRIPTION
Should fix #15085 .

@JiriOndrusek could you check serialization still works for you with GraalVM 21?
@Sgitario could you check things work fine with GraalVM 20.3? (I tested our Kafka IT but I'm not sure it's enough)