### PR TITLE
Prefer output dir for hot deployment of resources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -118,7 +118,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     public Path getClassesDir() {
         //TODO: fix all these
         for (DevModeContext.ModuleInfo i : context.getAllModules()) {
-            return Paths.get(i.getResourcePath());
+            return Paths.get(i.getClassesPath());
         }
         return null;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
@@ -14,11 +14,9 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
         List<Path> resources = new ArrayList<>();
+        addPathIfContainsStaticResources(resources, context.getClassesDir());
         for (Path resourceDir : context.getResourcesDir()) {
-            Path resource = resourceDir.resolve(StaticResourcesRecorder.META_INF_RESOURCES);
-            if (Files.exists(resource)) {
-                resources.add(resource);
-            }
+            addPathIfContainsStaticResources(resources, resourceDir);
         }
         StaticResourcesRecorder.setHotDeploymentResources(resources);
     }
@@ -31,4 +29,12 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
     public void close() {
         StaticResourcesRecorder.setHotDeploymentResources(null);
     }
+
+    private void addPathIfContainsStaticResources(List<Path> resources, Path resourceDir) {
+        Path resource = resourceDir.resolve(StaticResourcesRecorder.META_INF_RESOURCES);
+        if (Files.exists(resource)) {
+            resources.add(resource);
+        }
+    }
+
 }


### PR DESCRIPTION
The original resources without Maven properties resolution were provided by Static Handler for `src/main/resources/META-INF/resources` files when running in dev mode. The strategy used for hot deployment doesn't consider the resources filtering. So the interpolation of Maven properties wasn't processed.

Resolves #15303