### PR TITLE
Allow extending gradle nativetest source set

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -1,4 +1,4 @@
-package io.quarkus.gradle;
+package io.quarkus.gradle.extension;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
@@ -28,6 +29,7 @@ import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.model.ModelParameter;
 import io.quarkus.bootstrap.resolver.model.QuarkusModel;
 import io.quarkus.bootstrap.resolver.model.impl.ModelParameterImpl;
+import io.quarkus.gradle.AppModelGradleResolver;
 import io.quarkus.gradle.builder.QuarkusModelBuilder;
 import io.quarkus.gradle.tasks.QuarkusGradleUtils;
 import io.quarkus.runtime.LaunchMode;
@@ -46,11 +48,14 @@ public class QuarkusPluginExtension {
 
     private File outputConfigDirectory;
 
+    private final SourceSetExtension sourceSetExtension;
+
     public QuarkusPluginExtension(Project project) {
         this.project = project;
+        this.sourceSetExtension = new SourceSetExtension();
     }
 
-    void beforeTest(Test task) {
+    public void beforeTest(Test task) {
         try {
             final Map<String, Object> props = task.getSystemProperties();
 
@@ -174,6 +179,14 @@ public class QuarkusPluginExtension {
 
     public void setFinalName(String finalName) {
         this.finalName = finalName;
+    }
+
+    public void sourceSets(Action<? super SourceSetExtension> action) {
+        action.execute(this.sourceSetExtension);
+    }
+
+    public SourceSetExtension sourceSetExtension() {
+        return sourceSetExtension;
     }
 
     public Set<File> resourcesDir() {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/extension/SourceSetExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/extension/SourceSetExtension.java
@@ -1,0 +1,16 @@
+package io.quarkus.gradle.extension;
+
+import org.gradle.api.tasks.SourceSet;
+
+public class SourceSetExtension {
+
+    private SourceSet extraNativeTestSourceSet;
+
+    public SourceSet extraNativeTest() {
+        return extraNativeTestSourceSet;
+    }
+
+    public void setExtraNativeTest(SourceSet extraNativeTestSourceSet) {
+        this.extraNativeTestSourceSet = extraNativeTestSourceSet;
+    }
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import org.gradle.api.DefaultTask;
 
 import io.quarkus.bootstrap.model.AppArtifact;
-import io.quarkus.gradle.QuarkusPluginExtension;
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
 
 public abstract class QuarkusTask extends DefaultTask {
 

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -14,6 +14,8 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
+
 public class QuarkusPluginTest {
 
     @Test

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -397,6 +397,21 @@ Run the native tests using:
 
 This task depends on `quarkusBuild`, so it will generate the native image before running the tests.
 
+[NOTE]
+====
+By default, the `native-test` source set is based on `main` and `test` source sets. It is possible to add an extra source set. For example, if your integration tests are located in an `integrationTest` source set, you can specify it as:
+
+[source,groovy]
+----
+quarkus {
+    sourceSets {
+        extraNativeTest = sourceSets.integrationTest
+    }
+}
+----
+
+====
+
 == Building Uber-Jars
 
 Quarkus Gradle plugin supports the generation of Uber-Jars by specifying a `quarkus.package.type` argument as follows:

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/CustomNativeTestSourceSetTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/CustomNativeTestSourceSetTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.nativeimage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.gradle.BuildResult;
+
+public class CustomNativeTestSourceSetTest extends QuarkusNativeGradleTestBase {
+
+    @Test
+    public void runNativeTests() throws Exception {
+        final File projectDir = getProjectDir("custom-java-native-sourceset-module");
+
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "testNative");
+        assertThat(build.getTasks().get(":testNative")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+sourceSets {
+    integrationTest {
+        java.srcDir file('src/integration-test/java')
+        resources.srcDir file('src/integration-test/resources')
+        compileClasspath += sourceSets.main.output + project.configurations.testCompileClasspath
+        runtimeClasspath += sourceSets.main.output + project.configurations.testRuntimeClasspath
+    }
+}
+
+quarkus {
+    sourceSets {
+        extraNativeTest = sourceSets.integrationTest
+    }
+}
+quarkusBuild {
+    nativeArgs {
+        additionalArgs= ["--verbose"]
+    }
+}

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='foo'

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/integration-test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/integration-test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello"));
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/native-test/java/org/acme/ExampleResourceNativeTest.java
+++ b/integration-tests/gradle/src/test/resources/custom-java-native-sourceset-module/src/native-test/java/org/acme/ExampleResourceNativeTest.java
@@ -1,0 +1,6 @@
+package org.acme;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class ExampleResourceNativeTest extends ExampleResourceTest {}


### PR DESCRIPTION
Native test are located in the `native-test` source set which extends the `main` and `test` sourcesets.
Some projects creates custom sourcesets for integrationTests. This branch allows to configure an extra source set that will be added to the `native-test` source set.

As the configuration of the source set is not bound to a task (it is created in the plugin configuration), I added the property in the `QuarkusExtension` extension. To be able to get the value, we need to wait for the project to be configured that's why this is configuration is done in `afterEvaluate`.

close #15236 