### PR TITLE
Add Jackson pointers with Kotlin and cleanup the example Gradle build scripts

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -190,24 +190,22 @@ Similar to the Maven configuration, when using Gradle, the following modificatio
 ----
 plugins {
     id 'java'
-    id 'io.quarkus' version '{quarkus-version}' // <1>
+    id 'io.quarkus' 
 
-    id "org.jetbrains.kotlin.jvm" version "{kotlin-version}" // <2>
-    id "org.jetbrains.kotlin.plugin.allopen" version "{kotlin-version}" // <2>
+    id "org.jetbrains.kotlin.jvm" version "{kotlin-version}" // <1>
+    id "org.jetbrains.kotlin.plugin.allopen" version "{kotlin-version}" // <1>
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
-
-group = '...' // set your group
-version = '1.0.0-SNAPSHOT'
 
 dependencies { 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:{kotlin-version}'
 
-    // <3>
-    implementation enforcedPlatform('io.quarkus:quarkus-bom:{quarkus-version}')
+   implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+ 
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-resteasy-jackson'
     implementation 'io.quarkus:quarkus-kotlin'
@@ -216,57 +214,67 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+group = '...' // set your group
+version = '1.0.0-SNAPSHOT'
 
-test {
-    useJUnitPlatform()
-    exclude '**/Native*'
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
-buildNative {
-    enableHttpUrlHandler = true
-}
-
-allOpen { // <4>
+allOpen { // <2>
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
+
+compileKotlin {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+    kotlinOptions.javaParameters = true
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+}
 ----
 
-<1> The Quarkus plugin needs to be applied.
-<2> The Kotlin plugin version needs to be specified.
-<3> We include the Quarkus BOM using Gradle's link:https://docs.gradle.org/5.4.1/userguide/managing_transitive_dependencies.html#sec:bom_import[relevant syntax]
-<4> The all-open configuration required, as per Maven guide above
+<1> The Kotlin plugin version needs to be specified.
+<2> The all-open configuration required, as per Maven guide above
 
 or, if you use the Gradle Kotlin DSL:
 
 [source,kotlin,subs=attributes+]
 ----
-import io.quarkus.gradle.tasks.QuarkusNative
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "{kotlin-version}" // <1>
+    kotlin("plugin.allopen") version "{kotlin-version}"
+    id("io.quarkus")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
 
 group = "..."
 version = "1.0.0-SNAPSHOT"
 
-plugins {
-    java
-    id("io.quarkus") version "{quarkus-version}" // <1>
-
-    kotlin("jvm") version "{kotlin-version}" // <2>
-    id("org.jetbrains.kotlin.plugin.allopen") version "{kotlin-version}" // <2>
-}
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
-    // <3>
-    implementation(enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}"))
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+
     implementation("io.quarkus:quarkus-kotlin")
     implementation("io.quarkus:quarkus-resteasy")
     implementation("io.quarkus:quarkus-resteasy-jackson")
@@ -275,38 +283,106 @@ dependencies {
     testImplementation("io.rest-assured:rest-assured")
 }
 
-tasks {
-    named<QuarkusNative>("buildNative") {
-        setEnableHttpUrlHandler(true)
-    }
+group = '...' // set your group
+version = "1.0.0-SNAPSHOT"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
-allOpen { // <4>
+allOpen { // <2>
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+    kotlinOptions.javaParameters = true
 }
 
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
-}
-
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
-}
 ----
 
-<1> The Quarkus plugin needs to be applied.
-<2> The Kotlin plugin version needs to be specified.
-<3> We include the Quarkus BOM using Gradle's link:https://docs.gradle.org/5.4.1/userguide/managing_transitive_dependencies.html#sec:bom_import[relevant syntax]
-<4> The all-open configuration required, as per Maven guide above
+<1> The Kotlin plugin version needs to be specified.
+<2> The all-open configuration required, as per Maven guide above
+
+
+
+== Live reload
+
+Quarkus provides support for live reloading changes made to source code. This support is also available to Kotlin, meaning that developers can update their Kotlin source
+code and immediately see their changes reflected.
+
+To see this feature in action, first execute: `./mvnw compile quarkus:dev`
+
+When executing an HTTP GET request against `http://localhost:8080/greeting`, you see a JSON message with the value `hello` as its `message` field.
+
+Now using your favorite editor or IDE, update `GreetingResource.kt` and change the `hello` method to the following:
+
+[source,kotlin]
+----
+fun hello() = Greeting("hi")
+----
+
+When you now execute an HTTP GET request against `http://localhost:8080/greeting`, you should see a JSON message with the value `hi` as its `message` field.
+
+One thing to note is that the live reload feature is not available when making changes to both Java and Kotlin source that have dependencies on each other. We hope to alleviate this limitation in the future.
+
+== Packaging the application
+
+As usual, the application can be packaged using `./mvnw clean package` and executed using the `target/quarkus-app/quarkus-run.jar` file. You can also build the native executable using `./mvnw package -Pnative`, or `./gradlew buildNative`.
+
+== Kotlin and Jackson
+
+If the `com.fasterxml.jackson.module:jackson-module-kotlin` dependency and the `quarkus-jackson` extension (or the `quarkus-resteasy-jackson` extension) have been added to the project,
+then Quarkus automatically registers the `KotlinModule` to the `ObjectMapper` bean (see link:rest-json#jackson[this] guide for more details).
+
+When using Kotlin data classes with `native-image` you may experience serialization errors that do not occur with the `JVM` version, despite the Kotlin Jackson Module being registered. This is especially so if you have a more complex JSON hierarchy, where an issue on a lower node causes a serialization failure. The error message displayed is a catch-all and typically displays an issue with the root object, which may not necessarily be the case.
+
+[source]
+----
+com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `Address` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
+----
+
+To ensure full-compability with `native-image`, it is recommended to apply the Jackson `@field:JsonProperty("fieldName")` annotation, and set a nullable default, as illustrated below. You can automate the generation of Kotlin data classes for your sample JSON using Intellij plugins (such as JSON to Kotlin Class), and easily enable the Jackson annotation and select nullable parameters as part of the auto-code generation.
+
+[source,kotlin]
+----
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class Response(
+	@field:JsonProperty("chart")
+	val chart: ChartData? = null
+)
+
+data class ChartData(
+	@field:JsonProperty("result")
+	val result: List<ResultItem?>? = null,
+
+	@field:JsonProperty("error")
+	val error: Any? = null
+)
+
+data class ResultItem(
+	@field:JsonProperty("meta")
+	val meta: Meta? = null,
+
+	@field:JsonProperty("indicators")
+	val indicators: IndicatorItems? = null,
+
+	@field:JsonProperty("timestamp")
+	val timestamp: List<Int?>? = null
+)
+
+...
+----
+
+
+== Kotlin coroutines and Mutiny
+
+Kotlin coroutines provide a imperative programming model that actually gets executed in an asynchronous, reactive manner.
+To simplify the interoperation between Mutiny and Kotlin there is the module `io.smallrye.reactive:mutiny-kotlin`, described link:https://smallrye.io/smallrye-mutiny/guides/kotlin[here].
 
 == CDI @Inject with Kotlin
 
@@ -360,37 +436,3 @@ class GreetingResource {
 <1> Kotlin requires a @field: xxx qualifier as it has no @Target on the annotation definition. Add @field: xxx in this example. @Default is used as the qualifier, explicitly specifying the use of the default bean.
 
 
-
-== Live reload
-
-Quarkus provides support for live reloading changes made to source code. This support is also available to Kotlin, meaning that developers can update their Kotlin source
-code and immediately see their changes reflected.
-
-To see this feature in action, first execute: `./mvnw compile quarkus:dev`
-
-When executing an HTTP GET request against `http://localhost:8080/greeting`, you see a JSON message with the value `hello` as its `message` field.
-
-Now using your favorite editor or IDE, update `GreetingResource.kt` and change the `hello` method to the following:
-
-[source,kotlin]
-----
-fun hello() = Greeting("hi")
-----
-
-When you now execute an HTTP GET request against `http://localhost:8080/greeting`, you should see a JSON message with the value `hi` as its `message` field.
-
-One thing to note is that the live reload feature is not available when making changes to both Java and Kotlin source that have dependencies on each other. We hope to alleviate this limitation in the future.
-
-== Packaging the application
-
-As usual, the application can be packaged using `./mvnw clean package` and executed using the `target/quarkus-app/quarkus-run.jar` file. You can also build the native executable using `./mvnw package -Pnative`, or `./gradlew buildNative`.
-
-== Kotlin and Jackson
-
-If the `com.fasterxml.jackson.module:jackson-module-kotlin` dependency and the `quarkus-jackson` extension (or the `quarkus-resteasy-jackson` extension) have been added to the project,
-then Quarkus automatically registers the `KotlinModule` to the `ObjectMapper` bean (see link:rest-json#jackson[this] guide for more details).
-
-== Kotlin coroutines and Mutiny
-
-Kotlin coroutines provide a imperative programming model that actually gets executed in an asynchronous, reactive manner.
-To simplify the interoperation between Mutiny and Kotlin there is the module `io.smallrye.reactive:mutiny-kotlin`, described link:https://smallrye.io/smallrye-mutiny/guides/kotlin[here].


### PR DESCRIPTION
What works on the JVM doesn't always work for native-image.  This is particularly true for Kotlin Jackson serialisation.  Provide guidance in the docs to help overcome these issues, which is to add the Jackson field annotation, and also to set nullable parameters. Coverage of the issue can be seen in #3954.

The Gradle build scripts are now outdated. I've updated them in line with the Code-with-Quarkus defaults, and Java 11. 

I've also re-ordered one section for the CDI since this issue is no longer present in Quarkus, and put it at the end (I had contributed this in the guide earlier), which shows some noise in + - in the diff.

\CC @geoand 

