### PR TITLE
Use `Duration` instead of `long` (holding seconds) for Redis synchronous client timeout

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisAPIProducer.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.client.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -29,11 +30,11 @@ class RedisAPIProducer {
         return REDIS_APIS.computeIfAbsent(name, new Function<String, RedisAPIContainer>() {
             @Override
             public RedisAPIContainer apply(String s) {
-                long timeout = 10;
+                Duration timeout = Duration.ofSeconds(10);
                 RedisConfiguration redisConfiguration = RedisClientUtil.getConfiguration(RedisAPIProducer.this.redisConfig,
                         name);
                 if (redisConfiguration.timeout.isPresent()) {
-                    timeout = redisConfiguration.timeout.get().getSeconds();
+                    timeout = redisConfiguration.timeout.get();
                 }
                 RedisOptions options = RedisClientUtil.buildOptions(redisConfiguration);
                 Redis redis = Redis.createClient(vertx, options);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisClientImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisClientImpl.java
@@ -10,9 +10,9 @@ import io.vertx.redis.client.Response;
 
 class RedisClientImpl implements RedisClient {
     private final RedisAPI redisAPI;
-    private final long timeout;
+    private final Duration timeout;
 
-    public RedisClientImpl(RedisAPI redisAPI, long timeout) {
+    public RedisClientImpl(RedisAPI redisAPI, Duration timeout) {
         this.redisAPI = redisAPI;
         this.timeout = timeout;
     }
@@ -1023,7 +1023,7 @@ class RedisClientImpl implements RedisClient {
     }
 
     private Response await(Uni<io.vertx.mutiny.redis.client.Response> mutinyResponse) {
-        io.vertx.mutiny.redis.client.Response response = mutinyResponse.await().atMost(Duration.ofSeconds(timeout));
+        io.vertx.mutiny.redis.client.Response response = mutinyResponse.await().atMost(timeout);
         if (response == null) {
             return null;
         }


### PR DESCRIPTION
Timeout is defined as `Duration` in the property file, then it gets converted to `long` number of seconds to be stored internally, and then this number of seconds is converted to `Duration` in order to be passed to underlying Vert.x Mutiny Redis client.

As a side-effect, _under a second_ timeouts can not be defined, which might be too limiting for Redis.

This PR changes this so there's no `Duration -> seconds -> Duration` conversion - `Duration` is used all the time, preserving the fractional seconds precision.

Fixes: #15194