### PR TITLE
Fix file permission issue for container builds on remote daemons

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -1,7 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -12,7 +10,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
@@ -33,23 +30,10 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         containerRuntime = nativeConfig.containerRuntime.orElseGet(NativeImageBuildContainerRunner::detectContainerRuntime);
         log.infof("Using %s to run the native image builder", containerRuntime.getExecutableName());
 
-        List<String> containerRuntimeArgs = new ArrayList<>();
-        Collections.addAll(containerRuntimeArgs, "--env", "LANG=C");
+        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C" };
 
         outputPath = outputDir == null ? null : outputDir.toAbsolutePath().toString();
 
-        if (SystemUtils.IS_OS_LINUX) {
-            String uid = getLinuxID("-ur");
-            String gid = getLinuxID("-gr");
-            if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
-                Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
-                if (containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
-                    // Needed to avoid AccessDeniedExceptions
-                    containerRuntimeArgs.add("--userns=keep-id");
-                }
-            }
-        }
-        this.baseContainerRuntimeArgs = containerRuntimeArgs.toArray(new String[0]);
     }
 
     @Override


### PR DESCRIPTION
Don't use --user and --userns in remote containers

Using them results in files being copied back to host to be owned by the
guest user instead of the host user.

e.g.
$ podman create --name temp --user 1000:1000 --userns=keep-id -it \
    quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11
$ podman cp temp:/opt/graalvm/bin/native-image remote-native-image
$ ls -la remote-native-image
-rwxr-xr-x. 1 100000 100000 14641161 Feb 14 03:28 remote-native-image*
$ id -u
1000

(cherry picked from commit 5d4f39d78c113a17b45b4a16973dbcf3a41ea949, PR #15288)