### PR TITLE
Avoid NPE in dev console when there aren't any indexed entities with the Hibernate Search extension enabled

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/devconsole/DevConsoleProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/devconsole/DevConsoleProcessor.java
@@ -14,12 +14,12 @@ public class DevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("entities", new HibernateSearchSupplier());
+        return new DevConsoleRuntimeTemplateInfoBuildItem("entityTypes", new HibernateSearchSupplier());
     }
 
     @BuildStep
     @Record(value = STATIC_INIT, optional = true)
     DevConsoleRouteBuildItem invokeEndpoint(HibernateSearchDevConsoleRecorder recorder) {
-        return new DevConsoleRouteBuildItem("entities", "POST", recorder.indexEntity());
+        return new DevConsoleRouteBuildItem("entity-types", "POST", recorder.indexEntity());
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,4 +1,4 @@
-<a href="{urlbase}/entities" class="badge badge-light">
+<a href="{urlbase}/entity-types" class="badge badge-light">
     <i class="fa fa-search fa-fw"></i>
-    Indexed entities <span class="badge badge-light">{info:entities.size()}</span></a>
+    Indexed entity types <span class="badge badge-light">{info:entityTypes.size()}</span></a>
 <br>

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-templates/entity-types.html
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-templates/entity-types.html
@@ -11,18 +11,18 @@
                     <input type="checkbox" class="form-check-input" id="check-all">
                 </div>
             </th>
-            <th scope="col">Entity</th>
+            <th scope="col">Entity type</th>
         </tr>
         </thead>
         <tbody>
-        {#for entity in info:entities}
+        {#for entityType in info:entityTypes}
         <tr>
             <td>
                 <div class="custom-control">
-                    <input type="checkbox" class="form-check-input checkbox" name="{entity}" id="{entity}">
+                    <input type="checkbox" class="form-check-input checkbox" name="{entityType}" id="{entityType}">
                 </div>
             </td>
-            <td>{entity}</td>
+            <td>{entityType}</td>
         </tr>
         {/for}
         </tbody>

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
@@ -25,7 +25,7 @@ public class HibernateSearchDevConsoleRecorder {
                 }
                 SearchMapping mapping = HibernateSearchSupplier.searchMapping();
                 if (mapping == null) {
-                    flashMessage(event, "There aren't any indexed entities!", FlashScopeUtil.FlashMessageStatus.ERROR);
+                    flashMessage(event, "There aren't any indexed entity types!", FlashScopeUtil.FlashMessageStatus.ERROR);
                     return;
                 }
                 mapping.scope(Object.class,

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
@@ -7,6 +7,7 @@ import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
+import io.quarkus.devconsole.runtime.spi.FlashScopeUtil;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -22,9 +23,13 @@ public class HibernateSearchDevConsoleRecorder {
                 if (form.isEmpty()) {
                     return;
                 }
-                SearchMapping searchMapping = HibernateSearchSupplier.searchMapping();
-                searchMapping.scope(Object.class,
-                        searchMapping.allIndexedEntities().stream()
+                SearchMapping mapping = HibernateSearchSupplier.searchMapping();
+                if (mapping == null) {
+                    flashMessage(event, "There aren't any indexed entities!", FlashScopeUtil.FlashMessageStatus.ERROR);
+                    return;
+                }
+                mapping.scope(Object.class,
+                        mapping.allIndexedEntities().stream()
                                 .map(SearchIndexedEntity::jpaName)
                                 .filter(form::contains)
                                 .collect(Collectors.toList()))

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -12,7 +13,11 @@ import io.quarkus.arc.Arc;
 public class HibernateSearchSupplier implements Supplier<List<String>> {
     @Override
     public List<String> get() {
-        return searchMapping().allIndexedEntities().stream().map(SearchIndexedEntity::jpaName).sorted()
+        SearchMapping mapping = searchMapping();
+        if (mapping == null) {
+            return Collections.emptyList();
+        }
+        return mapping.allIndexedEntities().stream().map(SearchIndexedEntity::jpaName).sorted()
                 .collect(Collectors.toList());
 
     }


### PR DESCRIPTION
Fixes #15352

Also includes a small cosmetic change in the Hibernate Search devcard to avoid confusing entity instances with entity types.