### PR TITLE
Include quarkus-mutiny instead of vanilla mutiny in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-common</artifactId>
         </dependency>
         <dependency>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Fixes: #15400

The warning in the issue is triggered by the inclusion of the client, but nonetheless we should be including quarkus munity in RESTEasy Reactive