### PR TITLE
Allow to define the build profile at maven plugin level

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -25,6 +25,7 @@ import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.runtime.configuration.ProfileManager;
 
 /**
  * Builds the Quarkus application.
@@ -96,6 +97,14 @@ public class BuildMojo extends QuarkusBootstrapMojo {
                 }
                 System.setProperty(PACKAGE_TYPE_PROP, packageType);
                 clearPackageTypeSysProp = true;
+            }
+            // Set the build profile based on the value of the project property ProfileManager.QUARKUS_PROFILE_PROP
+            // if and only if it has not already been set using the corresponding system property
+            // or environment variable.
+            final Object profile = mavenProject().getProperties().get(ProfileManager.QUARKUS_PROFILE_PROP);
+            if (profile != null && System.getProperty(ProfileManager.QUARKUS_PROFILE_PROP) == null
+                    && System.getenv(ProfileManager.QUARKUS_PROFILE_ENV) == null) {
+                System.setProperty(ProfileManager.QUARKUS_PROFILE_PROP, profile.toString());
             }
             try (CuratedApplication curatedApplication = bootstrapApplication()) {
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
@@ -6,41 +6,86 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
 import io.quarkus.maven.it.verifier.RunningInvoker;
+import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 @DisableForNative
-public class BuildIT extends MojoTestBase {
+class BuildIT extends MojoTestBase {
 
     private RunningInvoker running;
     private File testDir;
 
     @Test
-    public void testMultiModuleAppRootWithNoSources()
+    void testMultiModuleAppRootWithNoSources()
             throws MavenInvocationException, IOException, InterruptedException {
         testDir = initProject("projects/multimodule-root-no-src", "projects/multimodule-root-no-src-build");
 
         running = new RunningInvoker(testDir, false);
         MavenProcessInvocationResult result = running.execute(Collections.singletonList("install -pl .,html,rest"),
                 Collections.emptyMap());
-        assertThat(result.getProcess().waitFor()).isEqualTo(0);
+        assertThat(result.getProcess().waitFor()).isZero();
 
         result = running.execute(Collections.singletonList("quarkus:build -f runner"), Collections.emptyMap());
 
-        assertThat(result.getProcess().waitFor()).isEqualTo(0);
+        assertThat(result.getProcess().waitFor()).isZero();
 
         final File targetDir = new File(testDir, "runner" + File.separator + "target");
         final File runnerJar = targetDir.toPath().resolve("quarkus-app").resolve("quarkus-run.jar").toFile();
 
         // make sure the jar can be read by JarInputStream
         ensureManifestOfJarIsReadableByJarInputStream(runnerJar);
+    }
+
+    @Test
+    void testModuleWithBuildProfileInProperty() throws MavenInvocationException, InterruptedException, IOException {
+        testDir = initProject("projects/build-mode-quarkus-profile-property");
+        build(null);
+        launch();
+    }
+
+    @Test
+    void testModuleWithOverriddenBuildProfile() throws MavenInvocationException, InterruptedException, IOException {
+        testDir = initProject("projects/build-mode-quarkus-profile-override");
+        build(String.format("-D%s=foo", ProfileManager.QUARKUS_PROFILE_PROP));
+        launch();
+    }
+
+    private void launch() throws IOException {
+        File output = new File(testDir, "target/output.log");
+        output.createNewFile();
+        Process process = JarRunnerIT.doLaunch(new File(testDir, "target/quarkus-app"), Paths.get("quarkus-run.jar"), output,
+                Collections.emptyList()).start();
+        try {
+            Assertions.assertEquals("hello, from foo", DevModeTestUtils.getHttpResponse("/hello"));
+        } finally {
+            process.destroy();
+        }
+    }
+
+    private void build(String arg) throws MavenInvocationException, InterruptedException, IOException {
+        assertThat(testDir).isDirectory();
+        running = new RunningInvoker(testDir, false);
+
+        final List<String> args = new ArrayList<>(2);
+        args.add("package");
+        if (arg != null) {
+            args.add(arg);
+        }
+        MavenProcessInvocationResult result = running.execute(args, Collections.emptyMap());
+        assertThat(result.getProcess().waitFor()).isZero();
     }
 
     private void ensureManifestOfJarIsReadableByJarInputStream(File jar) throws IOException {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -427,7 +427,7 @@ public class JarRunnerIT extends MojoTestBase {
         return doLaunch(null, jar, output, vmArgs);
     }
 
-    private ProcessBuilder doLaunch(final File workingDir, final Path jar, File output, Collection<String> vmArgs)
+    static ProcessBuilder doLaunch(final File workingDir, final Path jar, File output, Collection<String> vmArgs)
             throws IOException {
         List<String> commands = new ArrayList<>();
         commands.add(JavaBinFinder.findBin());

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>acme</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus.profile>bar</quarkus.profile>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- insert managed dependencies here -->
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <!-- insert test dependencies here -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,22 @@
+package org.acme;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @Inject
+    HelloService service;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello, " + service.name();
+    }
+}

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/java/org/acme/HelloService.java
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/java/org/acme/HelloService.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@IfBuildProfile("foo")
+@ApplicationScoped
+public class HelloService {
+
+    @ConfigProperty(name = "name")
+    String name;
+
+    public String name() {
+        return name;
+    }
+}

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-override/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+name=from default
+%foo.name=from foo

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>acme</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus.profile>foo</quarkus.profile>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- insert managed dependencies here -->
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <!-- insert test dependencies here -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,22 @@
+package org.acme;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @Inject
+    HelloService service;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello, " + service.name();
+    }
+}

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/java/org/acme/HelloService.java
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/java/org/acme/HelloService.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@IfBuildProfile("foo")
+@ApplicationScoped
+public class HelloService {
+
+    @ConfigProperty(name = "name")
+    String name;
+
+    public String name() {
+        return name;
+    }
+}

--- a/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources/projects/build-mode-quarkus-profile-property/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+name=from default
+%foo.name=from foo


### PR DESCRIPTION
fixes #13341

## Motivation

We would like to have the ability to define the build profile directly in the configuration of the plugin or via a project property.

## Modifications:

* Checks if the project property `quarkus.profile` has been set and if so uses this value as build profile if and only if it has not already been set using the corresponding system property or environment variable.