### PR TITLE
Allow to exclude JAX-RS classes with annotations

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -605,6 +605,28 @@ If set to `true` (default) then a *single instance* of a resource class is creat
 If set to `false` then a *new instance* of the resource class is created per each request.
 An explicit CDI scope annotation (`@RequestScoped`, `@ApplicationScoped`, etc.) always overrides the default behavior and specifies the lifecycle of resource instances.
 
+== Include/Exclude JAX-RS classes with build time conditions
+
+Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.
+Thus, the various JAX-RS classes can be annotated with profile conditions (`@io.quarkus.arc.profile.IfBuildProfile` or `@io.quarkus.arc.profile.UnlessBuildProfile`) and/or with property conditions (`io.quarkus.arc.properties.IfBuildProperty` or `io.quarkus.arc.properties.UnlessBuildProperty`) to indicate to Quarkus at build time under which conditions these JAX-RS classes should be included.
+
+In the following example, Quarkus includes the endpoint `sayHello` if and only if the build profile `app1` has been enabled.
+
+[source,java]
+----
+@IfBuildProfile("app1")
+public class ResourceForApp1Only {
+
+    @GET
+    @Path("sayHello")
+    public String sayHello() {
+        return "hello";
+     }
+}
+----
+
+Please note that if a JAX-RS Application has been detected and the method `getClasses()` and/or `getSingletons()` has/have been overridden, Quarkus will ignore the build time conditions and consider only what has been defined in the JAX-RS Application.
+
 == Conclusion
 
 Creating JSON REST services with Quarkus is easy as it relies on proven and well known technologies.

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1790,3 +1790,25 @@ Or plain text:
 < 
 < {"name":"roquefort"} 
 ----
