### PR TITLE
Upgrade to Hibernate Search 6.0.2.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -93,7 +93,7 @@
         <hibernate-orm.version>5.4.28.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Beta4</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.1.Final</hibernate-search.version>
+        <hibernate-search.version>6.0.2.Final</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>


### PR DESCRIPTION
Bugfixes only, no breaking change to report.

https://in.relation.to/2021/02/24/hibernate-search-6-0-2-Final/