### PR TITLE
Update link to gradle limitations

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -9,7 +9,7 @@ include::./attributes.adoc[]
 
 CAUTION: Quarkus Gradle support is considered preview.
 You can use Gradle to create Quarkus projects as outlined in our guides. If you go beyond there will be cases where
-the Gradle tasks https://github.com/quarkusio/quarkus/issues/5101[does not behave as expected].
+the Gradle tasks https://github.com/quarkusio/quarkus/issues/10189[does not behave as expected].
 This is just a caution, and we recommend if you like Gradle you try it out and give us feedback.
 
 [[project-creation]]


### PR DESCRIPTION
The mentioned issue is close. This branch update the documentation to reference #10189 which refers important known issues/limitations. 