### PR TITLE
Include a list of dependencies in the app

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -106,6 +106,15 @@ public class PackageConfig {
     @ConfigItem
     public Optional<String> userProvidersDirectory;
 
+    /**
+     * This option only applies when using fast-jar or mutable-jar. If this option is true
+     * then a list of all the coordinates of the artifacts that made up this image will be included
+     * in the quarkus-app directory. This list can be used by vulnerability scanners to determine
+     * if your application has any vulnerable dependencies.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean includeDependencyList;
+
     public boolean isAnyJarType() {
         return (type.equalsIgnoreCase(PackageConfig.JAR) ||
                 type.equalsIgnoreCase(PackageConfig.FAST_JAR) ||

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -135,6 +136,7 @@ public class JarResultBuildStep {
     public static final String DEPLOYMENT_LIB = "deployment";
     public static final String APPMODEL_DAT = "appmodel.dat";
     public static final String QUARKUS_RUN_JAR = "quarkus-run.jar";
+    public static final String QUARKUS_APP_DEPS = "quarkus-app-dependencies.txt";
     public static final String BOOT_LIB = "boot";
     public static final String LIB = "lib";
     public static final String MAIN = "main";
@@ -639,6 +641,16 @@ public class JarResultBuildStep {
                 try (OutputStream out = Files.newOutputStream(buildSystemProps)) {
                     outputTargetBuildItem.getBuildSystemProperties().store(out, "The original build properties");
                 }
+            }
+
+            if (packageConfig.includeDependencyList) {
+                Path deplist = buildDir.resolve(QUARKUS_APP_DEPS);
+                List<String> lines = new ArrayList<>();
+                for (AppDependency i : curateOutcomeBuildItem.getEffectiveModel().getUserDependencies()) {
+                    lines.add(i.getArtifact().toString());
+                }
+                lines.sort(Comparator.naturalOrder());
+                Files.write(deplist, lines);
             }
         } else {
             //if it is a rebuild we might have classes


### PR DESCRIPTION
This will allow vulnerability scanners to easily determine if
you application has any vulnerabilities.

Note that the 'vulnerability scanner' bit is still very much
a work in progress, however it makes more sense to include
this information on our side, then work on the scanner
once we have something it can work with.