### PR TITLE
Enforce DB_CLOSE_DELAY=-1 for H2 databases

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
@@ -2,11 +2,16 @@ package io.quarkus.agroal.runtime;
 
 import org.jboss.logging.Logger;
 
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 
 public interface AgroalConnectionConfigurer {
 
     Logger log = Logger.getLogger(AgroalConnectionConfigurer.class.getName());
+
+    default void contributeJdbcProperties(
+            AgroalConnectionFactoryConfigurationSupplier agroalConnectionFactoryConfigurationSupplier) {
+    }
 
     default void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
         log.warnv("Agroal does not support disabling SSL for database kind: {0}", databaseKind);

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -165,6 +165,10 @@ public class DataSources {
         AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfiguration = poolConfiguration
                 .connectionFactoryConfiguration();
 
+        if (agroalConnectionConfigurerHandle.isAvailable()) {
+            agroalConnectionConfigurerHandle.get().contributeJdbcProperties(connectionFactoryConfiguration);
+        }
+
         boolean mpMetricsPresent = dataSourceSupport.mpMetricsPresent;
         applyNewConfiguration(dataSourceConfiguration, poolConfiguration, connectionFactoryConfiguration, driver,
                 dataSourceJdbcBuildTimeConfig, dataSourceRuntimeConfig, dataSourceJdbcRuntimeConfig, mpMetricsPresent);

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2AgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2AgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.h2.runtime;
 
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
 import io.quarkus.agroal.runtime.JdbcDriver;
@@ -7,6 +8,12 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 
 @JdbcDriver(DatabaseKind.H2)
 public class H2AgroalConnectionConfigurer implements AgroalConnectionConfigurer {
+
+    @Override
+    public void contributeJdbcProperties(
+            AgroalConnectionFactoryConfigurationSupplier agroalConnectionFactoryConfigurationSupplier) {
+        agroalConnectionFactoryConfigurationSupplier.jdbcProperty("DB_CLOSE_DELAY", "-1");
+    }
 
     @Override
     public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {


### PR DESCRIPTION
I can't see why you would want the default behavior in Quarkus and it
causes a lot of problems so let's enforce DB_CLOSE_DELAY to -1.