### PR TITLE
Less reflection and move to MethodHandles in Hibernate Search extension

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchClasses.java
@@ -5,16 +5,11 @@ import java.util.List;
 
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonClasses;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMapping;
 import org.jboss.jandex.DotName;
 
 class HibernateSearchClasses {
 
     static final DotName INDEXED = DotName.createSimple(Indexed.class.getName());
-
-    static final DotName PROPERTY_MAPPING_META_ANNOTATION = DotName.createSimple(
-            org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping.class.getName());
-    static final DotName TYPE_MAPPING_META_ANNOTATION = DotName.createSimple(TypeMapping.class.getName());
 
     static final List<DotName> GSON_CLASSES = new ArrayList<>();
     static {

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/MethodAccessEntity.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/MethodAccessEntity.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.hibernate.search.elasticsearch.propertyaccess;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class MethodAccessEntity {
+
+    private Long id;
+
+    private String property;
+
+    public MethodAccessEntity() {
+    }
+
+    public MethodAccessEntity(Long id, String property) {
+        this.id = id;
+        this.property = property;
+    }
+
+    @Id
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @FullTextField
+    public String getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/PrivateFieldAccessEntity.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/PrivateFieldAccessEntity.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.hibernate.search.elasticsearch.propertyaccess;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class PrivateFieldAccessEntity {
+
+    @Id
+    private Long id;
+
+    @Basic(fetch = FetchType.LAZY)
+    @LazyGroup("group1")
+    @FullTextField
+    private String property;
+
+    @Basic(fetch = FetchType.LAZY)
+    @LazyGroup("group2")
+    @FullTextField
+    private String otherProperty;
+
+    public PrivateFieldAccessEntity() {
+    }
+
+    public PrivateFieldAccessEntity(Long id, String property) {
+        this.id = id;
+        this.property = property;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+
+    public String getOtherProperty() {
+        return otherProperty;
+    }
+
+    public void setOtherProperty(String otherProperty) {
+        this.otherProperty = otherProperty;
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/PropertyAccessTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/PropertyAccessTestResource.java
@@ -1,0 +1,211 @@
+package io.quarkus.it.hibernate.search.elasticsearch.propertyaccess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hibernate.Hibernate;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+@Path("/test/property-access")
+public class PropertyAccessTestResource {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    SearchSession searchSession;
+
+    @Inject
+    UserTransaction transaction;
+
+    @GET
+    @Path("/private-field")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPrivateFieldAccess() {
+        long id = 1L;
+        String value = "foo";
+
+        inTransaction(() -> assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                .where(f -> f.match().field("property")
+                        .matching(value))
+                .fetchAllHits())
+                        .isEmpty());
+
+        // While indexing, HSearch will read the entity property by calling a synthetic getter
+        inTransaction(() -> entityManager.persist(new PrivateFieldAccessEntity(id, value)));
+
+        inTransaction(() -> assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                .where(f -> f.match().field("property")
+                        .matching(value))
+                .fetchAllHits())
+                        .hasSize(1));
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/private-field-lazy-init")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPrivateFieldAccessLazyInitialization() {
+        long id = 2L;
+        String value = "bar";
+
+        inTransaction(() -> assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                .where(f -> f.match().field("property")
+                        .matching(value))
+                .fetchAllHits())
+                        .isEmpty());
+
+        inTransaction(() -> entityManager.persist(new PrivateFieldAccessEntity(id, value)));
+
+        inTransaction(() -> {
+            // "otherProperty" has no value in the index...
+            assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                    .where(f -> f.match().field("otherProperty")
+                            .matching(value))
+                    .fetchAllHits())
+                            .isEmpty();
+
+            // but "property" has.
+            assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value))
+                    .fetchAllHits())
+                            .hasSize(1);
+        });
+
+        // While indexing, HSearch will read the entity property by calling a synthetic getter,
+        // ensuring that it gets initialized automatically
+        inTransaction(() -> {
+            PrivateFieldAccessEntity entity = entityManager.getReference(PrivateFieldAccessEntity.class, id);
+            // The entity is not initialized
+            assertThat(entity)
+                    .returns(false, e -> Hibernate.isPropertyInitialized(e, "property"))
+                    .returns(false, e -> Hibernate.isPropertyInitialized(e, "otherProperty"));
+
+            // We update "otherProperty"
+            entity.setOtherProperty(value);
+
+            // Consequently, "otherProperty" is initialized,
+            // but "property" (which is in a different @LazyGroup) still isn't.
+            assertThat(entity)
+                    .returns(false, e -> Hibernate.isPropertyInitialized(e, "property"));
+        });
+
+        inTransaction(() -> {
+            // "otherProperty" was updated in the index...
+            assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                    .where(f -> f.match().field("otherProperty")
+                            .matching(value))
+                    .fetchAllHits())
+                            .hasSize(1);
+
+            // and "property" still has a value, proving that it was lazily initialized upon indexing.
+            assertThat(searchSession.search(PrivateFieldAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value))
+                    .fetchAllHits())
+                            .hasSize(1);
+        });
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/method")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testMethodAccess() {
+        long id = 1L;
+        String value = "foo";
+
+        inTransaction(() -> assertThat(searchSession.search(MethodAccessEntity.class)
+                .where(f -> f.match().field("property")
+                        .matching(value))
+                .fetchAllHits())
+                        .isEmpty());
+
+        // While indexing, HSearch will read the entity property through its getter method
+        inTransaction(() -> entityManager.persist(new MethodAccessEntity(id, value)));
+
+        inTransaction(() -> assertThat(searchSession.search(MethodAccessEntity.class)
+                .where(f -> f.match().field("property")
+                        .matching(value))
+                .fetchAllHits())
+                        .hasSize(1));
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/transient-method")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testTransientMethodAccess() {
+        long id = 1L;
+        String value1 = "foo1";
+        String value2 = "foo2";
+
+        inTransaction(() -> {
+            assertThat(searchSession.search(TransientMethodAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value1))
+                    .fetchAllHits())
+                            .isEmpty();
+            assertThat(searchSession.search(TransientMethodAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value2))
+                    .fetchAllHits())
+                            .isEmpty();
+        });
+
+        // While indexing, HSearch will read the (@Transient) entity property through its getter method
+        inTransaction(() -> entityManager.persist(new TransientMethodAccessEntity(id, value1, value2)));
+
+        inTransaction(() -> {
+            assertThat(searchSession.search(TransientMethodAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value1))
+                    .fetchAllHits())
+                            .hasSize(1);
+            assertThat(searchSession.search(TransientMethodAccessEntity.class)
+                    .where(f -> f.match().field("property")
+                            .matching(value2))
+                    .fetchAllHits())
+                            .hasSize(1);
+        });
+
+        return "OK";
+    }
+
+    private void inTransaction(Runnable runnable) {
+        try {
+            transaction.begin();
+            try {
+                runnable.run();
+                transaction.commit();
+            } catch (Throwable t) {
+                try {
+                    transaction.rollback();
+                } catch (RuntimeException e2) {
+                    t.addSuppressed(e2);
+                }
+                throw t;
+            }
+        } catch (NotSupportedException | SystemException | RollbackException | HeuristicMixedException
+                | HeuristicRollbackException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/TransientMethodAccessEntity.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/propertyaccess/TransientMethodAccessEntity.java
@@ -1,0 +1,66 @@
+package io.quarkus.it.hibernate.search.elasticsearch.propertyaccess;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Transient;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+
+@Entity
+@Indexed
+public class TransientMethodAccessEntity {
+
+    private Long id;
+
+    private String property1;
+
+    private String property2;
+
+    public TransientMethodAccessEntity() {
+    }
+
+    public TransientMethodAccessEntity(Long id, String property1, String property2) {
+        this.id = id;
+        this.property1 = property1;
+        this.property2 = property2;
+    }
+
+    @Id
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getProperty1() {
+        return property1;
+    }
+
+    public void setProperty1(String property1) {
+        this.property1 = property1;
+    }
+
+    public String getProperty2() {
+        return property2;
+    }
+
+    public void setProperty2(String property2) {
+        this.property2 = property2;
+    }
+
+    @Transient
+    @FullTextField
+    @IndexingDependency(derivedFrom = {
+            @ObjectPath(@PropertyValue(propertyName = "property1")),
+            @ObjectPath(@PropertyValue(propertyName = "property2"))
+    })
+    public String getProperty() {
+        return property1 + " " + property2;
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/PropertyAccessInGraalIT.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/PropertyAccessInGraalIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.hibernate.search.elasticsearch;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class PropertyAccessInGraalIT extends PropertyAccessTest {
+
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/PropertyAccessTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/PropertyAccessTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.hibernate.search.elasticsearch;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PropertyAccessTest {
+
+    @Test
+    public void testPrivateFieldAccess() {
+        when().get("/test/property-access/private-field").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testPrivateFieldAccessLazyInitialization() {
+        when().get("/test/property-access/private-field-lazy-init").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testMethodAccess() {
+        when().get("/test/property-access/method").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testTransientMethodAccess() {
+        when().get("/test/property-access/transient-method").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+}


### PR DESCRIPTION
We don't need to enable runtime reflection on user classes, because:

1. We perform all reflection operations, except getting values from entities,
   at static init.
2. After static init, we hold references to all Methods/Fields that we
   will actually use at runtime. SubstrateVM is able to detect those and
   to properly build a native image that will handle calling invoke() on
   these Methods/Fields.

Also, when using GraalVM 21 or OpenJDK, we can move from `java.lang.reflect` to `MethodHandles`. Which is what Hibernate Search uses by default, and what we tested in most depth.

This supersedes #14739: I added conditional behavior so that we use `java.lang.reflect` on GraalVM 20 and below, but `MethodHandles` on OpenJDK and GraalVM 21+. The original PR was always using `MethodHandles`, which could be a problem with GraalVM 20 and below. I also added specific tests to check that property access works as expected.

Related: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/MethodHandles.20in.20Hibernate.20Search