### PR TITLE
Copy sources from remote container when quarkus.native.debug.enabled=true

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -23,7 +23,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
 
     private static final Logger log = Logger.getLogger(NativeImageBuildContainerRunner.class);
 
-    private final NativeConfig nativeConfig;
+    final NativeConfig nativeConfig;
     protected final NativeConfig.ContainerRuntime containerRuntime;
     private final String[] baseContainerRuntimeArgs;
     protected final String outputPath;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -12,7 +10,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
@@ -33,23 +30,10 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         containerRuntime = nativeConfig.containerRuntime.orElseGet(NativeImageBuildContainerRunner::detectContainerRuntime);
         log.infof("Using %s to run the native image builder", containerRuntime.getExecutableName());
 
-        List<String> containerRuntimeArgs = new ArrayList<>();
-        Collections.addAll(containerRuntimeArgs, "--env", "LANG=C");
+        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C" };
 
         outputPath = outputDir == null ? null : outputDir.toAbsolutePath().toString();
 
-        if (SystemUtils.IS_OS_LINUX) {
-            String uid = getLinuxID("-ur");
-            String gid = getLinuxID("-gr");
-            if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
-                Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
-                if (containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
-                    // Needed to avoid AccessDeniedExceptions
-                    containerRuntimeArgs.add("--userns=keep-id");
-                }
-            }
-        }
-        this.baseContainerRuntimeArgs = containerRuntimeArgs.toArray(new String[0]);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-import io.quarkus.deployment.util.ProcessUtil;
-
 public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
 
     private final String nativeImageExecutable;
@@ -16,11 +14,9 @@ public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
     }
 
     @Override
-    public void cleanupServer(File outputDir, boolean processInheritIODisabled) throws InterruptedException, IOException {
-        final ProcessBuilder pb = new ProcessBuilder(nativeImageExecutable, "--server-shutdown");
-        pb.directory(outputDir);
-        final Process process = ProcessUtil.launchProcess(pb, processInheritIODisabled);
-        process.waitFor();
+    public void cleanupServer(File outputDir) throws InterruptedException, IOException {
+        final String[] cleanupCommand = { nativeImageExecutable, "--server-shutdown" };
+        runCommand(cleanupCommand, null, outputDir);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -6,9 +6,13 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.deployment.pkg.NativeConfig;
 
 public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildContainerRunner {
+
+    private static final Logger log = Logger.getLogger(NativeImageBuildRemoteContainerRunner.class);
 
     private final String nativeImageName;
     private String containerId;
@@ -22,6 +26,7 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
     protected void preBuild(List<String> buildArgs) throws InterruptedException, IOException {
         List<String> containerRuntimeArgs = getContainerRuntimeBuildArgs();
         String[] createContainerCommand = buildCommand("create", containerRuntimeArgs, buildArgs);
+        log.info(String.join(" ", createContainerCommand).replace("$", "\\$"));
         Process createContainerProcess = new ProcessBuilder(createContainerCommand).start();
         createContainerProcess.waitFor();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(createContainerProcess.getInputStream()))) {
@@ -29,6 +34,7 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
         }
         String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp", outputPath + "/.",
                 containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH };
+        log.info(String.join(" ", copyCommand).replace("$", "\\$"));
         Process copyProcess = new ProcessBuilder(copyCommand).start();
         copyProcess.waitFor();
         super.preBuild(buildArgs);
@@ -47,6 +53,7 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
         }
         String[] removeCommand = new String[] { containerRuntime.getExecutableName(), "container", "rm", "--volumes",
                 containerId };
+        log.info(String.join(" ", removeCommand).replace("$", "\\$"));
         Process removeProcess = new ProcessBuilder(removeCommand).start();
         removeProcess.waitFor();
     }
@@ -54,6 +61,7 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
     private void copy(String path) throws IOException, InterruptedException {
         String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp",
                 containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + "/" + path, outputPath };
