### PR TITLE
CI: Align ci-fork-mvn-cache to initial build

### DIFF
--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -55,7 +55,7 @@ jobs:
           key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build
         run: |
-          mvn -e -B -Dquickly-ci -Dtcks clean install
+          mvn -T1C -e -B --settings .github/mvn-settings.xml -Dquickly-ci -Dtcks clean install
       - name: Delete Local Artifacts From Cache
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus


### PR DESCRIPTION
Note: This workflow isn't used in the regular CI, so it doesn't really make sense to run a full build here...