### PR TITLE
Added filter and other updates to config screen in Dev UI

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -27,7 +27,7 @@
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <jaeger.version>0.34.3</jaeger.version>
-        <quarkus-http.version>3.1.0.Beta1</quarkus-http.version>
+        <quarkus-http.version>3.1.0.Beta2</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <threetenbp.version>1.4.3</threetenbp.version>
         <micrometer.version>1.6.4</micrometer.version> <!-- when updating, verify if com.google.auth should not be updated too -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -180,7 +180,7 @@
         <quarkus-spring-security-api.version>5.2.Final</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <htmlunit.version>2.40.0</htmlunit.version>
-        <mockito.version>3.7.7</mockito.version>
+        <mockito.version>3.8.0</mockito.version>
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.8</antlr.version>
         <quarkus-security.version>1.1.3.Final</quarkus-security.version>

--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -222,6 +222,55 @@ HTTP response messages and the `sam.yaml` file must configure the API Gateway to
         - "*/*"
 ----
 
+== Injectable AWS Context Variables
+
+If you are using Resteasy and JAX-RS, you can inject various AWS Context variables into your JAX-RS resource classes
+using the JAX-RS `@Context` annotation.
+
+For the AWS HTTP API you can inject the AWS variables `com.amazonaws.services.lambda.runtime.Context` and
+`com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent`.  Here is an example:
+
+[source, java]
+----
+import javax.ws.rs.core.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+
+@Path("/myresource")
+public class MyResource {
+    @GET
+    public String ctx(@Context com.amazonaws.services.lambda.runtime.Context ctx) { }
+
+    @GET
+    public String event(@Context APIGatewayV2HTTPEvent event) { }
+
+    @GET
+    public String requestContext(@Context APIGatewayV2HTTPEvent.RequestContext req) { }
+
+
+}
+----
+
+For the AWS REST API you can inject the AWS variables `com.amazonaws.services.lambda.runtime.Context` and
+`io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext`.  Here is an example:
+
+[source, java]
+----
+import javax.ws.rs.core.Context;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+
+
+@Path("/myresource")
+public class MyResource {
+    @GET
+    public String ctx(@Context com.amazonaws.services.lambda.runtime.Context ctx) { }
+
+    @GET
+    public String req(@Context AwsProxyRequestContext req) { }
+
+}
+----
+
 == Tracing with AWS XRay and GraalVM
 
 If you are building native images, and want to use https://aws.amazon.com/xray[AWS X-Ray Tracing] with your lambda

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -64,7 +64,7 @@ link:qute[the Qute template engine].
 This also means that you can link:qute-reference#user_tags[add custom Qute tags] in 
 `/dev-templates/tags` for your templates to use.
 
-The style system currently in use is https://getbootstrap.com/docs/4.0/getting-started/introduction/[Bootstrap V4 (4.5.3)]
+The style system currently in use is https://getbootstrap.com/docs/4.6/getting-started/introduction/[Bootstrap V4 (4.6.0)]
 but note that this might change in the future.
 
 The main template also includes https://jquery.com/[jQuery 3.5.1], but here again this might change.
@@ -94,8 +94,15 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
             color: gray;
         }
     {/style}