+        log.info(String.join(" ", copyCommand).replace("$", "\\$"));
         Process copyProcess = new ProcessBuilder(copyCommand).start();
         copyProcess.waitFor();
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -41,13 +41,20 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
 
     @Override
     protected void postBuild() throws InterruptedException, IOException {
-        String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp",
-                containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + "/" + nativeImageName, outputPath };
-        Process copyProcess = new ProcessBuilder(copyCommand).start();
-        copyProcess.waitFor();
+        copy(nativeImageName);
+        if (nativeConfig.debug.enabled) {
+            copy("sources");
+        }
         String[] removeCommand = new String[] { containerRuntime.getExecutableName(), "container", "rm", "--volumes",
                 containerId };
         Process removeProcess = new ProcessBuilder(removeCommand).start();
         removeProcess.waitFor();
+    }
+
+    private void copy(String path) throws IOException, InterruptedException {
+        String[] copyCommand = new String[] { containerRuntime.getExecutableName(), "cp",
+                containerId + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + "/" + path, outputPath };
+        Process copyProcess = new ProcessBuilder(copyCommand).start();
+        copyProcess.waitFor();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -12,10 +12,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM;
 import io.quarkus.deployment.util.ProcessUtil;
 
 public abstract class NativeImageBuildRunner {
+
+    private static final Logger log = Logger.getLogger(NativeImageBuildRunner.class);
 
     public GraalVM.Version getGraalVMVersion() {
         final GraalVM.Version graalVMVersion;
@@ -46,8 +50,10 @@ public abstract class NativeImageBuildRunner {
         preBuild(args);
         try {
             CountDownLatch errorReportLatch = new CountDownLatch(1);
-            final ProcessBuilder processBuilder = new ProcessBuilder(getBuildCommand(args))
+            final String[] buildCommand = getBuildCommand(args);
+            final ProcessBuilder processBuilder = new ProcessBuilder(buildCommand)
                     .directory(outputDir.toFile());
+            log.info(String.join(" ", buildCommand).replace("$", "\\$"));
             final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);
             ExecutorService executor = Executors.newSingleThreadExecutor();
             executor.submit(new ErrorReplacingProcessReader(process.getErrorStream(), outputDir.resolve("reports").toFile(),

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -175,7 +175,6 @@ public class NativeImageBuildStep {
 
             List<String> nativeImageArgs = commandAndExecutable.args;
 
-            log.info(String.join(" ", nativeImageArgs).replace("$", "\\$"));
             int exitCode = buildRunner.build(nativeImageArgs, outputDir, processInheritIODisabled.isPresent());
             if (exitCode != 0) {
                 throw imageGenerationFailed(exitCode, nativeImageArgs);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -158,7 +158,7 @@ public class NativeImageBuildStep {
 
         try {
             if (nativeConfig.cleanupServer && !graalVMVersion.isMandrel()) {
-                buildRunner.cleanupServer(outputDir.toFile(), processInheritIODisabled.isPresent());
+                buildRunner.cleanupServer(outputDir.toFile());
             }
 
             NativeImageInvokerInfo commandAndExecutable = new NativeImageInvokerInfo.Builder()


### PR DESCRIPTION
When using `-Dquarkus.native.remote-container-build=true` in combination with `-Dquarkus.native.debug.enabled=true` native image generation fails with:
```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:build (default) on project quarkus-integration-test-main: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.deployment.pkg.steps.NativeImageBuildStep#build threw an exception: java.lang.RuntimeException: Failed to build native image
[ERROR]         at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:209)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:920)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:277)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2415)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:834)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:501)
[ERROR] Caused by: java.nio.file.NoSuchFileException: /home/zakkak/code/quarkus/integration-tests/main/target/quarkus-integration-test-main-999-SNAPSHOT-native-image-source-jar/sources
[ERROR]         at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
[ERROR]         at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[ERROR]         at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
[ERROR]         at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
[ERROR]         at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
[ERROR]         at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
[ERROR]         at java.base/java.nio.file.Files.readAttributes(Files.java:1764)
[ERROR]         at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:225)
[ERROR]         at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
[ERROR]         at java.base/java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
[ERROR]         at java.base/java.nio.file.Files.walkFileTree(Files.java:2717)
[ERROR]         at io.quarkus.bootstrap.util.IoUtils.copy(IoUtils.java:126)
[ERROR]         at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:191)
[ERROR]         ... 10 more
```

This PR fixes this by copying the sources from the container back to the host.