### PR TITLE
Only keep resteasy-qute example codestart binded to resteasy-qute

### DIFF
--- a/extensions/qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   categories:
   - "miscellaneous"
   status: "experimental"
-  codestart: "qute"
+  


### PR DESCRIPTION
This is a merge to the 1.11 branch