### PR TITLE
Group all raw service binding properties under quarkus.service-binding

### DIFF
--- a/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProvider.java
+++ b/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProvider.java
@@ -84,7 +84,8 @@ public class KubernetesServiceBindingConfigSourceProvider implements ConfigSourc
             Map<String, String> serviceBindingProperties = serviceBinding.getProperties();
             Map<String, String> rawConfigSourceProperties = new HashMap<>();
             for (Map.Entry<String, String> entry : serviceBindingProperties.entrySet()) {
-                rawConfigSourceProperties.put("quarkus." + serviceBinding.getName() + "." + entry.getKey(), entry.getValue());
+                rawConfigSourceProperties.put("quarkus.service-binding." + serviceBinding.getName() + "." + entry.getKey(),
+                        entry.getValue());
             }
             result.add(new ServiceBindingConfigSource("service-binding-" + serviceBinding.getName() + "-raw",
                     rawConfigSourceProperties));

--- a/extensions/kubernetes-service-binding/runtime/src/test/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProviderTest.java
+++ b/extensions/kubernetes-service-binding/runtime/src/test/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingConfigSourceProviderTest.java
@@ -64,8 +64,8 @@ class KubernetesServiceBindingConfigSourceProviderTest {
         assertThat(configSources).filteredOn(c -> c.getName().equals("service-binding-test-name-raw")).singleElement()
                 .satisfies(c -> {
                     assertThat(c.getProperties()).containsOnly(
-                            entry("quarkus.test-name.test-secret-key", "test-secret-value-2"),
-                            entry("quarkus.test-name.test-other-secret-key", "test-other-secret-value-2"));
+                            entry("quarkus.service-binding.test-name.test-secret-key", "test-secret-value-2"),
+                            entry("quarkus.service-binding.test-name.test-other-secret-key", "test-other-secret-value-2"));
                 });
     }
 }


### PR DESCRIPTION
This is done in order to avoid accidental collision of properties
when only quarkus was used as a prefix