### PR TITLE
Return properly encoded URLs from JarResource#getResourceURL()

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -108,9 +108,14 @@ public class JarResource implements ClassLoadingResource {
                 if (realName.endsWith("/")) {
                     realName = realName.substring(0, realName.length() - 1);
                 }
-                URI jarUri = jarPath.toUri();
-                return new URL("jar", null, jarUri.getScheme() + ':' + jarUri.getPath() + "!/" + resource);
-            } catch (MalformedURLException e) {
+                final URI jarUri = jarPath.toUri();
+                // first create a URI which includes both the jar file path and the relative resource name
+                // and then invoke a toURL on it. The URI reconstruction allows for any encoding to be done
+                // for the "path" which includes the "realName"
+                final URL resUrl = new URI(jarUri.getScheme(), jarUri.getPath() + "!/" + realName, null).toURL();
+                // wrap it up into a "jar" protocol URL
+                return new URL("jar", null, resUrl.getProtocol() + ':' + resUrl.getPath());
+            } catch (MalformedURLException | URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         } finally {

--- a/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/JarResourceTest.java
+++ b/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/JarResourceTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.bootstrap.runner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link JarResource}
+ */
+public class JarResourceTest {
+
+    /**
+     * Tests that the URL(s) returned from {@link JarResource#getResourceURL(String)} are properly encoded and can be used
+     * to open connection to the URL to read data
+     */
+    @Test
+    public void testResourceURLEncoding() throws Exception {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class);
+        final String[] files = new String[] { "a.txt", "a b.txt", ",;~!@#$%^&().txt" };
+        for (final String file : files) {
+            jar.add(new StringAsset("hello"), file);
+        }
+        final Path testDir = Files.createTempDirectory("test");
+        // create a child dir with special characters
+        final Path specialCharDir = Files.createDirectory(Paths.get(testDir.toString(), ",;~!@#$%^&()"));
+        final Path jarFilePath = Files.createTempFile(specialCharDir, "test", "quarkus-test.jar");
+        // create a jar file under the directory which has the special characters
+        jar.as(ZipExporter.class).exportTo(jarFilePath.toFile(), true);
+        final JarResource jarResource = new JarResource(null, jarFilePath);
+        for (final String resource : files) {
+            final URL url = jarResource.getResourceURL(resource);
+            Assertions.assertNotNull(url, resource + " is missing in jar");
+            // check that opening the resource URL works and data can be read
+            final URLConnection conn = url.openConnection();
+            try (final InputStream is = conn.getInputStream()) {
+                drainFully(is);
+            }
+        }
+    }
+
+    private static void drainFully(final InputStream inputStream) throws IOException {
+        int read = -1;
+        final byte[] data = new byte[1024];
+        while ((read = inputStream.read(data)) != -1) {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/15358

The commit here fixes the issue reported in https://github.com/quarkusio/quarkus/issues/15358. The change involves, using the `URI` constructor to first properly encode (any special characters in) the resource name and then use the `URI.toURL()` to allow for the encoded path part to be used in the newly constructed URL.

This also include a test case which reproduces this issue and verifies the fix.

P.S: The test uses some special characters for directory and file names. These characters work fine on Linux, but I don't know if they are all allowed on Windows. So if this test case does indeed fail on Windows while trying to create a file or a directory, I will modify the test case to have it run only on *nix and maybe come up with some other characters for the file/directory for Windows. 