### PR TITLE
Disable flaky container image test

### DIFF
--- a/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/GreetingResourceIT.java
+++ b/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/GreetingResourceIT.java
@@ -3,10 +3,12 @@ package io.quarkus.it.container.image;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
+@Disabled("This test seems flaky")
 @QuarkusIntegrationTest
 public class GreetingResourceIT {
 


### PR DESCRIPTION
I'll need to look into why the test is flaky, but for now, let's just disable it 