### PR TITLE
Reactive routes - fail the build if a path param contains invalid chars

### DIFF
--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.web.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
-import static io.quarkus.vertx.web.deployment.DotNames.PARAM;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
@@ -23,6 +22,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ContextNotActiveException;
@@ -128,6 +128,8 @@ class VertxWebProcessor {
     private static final String SLASH = "/";
 
     private static final List<ParameterInjector> PARAM_INJECTORS = initParamInjectors();
+
+    private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("[a-zA-Z_0-9]+");
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -501,6 +503,9 @@ class VertxWebProcessor {
                             "HandlerType.%s is not legal for parameter %s of route method %s declared on %s",
                             injector.getTargetHandlerType(), idx, method, bean));
                 }
+
+                // A param injector may validate the parameter annotations
+                injector.validate(bean, method, routeAnnotation, paramType, paramAnnotations);
 
                 if (Route.HandlerType.FAILURE == handlerType && isThrowable(paramType, index)) {
                     failureParams++;
@@ -1211,8 +1216,34 @@ class VertxWebProcessor {
                 .matchType(io.quarkus.arc.processor.DotNames.STRING)
                 .matchOptionalOf(io.quarkus.arc.processor.DotNames.STRING)
                 .matchListOf(io.quarkus.arc.processor.DotNames.STRING)
-                .requireAnnotations(PARAM)
-                .resultHandleProvider(new ParamAndHeaderProvider(PARAM, Methods.REQUEST_PARAMS, Methods.REQUEST_GET_PARAM))
+                .requireAnnotations(DotNames.PARAM)
+                .resultHandleProvider(
+                        new ParamAndHeaderProvider(DotNames.PARAM, Methods.REQUEST_PARAMS, Methods.REQUEST_GET_PARAM))
+                .validate(new ParamValidator() {
+                    @Override
+                    public void validate(BeanInfo bean, MethodInfo method, AnnotationInstance routeAnnotation, Type paramType,
+                            Set<AnnotationInstance> paramAnnotations) {
+                        AnnotationInstance paramAnnotation = Annotations.find(paramAnnotations, DotNames.PARAM);
+                        AnnotationValue paramNameValue = paramAnnotation.value();
+                        if (paramNameValue != null && !paramNameValue.asString().equals(Param.ELEMENT_NAME)) {
+                            String paramName = paramNameValue.asString();
+                            AnnotationValue regexValue = routeAnnotation.value(VALUE_REGEX);
+                            AnnotationValue pathValue = routeAnnotation.value(VALUE_PATH);
+                            if (regexValue == null && pathValue != null) {
+                                String path = pathValue.asString();
+                                // Validate the name if used as a path parameter
+                                if (path.contains(":" + paramName) && !PATH_PARAM_PATTERN.matcher(paramName).matches()) {
+                                    // TODO This requirement should be relaxed in vertx 4.0.3+
+                                    // https://github.com/vert-x3/vertx-web/pull/1881
+                                    throw new IllegalStateException(String.format(
+                                            "A path param name must only contain word characters (a-zA-Z_0-9): %s [route method %s declared on %s]",
+                                            paramName,
+                                            method, bean.getBeanClass()));
+                                }
+                            }
+                        }
+                    }
+                })
                 .build());
 
         injectors.add(ParameterInjector.builder().matchPrimitiveWrappers()
@@ -1397,6 +1428,7 @@ class VertxWebProcessor {
         final TriPredicate<Type, Set<AnnotationInstance>, IndexView> predicate;
         final ResultHandleProvider provider;
         final Route.HandlerType targetHandlerType;
+        final ParamValidator validator;
 
         ParameterInjector(ParameterInjector.Builder builder) {
             if (builder.predicate != null) {
@@ -1461,6 +1493,7 @@ class VertxWebProcessor {
             }
             this.provider = builder.provider;
             this.targetHandlerType = builder.targetHandlerType;
+            this.validator = builder.validator;
         }
 
         boolean matches(Type paramType, Set<AnnotationInstance> paramAnnotations, IndexView index) {
@@ -1469,6 +1502,13 @@ class VertxWebProcessor {
 
         Route.HandlerType getTargetHandlerType() {
             return targetHandlerType;
+        }
+
+        void validate(BeanInfo bean, MethodInfo method, AnnotationInstance routeInstance, Type paramType,
+                Set<AnnotationInstance> paramAnnotations) {
+            if (validator != null) {
+                validator.validate(bean, method, routeInstance, paramType, paramAnnotations);
+            }
         }
 
         ResultHandle getResultHandle(MethodInfo method, Type paramType, Set<AnnotationInstance> annotations,
@@ -1486,6 +1526,7 @@ class VertxWebProcessor {
             List<DotName> requiredAnnotationNames = Collections.emptyList();
             ResultHandleProvider provider;
             Route.HandlerType targetHandlerType;
+            ParamValidator validator;
 
             Builder matchType(DotName className) {
                 return matchType(Type.create(className, Kind.CLASS));
@@ -1563,6 +1604,11 @@ class VertxWebProcessor {
                 return this;
             }
 
+            Builder validate(ParamValidator validator) {
+                this.validator = validator;
+                return this;
+            }
+
             ParameterInjector build() {
                 return new ParameterInjector(this);
             }
@@ -1630,6 +1676,14 @@ class VertxWebProcessor {
     interface TriPredicate<A, B, C> {
 
         boolean test(A a, B b, C c);
+
+    }
+
+    @FunctionalInterface
+    interface ParamValidator {
+
+        void validate(BeanInfo bean, MethodInfo method, AnnotationInstance routeAnnotation, Type paramType,
+                Set<AnnotationInstance> paramAnnotations);
 
     }
 

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/params/InvalidPathParameterNameTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/params/InvalidPathParameterNameTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.vertx.web.params;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+
+public class InvalidPathParameterNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleBean.class))
+            .setExpectedException(IllegalStateException.class);
+
+    @Test
+    public void testValidationFailed() {
+        fail();
+    }
+
+    static class SimpleBean {
+
+        @Route(path = "/hello/:my-param")
+        String hello(@Param("my-param") String param) {
+            return param;
+        }
+
+    }
+
+}


### PR DESCRIPTION
- resolves #15185

NOTE: We only fail the build if the `@Param` maps to a path param (not for example a query param).