### PR TITLE
Allow concurrent event handling and add ordered to @ConsumeEvent

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
@@ -109,6 +109,13 @@ class EventBusConsumer {
             isBlocking.returnValue(isBlocking.load(true));
         }
 
+        AnnotationValue orderedValue = consumeEvent.value("ordered");
+        boolean ordered = orderedValue != null && orderedValue.asBoolean();
+        if (ordered) {
+            MethodCreator isOrdered = invokerCreator.getMethodCreator("isOrdered", boolean.class);
+            isOrdered.returnValue(isOrdered.load(true));
+        }
+
         implementConstructor(bean, invokerCreator, beanField, containerField);
         implementInvoke(bean, method, invokerCreator, beanField.getFieldDescriptor(), containerField.getFieldDescriptor());
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
@@ -84,11 +84,18 @@ public @interface ConsumeEvent {
     boolean blocking() default false;
 
     /**
+     * @return {@code true} if the <em>blocking</em> consumption of the event must be ordered, meaning that the method
+     *         won't be called concurrently. Instead it serializes all the invocations based on the event order.
+     *         {@code ordered} must be used in conjunction with {@code blocking=true} or {@code @Blocking}.
+     * @see io.vertx.core.Vertx#executeBlocking(io.vertx.core.Handler, boolean, io.vertx.core.Handler)
+     */
+    boolean ordered() default false;
+
+    /**
      * 
      * @return {@code null} if it should use a default MessageCodec
      * @see io.quarkus.vertx.LocalEventBusCodec
      */
-    @SuppressWarnings("rawtypes")
     Class<? extends MessageCodec> codec() default LocalEventBusCodec.class;
 
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/EventConsumerInvoker.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/EventConsumerInvoker.java
@@ -18,6 +18,10 @@ public abstract class EventConsumerInvoker {
         return false;
     }
 
+    public boolean isOrdered() {
+        return false;
+    }
+
     public void invoke(Message<Object> message) throws Exception {
         ManagedContext requestContext = Arc.container().requestContext();
         if (requestContext.isActive()) {

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
@@ -98,7 +98,7 @@ public class VertxRecorder {
                                     }
                                     event.complete();
                                 }
-                            }, null);
+                            }, invoker.isOrdered(), null);
                         } else {
                             try {
                                 invoker.invoke(m);


### PR DESCRIPTION
Fix #15351

- Add an `ordered` attribute to the `@ConsumeEvent` annotation (false by default, which was the previous behavior)
- When calling `executeBlocking`, configure whether the calls should be ordered or not