-    {#title}Cache{/title}// <3>
-    {#body}// <4>
+    {#script} // <3>
+    $(document).ready(function(){
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        });
+    });
+    {/script}
+    {#title}Cache{/title}// <4>
+    {#body}// <5>
         <table class="table table-striped custom">
             <thead class="thead-dark">
                 <tr>
@@ -104,13 +111,13 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
                 </tr>
             </thead>
             <tbody>
-                {#for cacheInfo in info:cacheInfos}// <5>
+                {#for cacheInfo in info:cacheInfos}// <6>
                     <tr>
                         <td>
                             {cacheInfo.name}
                         </td>
                         <td>
-                            <form method="post"// <6> 
+                            <form method="post"// <7> 
                                   enctype="application/x-www-form-urlencoded">
                                 <label class="form-check-label" for="clear">
                                     {cacheInfo.size}
@@ -129,11 +136,12 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
 ----
 <1> In order to benefit from the same style as other Dev UI pages, extend the `main` template
 <2> You can pass extra CSS for your page in the `style` template parameter
-<3> Don't forget to set your page title in the `title` template parameter
-<4> The `body` template parameter will contain your content
-<5> In order for your template to read custom information from your Quarkus extension, you can use
+<3> You can pass extra JavaScript for your page in the `script` template parameter. This will be added inline after the JQuery script, so you can safely use JQuery in your script.
+<4> Don't forget to set your page title in the `title` template parameter
+<5> The `body` template parameter will contain your content
+<6> In order for your template to read custom information from your Quarkus extension, you can use
     the `info` link:qute-reference#namespace_extension_methods[namespace].
-<6> This shows an <<advanced-usage-adding-actions,interactive page>>
+<7> This shows an <<advanced-usage-adding-actions,interactive page>>
 
 == Linking to your full-page templates
 

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -663,6 +663,28 @@ If set to `true` (default) then a *single instance* of a resource class is creat
 If set to `false` then a *new instance* of the resource class is created per each request.
 An explicit CDI scope annotation (`@RequestScoped`, `@ApplicationScoped`, etc.) always overrides the default behavior and specifies the lifecycle of resource instances.
 
+== Include/Exclude JAX-RS classes with build time conditions
+
+Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.
+Thus, the various JAX-RS classes can be annotated with profile conditions (`@io.quarkus.arc.profile.IfBuildProfile` or `@io.quarkus.arc.profile.UnlessBuildProfile`) and/or with property conditions (`io.quarkus.arc.properties.IfBuildProperty` or `io.quarkus.arc.properties.UnlessBuildProperty`) to indicate to Quarkus at build time under which conditions these JAX-RS classes should be included.
+
+In the following example, Quarkus includes the endpoint `sayHello` if and only if the build profile `app1` has been enabled.
+
+[source,java]
+----
+@IfBuildProfile("app1")
+public class ResourceForApp1Only {
+
+    @GET
+    @Path("sayHello")
+    public String sayHello() {
+        return "hello";
+     }
+}
+----
+
+Please note that if a JAX-RS Application has been detected and the method `getClasses()` and/or `getSingletons()` has/have been overridden, Quarkus will ignore the build time conditions and consider only what has been defined in the JAX-RS Application.
+
 == Conclusion
 
 Creating JSON REST services with Quarkus is easy as it relies on proven and well known technologies.

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -222,7 +222,32 @@ public class RegisterCustomModuleCustomizer implements ObjectMapperCustomizer {
 
 Users can even provide their own `ObjectMapper` bean if they so choose.
 If this is done, it is very important to manually inject and apply all `io.quarkus.jackson.ObjectMapperCustomizer` beans in the CDI producer that produces `ObjectMapper`.
-Failure to do so will prevent Jackson specific customizations provided by various extensions from being applied.
+Failure to do so will prevent Jackson specific customizations provided by various extensions from being applied. 
+
+[source,java]
+----
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Singleton;
+
+public class CustomObjectMapper {
+
+    // Replaces the CDI producer for ObjectMapper built into Quarkus
+    @Singleton
+    ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers) {
+        ObjectMapper mapper = myObjectMapper(); // Custom `ObjectMapper`
+
+        // Apply all ObjectMapperCustomerizer beans (incl. Quarkus)
+        for (ObjectMapperCustomizer customizer : customizers) {
+            customizer.customize(mapper);
+        }
+
+        return mapper;
+    }
+}
+----
 
 ==== JSON-B
 
@@ -251,6 +276,32 @@ public class FooSerializerRegistrationCustomizer implements JsonbConfigCustomize
 A more advanced option would be to directly provide a bean of `javax.json.bind.JsonbConfig` (with a `Dependent` scope) or in the extreme case to provide a bean of type `javax.json.bind.Jsonb` (with a `Singleton` scope).
 If the latter approach is leveraged it is very important to manually inject and apply all `io.quarkus.jsonb.JsonbConfigCustomizer` beans in the CDI producer that produces `javax.json.bind.Jsonb`.
 Failure to do so will prevent JSON-B specific customizations provided by various extensions from being applied.
+
+[source,java]
+----
+import io.quarkus.jsonb.JsonbConfigCustomizer;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.json.bind.JsonbConfig;
+
+public class CustomJsonbConfig {
+
+    // Replaces the CDI producer for JsonbConfig built into Quarkus
+    @Dependent
+    JsonbConfig jsonConfig(Instance<JsonbConfigCustomizer> customizers) {
+        JsonbConfig config = myJsonbConfig(); // Custom `JsonbConfig`
+
+        // Apply all JsonbConfigCustomizer beans (incl. Quarkus)
+        for (JsonbConfigCustomizer customizer : customizers) {
+            customizer.customize(config);
+        }
+
+        return config;
+    }
+}
+----
+
 
 == Creating a frontend
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1790,3 +1790,25 @@ Or plain text:
 < 
 < {"name":"roquefort"} 
 ----
+
+== Include/Exclude JAX-RS classes with build time conditions
+
+Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.
+Thus, the various JAX-RS classes can be annotated with profile conditions (`@io.quarkus.arc.profile.IfBuildProfile` or `@io.quarkus.arc.profile.UnlessBuildProfile`) and/or with property conditions (`io.quarkus.arc.properties.IfBuildProperty` or `io.quarkus.arc.properties.UnlessBuildProperty`) to indicate to Quarkus at build time under which conditions these JAX-RS classes should be included.
+
+In the following example, Quarkus includes the endpoint `sayHello` if and only if the build profile `app1` has been enabled.
+
+[source,java]
+----
+@IfBuildProfile("app1")
+public class ResourceForApp1Only {
+
+    @GET
+    @Path("sayHello")
+    public String sayHello() {
+        return "hello";
+     }
+}
+----
+
+Please note that if a JAX-RS Application has been detected and the method `getClasses()` and/or `getSingletons()` has/have been overridden, Quarkus will ignore the build time conditions and consider only what has been defined in the JAX-RS Application.

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
@@ -1,0 +1,40 @@
+package io.quarkus.arc.deployment;
+
+import org.jboss.jandex.AnnotationTarget;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A type of build item that is similar to {@link BuildTimeConditionBuildItem} but evaluated before
+ * processing the {@link AdditionalBeanBuildItem} in order to filter the beans thanks to build time conditions
+ * before actually adding them with a {@link AdditionalBeanBuildItem}.
+ *
+ * @see io.quarkus.arc.deployment.BuildTimeConditionBuildItem
+ * @see io.quarkus.arc.deployment.AdditionalBeanBuildItem
+ */
+public final class PreAdditionalBeanBuildTimeConditionBuildItem extends MultiBuildItem {
+
+    private final AnnotationTarget target;
+    private final boolean enabled;
+
+    public PreAdditionalBeanBuildTimeConditionBuildItem(AnnotationTarget target, boolean enabled) {
+        switch (target.kind()) {
+            case CLASS:
+            case METHOD:
+            case FIELD:
+                this.target = target;
+                break;
+            default:
+                throw new IllegalArgumentException("'target' can only be a class, a field or a method");
+        }
+        this.enabled = enabled;
+    }
+
+    public AnnotationTarget getTarget() {
+        return target;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProvider.java
+++ b/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProvider.java
@@ -84,7 +84,8 @@ public class KubernetesServiceBindingConfigSourceProvider implements ConfigSourc
             Map<String, String> serviceBindingProperties = serviceBinding.getProperties();
             Map<String, String> rawConfigSourceProperties = new HashMap<>();
             for (Map.Entry<String, String> entry : serviceBindingProperties.entrySet()) {
-                rawConfigSourceProperties.put("quarkus." + serviceBinding.getName() + "." + entry.getKey(), entry.getValue());
+                rawConfigSourceProperties.put("quarkus.service-binding." + serviceBinding.getName() + "." + entry.getKey(),
+                        entry.getValue());
             }
             result.add(new ServiceBindingConfigSource("service-binding-" + serviceBinding.getName() + "-raw",
                     rawConfigSourceProperties));

--- a/extensions/kubernetes-service-binding/runtime/src/test/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProviderTest.java
+++ b/extensions/kubernetes-service-binding/runtime/src/test/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProviderTest.java
@@ -64,8 +64,8 @@ class KubernetesServiceBindingConfigSourceProviderTest {
         assertThat(configSources).filteredOn(c -> c.getName().equals("service-binding-test-name-raw")).singleElement()
                 .satisfies(c -> {
                     assertThat(c.getProperties()).containsOnly(
-                            entry("quarkus.test-name.test-secret-key", "test-secret-value-2"),
-                            entry("quarkus.test-name.test-other-secret-key", "test-other-secret-value-2"));
+                            entry("quarkus.service-binding.test-name.test-secret-key", "test-secret-value-2"),
+                            entry("quarkus.service-binding.test-name.test-other-secret-key", "test-other-secret-value-2"));
                 });
     }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -20,8 +20,10 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 class HibernateOrmPanacheRestProcessor {
 
@@ -34,6 +36,11 @@ class HibernateOrmPanacheRestProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(HIBERNATE_ORM_REST_DATA_PANACHE);
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     /**

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/ResourceImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/ResourceImplementor.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
 
 import org.jboss.jandex.FieldInfo;
 import org.jboss.logging.Logger;
@@ -89,6 +90,7 @@ class ResourceImplementor {
 
     private void implementAdd(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("add", Object.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle entity = methodCreator.getMethodParam(0);
         methodCreator.returnValue(dataAccessImplementor.persist(methodCreator, entity));
         methodCreator.close();
@@ -97,6 +99,7 @@ class ResourceImplementor {
     private void implementUpdate(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor,
             String entityType) {
         MethodCreator methodCreator = classCreator.getMethodCreator("update", Object.class, Object.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
         ResultHandle entity = methodCreator.getMethodParam(1);
         // Set entity ID before executing an update to make sure that a requested object ID matches a given entity ID.
@@ -107,6 +110,7 @@ class ResourceImplementor {
 
     private void implementDelete(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("delete", boolean.class, Object.class);
+        methodCreator.addAnnotation(Transactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
         methodCreator.returnValue(dataAccessImplementor.deleteById(methodCreator, id));
         methodCreator.close();

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPostMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPostMethodTest.java
@@ -60,6 +60,11 @@ public abstract class AbstractPostMethodTest {
                 .and().body("id", is(equalTo("test-complex")))
                 .and().body("name", is(equalTo("test collection")))
                 .and().body("items", is(empty()));
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"test-complex\", \"name\": \"test collection\"}")
+                .when().post("/collections")
+                .then().statusCode(409);
     }
 
     @Test
@@ -78,5 +83,10 @@ public abstract class AbstractPostMethodTest {
                 .and().body("_links.self.href", endsWith("/collections/test-complex-hal"))
                 .and().body("_links.update.href", endsWith("/collections/test-complex-hal"))
                 .and().body("_links.remove.href", endsWith("/collections/test-complex-hal"));
+        given().accept("application/hal+json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"test-complex-hal\", \"name\": \"test collection\"}")
+                .when().post("/collections")
+                .then().statusCode(409);
     }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.rest.data.panache.runtime;
+
+import javax.persistence.PersistenceException;
+import javax.transaction.RollbackException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+import io.quarkus.arc.ArcUndeclaredThrowableException;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
+
+public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+    @Override
+    public Response toResponse(RestDataPanacheException exception) {
+        exception.printStackTrace();
+
+        if (exception.getCause() instanceof ArcUndeclaredThrowableException) {
+            return toResponse((ArcUndeclaredThrowableException) exception.getCause(), exception.getMessage());
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), exception.getMessage()).build();
+    }
+
+    private Response toResponse(ArcUndeclaredThrowableException exception, String message) {
+        if (exception.getCause() instanceof RollbackException) {
+            return toResponse((RollbackException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(RollbackException exception, String message) {
+        if (exception.getCause() instanceof PersistenceException) {
+            return toResponse((PersistenceException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(PersistenceException exception, String message) {
+        if (exception.getCause() instanceof ConstraintViolationException) {
+            return toResponse((ConstraintViolationException) exception.getCause(), message);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+    private Response toResponse(ConstraintViolationException exception, String message) {
+        return Response.status(Response.Status.CONFLICT.getStatusCode(), message).build();
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -2,11 +2,14 @@ package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 
+import javax.ws.rs.core.Response;
+
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -33,12 +36,16 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
      *         rel = "self",
      *         entityClassName = "com.example.Entity"
      *     )
-     *     public Entity get(@PathParam("id") ID id) {
-     *         Entity entity = restDataResource.get(id);
-     *         if (entity != null) {
-     *             return entity;
-     *         } else {
-     *             throw new WebApplicationException(404);
+     *     public Response get(@PathParam("id") ID id) {
+     *         try {
+     *             Entity entity = restDataResource.get(id);
+     *             if (entity != null) {
+     *                 return entity;
+     *             } else {
+     *                 return Response.status(404).build();
+     *             }
+     *         } catch (Throwable t) {
+     *             throw new RestDataPanacheException(t);
      *         }
      *     }
      * }
@@ -47,7 +54,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, resourceMetadata.getEntityType(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getIdType());
 
         // Add method annotations
@@ -57,17 +64,21 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);
-        ResultHandle entity = methodCreator.invokeVirtualMethod(
+
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to get an entity");
+        ResultHandle entity = tryBlock.invokeVirtualMethod(
                 ofMethod(resourceMetadata.getResourceClass(), RESOURCE_METHOD_NAME, Object.class, Object.class),
                 resource, id);
-        BranchResult entityNotFound = methodCreator.ifNull(entity);
 
         // Return response
-        entityNotFound.trueBranch().throwException(ResponseImplementor.notFoundException(entityNotFound.trueBranch()));
-        entityNotFound.falseBranch().returnValue(entity);
+        BranchResult wasNotFound = tryBlock.ifNull(entity);
+        wasNotFound.trueBranch().returnValue(ResponseImplementor.notFound(wasNotFound.trueBranch()));
+        wasNotFound.falseBranch().returnValue(ResponseImplementor.ok(wasNotFound.falseBranch(), entity));
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -1,6 +1,5 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
-import javax.transaction.Transactional;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -17,8 +16,12 @@ import org.jboss.resteasy.links.LinkResource;
 
 import io.quarkus.gizmo.AnnotatedElement;
 import io.quarkus.gizmo.AnnotationCreator;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.rest.data.panache.runtime.sort.SortQueryParamValidator;
@@ -50,8 +53,12 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
      */
     protected abstract String getResourceMethodName();
 
-    protected void addTransactionalAnnotation(AnnotatedElement element) {
-        element.addAnnotation(Transactional.class);
+    protected TryBlock implementTryBlock(BytecodeCreator bytecodeCreator, String message) {
+        TryBlock tryBlock = bytecodeCreator.tryBlock();
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.throwException(RestDataPanacheException.class, message, catchBlock.getCaughtException());
+        catchBlock.close();
+        return tryBlock;
     }
 
     protected void addGetAnnotation(AnnotatedElement element) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -10,6 +10,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -32,7 +33,6 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
      *
      * <pre>
      * {@code
-     *     &#64;Transactional
      *     &#64;PUT
      *     &#64;Path("{id}")
      *     &#64;Consumes({"application/json"})
@@ -42,19 +42,23 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
      *         entityClassName = "com.example.Entity"
      *     )
      *     public Response update(@PathParam("id") ID id, Entity entityToSave) {
-     *         if (resource.get(id) != null) {
-     *             resource.update(id, entityToSave);
-     *             return Response.status(204).build();
-     *         } else {
-     *             Entity entity = resource.update(id, entityToSave);
-     *             String location = new ResourceLinksProvider().getSelfLink(entity);
-     *             if (location != null) {
-     *                 ResponseBuilder responseBuilder = Response.status(201);
-     *                 responseBuilder.entity(entity);
-     *                 responseBuilder.location(URI.create(location));
-     *                 return responseBuilder.build();
+     *         try {
+     *             if (resource.get(id) != null) {
+     *                 resource.update(id, entityToSave);
+     *                 return Response.status(204).build();
      *             } else {
-     *                 throw new RuntimeException("Could not extract a new entity URL")
+     *                 Entity entity = resource.update(id, entityToSave);
+     *                 String location = new ResourceLinksProvider().getSelfLink(entity);
+     *                 if (location != null) {
+     *                     ResponseBuilder responseBuilder = Response.status(201);
+     *                     responseBuilder.entity(entity);
+     *                     responseBuilder.location(URI.create(location));
+     *                     return responseBuilder.build();
+     *                 } else {
+     *                     throw new RuntimeException("Could not extract a new entity URL")
+     *                 }
+     *             } catch (Throwable t) {
+     *                 throw new RestDataPanacheException(t);
      *             }
      *         }
      *     }
@@ -64,27 +68,29 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class.getName(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getIdType(), resourceMetadata.getEntityType());
 
         // Add method annotations
         addPathAnnotation(methodCreator,
                 appendToPath(resourceProperties.getPath(RESOURCE_UPDATE_METHOD_NAME), "{id}"));
-        addTransactionalAnnotation(methodCreator);
         addPutAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);
         ResultHandle entityToSave = methodCreator.getMethodParam(1);
 
-        BranchResult entityExists = doesEntityExist(methodCreator, resourceMetadata.getResourceClass(), resource, id);
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to update an entity");
+        BranchResult entityExists = doesEntityExist(tryBlock, resourceMetadata.getResourceClass(), resource, id);
         updateAndReturn(entityExists.trueBranch(), resourceMetadata.getResourceClass(), resource, id, entityToSave);
         createAndReturn(entityExists.falseBranch(), resourceMetadata.getResourceClass(), resource, id, entityToSave);
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
@@ -8,6 +8,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -25,22 +26,25 @@ public final class AddHalMethodImplementor extends HalMethodImplementor {
      *
      * <pre>
      * {@code
-     *     &#64;Transactional
      *     &#64;POST
      *     &#64;Path("")
      *     &#64;Consumes({"application/json"})
      *     &#64;Produces({"application/hal+json"})
      *     public Response addHal(Entity entityToSave) {
-     *         Entity entity = resource.add(entityToSave);
-     *         HalEntityWrapper wrapper = new HalEntityWrapper(entity);
-     *         String location = new ResourceLinksProvider().getSelfLink(entity);
-     *         if (location != null) {
-     *             ResponseBuilder responseBuilder = Response.status(201);
-     *             responseBuilder.entity(wrapper);
-     *             responseBuilder.location(URI.create(location));
-     *             return responseBuilder.build();
-     *         } else {
-     *             throw new RuntimeException("Could not extract a new entity URL")
+     *         try {
+     *             Entity entity = resource.add(entityToSave);
+     *             HalEntityWrapper wrapper = new HalEntityWrapper(entity);
+     *             String location = new ResourceLinksProvider().getSelfLink(entity);
+     *             if (location != null) {
+     *                 ResponseBuilder responseBuilder = Response.status(201);
+     *                 responseBuilder.entity(wrapper);
+     *                 responseBuilder.location(URI.create(location));
+     *                 return responseBuilder.build();
+     *             } else {
+     *                 throw new RuntimeException("Could not extract a new entity URL");
+     *             }
+     *         } catch (Throwable t) {
+     *             throw new RestDataPanacheException(t);
      *         }
      *     }
      * }
@@ -49,26 +53,29 @@ public final class AddHalMethodImplementor extends HalMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class.getName(),
+        MethodCreator methodCreator = classCreator.getMethodCreator(METHOD_NAME, Response.class,
                 resourceMetadata.getEntityType());
 
         // Add method annotations
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
-        addTransactionalAnnotation(methodCreator);
         addPostAnnotation(methodCreator);
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
 
-        // Invoke resource methods
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle entityToSave = methodCreator.getMethodParam(0);
-        ResultHandle entity = methodCreator.invokeVirtualMethod(
+
+        // Invoke resource methods
+        TryBlock tryBlock = implementTryBlock(methodCreator, "Failed to add an entity");
+        ResultHandle entity = tryBlock.invokeVirtualMethod(
                 ofMethod(resourceMetadata.getResourceClass(), RESOURCE_METHOD_NAME, Object.class, Object.class),
                 resource, entityToSave);
 
         // Wrap and return response
-        methodCreator.returnValue(ResponseImplementor.created(methodCreator, wrapHalEntity(methodCreator, entity),
-                ResponseImplementor.getEntityUrl(methodCreator, entity)));
+        tryBlock.returnValue(ResponseImplementor.created(tryBlock, wrapHalEntity(tryBlock, entity),
+                ResponseImplementor.getEntityUrl(tryBlock, entity)));
+
+        tryBlock.close();
         methodCreator.close();
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -55,6 +55,10 @@ public final class ResponseImplementor {
         return status(creator, Response.Status.NO_CONTENT.getStatusCode());
     }
 
+    public static ResultHandle notFound(BytecodeCreator creator) {
+        return status(creator, Response.Status.NOT_FOUND.getStatusCode());
+    }
+
     public static ResultHandle notFoundException(BytecodeCreator creator) {
         return creator.newInstance(MethodDescriptor.ofConstructor(WebApplicationException.class, int.class),
                 creator.load(Response.Status.NOT_FOUND.getStatusCode()));

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataPanacheException.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataPanacheException.java
@@ -1,0 +1,8 @@
+package io.quarkus.rest.data.panache;
+
+public class RestDataPanacheException extends RuntimeException {
+
+    public RestDataPanacheException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -34,4 +34,11 @@ public class ResteasyReactiveConfig {
     @ConfigItem(defaultValue = "true")
     @Experimental("This flag has a high probability of going away in the future")
     public boolean defaultProduces;
+
+    /**
+     * Whether or not annotations such `@IfBuildTimeProfile`, `@IfBuildTimeProperty` and friends will be taken
+     * into account when used on JAX-RS classes.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean buildTimeConditionAware;
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -271,9 +271,7 @@ public class ResteasyReactiveProcessor {
         Map<DotName, String> pathInterfaces = result.getPathInterfaces();
 
         ApplicationScanningResult appResult = applicationResultBuildItem.getResult();
-        Set<String> allowedClasses = appResult.getAllowedClasses();
         Set<String> singletonClasses = appResult.getSingletonClasses();
-        boolean filterClasses = appResult.isFilterClasses();
         Application application = appResult.getApplication();
 
         Map<String, String> existingConverters = new HashMap<>();
@@ -382,7 +380,7 @@ public class ResteasyReactiveProcessor {
             serverEndpointIndexer = serverEndpointIndexerBuilder.build();
 
             for (ClassInfo i : scannedResources.values()) {
-                if (filterClasses && !allowedClasses.contains(i.name().toString())) {
+                if (!appResult.keepClass(i.name().toString())) {
                     continue;
                 }
                 ResourceClass endpoints = serverEndpointIndexer.createEndpoints(i);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
@@ -1,0 +1,240 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The integration test for the support of build time conditions on JAX-RS resource classes.
+ */
+class BuildProfileTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            ResourceTest1.class, ResourceTest2.class, ResponseFilter1.class, ResponseFilter2.class,
+                            ResponseFilter3.class, ResponseFilter4.class, ResponseFilter5.class, ResponseFilter6.class,
+                            Feature1.class, Feature2.class, DynamicFeature1.class, DynamicFeature2.class,
+                            ExceptionMapper1.class, ExceptionMapper2.class))
+            .overrideConfigKey("some.prop1", "v1")
+            .overrideConfigKey("some.prop2", "v2");
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_call_ok_of_resource_1() {
+        when()
+                .get("/rt-1/ok")
+                .then()
+                .header("X-RF-1", notNullValue())
+                .header("X-RF-2", nullValue())
+                .header("X-RF-3", notNullValue())
+                .header("X-RF-4", nullValue())
+                .header("X-RF-5", notNullValue())
+                .header("X-RF-6", nullValue())
+                .body(Matchers.is("ok1"));
+    }
+
+    @DisplayName("Should access to ko of resource 1 and call the expected exception mapper")
+    @Test
+    void should_call_ko_of_resource_1() {
+        when()
+                .get("/rt-1/ko")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_not_call_ok_of_resource_2() {
+        when()
+                .get("/rt-2/ok")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @IfBuildProfile("test")
+    @Path("rt-1")
+    public static class ResourceTest1 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok1";
+        }
+
+        @GET
+        @Path("ko")
+        public String ko() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @IfBuildProfile("foo")
+    @Path("rt-2")
+    public static class ResourceTest2 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok2";
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v1") // will be enabled because the value matches
+    @Provider
+    public static class ResponseFilter1 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-1", "Value");
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v") // won't be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter2 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-2", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v1") // will be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter3 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-3", "Value");
+        }
+    }
+
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v2") // won't be enabled because the value matches
+    @Provider
+    public static class ResponseFilter4 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-4", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ResponseFilter5 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-5", "Value");
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class ResponseFilter6 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-6", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class Feature1 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter3.class);
+            return true;
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class Feature2 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter4.class);
+            return true;
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper1 implements ExceptionMapper<RuntimeException> {
+
+        @Override
+        public Response toResponse(RuntimeException exception) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE.getStatusCode()).build();
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper2 implements ExceptionMapper<UnsupportedOperationException> {
+
+        @Override
+        public Response toResponse(UnsupportedOperationException exception) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED.getStatusCode()).build();
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class DynamicFeature1 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter5.class);
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class DynamicFeature2 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter6.class);
+        }
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/BuildProfileTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/BuildProfileTest.java
@@ -1,0 +1,240 @@
+package io.quarkus.resteasy.test.root;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The integration test for the support of build time conditions on JAX-RS resource classes.
+ */
+class BuildProfileTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            ResourceTest1.class, ResourceTest2.class, ResponseFilter1.class, ResponseFilter2.class,
+                            ResponseFilter3.class, ResponseFilter4.class, ResponseFilter5.class, ResponseFilter6.class,
+                            Feature1.class, Feature2.class, DynamicFeature1.class, DynamicFeature2.class,
+                            ExceptionMapper1.class, ExceptionMapper2.class))
+            .overrideConfigKey("some.prop1", "v1")
+            .overrideConfigKey("some.prop2", "v2");
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_call_ok_of_resource_1() {
+        when()
+                .get("/rt-1/ok")
+                .then()
+                .header("X-RF-1", notNullValue())
+                .header("X-RF-2", nullValue())
+                .header("X-RF-3", notNullValue())
+                .header("X-RF-4", nullValue())
+                .header("X-RF-5", notNullValue())
+                .header("X-RF-6", nullValue())
+                .body(Matchers.is("ok1"));
+    }
+
+    @DisplayName("Should access to ko of resource 1 and call the expected exception mapper")
+    @Test
+    void should_call_ko_of_resource_1() {
+        when()
+                .get("/rt-1/ko")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @DisplayName("Should access to ok of resource 1 and provide a response with the expected headers")
+    @Test
+    void should_not_call_ok_of_resource_2() {
+        when()
+                .get("/rt-2/ok")
+                .then()
+                .statusCode(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @IfBuildProfile("test")
+    @Path("rt-1")
+    public static class ResourceTest1 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok1";
+        }
+
+        @GET
+        @Path("ko")
+        public String ko() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @IfBuildProfile("foo")
+    @Path("rt-2")
+    public static class ResourceTest2 {
+
+        @GET
+        @Path("ok")
+        public String ok() {
+            return "ok2";
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v1") // will be enabled because the value matches
+    @Provider
+    public static class ResponseFilter1 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-1", "Value");
+        }
+    }
+
+    @IfBuildProperty(name = "some.prop1", stringValue = "v") // won't be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter2 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-2", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v1") // will be enabled because the value doesn't match
+    @Provider
+    public static class ResponseFilter3 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-3", "Value");
+        }
+    }
+
+    @UnlessBuildProperty(name = "some.prop2", stringValue = "v2") // won't be enabled because the value matches
+    @Provider
+    public static class ResponseFilter4 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-4", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ResponseFilter5 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-5", "Value");
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class ResponseFilter6 implements ContainerResponseFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-6", "Value");
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class Feature1 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter3.class);
+            return true;
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class Feature2 implements Feature {
+
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(ResponseFilter4.class);
+            return true;
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper1 implements ExceptionMapper<RuntimeException> {
+
+        @Override
+        public Response toResponse(RuntimeException exception) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE.getStatusCode()).build();
+        }
+    }
+
+    @UnlessBuildProfile("test")
+    @Provider
+    public static class ExceptionMapper2 implements ExceptionMapper<UnsupportedOperationException> {
+
+        @Override
+        public Response toResponse(UnsupportedOperationException exception) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED.getStatusCode()).build();
+        }
+    }
+
+    @IfBuildProfile("test")
+    @Provider
+    public static class DynamicFeature1 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter5.class);
+        }
+    }
+
+    @IfBuildProfile("bar")
+    @Provider
+    public static class DynamicFeature2 implements DynamicFeature {
+
+        @Override
+        public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+            context.register(ResponseFilter6.class);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
@@ -18,8 +18,23 @@
 
 .navbar-text {
     font-size: 0.9em;
+    position: absolute;
+    right: 5px;
+    bottom: 9px;
+}
+.navbar {
+    justify-content: unset;
+    
 }
 
+#navbar_title:hover {
+    color: #4695eb !important;
+}
+
+#navbar_subtitle {
+    padding-top: 3px;
+    color: #4695eb;
+}
 .breadcrumb {
     border-radius: 0px;
     background-color: #f5f5f5;

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
@@ -1,48 +1,134 @@
 {#include main fluid=true}
+
 {#style}
-.annotation {
-color: gray;
+table {
+    table-layout:fixed;
+    width:100%;
+}
+
+td {
+  word-wrap:break-word;
+  word-break:break-all;
+}
+
+.formInputButton:hover {
+    color: #3366ac !important;
+    cursor: pointer;
 }
 {/style}
+
+{#script}
+$(document).ready(function(){
+  $("#filterInput").on("keyup", function() {
+    var value = $(this).val().toLowerCase();
+    $("#configTable tr").filter(function() {
+      $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+    });
+  });
+  
+  $(".configInput").on("keyup", function(event) {
+    event.preventDefault();
+    if (event.keyCode === 13) {
+        event.preventDefault();
+        changeInputValue(event.target.id);
+    }
+  });
+  
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  });
+  
+});
+
+function clearFilterInput(){
+    $("#filterInput").val("");
+    $("#configTable tr").filter(function() {
+      $(this).toggle($(this).text().toLowerCase().indexOf("") > -1)
+    });
+}
+
+function changeInputValue(name){
+    var $el = $("input[id='" + name + "']");
+    var value = $el.val();
+    $.post("",
+        {
+          name: name,
+          value: value
+        },
+        function(data, status){
+            if(status === "success"){
+                changeBackgroundColor("#76be6b", $el);
+            }else{
+                changeBackgroundColor("#ff6366", $el);
+            }
+        });
+    
+}
+
+function changeBackgroundColor(color, element){
+    var x = 3000;
+    var originalColor = element.css("background");
+
+    element.css("background", color);
+        setTimeout(function(){
+        element.css("background", originalColor);
+    }, x);
+}
+
+{/script}
+
 {#title}Config Editor{/title}
 {#body}
-<table class="table table-striped">
-    <thead class="thead-dark">
-    <tr>
-        <th scope="col">Property</th>
-        <th scope="col">Value</th>
-        <th scope="col">Update</th>
-        <th scope="col">Default Value</th>
-        <th scope="col">Source</th>
-        <th scope="col">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    {#for item in info:config}
-    <tr>
-        <form method="post" enctype="application/x-www-form-urlencoded">
-            <input type="hidden" name="name" value="{item.configValue.name}"/>
+
+<!-- Filter input -->
+<div class="input-group">
+  <div class="input-group-prepend">
+    <span class="input-group-text" id="filterInputPrepend"><i class="fas fa-filter"></i></span>
+  </div>
+  <input id="filterInput" type="text" class="form-control" aria-describedby="filterInputPrepend" placeholder="Search...">
+  <div class="input-group-append">
+    <span class="input-group-text formInputButton" onclick="clearFilterInput();"><i class="fas fa-times"></i></span>
+  </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead class="thead-dark">
+        <tr>
+            <th scope="col">Property</th>
+            <th scope="col">Value</th>
+            <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody id="configTable">
+        {#for item in info:config}
+        <tr>
             <td>
                 {item.configValue.name}
+                
+                {#if item.configValue.configSourceName && item.configValue.configSourceName != ''}
+                    <i class="fas fa-info-circle formInputButton" data-toggle="tooltip" data-placement="right" title="From: {item.configValue.configSourceName}"></i>
+                {/if} 
             </td>
             <td>
-                <input type="text" name="value" value="{item.configValue.value}"/>
+                <div class="input-group" {#if item.defaultValue}data-toggle="tooltip" data-placement="top" title="Default value: {item.defaultValue}"{/if}>
+                    <input id="{item.configValue.name}" type="text" name="value" class="form-control configInput" value="{item.configValue.value}"/>
+                    <div class="input-group-append">
+                        <span class="input-group-text formInputButton" onclick="changeInputValue('{item.configValue.name}');"><i class="fas fa-check text-success"></i></span>
+                    </div>
+                </div>
             </td>
+            
             <td>
-                <input type="submit" value="Update" >
+                {#if item.description.fmtJavadoc && item.description.fmtJavadoc != 'NOT_FOUND'}
+                    {item.description.fmtJavadoc}
+                {/if}    
             </td>
-            <td>
-                {item.defaultValue}
-            </td>
-            <td>
-                {item.configValue.configSourceName}
-            </td>
-            <td>
-                {item.description.fmtJavadoc}
-            </td>
-        </form>
-        {/for}
-    </tbody>
-</table>
+            
+            {/for}
+        </tbody>
+    </table>
+    
+</div>
 {/body}
 {/include}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
@@ -15,6 +15,11 @@ td {
     color: #3366ac !important;
     cursor: pointer;
 }
+
+#filterInputGroup {
+    padding-bottom: 10px;
+}
+
 {/style}
 
 {#script}
@@ -81,7 +86,7 @@ function changeBackgroundColor(color, element){
 {#body}
 
 <!-- Filter input -->
-<div class="input-group">
+<div id="filterInputGroup" class="input-group">
   <div class="input-group-prepend">
     <span class="input-group-text" id="filterInputPrepend"><i class="fas fa-filter"></i></span>
   </div>

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
@@ -88,8 +88,8 @@
        }, jQuery(".alert").data("timer"));
      });
     }
-  |}
   </script>
+  |}    
   
   <script>
     {#insert script/}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
@@ -32,24 +32,25 @@
       <img src="{frameworkRootPath}/dev/resources/images/quarkus_icon_rgb_reverse.svg" width="40" height="30" class="d-inline-block align-middle" alt="Quarkus"/>
       <span id="navbar_title" class="align-middle">Dev UI</span>
     </a>
+    
+    {#if currentExtensionName}
+    <span id="navbar_subtitle" class="navbar-nav">
+      <span class="navbar-item">
+      {#if currentExtensionName == 'Eclipse Vert.x - HTTP'}
+        <i class="fas fa-chevron-right fa-sm"></i> {#insert title/}
+      {#else}
+        <i class="fas fa-chevron-right fa-sm"></i> {currentExtensionName} <i class="fas fa-chevron-right"></i> {#insert title/}
+      {/if}
+      </span>
+    </span>   
+    {/}  
+    
     <span class="navbar-text">
       {#if applicationName and applicationVersion}{applicationName} {applicationVersion} (powered by Quarkus {quarkusVersion}){/if}
     </span>
   </nav>
 
   <div class="container{#if fluid}-fluid{/if} main-container">
-    {#if currentExtensionName}
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        {#if currentExtensionName == 'Eclipse Vert.x - HTTP'}
-        <li class="breadcrumb-item" aria-current="page">{#insert title/}</li>
-        {#else}
-        <li class="breadcrumb-item">{currentExtensionName}</li>
-        <li class="breadcrumb-item" aria-current="page">{#insert title/}</li>
-        {/if}
-      </ol>
-    </nav>
-    {/}
 
    {#if flash['message']}
      <div class="alert alert-{flash['message']['class']} show fade" role="alert" data-timer="{flash['displayTime']}">
@@ -89,5 +90,9 @@
     }
   </script>
   |}
+  
+  <script>
+    {#insert script/}
+  </script>
  </body>
 </html>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsSupplier.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsSupplier.java
@@ -4,7 +4,10 @@ import static io.smallrye.config.Expressions.withoutExpansion;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -24,12 +27,20 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
 
     @Override
     public List<ConfigDescription> get() {
+
+        Map<String, List<ConfigDescription>> mappedBySource = new HashMap<>();
+
         List<String> properties = new ArrayList<>();
         SmallRyeConfig current = (SmallRyeConfig) ConfigProvider.getConfig();
 
         for (ConfigDescription item : configDescriptions) {
             properties.add(item.getName());
             item.setConfigValue(current.getConfigValue(item.getName()));
+
+            String configSourceName = item.getConfigValue().getConfigSourceName();
+
+            mappedBySource.putIfAbsent(configSourceName, new ArrayList<>());
+            mappedBySource.get(configSourceName).add(item);
         }
 
         for (ConfigSource configSource : current.getConfigSources()) {
@@ -44,12 +55,54 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
                     continue;
                 }
 
-                configDescriptions.add(new ConfigDescription(propertyName, null, null, current.getConfigValue(propertyName)));
+                ConfigDescription item = new ConfigDescription(propertyName, null, null, current.getConfigValue(propertyName));
+                String configSourceName = current.getConfigValue(propertyName).getConfigSourceName();
+                mappedBySource.putIfAbsent(configSourceName, new ArrayList<>());
+                mappedBySource.get(configSourceName).add(item);
+
+                configDescriptions.add(item);
             }
         });
 
-        Collections.sort(configDescriptions);
-        return configDescriptions;
+        List<ConfigDescription> orderedBySource = new ArrayList<>();
+
+        // PropertiesConfigSource[source=application.properties]
+        if (mappedBySource.containsKey(APPLICATION_PROPERTIES_CONFIG_SOURCE)) {
+            List<ConfigDescription> applicationProperties = mappedBySource.remove(APPLICATION_PROPERTIES_CONFIG_SOURCE);
+            Collections.sort(applicationProperties);
+            orderedBySource.addAll(applicationProperties);
+        }
+
+        // All other PropertiesConfigSource
+        List<String> otherPropertySources = getOtherPropertiesConfigSources(mappedBySource.keySet());
+        for (String name : otherPropertySources) {
+            List<ConfigDescription> other = mappedBySource.remove(name);
+            Collections.sort(other);
+            orderedBySource.addAll(other);
+        }
+
+        // default value
+        if (mappedBySource.containsKey(DEFAULT_VALUES)) {
+            List<ConfigDescription> p = mappedBySource.remove(DEFAULT_VALUES);
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+        // null 
+        if (mappedBySource.containsKey(null)) {
+            List<ConfigDescription> p = mappedBySource.remove(null);
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+
+        // Now the rest
+        Set<Map.Entry<String, List<ConfigDescription>>> entrySet = mappedBySource.entrySet();
+        for (Map.Entry<String, List<ConfigDescription>> e : entrySet) {
+            List<ConfigDescription> p = e.getValue();
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+
+        return orderedBySource;
     }
 
     public List<ConfigDescription> getConfigDescriptions() {
@@ -59,4 +112,19 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
     public void setConfigDescriptions(final List<ConfigDescription> configDescriptions) {
         this.configDescriptions = configDescriptions;
     }
+
+    private List<String> getOtherPropertiesConfigSources(Set<String> allNames) {
+        List<String> l = new ArrayList<>();
+        for (String name : allNames) {
+            if (name != null && name.startsWith(PROPERTIES_CONFIG_SOURCE)) {
+                l.add(name);
+            }
+        }
+        return l;
+    }
+
+    private static final String APPLICATION_PROPERTIES_CONFIG_SOURCE = "PropertiesConfigSource[source=application.properties]";
+    private static final String PROPERTIES_CONFIG_SOURCE = "PropertiesConfigSource";
+    private static final String DEFAULT_VALUES = "default values";
+
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -45,13 +45,13 @@ public class ResteasyReactiveScanner {
         BUILTIN_HTTP_ANNOTATIONS_TO_METHOD = Collections.unmodifiableMap(BUILTIN_HTTP_ANNOTATIONS_TO_METHOD);
     }
 
-    public static ApplicationScanningResult scanForApplicationClass(IndexView index) {
+    public static ApplicationScanningResult scanForApplicationClass(IndexView index, Set<String> excludedClasses) {
         Collection<ClassInfo> applications = index
                 .getAllKnownSubclasses(ResteasyReactiveDotNames.APPLICATION);
         Set<String> allowedClasses = new HashSet<>();
         Set<String> singletonClasses = new HashSet<>();
         Set<String> globalNameBindings = new HashSet<>();
-        boolean filterClasses = false;
+        boolean filterClasses = !excludedClasses.isEmpty();
         Application application = null;
         ClassInfo selectedAppClass = null;
         boolean blocking = false;
@@ -93,7 +93,8 @@ public class ResteasyReactiveScanner {
         if (selectedAppClass != null) {
             globalNameBindings = NameBindingUtil.nameBindingNames(index, selectedAppClass);
         }
-        return new ApplicationScanningResult(allowedClasses, singletonClasses, globalNameBindings, filterClasses, application,
+        return new ApplicationScanningResult(allowedClasses, singletonClasses, excludedClasses, globalNameBindings,
+                filterClasses, application,
                 selectedAppClass, blocking);
     }
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -207,7 +207,8 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
         }
 
         Index index = JandexUtil.createIndex(deploymentDir);
-        ApplicationScanningResult applicationScanningResult = ResteasyReactiveScanner.scanForApplicationClass(index);
+        ApplicationScanningResult applicationScanningResult = ResteasyReactiveScanner.scanForApplicationClass(index,
+                Collections.emptySet());
         ResourceScanningResult resources = ResteasyReactiveScanner.scanResources(index);
         if (resources == null) {
             throw new RuntimeException("no JAX-RS resources found");

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -46,7 +46,7 @@
         <commons-compress.version>1.20</commons-compress.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <maven-core.version>3.6.3</maven-core.version>
-        <mockito.version>3.7.7</mockito.version>
+        <mockito.version>3.8.0</mockito.version>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <quarkus.version>999-SNAPSHOT</quarkus.version>


### PR DESCRIPTION
This PR updates the config properties screen in Dev UI.

Fix #15196

Here the changes:

- Changed the sub header (of all screens) to be in the nav bar header (space saving)
- Added a way for extension pages to add javascript
- Added a search/filter bar for the config properties
- Changed the order of the config properties to first show properties from `application.properties` and then other Quarkus properties and moved `System` and `Environment` to the bottom, the logic here is that the developer would probably change properties in `application.properties` and other Quarkus properties (rather than a system property like `awt.toolkit` that is currently showing at the top)
- Changed the default value to be a tool-tip to the input-box, rather than a column (space saving)
- Changed the information about what config source this comes from to a tool-tip next to the config key (because does that really matter ?) (space saving)
- Changed the Update button, that is currently a separate button in a table col to be next to the input-box (space saving)
- Added a Key listener to the inputbox to allow using Enter as a submit
- Made sure the columns wrap as to not make the table bigger than the view-port (horizontal scroll)
- Changed the form submit, that currently reloads the page to a Javascript POST. Better user experience to not reload the page and loose the state. This is also nice if you have the log open for instance.

Screen before:
![old_config](https://user-images.githubusercontent.com/6836179/108896830-10547900-761e-11eb-9d09-cbca5fd4e391.gif)


Screen after:
![new_config](https://user-images.githubusercontent.com/6836179/108896071-172ebc00-761d-11eb-8bff-7cc0e26ba435.gif)


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>