### PR TITLE
Added filter and other updates to config screen in Dev UI

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -64,7 +64,7 @@ link:qute[the Qute template engine].
 This also means that you can link:qute-reference#user_tags[add custom Qute tags] in 
 `/dev-templates/tags` for your templates to use.
 
-The style system currently in use is https://getbootstrap.com/docs/4.0/getting-started/introduction/[Bootstrap V4 (4.5.3)]
+The style system currently in use is https://getbootstrap.com/docs/4.6/getting-started/introduction/[Bootstrap V4 (4.6.0)]
 but note that this might change in the future.
 
 The main template also includes https://jquery.com/[jQuery 3.5.1], but here again this might change.
@@ -94,8 +94,15 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
             color: gray;
         }
     {/style}
-    {#title}Cache{/title}// <3>
-    {#body}// <4>
+    {#script} // <3>
+     $(document).ready(function(){
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        });
+    });
+    {/script}
+    {#title}Cache{/title}// <4>
+    {#body}// <5>
         <table class="table table-striped custom">
             <thead class="thead-dark">
                 <tr>
@@ -104,13 +111,13 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
                 </tr>
             </thead>
             <tbody>
-                {#for cacheInfo in info:cacheInfos}// <5>
+                {#for cacheInfo in info:cacheInfos}// <6>
                     <tr>
                         <td>
                             {cacheInfo.name}
                         </td>
                         <td>
-                            <form method="post"// <6> 
+                            <form method="post"// <7> 
                                   enctype="application/x-www-form-urlencoded">
                                 <label class="form-check-label" for="clear">
                                     {cacheInfo.size}
@@ -129,11 +136,12 @@ link:building-my-first-extension#description-of-a-quarkus-extension[`deployment`
 ----
 <1> In order to benefit from the same style as other Dev UI pages, extend the `main` template
 <2> You can pass extra CSS for your page in the `style` template parameter
-<3> Don't forget to set your page title in the `title` template parameter
-<4> The `body` template parameter will contain your content
-<5> In order for your template to read custom information from your Quarkus extension, you can use
+<3> You can pass extra JavaScript for your page in the `script` template parameter. This will be added inline after the JQuery script, so you can safely use JQuery in your script.
+<4> Don't forget to set your page title in the `title` template parameter
+<5> The `body` template parameter will contain your content
+<6> In order for your template to read custom information from your Quarkus extension, you can use
     the `info` link:qute-reference#namespace_extension_methods[namespace].
-<6> This shows an <<advanced-usage-adding-actions,interactive page>>
+<7> This shows an <<advanced-usage-adding-actions,interactive page>>
 
 == Linking to your full-page templates
 

--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
@@ -10,6 +10,10 @@
     padding-top: 1em;
 }
 
+.navbar-brand {
+    margin-right: 0.9rem;
+}
+
 .navbar-brand img {
     border-right: 1px solid darkgrey;
     padding-right: 10px;
@@ -27,13 +31,18 @@
     justify-content: unset;
 }
 
-#navbar_title:hover {
+#navbar-title:hover {
     color: #4695eb !important;
 }
 
-#navbar_subtitle {
-    padding-top: 3px;
+#navbar-subtitle {
+    padding-top: 6px;
     color: #4695eb;
+}
+
+.breadcrumb-separator {
+    margin-right: 2px;
+    margin-left: 4px;
 }
 
 .breadcrumb {

--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
@@ -18,6 +18,22 @@
 
 .navbar-text {
     font-size: 0.9em;
+    position: absolute;
+    right: 5px;
+    bottom: 9px;
+}
+
+.navbar {
+    justify-content: unset;
+}
+
+#navbar_title:hover {
+    color: #4695eb !important;
+}
+
+#navbar_subtitle {
+    padding-top: 3px;
+    color: #4695eb;
 }
 
 .breadcrumb {

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
@@ -1,48 +1,135 @@
 {#include main fluid=true}
 {#style}
-.annotation {
-color: gray;
+table {
+    table-layout:fixed;
+    width:100%;
+}
+
+td {
+  word-wrap:break-word;
+  word-break:break-all;
+}
+
+.formInputButton:hover {
+    color: #3366ac !important;
+    cursor: pointer;
+}
+
+#filterInputGroup {
+    padding-bottom: 10px;
 }
 {/style}
+
+{#script}
+$(document).ready(function(){
+  $("#filterInput").on("keyup", function() {
+    var value = $(this).val().toLowerCase();
+    $("#configTable tr").filter(function() {
+      $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+    });
+  });
+
+  $(".configInput").on("keyup", function(event) {
+    event.preventDefault();
+    if (event.keyCode === 13) {
+        event.preventDefault();
+        changeInputValue(event.target.id);
+    }
+  });
+
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  });
+
+});
+
+function clearFilterInput(){
+    $("#filterInput").val("");
+    $("#configTable tr").filter(function() {
+      $(this).toggle($(this).text().toLowerCase().indexOf("") > -1)
+    });
+}
+
+function changeInputValue(name){
+    var $el = $("input[id='" + name + "']");
+    var value = $el.val();
+    $.post("",
+        {
+          name: name,
+          value: value
+        },
+        function(data, status){
+            if(status === "success"){
+                changeBackgroundColor("#76be6b", $el);
+            }else{
+                changeBackgroundColor("#ff6366", $el);
+            }
+        });
+
+}
+
+function changeBackgroundColor(color, element){
+    var x = 3000;
+    var originalColor = element.css("background");
+
+    element.css("background", color);
+        setTimeout(function(){
+        element.css("background", originalColor);
+    }, x);
+}
+
+{/script}
+
 {#title}Config Editor{/title}
 {#body}
-<table class="table table-striped">
-    <thead class="thead-dark">
-    <tr>
-        <th scope="col">Property</th>
-        <th scope="col">Value</th>
-        <th scope="col">Update</th>
-        <th scope="col">Default Value</th>
-        <th scope="col">Source</th>
-        <th scope="col">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    {#for item in info:config}
-    <tr>
-        <form method="post" enctype="application/x-www-form-urlencoded">
-            <input type="hidden" name="name" value="{item.configValue.name}"/>
+
+<!-- Filter input -->
+<div id="filterInputGroup" class="input-group">
+    <div class="input-group-prepend">
+        <span class="input-group-text" id="filterInputPrepend"><i class="fas fa-filter"></i></span>
+    </div>
+    <input id="filterInput" type="text" class="form-control" aria-describedby="filterInputPrepend" placeholder="Search...">
+    <div class="input-group-append">
+        <span class="input-group-text formInputButton" onclick="clearFilterInput();"><i class="fas fa-times"></i></span> 
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead class="thead-dark">
+        <tr>
+            <th scope="col">Property</th>
+            <th scope="col">Value</th>
+            <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody id="configTable">
+        {#for item in info:config}
+        <tr>
             <td>
                 {item.configValue.name}
+                
+                {#if item.configValue.configSourceName && item.configValue.configSourceName != ''}
+                    <i class="fas fa-info-circle formInputButton" data-toggle="tooltip" data-placement="right" title="From: {item.configValue.configSourceName}"></i>
+                {/if}
             </td>
             <td>
-                <input type="text" name="value" value="{item.configValue.value}"/>
+                <div class="input-group" {#if item.defaultValue}data-toggle="tooltip" data-placement="top" title="Default value: {item.defaultValue}"{/if}>
+                    <input id="{item.configValue.name}" type="text" name="value" class="form-control configInput" value="{item.configValue.value}"/>
+                    <div class="input-group-append">
+                        <span class="input-group-text formInputButton" onclick="changeInputValue('{item.configValue.name}');"><i class="fas fa-check text-success"></i></span>
+                    </div>
+                </div>
             </td>
             <td>
-                <input type="submit" value="Update" >
+                {#if item.description.fmtJavadoc && item.description.fmtJavadoc != 'NOT_FOUND'}
+                    {item.description.fmtJavadoc}
+                {/if}    
             </td>
-            <td>
-                {item.defaultValue}
-            </td>
-            <td>
-                {item.configValue.configSourceName}
-            </td>
-            <td>
-                {item.description.fmtJavadoc}
-            </td>
-        </form>
-        {/for}
-    </tbody>
-</table>
+            
+            {/for}
+        </tbody>
+    </table>
+</div>
 {/body}
 {/include}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
@@ -32,25 +32,24 @@
       <img src="{frameworkRootPath}/dev/resources/images/quarkus_icon_rgb_reverse.svg" width="40" height="30" class="d-inline-block align-middle" alt="Quarkus"/>
       <span id="navbar_title" class="align-middle">Dev UI</span>
     </a>
+    {#if currentExtensionName}
+    <span id="navbar_subtitle" class="navbar-nav">
+      <span class="navbar-item">
+      {#if currentExtensionName == 'Eclipse Vert.x - HTTP'}
+        <i class="fas fa-chevron-right fa-sm"></i> {#insert title/}
+      {#else}
+        <i class="fas fa-chevron-right fa-sm"></i> {currentExtensionName} <i class="fas fa-chevron-right"></i> {#insert title/}
+      {/if}
+      </span>
+    </span>   
+    {/}  
     <span class="navbar-text">
       {#if applicationName and applicationVersion}{applicationName} {applicationVersion} (powered by Quarkus {quarkusVersion}){/if}
     </span>
   </nav>
 
   <div class="container{#if fluid}-fluid{/if} main-container">
-    {#if currentExtensionName}
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        {#if currentExtensionName == 'Eclipse Vert.x - HTTP'}
-        <li class="breadcrumb-item" aria-current="page">{#insert title/}</li>
-        {#else}
-        <li class="breadcrumb-item">{currentExtensionName}</li>
-        <li class="breadcrumb-item" aria-current="page">{#insert title/}</li>
-        {/if}
-      </ol>
-    </nav>
-    {/}
-
+    
    {#if flash['message']}
      <div class="alert alert-{flash['message']['class']} show fade" role="alert" data-timer="{flash['displayTime']}">
       {flash['message']['text']}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
@@ -19,7 +19,7 @@
   
   <title>
     {#if currentExtensionName && currentExtensionName != 'Eclipse Vert.x - HTTP'}
-      {currentExtensionName} /
+      {currentExtensionName} ›
     {/if}
     {#insert title/}
     {#if applicationName and applicationVersion} | {applicationName} {applicationVersion}{/if}
@@ -30,15 +30,15 @@
   <nav class="navbar sticky-top navbar-dark bg-dark">
     <a class="navbar-brand" href="{frameworkRootPath}/dev/">
       <img src="{frameworkRootPath}/dev/resources/images/quarkus_icon_rgb_reverse.svg" width="40" height="30" class="d-inline-block align-middle" alt="Quarkus"/>
-      <span id="navbar_title" class="align-middle">Dev UI</span>
+      <span id="navbar-title" class="align-middle">Dev UI</span>
     </a>
     {#if currentExtensionName}
-    <span id="navbar_subtitle" class="navbar-nav">
+    <span id="navbar-subtitle" class="navbar-nav">
       <span class="navbar-item">
       {#if currentExtensionName == 'Eclipse Vert.x - HTTP'}
-        <i class="fas fa-chevron-right fa-sm"></i> {#insert title/}
+        <i class="fas fa-chevron-right fa-sm breadcrumb-separator"></i> {#insert title/}
       {#else}
-        <i class="fas fa-chevron-right fa-sm"></i> {currentExtensionName} <i class="fas fa-chevron-right"></i> {#insert title/}
+        <i class="fas fa-chevron-right fa-sm breadcrumb-separator"></i> {currentExtensionName} <i class="fas fa-chevron-right fa-sm breadcrumb-separator"></i> {#insert title/}
       {/if}
       </span>
     </span>   

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/main.html
@@ -8,7 +8,7 @@
   <!-- Bootstrap CSS -->
   <link rel="stylesheet" href="{frameworkRootPath}/dev/resources/css/bootstrap.min.css">
   <link rel="stylesheet" href="{frameworkRootPath}/dev/resources/fontawesome/css/all.min.css">
-  <link rel="stylesheet" href="{frameworkRootPath}/dev/resources/css/dev-console.css">
+  <link rel="stylesheet" href="{frameworkRootPath}/dev/resources/css/dev-console.css?2">
   <link rel="stylesheet" href="{frameworkRootPath}/dev/resources/css/logstream.css">
   
   <link rel="shortcut icon" type="image/png" href="{frameworkRootPath}/dev/resources/images/favicon.ico" >

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsSupplier.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsSupplier.java
@@ -4,7 +4,10 @@ import static io.smallrye.config.Expressions.withoutExpansion;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -13,6 +16,9 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 
 public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescription>> {
+
+    Map<String, List<ConfigDescription>> mappedBySource = new HashMap<>();
+
     private List<ConfigDescription> configDescriptions;
 
     public ConfigDescriptionsSupplier() {
@@ -30,6 +36,11 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
         for (ConfigDescription item : configDescriptions) {
             properties.add(item.getName());
             item.setConfigValue(current.getConfigValue(item.getName()));
+
+            String configSourceName = item.getConfigValue().getConfigSourceName();
+
+            mappedBySource.putIfAbsent(configSourceName, new ArrayList<>());
+            mappedBySource.get(configSourceName).add(item);
         }
 
         for (ConfigSource configSource : current.getConfigSources()) {
@@ -44,12 +55,54 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
                     continue;
                 }
 
-                configDescriptions.add(new ConfigDescription(propertyName, null, null, current.getConfigValue(propertyName)));
+                ConfigDescription item = new ConfigDescription(propertyName, null, null, current.getConfigValue(propertyName));
+                String configSourceName = current.getConfigValue(propertyName).getConfigSourceName();
+                mappedBySource.putIfAbsent(configSourceName, new ArrayList<>());
+                mappedBySource.get(configSourceName).add(item);
+
+                configDescriptions.add(item);
             }
         });
 
-        Collections.sort(configDescriptions);
-        return configDescriptions;
+        List<ConfigDescription> orderedBySource = new ArrayList<>();
+
+        // PropertiesConfigSource[source=application.properties]
+        if (mappedBySource.containsKey(APPLICATION_PROPERTIES_CONFIG_SOURCE)) {
+            List<ConfigDescription> applicationProperties = mappedBySource.remove(APPLICATION_PROPERTIES_CONFIG_SOURCE);
+            Collections.sort(applicationProperties);
+            orderedBySource.addAll(applicationProperties);
+        }
+
+        // All other PropertiesConfigSource
+        List<String> otherPropertySources = getOtherPropertiesConfigSources(mappedBySource.keySet());
+        for (String name : otherPropertySources) {
+            List<ConfigDescription> other = mappedBySource.remove(name);
+            Collections.sort(other);
+            orderedBySource.addAll(other);
+        }
+
+        // default value
+        if (mappedBySource.containsKey(DEFAULT_VALUES)) {
+            List<ConfigDescription> p = mappedBySource.remove(DEFAULT_VALUES);
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+        // null 
+        if (mappedBySource.containsKey(null)) {
+            List<ConfigDescription> p = mappedBySource.remove(null);
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+
+        // Now the rest
+        Set<Map.Entry<String, List<ConfigDescription>>> entrySet = mappedBySource.entrySet();
+        for (Map.Entry<String, List<ConfigDescription>> e : entrySet) {
+            List<ConfigDescription> p = e.getValue();
+            Collections.sort(p);
+            orderedBySource.addAll(p);
+        }
+
+        return orderedBySource;
     }
 
     public List<ConfigDescription> getConfigDescriptions() {
@@ -59,4 +112,18 @@ public class ConfigDescriptionsSupplier implements Supplier<List<ConfigDescripti
     public void setConfigDescriptions(final List<ConfigDescription> configDescriptions) {
         this.configDescriptions = configDescriptions;
     }
+
+    private List<String> getOtherPropertiesConfigSources(Set<String> allNames) {
+        List<String> l = new ArrayList<>();
+        for (String name : allNames) {
+            if (name != null && name.startsWith(PROPERTIES_CONFIG_SOURCE)) {
+                l.add(name);
+            }
+        }
+        return l;
+    }
+
+    private static final String APPLICATION_PROPERTIES_CONFIG_SOURCE = "PropertiesConfigSource[source=application.properties]";
+    private static final String PROPERTIES_CONFIG_SOURCE = "PropertiesConfigSource";
+    private static final String DEFAULT_VALUES = "default values";
 }


### PR DESCRIPTION
New attempt at #15280

This PR updates the config properties screen in Dev UI.

Fix #15196

Here the changes:

- Changed the sub header (of all screens) to be in the nav bar header (space saving)
- Added a way for extension pages to add javascript
- Added a search/filter bar for the config properties
- Changed the order of the config properties to first show properties from `application.properties` and then other Quarkus properties and moved `System` and `Environment` to the bottom, the logic here is that the developer would probably change properties in `application.properties` and other Quarkus properties (rather than a system property like `awt.toolkit` that is currently showing at the top)
- Changed the default value to be a tool-tip to the input-box, rather than a column (space saving)
- Changed the information about what config source this comes from to a tool-tip next to the config key (because does that really matter ?) (space saving)
- Changed the Update button, that is currently a separate button in a table col to be next to the input-box (space saving)
- Added a Key listener to the inputbox to allow using Enter as a submit
- Made sure the columns wrap as to not make the table bigger than the view-port (horizontal scroll)
- Changed the form submit, that currently reloads the page to a Javascript POST. Better user experience to not reload the page and loose the state. This is also nice if you have the log open for instance.

Screen before:
![old_config](https://user-images.githubusercontent.com/6836179/108896830-10547900-761e-11eb-9d09-cbca5fd4e391.gif)


Screen after:
![new_config](https://user-images.githubusercontent.com/6836179/108896071-172ebc00-761d-11eb-8bff-7cc0e26ba435.gif)


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>