### PR TITLE
Dev UI - Add a margin-bottom to main-container

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/css/dev-console.css
@@ -4,6 +4,7 @@
 
 .main-container {
     margin-top: 1em;
+    margin-bottom: 4em;
 }
 
 .cards-index {


### PR DESCRIPTION
When the page is long, there was no margin at all between the content
and the log bar at the bottom.