### PR TITLE
Serialization feature support

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -19,6 +19,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final boolean constructors;
     private final boolean finalFieldsWritable;
     private final boolean weak;
+    private final boolean serialization;
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, Class<?>... className) {
         this(true, methods, fields, className);
@@ -30,6 +31,11 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
             boolean weak, Class<?>... className) {
+        this(constructors, methods, fields, false, false, false, className);
+    }
+
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
+            boolean weak, boolean serialization, Class<?>... className) {
         List<String> names = new ArrayList<>();
         for (Class<?> i : className) {
             if (i == null) {
@@ -43,6 +49,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.constructors = constructors;
         this.finalFieldsWritable = finalFieldsWritable;
         this.weak = weak;
+        this.serialization = serialization;
     }
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, String... className) {
@@ -53,12 +60,26 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this(constructors, methods, fields, false, false, className);
     }
 
+    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean serialization,
+            String... className) {
+        this(constructors, methods, fields, false, false, serialization, className);
+    }
+
     public static ReflectiveClassBuildItem weakClass(String... className) {
         return new ReflectiveClassBuildItem(true, true, true, false, true, className);
     }
 
+    public static ReflectiveClassBuildItem serializationClass(String... className) {
+        return new ReflectiveClassBuildItem(false, false, false, false, false, true, className);
+    }
+
     private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
             boolean weak, String... className) {
+        this(constructors, methods, fields, finalFieldsWritable, weak, false, className);
+    }
+
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
+            boolean weak, boolean serialization, String... className) {
         for (String i : className) {
             if (i == null) {
                 throw new NullPointerException();
@@ -70,6 +91,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.constructors = constructors;
         this.finalFieldsWritable = finalFieldsWritable;
         this.weak = weak;
+        this.serialization = serialization;
     }
 
     public List<String> getClassNames() {
@@ -94,6 +116,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isWeak() {
         return weak;
+    }
+
+    public boolean isSerialization() {
+        return serialization;
     }
 
     public static Builder builder(Class<?>... className) {
@@ -122,6 +148,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean fields;
         private boolean finalFieldsWritable;
         private boolean weak;
+        private boolean serialization;
 
         private Builder() {
         }
@@ -153,6 +180,11 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         public Builder weak(boolean weak) {
             this.weak = weak;
+            return this;
+        }
+
+        public Builder serialization(boolean serialize) {
+            this.serialization = serialization;
             return this;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -41,6 +41,7 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     private final Predicate<FieldInfo> ignoreFieldPredicate;
     private final Predicate<MethodInfo> ignoreMethodPredicate;
     private final String source;
+    private final boolean serialization;
 
     /**
      * @deprecated Use the Builder instead.
@@ -104,17 +105,19 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     @Deprecated
     public ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignoreTypePredicate, String source) {
         this(type, index, ignoreTypePredicate, DefaultIgnoreFieldPredicate.INSTANCE, DefaultIgnoreMethodPredicate.INSTANCE,
-                source);
+                source, false);
     }
 
     private ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignoreTypePredicate,
-            Predicate<FieldInfo> ignoreFieldPredicate, Predicate<MethodInfo> ignoreMethodPredicate, String source) {
+            Predicate<FieldInfo> ignoreFieldPredicate, Predicate<MethodInfo> ignoreMethodPredicate, String source,
+            boolean serialization) {
         this.type = type;
         this.index = index;
         this.ignoreTypePredicate = ignoreTypePredicate;
         this.ignoreFieldPredicate = ignoreFieldPredicate;
         this.ignoreMethodPredicate = ignoreMethodPredicate;
         this.source = source;
+        this.serialization = serialization;
     }
 
     public Type getType() {
@@ -141,6 +144,10 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         return source != null;
     }
 
+    public boolean isSerialization() {
+        return serialization;
+    }
+
     public String getSource() {
         return source;
     }
@@ -153,6 +160,7 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         private Predicate<FieldInfo> ignoreFieldPredicate = DefaultIgnoreFieldPredicate.INSTANCE;
         private Predicate<MethodInfo> ignoreMethodPredicate = DefaultIgnoreMethodPredicate.INSTANCE;
         private String source = UNKNOWN_SOURCE;
+        private boolean serialization;
 
         public Builder type(Type type) {
             this.type = type;
@@ -184,9 +192,14 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
             return this;
         }
 
+        public Builder serialization(boolean serialization) {
+            this.serialization = serialization;
+            return this;
+        }
+
         public ReflectiveHierarchyBuildItem build() {
             return new ReflectiveHierarchyBuildItem(type, index, ignoreTypePredicate, ignoreFieldPredicate,
-                    ignoreMethodPredicate, source);
+                    ignoreMethodPredicate, source, serialization);
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.steps;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 
+import java.io.ObjectStreamClass;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -37,6 +38,8 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuil
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
@@ -269,6 +272,7 @@ public class NativeImageAutoFeatureStep {
             addReflectiveClass(reflectiveClasses, forcedNonWeakClasses, i.isConstructors(), i.isMethods(), i.isFields(),
                     i.areFinalFieldsWritable(),
                     i.isWeak(),
+                    i.isSerialization(),
                     i.getClassNames().toArray(new String[0]));
         }
         for (ReflectiveFieldBuildItem i : reflectiveFields) {
@@ -279,12 +283,13 @@ public class NativeImageAutoFeatureStep {
         }
 
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
-            addReflectiveClass(reflectiveClasses, forcedNonWeakClasses, true, false, false, false, false,
+            addReflectiveClass(reflectiveClasses, forcedNonWeakClasses, true, false, false, false, false, false,
                     i.providers().toArray(new String[] {}));
         }
 
-        for (Map.Entry<String, ReflectionInfo> entry : reflectiveClasses.entrySet()) {
+        MethodDescriptor registerSerializationMethod = null;
 
+        for (Map.Entry<String, ReflectionInfo> entry : reflectiveClasses.entrySet()) {
             MethodCreator mv = file.getMethodCreator("registerClass" + count++, "V");
             mv.setModifiers(Modifier.PRIVATE | Modifier.STATIC);
             overallCatch.invokeStaticMethod(mv.getMethodDescriptor());
@@ -357,8 +362,8 @@ public class NativeImageAutoFeatureStep {
             if (entry.getValue().fields) {
                 tc.invokeStaticMethod(
                         ofMethod(RUNTIME_REFLECTION, "register", void.class,
-                                boolean.class, Field[].class),
-                        tc.load(entry.getValue().finalFieldsWritable), fields);
+                                boolean.class, boolean.class, Field[].class),
+                        tc.load(entry.getValue().finalFieldsWritable), tc.load(entry.getValue().serialization), fields);
             } else if (!entry.getValue().fieldSet.isEmpty()) {
                 ResultHandle farray = tc.newArray(Field.class, tc.load(1));
                 for (String field : entry.getValue().fieldSet) {
@@ -370,6 +375,15 @@ public class NativeImageAutoFeatureStep {
                             farray);
                 }
             }
+
+            if (entry.getValue().serialization) {
+                if (registerSerializationMethod == null) {
+                    registerSerializationMethod = createRegisterSerializationForClassMethod(file);
+                }
+
+                tc.invokeStaticMethod(registerSerializationMethod, clazz);
+            }
+
             CatchBlockCreator cc = tc.addCatch(Throwable.class);
             //cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
             mv.returnValue(null);
@@ -439,11 +453,143 @@ public class NativeImageAutoFeatureStep {
         file.close();
     }
 
+    private MethodDescriptor createRegisterSerializationForClassMethod(ClassCreator file) {
+        //register serialization feature as requested
+        MethodCreator requiredFeatures = file.getMethodCreator("getRequiredFeatures", "java.util.List");
+        TryBlock requiredCatch = requiredFeatures.tryBlock();
+
+        ResultHandle serializationFeatureClass = requiredCatch
+                .loadClass("com.oracle.svm.reflect.serialize.hosted.SerializationFeature");
+        ResultHandle requiredFeaturesList = requiredCatch.invokeStaticMethod(
+                ofMethod("java.util.Collections", "singletonList", List.class, Object.class),
+                serializationFeatureClass);
+
+        requiredCatch.returnValue(requiredFeaturesList);
+
+        // method to register class for registration
+        MethodCreator addSerializationForClass = file.getMethodCreator("registerSerializationForClass", "V", Class.class);
+        addSerializationForClass.setModifiers(Modifier.PRIVATE | Modifier.STATIC);
+        ResultHandle clazz = addSerializationForClass.getMethodParam(0);
+
+        TryBlock tc = addSerializationForClass.tryBlock();
+
+        ResultHandle currentThread = tc
+                .invokeStaticMethod(ofMethod(Thread.class, "currentThread", Thread.class));
+        ResultHandle tccl = tc.invokeVirtualMethod(
+                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
+                currentThread);
+
+        ResultHandle objectClass = tc.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                tc.load("java.lang.Object"), tc.load(false), tccl);
+
+        ResultHandle serializationSupport = tc.invokeStaticMethod(
+                IMAGE_SINGLETONS_LOOKUP,
+                tc.loadClass("com.oracle.svm.core.jdk.serialize.SerializationRegistry"));
+
+        ResultHandle reflectionFactory = tc.invokeStaticMethod(
+                ofMethod("sun.reflect.ReflectionFactory", "getReflectionFactory", "sun.reflect.ReflectionFactory"));
+
+        AssignableResultHandle newSerializationConstructor = tc.createVariable(Constructor.class);
+
+        ResultHandle externalizableClass = tc.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                tc.load("java.io.Externalizable"), tc.load(false), tccl);
+
+        BranchResult isExternalizable = tc
+                .ifTrue(tc.invokeVirtualMethod(ofMethod(Class.class, "isAssignableFrom", boolean.class, Class.class),
+                        externalizableClass, clazz));
+        BytecodeCreator ifIsExternalizable = isExternalizable.trueBranch();
+
+        ResultHandle array1 = ifIsExternalizable.newArray(Class.class, tc.load(1));
+        ResultHandle classClass = ifIsExternalizable.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                ifIsExternalizable.load("java.lang.Class"), ifIsExternalizable.load(false), tccl);
+        ifIsExternalizable.writeArrayValue(array1, 0, classClass);
+
+        ResultHandle externalizableLookupMethod = ifIsExternalizable.invokeStaticMethod(
+                ofMethod("com.oracle.svm.util.ReflectionUtil", "lookupMethod", Method.class, Class.class, String.class,
+                        Class[].class),
+                ifIsExternalizable.loadClass(ObjectStreamClass.class), ifIsExternalizable.load("getExternalizableConstructor"),
+                array1);
+
+        ResultHandle array2 = ifIsExternalizable.newArray(Object.class, tc.load(1));
+        ifIsExternalizable.writeArrayValue(array2, 0, clazz);
+
+        ResultHandle externalizableConstructor = ifIsExternalizable.invokeVirtualMethod(
+                ofMethod(Method.class, "invoke", Object.class, Object.class,
+                        Object[].class),
+                externalizableLookupMethod, ifIsExternalizable.loadNull(), array2);
+
+        ResultHandle externalizableConstructorClass = ifIsExternalizable.invokeVirtualMethod(
+                ofMethod(Constructor.class, "getDeclaringClass", Class.class),
+                externalizableConstructor);
+
+        ifIsExternalizable.invokeStaticMethod(
+                ofMethod("com.oracle.svm.reflect.serialize.hosted.SerializationFeature", "addReflections", void.class,
+                        Class.class, Class.class),
+                clazz, externalizableConstructorClass);
+
+        ifIsExternalizable.returnValue(null);
+
+        ResultHandle clazzModifiers = tc
+                .invokeVirtualMethod(ofMethod(Class.class, "getModifiers", int.class), clazz);
+        BranchResult isAbstract = tc.ifTrue(tc
+                .invokeStaticMethod(ofMethod(Modifier.class, "isAbstract", boolean.class, int.class), clazzModifiers));
+
+        BytecodeCreator ifIsAbstract = isAbstract.trueBranch();
+        BytecodeCreator ifNotAbstract = isAbstract.falseBranch();
+
+        //abstract classes uses SerializationSupport$StubForAbstractClass for constructor
+        ResultHandle stubConstructor = ifIsAbstract.invokeVirtualMethod(
+                ofMethod("sun.reflect.ReflectionFactory", "newConstructorForSerialization", Constructor.class,
+                        Class.class),
+                reflectionFactory,
+                tc
+                        .loadClass("com.oracle.svm.reflect.serialize.SerializationSupport$StubForAbstractClass"));
+        ifIsAbstract.assign(newSerializationConstructor, stubConstructor);
+
+        ResultHandle classConstructor = ifNotAbstract.invokeVirtualMethod(
+                ofMethod("sun.reflect.ReflectionFactory", "newConstructorForSerialization", Constructor.class,
+                        Class.class),
+                reflectionFactory, clazz);
+        ifNotAbstract.assign(newSerializationConstructor, classConstructor);
+
+        ResultHandle newSerializationConstructorClass = tc.invokeVirtualMethod(
+                ofMethod(Constructor.class, "getDeclaringClass", Class.class),
+                newSerializationConstructor);
+
+        ResultHandle lookupMethod = tc.invokeStaticMethod(
+                ofMethod("com.oracle.svm.util.ReflectionUtil", "lookupMethod", Method.class, Class.class, String.class,
+                        Class[].class),
+                tc.loadClass(Constructor.class), tc.load("getConstructorAccessor"),
+                tc.newArray(Class.class, tc.load(0)));
+
+        ResultHandle accessor = tc.invokeVirtualMethod(
+                ofMethod(Method.class, "invoke", Object.class, Object.class,
+                        Object[].class),
+                lookupMethod, newSerializationConstructor,
+                tc.newArray(Object.class, tc.load(0)));
+
+        tc.invokeVirtualMethod(
+                ofMethod("com.oracle.svm.reflect.serialize.SerializationSupport", "addConstructorAccessor",
+                        Object.class, Class.class, Class.class, Object.class),
+                serializationSupport, clazz, newSerializationConstructorClass, accessor);
+        tc.invokeStaticMethod(
+                ofMethod("com.oracle.svm.reflect.serialize.hosted.SerializationFeature", "addReflections", void.class,
+                        Class.class, Class.class),
+                clazz, objectClass);
+
+        addSerializationForClass.returnValue(null);
+
+        return addSerializationForClass.getMethodDescriptor();
+    }
+
     public void addReflectiveMethod(Map<String, ReflectionInfo> reflectiveClasses, ReflectiveMethodBuildItem methodInfo) {
         String cl = methodInfo.getDeclaringClass();
         ReflectionInfo existing = reflectiveClasses.get(cl);
         if (existing == null) {
-            reflectiveClasses.put(cl, existing = new ReflectionInfo(false, false, false, false, false));
+            reflectiveClasses.put(cl, existing = new ReflectionInfo(false, false, false, false, false, false));
         }
         if (methodInfo.getName().equals("<init>")) {
             existing.ctorSet.add(methodInfo);
@@ -454,13 +600,13 @@ public class NativeImageAutoFeatureStep {
 
     public void addReflectiveClass(Map<String, ReflectionInfo> reflectiveClasses, Set<String> forcedNonWeakClasses,
             boolean constructors, boolean method,
-            boolean fields, boolean finalFieldsWritable, boolean weak,
+            boolean fields, boolean finalFieldsWritable, boolean weak, boolean serialization,
             String... className) {
         for (String cl : className) {
             ReflectionInfo existing = reflectiveClasses.get(cl);
             if (existing == null) {
                 reflectiveClasses.put(cl, new ReflectionInfo(constructors, method, fields, finalFieldsWritable,
-                        !forcedNonWeakClasses.contains(cl) && weak));
+                        !forcedNonWeakClasses.contains(cl) && weak, serialization));
             } else {
                 if (constructors) {
                     existing.constructors = true;
@@ -471,6 +617,9 @@ public class NativeImageAutoFeatureStep {
                 if (fields) {
                     existing.fields = true;
                 }
+                if (serialization) {
+                    existing.serialization = true;
+                }
             }
         }
     }
@@ -479,7 +628,7 @@ public class NativeImageAutoFeatureStep {
         String cl = fieldInfo.getDeclaringClass();
         ReflectionInfo existing = reflectiveClasses.get(cl);
         if (existing == null) {
-            reflectiveClasses.put(cl, existing = new ReflectionInfo(false, false, false, false, false));
+            reflectiveClasses.put(cl, existing = new ReflectionInfo(false, false, false, false, false, false));
         }
         existing.fieldSet.add(fieldInfo.getName());
     }
@@ -490,17 +639,20 @@ public class NativeImageAutoFeatureStep {
         boolean fields;
         boolean finalFieldsWritable;
         boolean weak;
+        boolean serialization;
         Set<String> fieldSet = new HashSet<>();
         Set<ReflectiveMethodBuildItem> methodSet = new HashSet<>();
         Set<ReflectiveMethodBuildItem> ctorSet = new HashSet<>();
 
         private ReflectionInfo(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
-                boolean weak) {
+                boolean weak, boolean serialization) {
             this.methods = methods;
             this.fields = fields;
             this.constructors = constructors;
             this.finalFieldsWritable = finalFieldsWritable;
             this.weak = weak;
+            this.serialization = serialization;
         }
     }
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -195,6 +195,7 @@ public class ReflectiveHierarchyStep {
                         .methods(true)
                         .fields(true)
                         .finalFieldsWritable(doFinalFieldsNeedToBeWritable(info, finalFieldsWritable))
+                        .serialization(reflectiveHierarchyBuildItem.isSerialization())
                         .build());
 
         processedReflectiveHierarchies.add(name);

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -43,4 +43,6 @@ public @interface RegisterForReflection {
      * register private classes for Reflection.
      */
     String[] classNames() default {};
+
+    boolean serialization() default false;
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationTestEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationTestEndpoint.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.corestuff;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.quarkus.it.corestuff.serialization.ExternalizablePerson;
+import io.quarkus.it.corestuff.serialization.Person;
+import io.quarkus.it.corestuff.serialization.SomeSerializationObject;
+
+/**
+ * Some core serialization functionality tests
+ */
+@WebServlet(name = "CoreSerializationTestEndpoint", urlPatterns = "/core/serialization")
+public class SerializationTestEndpoint extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        reflectiveSetterInvoke(resp);
+    }
+
+    private void reflectiveSetterInvoke(HttpServletResponse resp) throws IOException {
+        try {
+            SomeSerializationObject instance = new SomeSerializationObject();
+            instance.setPerson(new Person("Sheldon"));
+            ExternalizablePerson ep = new ExternalizablePerson();
+            ep.setName("Sheldon 2.0");
+            instance.setExternalizablePerson(ep);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ObjectOutputStream os = new ObjectOutputStream(out);
+            os.writeObject(instance);
+            ByteArrayInputStream bais = new ByteArrayInputStream(out.toByteArray());
+            ObjectInputStream is = new ObjectInputStream(bais);
+            SomeSerializationObject result = (SomeSerializationObject) is.readObject();
+            if (result.getPerson().getName().equals("Sheldon")
+                    && result.getExternalizablePerson().getName().equals("Sheldon 2.0")) {
+                resp.getWriter().write("OK");
+            } else {
+                reportException("Serialized output differs from input", null, resp);
+            }
+        } catch (Exception e) {
+            reportException(e, resp);
+        }
+    }
+
+    private void reportException(final Exception e, final HttpServletResponse resp) throws IOException {
+        reportException(null, e, resp);
+    }
+
+    private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {
+        final PrintWriter writer = resp.getWriter();
+        if (errorMessage != null) {
+            writer.write(errorMessage);
+            writer.write(" ");
+        }
+        writer.write(e.toString());
+        writer.append("\n\t");
+        e.printStackTrace(writer);
+        writer.append("\n\t");
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/AbstractParent.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/AbstractParent.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.corestuff.serialization;
+
+import java.io.Serializable;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(serialization = true)
+abstract class AbstractPerson implements Serializable {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/ExternalizablePerson.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/ExternalizablePerson.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.corestuff.serialization;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(serialization = true)
+public class ExternalizablePerson implements Externalizable {
+
+    private String name;
+
+    public ExternalizablePerson() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeUTF(name);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in)
+            throws IOException, ClassNotFoundException {
+        this.name = in.readUTF();
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/Person.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/Person.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.corestuff.serialization;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(serialization = true)
+public class Person extends AbstractPerson {
+    public Person() {
+    }
+
+    public Person(String name) {
+        setName(name);
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SomeSerializationObject.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SomeSerializationObject.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.corestuff.serialization;
+
+import java.io.Serializable;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(serialization = true)
+public class SomeSerializationObject implements Serializable {
+
+    private Person person;
+    private ExternalizablePerson externalizablePerson;
+
+    public Person getPerson() {
+        return person;
+    }
+
+    public void setPerson(Person person) {
+        this.person = person;
+    }
+
+    public ExternalizablePerson getExternalizablePerson() {
+        return externalizablePerson;
+    }
+
+    public void setExternalizablePerson(ExternalizablePerson externalizablePerson) {
+        this.externalizablePerson = externalizablePerson;
+    }
+}

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -52,4 +52,4 @@ quarkus.native.resources.excludes = **/unwanted.*
 
 quarkus.log.metrics.enabled=true
 
-quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection-config.json
+quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection-config.json,-H:SerializationConfigurationResources=serialization-config.json

--- a/integration-tests/main/src/main/resources/serialization-config.json
+++ b/integration-tests/main/src/main/resources/serialization-config.json
@@ -1,0 +1,5 @@
+[
+  {
+    "name" : "java.lang.String"
+  }
+]

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/CoreSerializationInGraalITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/CoreSerializationInGraalITCase.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.NativeImageTest;
+import io.restassured.RestAssured;
+
+@NativeImageTest
+public class CoreSerializationInGraalITCase {
+
+    @Test
+    public void testEntitySerializationFromServlet() throws Exception {
+        RestAssured.when().get("/core/serialization").then()
+                .body(is("OK"));
+    }
+
+}


### PR DESCRIPTION
fixes  https://github.com/quarkusio/quarkus/issues/14530

GraalVM contains support for serialization https://github.com/oracle/graal/pull/2730

This PR tries to add programmatical approach for extensions. Main idea is to provide generated registration of serialization classes using existing BuildItems. 

**Description**

-  `serialization` field is added into `ReflectiveClassBuildItem `, `ReflectiveHierarchyBuildItem` and `RegisterForReflection` annotation.
- If serialization requirement is detected, generated **AutoFeature** depends on **SerializationFeatue** (there is a "cache" of registered serialized classes, which is required in runtime.
- Each  class for serialization is registered via `com.oracle.svm.reflect.serialize.SerializationSupport.addConstructorAccessor` and reflection is registered via `com.oracle.svm.reflect.serialize.SerializationSupport.addReflections`
- Unfortunately there is a code which handles abstract classes, which had to be rewriten into bytecode generation. This seems to be a weak point of this approach, because it has to be kept in sync with graalVm code.

**Possible optimizations and features for better experience**

- There could be duplicate reflective registrations, one from our buildItem implementation, second from `com.oracle.svm.reflect.serialize.SerializationSupport.addReflections`. This could be avoided.
- There is no need to register classes with `Externalizable` interface. Similar classes could be skipped for serialization registration.
- It would be nice to add some kind of `ReferenceSerializationBuiltItem`, which register all `serializable` references of the target class. It would make registration easier, there will be no requirement to register for example `java.lang.String`, which is typically part of the serialized classes.

~~Problems and TODOs~~

- ~~I hit a problem with several types during its serialization. I'm not sure what is happening. But it has to be investigated and fixed.~~ 
- ~~If `java.util.concurrent.atomic.AtomicBoolean` is registered with this feature, I see following error (registration via config works):~~
> error:org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: VarHandle object must be a compile time constant
- ~~If `java.lang.String` is registered with this feature, I see following error (registration via config works):~~
>  error:org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.svm.core.util.VMError$HostedError: Discovered an unresolved calee while parsing java.lang.StringCoding$StringDecoder.decode(StringCoding.java:191)

**Alternative approaches**

It could be feasible to gather all classes registered for serialization, generate serialization-config.xml and attach it to build args. This approach won't duplicate any code from GraalVM.

JUnit test is present.

**Edited** - some problems were solved. See comments.

