### PR TITLE
Add quarkus.servlet.max-parameters setting

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/MaxParametersTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/MaxParametersTestCase.java
@@ -1,0 +1,54 @@
+package io.quarkus.undertow.test;
+
+import java.net.SocketTimeoutException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Tests the quarkus.servlet.max-parameters setting.
+ */
+public class MaxParametersTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestServlet.class, TestGreeter.class)
+                    .addAsResource(new StringAsset("quarkus.servlet.max-parameters=10"), "application.properties"));
+
+    @Test
+    public void testSmallRequest() {
+        RestAssured.given()
+                .params(generateParameters(10))
+                .get("/test")
+                .then().statusCode(200).body(Matchers.equalTo("test servlet"));
+    }
+
+    @Test
+    public void testLargeRequest() {
+        // A throw of io.undertow.util.ParameterLimitException causes Undertow to close the
+        // connection immediately without responding to the HTTP request.
+        Assertions.assertThrows(SocketTimeoutException.class, () -> RestAssured.given()
+                .params(generateParameters(11))
+                .get("/test")
+                .then().statusCode(414));
+    }
+
+    private static Map<String, String> generateParameters(int count) {
+        Map<String, String> params = new HashMap<>();
+        for (int i = 0; i < count; i++) {
+            params.put(String.format("q%d", i), String.format("%d", i));
+        }
+        return params;
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
@@ -26,4 +26,11 @@ public class ServletRuntimeConfig {
     @ConfigItem
     Optional<Boolean> directBuffers;
 
+    /**
+     * The maximum number of HTTP request parameters permitted for Servlet requests.
+     *
+     * If a client sends more than this number of parameters in a request, the connection is closed.
+     */
+    @ConfigItem(defaultValue = "1000")
+    Optional<Integer> maxParameters;
 }

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
@@ -32,5 +32,5 @@ public class ServletRuntimeConfig {
      * If a client sends more than this number of parameters in a request, the connection is closed.
      */
     @ConfigItem(defaultValue = "1000")
-    Optional<Integer> maxParameters;
+    int maxParameters;
 }

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -54,6 +54,8 @@ import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.undertow.httpcore.BufferAllocator;
 import io.undertow.httpcore.StatusCodes;
+import io.undertow.httpcore.UndertowOptionMap;
+import io.undertow.httpcore.UndertowOptions;
 import io.undertow.security.api.AuthenticationMode;
 import io.undertow.security.api.NotificationReceiver;
 import io.undertow.security.api.SecurityNotification;
@@ -371,23 +373,34 @@ public class UndertowDeploymentRecorder {
         UndertowBufferAllocator allocator = new UndertowBufferAllocator(
                 servletRuntimeConfig.directBuffers.orElse(DEFAULT_DIRECT_BUFFERS), (int) servletRuntimeConfig.bufferSize
                         .orElse(new MemorySize(BigInteger.valueOf(DEFAULT_BUFFER_SIZE))).asLongValue());
+
+        UndertowOptionMap.Builder undertowOptions = UndertowOptionMap.builder();
+        undertowOptions.set(UndertowOptions.MAX_PARAMETERS, servletRuntimeConfig.maxParameters.orElse(0));
+        UndertowOptionMap undertowOptionMap = undertowOptions.getMap();
+
         return new Handler<RoutingContext>() {
             @Override
             public void handle(RoutingContext event) {
                 if (!event.request().isEnded()) {
                     event.request().pause();
                 }
+
                 //we handle auth failure directly
                 event.remove(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+
                 VertxHttpExchange exchange = new VertxHttpExchange(event.request(), allocator, executorService, event,
                         event.getBody());
                 exchange.setPushHandler(VertxHttpRecorder.getRootHandler());
+
                 Optional<MemorySize> maxBodySize = httpConfiguration.limits.maxBodySize;
                 if (maxBodySize.isPresent()) {
                     exchange.setMaxEntitySize(maxBodySize.get().asLongValue());
                 }
                 Duration readTimeout = httpConfiguration.readTimeout;
                 exchange.setReadTimeout(readTimeout.toMillis());
+
+                exchange.setUndertowOptions(undertowOptionMap);
+
                 //we eagerly dispatch to the exector, as Undertow needs to be blocking anyway
                 //its actually possible to be on a different IO thread at this point which confuses Undertow
                 //see https://github.com/quarkusio/quarkus/issues/7782

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -375,7 +375,7 @@ public class UndertowDeploymentRecorder {
                         .orElse(new MemorySize(BigInteger.valueOf(DEFAULT_BUFFER_SIZE))).asLongValue());
 
         UndertowOptionMap.Builder undertowOptions = UndertowOptionMap.builder();
-        undertowOptions.set(UndertowOptions.MAX_PARAMETERS, servletRuntimeConfig.maxParameters.orElse(0));
+        undertowOptions.set(UndertowOptions.MAX_PARAMETERS, servletRuntimeConfig.maxParameters);
         UndertowOptionMap undertowOptionMap = undertowOptions.getMap();
 
         return new Handler<RoutingContext>() {


### PR DESCRIPTION
This configures the MAX_PARAMETERS setting in Undertow, which defaults
to 1,000.

Makes use of the UndertowOptionsMap setter introduced in quarkus-http
commit 00223f28f17a246a3075b3f1ce38dc289976a641 and therefore depends on
quarkus-http 3.1.0.Beta2.

Fixes quarkusio/quarkus-http#63.