### PR TITLE
Health checks with stereotypes - fix the default scope

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -389,6 +389,10 @@ public class BeanDeployment {
         return Collections.unmodifiableList(interceptors);
     }
 
+    public Collection<StereotypeInfo> getStereotypes() {
+        return Collections.unmodifiableCollection(stereotypes.values());
+    }
+
     /**
      * This index was used to discover components (beans, interceptors, qualifiers, etc.) and during type-safe resolution.
      * 
@@ -709,11 +713,10 @@ public class BeanDeployment {
         Map<MethodInfo, Set<ClassInfo>> syncObserverMethods = new HashMap<>();
         Map<MethodInfo, Set<ClassInfo>> asyncObserverMethods = new HashMap<>();
         // Stereotypes excluding additional BeanDefiningAnnotations
-        List<DotName> realStereotypes = this.stereotypes.entrySet().stream()
-                .filter(e -> !e.getValue().isAdditionalBeanDefiningAnnotation()
-                        && !e.getValue().isAdditionalStereotypeBuildItem())
-                .map(Entry::getKey)
-                .collect(Collectors.toList());
+        Set<DotName> realStereotypes = this.stereotypes.values().stream()
+                .filter(StereotypeInfo::isGenuine)
+                .map(StereotypeInfo::getName)
+                .collect(Collectors.toSet());
 
         for (ClassInfo beanClass : beanArchiveIndex.getKnownClasses()) {
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.processor;
 import java.util.List;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 
 public class StereotypeInfo {
 
@@ -61,6 +62,10 @@ public class StereotypeInfo {
         return target;
     }
 
+    public DotName getName() {
+        return target.name();
+    }
+
     public boolean isAdditionalBeanDefiningAnnotation() {
         return isAdditionalBeanDefiningAnnotation;
     }
@@ -68,4 +73,9 @@ public class StereotypeInfo {
     public boolean isAdditionalStereotypeBuildItem() {
         return isAdditionalStereotypeBuildItem;
     }
+
+    public boolean isGenuine() {
+        return !isAdditionalBeanDefiningAnnotation && !isAdditionalStereotypeBuildItem;
+    }
+
 }


### PR DESCRIPTION
- a health check annotated with a stereotype that has no default scope
should be also Singleton