### PR TITLE
Replace stack trace with a log message

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
@@ -6,14 +6,17 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import org.hibernate.exception.ConstraintViolationException;
+import org.jboss.logging.Logger;
 
 import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.rest.data.panache.RestDataPanacheException;
 
 public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+    private static final Logger LOGGER = Logger.getLogger(RestDataPanacheExceptionMapper.class);
+
     @Override
     public Response toResponse(RestDataPanacheException exception) {
-        exception.printStackTrace();
+        LOGGER.warnf(exception, "Mapping an unhandled %s", RestDataPanacheException.class.getSimpleName());
 
         if (exception.getCause() instanceof ArcUndeclaredThrowableException) {
             return toResponse((ArcUndeclaredThrowableException) exception.getCause(), exception.getMessage());


### PR DESCRIPTION
Replace a `printStackTrace` (left by accident) with a warning log message.