### PR TITLE
Remove jandex plugin from flaky test

### DIFF
--- a/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-included-build/external-library/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'java'
-    id 'io.quarkus'
-    id "org.kordamp.gradle.jandex" version '0.6.0'
 }
 
 repositories {


### PR DESCRIPTION
This removes the jandex plugin from a sample test project. On windows, it looks the `jandex` task was running after the `jar` task which is not correct. 