### PR TITLE
Disable instrumentation for remote-dev

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -823,12 +823,18 @@ public class DevMojo extends AbstractMojo {
                     && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
                 if (appDep.getArtifact().getGroupId().equals("io.quarkus")
                         && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
-                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                    if (enableInstrumentation()) {
+                        builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                    }
                 } else {
                     builder.classpathEntry(appDep.getArtifact().getFile());
                 }
             }
         }
+    }
+
+    protected boolean enableInstrumentation() {
+        return true;
     }
 
     private void setKotlinSpecificFlags(MavenDevModeLauncher.Builder builder) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -13,4 +13,9 @@ public class RemoteDevMojo extends DevMojo {
     protected void modifyDevModeContext(MavenDevModeLauncher.Builder builder) {
         builder.remoteDev(true);
     }
+
+    @Override
+    protected boolean enableInstrumentation() {
+        return false;
+    }
 }


### PR DESCRIPTION
Meant to overcome the following:

```
2021-02-23 10:19:21,484 INFO  [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Connected to remote server
2021-02-23 10:19:51,249 INFO  [io.qua.dep.dev.RuntimeUpdatesProcessor] (Remote dev client thread) Changed source files detected, recompiling [/home/kshpak/mySandbox/QuarkusPrj/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java]
2021-02-23 10:19:51,543 ERROR [io.qua.dep.dev.RuntimeUpdatesProcessor] (Remote dev client thread) Failed to replace classes via instrumentation: java.lang.ClassNotFoundException: org.acme.quickstart.GreetingResource
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:428)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:378)
	at io.quarkus.deployment.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:219)
	at io.quarkus.deployment.dev.IsolatedRemoteDevModeMain.runSync(IsolatedRemoteDevModeMain.java:263)
	at io.quarkus.deployment.dev.IsolatedRemoteDevModeMain.access$300(IsolatedRemoteDevModeMain.java:53)
	at io.quarkus.deployment.dev.IsolatedRemoteDevModeMain$5.get(IsolatedRemoteDevModeMain.java:253)
	at io.quarkus.deployment.dev.IsolatedRemoteDevModeMain$5.get(IsolatedRemoteDevModeMain.java:250)
	at io.quarkus.vertx.http.deployment.devmode.HttpRemoteDevClient$Session.run(HttpRemoteDevClient.java:197)
	at java.base/java.lang.Thread.run(Thread.java:834)

2021-02-23 10:19:51,604 INFO  [io.qua.kub.dep.KubernetesDeployer] (build-19) Selecting target 'openshift' since it has the highest priority among the implicitly enabled deployment targets
2021-02-23 10:19:51,852 INFO  [io.qua.dep.QuarkusAugmentor] (Remote dev client thread) Quarkus augmentation completed in 308ms
2021-02-23 10:19:51,854 INFO  [io.qua.dep.dev.RuntimeUpdatesProcessor] (Remote dev client thread) Hot replace total time: 0.607s 
2021-02-23 10:19:52,363 INFO  [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Sending dev/app/org/acme/quickstart/GreetingResource.class
2021-02-23 10:19:52,513 INFO  [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Sending app/getting-started-1.0.0-SNAPSHOT.jar
2021-02-23 10:19:52,693 INFO  [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Sending quarkus-run.jar
2021-02-23 10:19:52,827 INFO  [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Sending lib/deployment/build-system.properties

```

which can be seen in the logs of the client when remote-dev is being used