+
+== Include/Exclude JAX-RS classes with build time conditions
+
+Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.
+Thus, the various JAX-RS classes can be annotated with profile conditions (`@io.quarkus.arc.profile.IfBuildProfile` or `@io.quarkus.arc.profile.UnlessBuildProfile`) and/or with property conditions (`io.quarkus.arc.properties.IfBuildProperty` or `io.quarkus.arc.properties.UnlessBuildProperty`) to indicate to Quarkus at build time under which conditions these JAX-RS classes should be included.
+
+In the following example, Quarkus includes the endpoint `sayHello` if and only if the build profile `app1` has been enabled.
+
+[source,java]
+----
+@IfBuildProfile("app1")
+public class ResourceForApp1Only {
+
+    @GET
+    @Path("sayHello")
+    public String sayHello() {
+        return "hello";
+     }
+}
+----
+
+Please note that if a JAX-RS Application has been detected and the method `getClasses()` and/or `getSingletons()` has/have been overridden, Quarkus will ignore the build time conditions and consider only what has been defined in the JAX-RS Application.

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
@@ -1,0 +1,40 @@
+package io.quarkus.arc.deployment;
+
+import org.jboss.jandex.AnnotationTarget;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A type of build item that is similar to {@link BuildTimeConditionBuildItem} but evaluated before
+ * processing the {@link AdditionalBeanBuildItem} in order to filter the beans thanks to build time conditions
+ * before actually adding them with a {@link AdditionalBeanBuildItem}.
+ *
+ * @see io.quarkus.arc.deployment.BuildTimeConditionBuildItem
+ * @see io.quarkus.arc.deployment.AdditionalBeanBuildItem
+ */
+public final class PreAdditionalBeanBuildTimeConditionBuildItem extends MultiBuildItem {
+
+    private final AnnotationTarget target;
+    private final boolean enabled;
+
+    public PreAdditionalBeanBuildTimeConditionBuildItem(AnnotationTarget target, boolean enabled) {
+        switch (target.kind()) {
+            case CLASS:
+            case METHOD:
+            case FIELD:
+                this.target = target;
+                break;
+            default:
+                throw new IllegalArgumentException("'target' can only be a class, a field or a method");
+        }
+        this.enabled = enabled;
+    }
+
+    public AnnotationTarget getTarget() {
+        return target;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -34,4 +34,11 @@ public class ResteasyReactiveConfig {
     @ConfigItem(defaultValue = "true")
     @Experimental("This flag has a high probability of going away in the future")
     public boolean defaultProduces;
+
+    /**
+     * Whether or not annotations such `@IfBuildTimeProfile`, `@IfBuildTimeProperty` and friends will be taken
+     * into account when used on JAX-RS classes.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean buildTimeConditionAware;
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -271,9 +271,7 @@ public class ResteasyReactiveProcessor {
         Map<DotName, String> pathInterfaces = result.getPathInterfaces();
 
         ApplicationScanningResult appResult = applicationResultBuildItem.getResult();
-        Set<String> allowedClasses = appResult.getAllowedClasses();
         Set<String> singletonClasses = appResult.getSingletonClasses();
-        boolean filterClasses = appResult.isFilterClasses();
         Application application = appResult.getApplication();
 
         Map<String, String> existingConverters = new HashMap<>();
@@ -382,7 +380,7 @@ public class ResteasyReactiveProcessor {
             serverEndpointIndexer = serverEndpointIndexerBuilder.build();
 
             for (ClassInfo i : scannedResources.values()) {
-                if (filterClasses && !allowedClasses.contains(i.name().toString())) {
+                if (!appResult.keepClass(i.name().toString())) {
                     continue;
                 }
                 ResourceClass endpoints = serverEndpointIndexer.createEndpoints(i);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
@@ -1,0 +1,240 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The integration test for the support of build time conditions on JAX-RS resource classes.
+ */
+class BuildProfileTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            ResourceTest1.class, ResourceTest2.class, ResponseFilter1.class, ResponseFilter2.class,
+                            ResponseFilter3.class, ResponseFilter4.class, ResponseFilter5.class, ResponseFilter6.class,
+                            Feature1.class, Feature2.class, DynamicFeature1.class, DynamicFeature2.class,
+                            ExceptionMapper1.class, ExceptionMapper2.class))
+            .overrideConfigKey("some.prop1", "v1")
+            .overrideConfigKey("some.prop2", "v2");
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_call_ok_of_resource_1() {
+        when()
+                .get("/rt-1/ok")
+                .then()
+                .header("X-RF-1", notNullValue())
+                .header("X-RF-2", nullValue())
+                .header("X-RF-3", notNullValue())
+                .header("X-RF-4", nullValue())
+                .header("X-RF-5", notNullValue())
+                .header("X-RF-6", nullValue())
+                .body(Matchers.is("ok1"));
+    }
+
+    @DisplayName("Should access to ko of resource 1 and call the expected exception mapper")
+    @Test
+    void should_call_ko_of_resource_1() {
+        when()
+                .get("/rt-1/ko")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_not_call_ok_of_resource_2() {
+        when()
+                .get("/rt-2/ok")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @IfBuildProfile("test")
+    @Path("rt-1")
+    public static class ResourceTest1 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok1";
+        }
+
+        @GET
+        @Path("ko")
+        public String ko() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @IfBuildProfile("foo")
+    @Path("rt-2")
+    public static class ResourceTest2 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok2";
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v1") // will be enabled because the value matches
+    @Provider
+    public static class ResponseFilter1 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-1", "Value");
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v") // won't be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter2 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-2", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v1") // will be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter3 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-3", "Value");
+        }
+    }
+
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v2") // won't be enabled because the value matches
+    @Provider
+    public static class ResponseFilter4 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-4", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ResponseFilter5 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-5", "Value");
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class ResponseFilter6 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-6", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class Feature1 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter3.class);
+            return true;
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class Feature2 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter4.class);
+            return true;
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper1 implements ExceptionMapper<RuntimeException> {
+
+        @Override
+        public Response toResponse(RuntimeException exception) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE.getStatusCode()).build();
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper2 implements ExceptionMapper<UnsupportedOperationException> {
+
+        @Override
+        public Response toResponse(UnsupportedOperationException exception) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED.getStatusCode()).build();
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class DynamicFeature1 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter5.class);
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class DynamicFeature2 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter6.class);
+        }
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/BuildProfileTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/BuildProfileTest.java
@@ -1,0 +1,240 @@
+package io.quarkus.resteasy.test.root;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The integration test for the support of build time conditions on JAX-RS resource classes.
+ */
+class BuildProfileTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            ResourceTest1.class, ResourceTest2.class, ResponseFilter1.class, ResponseFilter2.class,
+                            ResponseFilter3.class, ResponseFilter4.class, ResponseFilter5.class, ResponseFilter6.class,
+                            Feature1.class, Feature2.class, DynamicFeature1.class, DynamicFeature2.class,
+                            ExceptionMapper1.class, ExceptionMapper2.class))
+            .overrideConfigKey("some.prop1", "v1")
+            .overrideConfigKey("some.prop2", "v2");
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_call_ok_of_resource_1() {
+        when()
+                .get("/rt-1/ok")
+                .then()
+                .header("X-RF-1", notNullValue())
+                .header("X-RF-2", nullValue())
+                .header("X-RF-3", notNullValue())
+                .header("X-RF-4", nullValue())
+                .header("X-RF-5", notNullValue())
+                .header("X-RF-6", nullValue())
+                .body(Matchers.is("ok1"));
+    }
+
+    @DisplayName("Should access to ko of resource 1 and call the expected exception mapper")
+    @Test
+    void should_call_ko_of_resource_1() {
+        when()
+                .get("/rt-1/ko")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_not_call_ok_of_resource_2() {
+        when()
+                .get("/rt-2/ok")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @IfBuildProfile("test")
+    @Path("rt-1")
+    public static class ResourceTest1 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok1";
+        }
+
+        @GET
+        @Path("ko")
+        public String ko() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @IfBuildProfile("foo")
+    @Path("rt-2")
+    public static class ResourceTest2 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok2";
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v1") // will be enabled because the value matches
+    @Provider
+    public static class ResponseFilter1 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-1", "Value");
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v") // won't be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter2 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-2", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v1") // will be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter3 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-3", "Value");
+        }
+    }
+
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v2") // won't be enabled because the value matches
+    @Provider
+    public static class ResponseFilter4 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-4", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ResponseFilter5 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-5", "Value");
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class ResponseFilter6 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-6", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class Feature1 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter3.class);
+            return true;
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class Feature2 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter4.class);
+            return true;
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper1 implements ExceptionMapper<RuntimeException> {
+
+        @Override
+        public Response toResponse(RuntimeException exception) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE.getStatusCode()).build();
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper2 implements ExceptionMapper<UnsupportedOperationException> {
+
+        @Override
+        public Response toResponse(UnsupportedOperationException exception) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED.getStatusCode()).build();
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class DynamicFeature1 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter5.class);
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class DynamicFeature2 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter6.class);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -45,13 +45,13 @@ public class ResteasyReactiveScanner {
         BUILTIN_HTTP_ANNOTATIONS_TO_METHOD = Collections.unmodifiableMap(BUILTIN_HTTP_ANNOTATIONS_TO_METHOD);
     }
 
