### PR TITLE
Treat MismatchedInputException as client error in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
 import java.util.function.Supplier;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -27,6 +25,6 @@ public class ExceptionInReaderTest {
     @Test
     public void test() {
         RestAssured.with().contentType("application/json").body("{\"name\": \"brie\"}").put("/fromage")
-                .then().statusCode(500).body(containsString("MismatchedInputException"));
+                .then().statusCode(400);
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/JacksonMessageBodyReader.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
 import org.jboss.resteasy.reactive.server.providers.serialisers.json.AbstractJsonMessageBodyReader;
@@ -16,6 +17,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 public class JacksonMessageBodyReader extends AbstractJsonMessageBodyReader {
 
@@ -29,13 +31,18 @@ public class JacksonMessageBodyReader extends AbstractJsonMessageBodyReader {
     @Override
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
-        return doReadFrom(type, genericType, entityStream);
+        throw new IllegalStateException("Should never be called");
     }
 
     @Override
     public Object readFrom(Class<Object> type, Type genericType, MediaType mediaType, ServerRequestContext context)
             throws WebApplicationException, IOException {
-        return doReadFrom(type, genericType, context.getInputStream());
+        try {
+            return doReadFrom(type, genericType, context.getInputStream());
+        } catch (MismatchedInputException e) {
+            context.abortWith(Response.status(Response.Status.BAD_REQUEST).build());
+            return null;
+        }
     }
 
     private Object doReadFrom(Class<Object> type, Type genericType, InputStream entityStream) throws IOException {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -179,6 +179,19 @@ public abstract class ResteasyReactiveRequestContext
     }
 
     /**
+     * Meant to be used when a error occurred early in processing chain
+     */
+    @Override
+    public void abortWith(Response response) {
+        setResult(response);
+        restart(getAbortHandlerChain());
+        // this is a valid action after suspend, in which case we must resume
+        if (isSuspended()) {
+            resume();
+        }
+    }
+
+    /**
      * Resets the build time serialization assumptions. Called if a filter
      * modifies the response
      */

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerRequestContext.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.server.spi;
 import java.io.InputStream;
 import java.io.OutputStream;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.common.core.ResteasyReactiveCallbackContext;
 
 public interface ServerRequestContext extends ResteasyReactiveCallbackContext {
@@ -18,4 +19,6 @@ public interface ServerRequestContext extends ResteasyReactiveCallbackContext {
     OutputStream getOrCreateOutputStream();
 
     ResteasyReactiveResourceInfo getResteasyReactiveResourceInfo();
+
+    void abortWith(Response response);
 }


### PR DESCRIPTION
The Javadoc of MismatchedInputException even mentions that these exceptions
should be treated as client exceptions

Relates to: #15302