### PR TITLE
Annotate mongo entity id field for RESTEasy Link

### DIFF
--- a/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
+++ b/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
@@ -43,8 +43,10 @@ class MongoPanacheRestProcessor {
     @BuildStep
     void findEntityResources(CombinedIndexBuildItem index,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
-            BuildProducer<RestDataResourceBuildItem> restDataResourceProducer) {
-        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getIndex()));
+            BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformersProducer) {
+        EntityClassHelper entityClassHelper = new EntityClassHelper(index.getIndex());
+        ResourceImplementor resourceImplementor = new ResourceImplementor(entityClassHelper);
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
         for (ClassInfo classInfo : index.getIndex()
@@ -62,6 +64,8 @@ class MongoPanacheRestProcessor {
 
             restDataResourceProducer.produce(new RestDataResourceBuildItem(
                     new ResourceMetadata(resourceClass, resourceInterface, entityType, idType)));
+            bytecodeTransformersProducer.produce(
+                    getEntityIdAnnotationTransformer(entityType, entityClassHelper.getIdField(entityType).name()));
         }
     }
 


### PR DESCRIPTION
Add a missing Mongo entity transformer that annotates its ID field so that RESTEasy Links could lookup its value.
We have been doing this for a repository resource already, but not for the entity resource.