### PR TITLE
Replace httpServerRequest.absoluteURI() with simple URI check in Root Handler

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -129,7 +131,10 @@ public class VertxHttpRecorder {
     private static final Handler<HttpServerRequest> ACTUAL_ROOT = new Handler<HttpServerRequest>() {
         @Override
         public void handle(HttpServerRequest httpServerRequest) {
-            if (httpServerRequest.absoluteURI() == null) {
+            try {
+                // we simply need to know if the URI is valid
+                new URI(httpServerRequest.uri());
+            } catch (URISyntaxException e) {
                 httpServerRequest.response().setStatusCode(400).end();
                 return;
             }


### PR DESCRIPTION
This is done because the check doesn't actually need the entire
absoluteURI, it just needs to make sure that the URI is correct.
The use of absoluteURI incurs a small performance penalty
which can be seen in the following flame graph.


![CPU-flame-graph](https://user-images.githubusercontent.com/4374975/109180968-1cfadd80-7794-11eb-8f56-7c9857c022b8.png)