### PR TITLE
Add the ability to configure vertx http client options in RESTEasy Reactive client

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.client.impl;
 
+import io.vertx.core.http.HttpClientOptions;
 import java.security.KeyStore;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -22,6 +23,7 @@ public class ClientBuilderImpl extends ClientBuilder {
     private KeyStore keyStore;
     private char[] keystorePassword;
     private HostnameVerifier hostnameVerifier;
+    private HttpClientOptions httpClientOptions = new HttpClientOptions();
     private static final ClientContextResolver CLIENT_CONTEXT_RESOLVER = ClientContextResolver.getInstance();
 
     @Override
@@ -74,9 +76,14 @@ public class ClientBuilderImpl extends ClientBuilder {
         return this;
     }
 
+    public ClientBuilder httpClientOptions(HttpClientOptions httpClientOptions) {
+        this.httpClientOptions = httpClientOptions;
+        return this;
+    }
+
     @Override
     public Client build() {
-        return new ClientImpl(configuration,
+        return new ClientImpl(httpClientOptions, configuration,
                 CLIENT_CONTEXT_RESOLVER.resolve(Thread.currentThread().getContextClassLoader()), hostnameVerifier,
                 sslContext);
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -76,7 +76,7 @@ public class ClientImpl implements Client {
     final ClientRestHandler[] abortHandlerChain;
     final Vertx vertx;
 
-    public ClientImpl(ConfigurationImpl configuration, ClientContext clientContext,
+    public ClientImpl(HttpClientOptions httpClientOptions, ConfigurationImpl configuration, ClientContext clientContext,
             HostnameVerifier hostnameVerifier,
             SSLContext sslContext) {
         this.configuration = configuration != null ? configuration : new ConfigurationImpl(RuntimeType.CLIENT);
@@ -96,7 +96,7 @@ public class ClientImpl implements Client {
             });
             closeVertx = true;
         }
-        this.httpClient = this.vertx.createHttpClient();
+        this.httpClient = this.vertx.createHttpClient(httpClientOptions);
         abortHandlerChain = new ClientRestHandler[] { new ClientErrorHandler() };
         handlerChain = new ClientRestHandler[] { new ClientRequestFiltersRestHandler(), new ClientSendRequestHandler(),
                 new ClientResponseRestHandler() };


### PR DESCRIPTION
Allows us to set whatever Vert.x HTTP Client options we like by doing do something like:

```java
new ClientBuilderImpl().httpClientOptions(new HttpClientOptions().setMaxPoolSize(100)).build()
```

instead of 

```java
ClientBuilder.newClient()
```