-    public static ApplicationScanningResult scanForApplicationClass(IndexView index) {
+    public static ApplicationScanningResult scanForApplicationClass(IndexView index, Set<String> excludedClasses) {
         Collection<ClassInfo> applications = index
                 .getAllKnownSubclasses(ResteasyReactiveDotNames.APPLICATION);
         Set<String> allowedClasses = new HashSet<>();
         Set<String> singletonClasses = new HashSet<>();
         Set<String> globalNameBindings = new HashSet<>();
-        boolean filterClasses = false;
+        boolean filterClasses = !excludedClasses.isEmpty();
         Application application = null;
         ClassInfo selectedAppClass = null;
         boolean blocking = false;
@@ -93,7 +93,8 @@ public class ResteasyReactiveScanner {
         if (selectedAppClass != null) {
             globalNameBindings = NameBindingUtil.nameBindingNames(index, selectedAppClass);
         }
-        return new ApplicationScanningResult(allowedClasses, singletonClasses, globalNameBindings, filterClasses, application,
+        return new ApplicationScanningResult(allowedClasses, singletonClasses, excludedClasses, globalNameBindings,
+                filterClasses, application,
                 selectedAppClass, blocking);
     }
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -207,7 +207,8 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
         }
 
         Index index = JandexUtil.createIndex(deploymentDir);
-        ApplicationScanningResult applicationScanningResult = ResteasyReactiveScanner.scanForApplicationClass(index);
+        ApplicationScanningResult applicationScanningResult = ResteasyReactiveScanner.scanForApplicationClass(index,
+                Collections.emptySet());
         ResourceScanningResult resources = ResteasyReactiveScanner.scanResources(index);
         if (resources == null) {
             throw new RuntimeException("no JAX-RS resources found");


### PR DESCRIPTION
fixes #15214 

## Motivation

The idea of this feature is to provide an easy way to include/exclude JAX-RS resource, provider and feature classes at build time by relying on the build time conditions

## Modifications:

* Makes `ResteasyReactiveCommonProcessor#handleApplication ` and `ResteasyServerCommonProcessor#build ` depend on `BuildTimeConditionBuildItem` to have access to all computed build time conditions.
* Adds a method `getExcludedClasses` to both extensions to retrieve the list of classes that need to be excluded
* Adds the property `buildTimeConditionAware` to both extensions to be able to disable the feature if needed knowing that it is enabled by default
* Ensures that the feature will be disabled if a JAX-RS Application with classes to include has been defined
* Adds a new build item `PreAdditionalBeanBuildTimeConditionBuildItem` to be able evaluate build time conditions before processing  `AdditionalBeanBuildItem` to avoid a circular dependency.

## Result

The JAX-RS classes can now be included/excluded thanks to the build time conditions