### PR TITLE
Wrap REST Data Panache exceptions for handling

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -20,8 +20,10 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 class HibernateOrmPanacheRestProcessor {
 
@@ -34,6 +36,11 @@ class HibernateOrmPanacheRestProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(HIBERNATE_ORM_REST_DATA_PANACHE);
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     /**

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/ResourceImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/ResourceImplementor.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
 
 import org.jboss.jandex.FieldInfo;
 import org.jboss.logging.Logger;
@@ -89,6 +90,7 @@ class ResourceImplementor {
 
     private void implementAdd(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("add", Object.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle entity = methodCreator.getMethodParam(0);
         methodCreator.returnValue(dataAccessImplementor.persist(methodCreator, entity));
         methodCreator.close();
@@ -97,6 +99,7 @@ class ResourceImplementor {
     private void implementUpdate(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor,
             String entityType) {
         MethodCreator methodCreator = classCreator.getMethodCreator("update", Object.class, Object.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
         ResultHandle entity = methodCreator.getMethodParam(1);
         // Set entity ID before executing an update to make sure that a requested object ID matches a given entity ID.
@@ -107,6 +110,7 @@ class ResourceImplementor {
 
     private void implementDelete(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("delete", boolean.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
         methodCreator.returnValue(dataAccessImplementor.deleteById(methodCreator, id));
         methodCreator.close();

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPostMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPostMethodTest.java
@@ -60,6 +60,11 @@ public abstract class AbstractPostMethodTest {
                 .and().body("id", is(equalTo("test-complex")))
                 .and().body("name", is(equalTo("test collection")))
                 .and().body("items", is(empty()));
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"test-complex\", \"name\": \"test collection\"}")
+                .when().post("/collections")
+                .then().statusCode(409);
     }
 
     @Test
@@ -78,5 +83,10 @@ public abstract class AbstractPostMethodTest {
                 .and().body("_links.self.href", endsWith("/collections/test-complex-hal"))
                 .and().body("_links.update.href", endsWith("/collections/test-complex-hal"))
                 .and().body("_links.remove.href", endsWith("/collections/test-complex-hal"));
+        given().accept("application/hal+json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"test-complex-hal\", \"name\": \"test collection\"}")
+                .when().post("/collections")
+                .then().statusCode(409);
     }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.rest.data.panache.runtime;
+
+import javax.persistence.PersistenceException;
+import javax.transaction.RollbackException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+import io.quarkus.arc.ArcUndeclaredThrowableException;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
+
+public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+    @Override
+    public Response toResponse(RestDataPanacheException exception) {
+        exception.printStackTrace();
+
+        if (exception.getCause() instanceof ArcUndeclaredThrowableException) {
+            return toResponse((ArcUndeclaredThrowableException) exception.getCause(), exception.getMessage());
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), exception.getMessage()).build();
+    }
+
+    private Response toResponse(ArcUndeclaredThrowableException exception, String message) {
+        if (exception.getCause() instanceof RollbackException) {
+            return toResponse((RollbackException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(RollbackException exception, String message) {
+        if (exception.getCause() instanceof PersistenceException) {
+            return toResponse((PersistenceException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(PersistenceException exception, String message) {
+        if (exception.getCause() instanceof ConstraintViolationException) {
+            return toResponse((ConstraintViolationException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(ConstraintViolationException exception, String message) {
+        return Response.status(Response.Status.CONFLICT.getStatusCode(), message).build();
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -2,11 +2,14 @@ package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 
+import javax.ws.rs.core.Response;
+
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -33,12 +36,16 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
      *         rel = "self",
      *         entityClassName = "com.example.Entity"
      *     )
-     *     public Entity get(@PathParam("id") ID id) {
-     *         Entity entity = restDataResource.get(id);
-     *         if (entity != null) {
-     *             return entity;
-     *         } else {
-     *             throw new WebApplicationException(404);
+     *     public Response get(@PathParam("id") ID id) {
+     *         try {
+     *             Entity entity = restDataResource.get(id);
+     *             if (entity != null) {
+     *                 return entity;
+     *             } else {
+     *                 return Response.status(404).build();
+     *             }
+     *         } catch (Throwable t) {
+     *             throw new RestDataPanacheException(t);
      *         }
      *     }
      * }
@@ -47,7 +54,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, resourceMetadata.getEntityType(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getIdType());
 
         // Add method annotations
@@ -57,17 +64,21 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);
-        ResultHandle entity = methodCreator.invokeVirtualMethod(
+
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to get an entity");
+        ResultHandle entity = tryBlock.invokeVirtualMethod(
                 ofMethod(resourceMetadata.getResourceClass(), RESOURCE_METHOD_NAME, Object.class, Object.class),
                 resource, id);
-        BranchResult entityNotFound = methodCreator.ifNull(entity);
 
         // Return response
-        entityNotFound.trueBranch().throwException(ResponseImplementor.notFoundException(entityNotFound.trueBranch()));
-        entityNotFound.falseBranch().returnValue(entity);
+        BranchResult wasNotFound = tryBlock.ifNull(entity);
+        wasNotFound.trueBranch().returnValue(ResponseImplementor.notFound(wasNotFound.trueBranch()));
+        wasNotFound.falseBranch().returnValue(ResponseImplementor.ok(wasNotFound.falseBranch(), entity));
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -1,6 +1,5 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
-import javax.transaction.Transactional;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -17,8 +16,12 @@ import org.jboss.resteasy.links.LinkResource;
 
 import io.quarkus.gizmo.AnnotatedElement;
 import io.quarkus.gizmo.AnnotationCreator;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.rest.data.panache.runtime.sort.SortQueryParamValidator;
@@ -50,8 +53,12 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
      */
     protected abstract String getResourceMethodName();
 
-    protected void addTransactionalAnnotation(AnnotatedElement element) {
-        element.addAnnotation(Transactional.class);
+    protected TryBlock implementTryBlock(BytecodeCreator bytecodeCreator, String message) {
+        TryBlock tryBlock = bytecodeCreator.tryBlock();
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.throwException(RestDataPanacheException.class, message, catchBlock.getCaughtException());
+        catchBlock.close();
+        return tryBlock;
     }
 
     protected void addGetAnnotation(AnnotatedElement element) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -10,6 +10,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -32,7 +33,6 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
      *
      * <pre>
      * {@code
-     *     &#64;Transactional
      *     &#64;PUT
      *     &#64;Path("{id}")
      *     &#64;Consumes({"application/json"})
@@ -42,19 +42,23 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
      *         entityClassName = "com.example.Entity"
      *     )
      *     public Response update(@PathParam("id") ID id, Entity entityToSave) {
-     *         if (resource.get(id) != null) {
-     *             resource.update(id, entityToSave);
-     *             return Response.status(204).build();
-     *         } else {
-     *             Entity entity = resource.update(id, entityToSave);
-     *             String location = new ResourceLinksProvider().getSelfLink(entity);
-     *             if (location != null) {
-     *                 ResponseBuilder responseBuilder = Response.status(201);
-     *                 responseBuilder.entity(entity);
-     *                 responseBuilder.location(URI.create(location));
-     *                 return responseBuilder.build();
+     *         try {
+     *             if (resource.get(id) != null) {
+     *                 resource.update(id, entityToSave);
+     *                 return Response.status(204).build();
      *             } else {
-     *                 throw new RuntimeException("Could not extract a new entity URL")
+     *                 Entity entity = resource.update(id, entityToSave);
+     *                 String location = new ResourceLinksProvider().getSelfLink(entity);
+     *                 if (location != null) {
+     *                     ResponseBuilder responseBuilder = Response.status(201);
+     *                     responseBuilder.entity(entity);
+     *                     responseBuilder.location(URI.create(location));
+     *                     return responseBuilder.build();
+     *                 } else {
+     *                     throw new RuntimeException("Could not extract a new entity URL")
+     *                 }
+     *             } catch (Throwable t) {
+     *                 throw new RestDataPanacheException(t);
      *             }
      *         }
      *     }
@@ -64,27 +68,29 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class.getName(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getIdType(), resourceMetadata.getEntityType());
 
         // Add method annotations
         addPathAnnotation(methodCreator,
                 appendToPath(resourceProperties.getPath(RESOURCE_UPDATE_METHOD_NAME), "{id}"));
-        addTransactionalAnnotation(methodCreator);
         addPutAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);
         ResultHandle entityToSave = methodCreator.getMethodParam(1);
 
-        BranchResult entityExists = doesEntityExist(methodCreator, resourceMetadata.getResourceClass(), resource, id);
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to update an entity");
+        BranchResult entityExists = doesEntityExist(tryBlock, resourceMetadata.getResourceClass(), resource, id);
         updateAndReturn(entityExists.trueBranch(), resourceMetadata.getResourceClass(), resource, id, entityToSave);
         createAndReturn(entityExists.falseBranch(), resourceMetadata.getResourceClass(), resource, id, entityToSave);
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
@@ -8,6 +8,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -25,22 +26,25 @@ public final class AddHalMethodImplementor extends HalMethodImplementor {
      *
      * <pre>
      * {@code
-     *     &#64;Transactional
      *     &#64;POST
      *     &#64;Path("")
      *     &#64;Consumes({"application/json"})
      *     &#64;Produces({"application/hal+json"})
      *     public Response addHal(Entity entityToSave) {
-     *         Entity entity = resource.add(entityToSave);
-     *         HalEntityWrapper wrapper = new HalEntityWrapper(entity);
-     *         String location = new ResourceLinksProvider().getSelfLink(entity);
-     *         if (location != null) {
-     *             ResponseBuilder responseBuilder = Response.status(201);
-     *             responseBuilder.entity(wrapper);
-     *             responseBuilder.location(URI.create(location));
-     *             return responseBuilder.build();
-     *         } else {
-     *             throw new RuntimeException("Could not extract a new entity URL")
+     *         try {
+     *             Entity entity = resource.add(entityToSave);
+     *             HalEntityWrapper wrapper = new HalEntityWrapper(entity);
+     *             String location = new ResourceLinksProvider().getSelfLink(entity);
+     *             if (location != null) {
+     *                 ResponseBuilder responseBuilder = Response.status(201);
+     *                 responseBuilder.entity(wrapper);
+     *                 responseBuilder.location(URI.create(location));
+     *                 return responseBuilder.build();
+     *             } else {
+     *                 throw new RuntimeException("Could not extract a new entity URL");
+     *             }
+     *         } catch (Throwable t) {
+     *             throw new RestDataPanacheException(t);
      *         }
      *     }
      * }
@@ -49,26 +53,29 @@ public final class AddHalMethodImplementor extends HalMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class.getName(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getEntityType());
 
         // Add method annotations
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
-        addTransactionalAnnotation(methodCreator);
         addPostAnnotation(methodCreator);
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle entityToSave = methodCreator.getMethodParam(0);
-        ResultHandle entity = methodCreator.invokeVirtualMethod(
+
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to add an entity");
+        ResultHandle entity = tryBlock.invokeVirtualMethod(
                 ofMethod(resourceMetadata.getResourceClass(), RESOURCE_METHOD_NAME, Object.class, Object.class),
                 resource, entityToSave);
 
         // Wrap and return response
-        methodCreator.returnValue(ResponseImplementor.created(methodCreator, wrapHalEntity(methodCreator, entity),
-                ResponseImplementor.getEntityUrl(methodCreator, entity)));
+        tryBlock.returnValue(ResponseImplementor.created(tryBlock, wrapHalEntity(tryBlock, entity),
+                ResponseImplementor.getEntityUrl(tryBlock, entity)));
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -55,6 +55,10 @@ public final class ResponseImplementor {
         return status(creator, Response.Status.NO_CONTENT.getStatusCode());
     }
 
+    public static ResultHandle notFound(BytecodeCreator creator) {
+        return status(creator, Response.Status.NOT_FOUND.getStatusCode());
+    }
+
     public static ResultHandle notFoundException(BytecodeCreator creator) {
         return creator.newInstance(MethodDescriptor.ofConstructor(WebApplicationException.class, int.class),
                 creator.load(Response.Status.NOT_FOUND.getStatusCode()));

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataPanacheException.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataPanacheException.java
@@ -1,0 +1,8 @@
+package io.quarkus.rest.data.panache;
+
+public class RestDataPanacheException extends RuntimeException {
+
+    public RestDataPanacheException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
This change wraps all data access logic with a try/catch block which then wraps any caught `Throwable` to a `RestDataPanacheException`. This will allow us to provide custom exception mappers. For now I've added a single mapper in a Hibernate module that maps a JPA constraint exception to an HTTP 409 exception.

Fixes https://github.com/quarkusio/quarkus/issues/14281