### PR TITLE
Check OIDC discovery 'introspection_endpont' property

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -3,6 +3,14 @@ package io.quarkus.oidc;
 import io.vertx.core.json.JsonObject;
 
 public class OidcConfigurationMetadata {
+    private static final String ISSUER = "issuer";
+    private static final String TOKEN_ENDPOINT = "token_endpoint";
+    private static final String INTROSPECTION_ENDPOINT = "introspection_endpoint";
+    private static final String AUTHORIZATION_ENDPOINT = "authorization_endpoint";
+    private static final String JWKS_ENDPOINT = "jwks_uri";
+    private static final String USERINFO_ENDPOINT = "userinfo_endpoint";
+    private static final String END_SESSION_ENDPOINT = "end_session_endpoint";
+
     private final String tokenUri;
     private final String introspectionUri;
     private final String authorizationUri;
@@ -28,13 +36,13 @@ public class OidcConfigurationMetadata {
     }
 
     public OidcConfigurationMetadata(JsonObject wellKnownConfig) {
-        this.tokenUri = wellKnownConfig.getString("token_endpoint");
-        this.introspectionUri = wellKnownConfig.getString("token_introspection_endpoint");
-        this.authorizationUri = wellKnownConfig.getString("authorization_endpoint");
-        this.jsonWebKeySetUri = wellKnownConfig.getString("jwks_uri");
-        this.userInfoUri = wellKnownConfig.getString("userinfo_endpoint");
-        this.endSessionUri = wellKnownConfig.getString("end_session_endpoint");
-        this.issuer = wellKnownConfig.getString("issuer");
+        this.tokenUri = wellKnownConfig.getString(TOKEN_ENDPOINT);
+        this.introspectionUri = wellKnownConfig.getString(INTROSPECTION_ENDPOINT);
+        this.authorizationUri = wellKnownConfig.getString(AUTHORIZATION_ENDPOINT);
+        this.jsonWebKeySetUri = wellKnownConfig.getString(JWKS_ENDPOINT);
+        this.userInfoUri = wellKnownConfig.getString(USERINFO_ENDPOINT);
+        this.endSessionUri = wellKnownConfig.getString(END_SESSION_ENDPOINT);
+        this.issuer = wellKnownConfig.getString(ISSUER);
     }
 
     public String getTokenUri() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -141,10 +141,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             tokenJson = OidcUtils.decodeJwtContent(tokenCred.getToken());
                         }
                         if (tokenJson != null) {
-                            OidcUtils.validatePrimaryJwtTokenType(resolvedContext.oidcConfig.token, tokenJson);
-                            JsonObject rolesJson = getRolesJson(vertxContext, resolvedContext, tokenCred, tokenJson,
-                                    userInfo);
                             try {
+                                OidcUtils.validatePrimaryJwtTokenType(resolvedContext.oidcConfig.token, tokenJson);
+                                JsonObject rolesJson = getRolesJson(vertxContext, resolvedContext, tokenCred, tokenJson,
+                                        userInfo);
                                 SecurityIdentity securityIdentity = validateAndCreateIdentity(vertxContext, tokenCred,
                                         resolvedContext.oidcConfig,
                                         tokenJson, rolesJson, userInfo);
@@ -154,7 +154,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                     return Uni.createFrom().item(securityIdentity);
                                 }
                             } catch (Throwable ex) {
-                                return Uni.createFrom().failure(ex);
+                                return Uni.createFrom().failure(new AuthenticationFailedException(ex));
                             }
                         } else if (tokenCred instanceof IdTokenCredential
                                 || tokenCred instanceof AccessTokenCredential

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -160,10 +160,6 @@ public class OidcRecorder {
             }
         }
 
-        final long connectionRetryCount = OidcCommonUtils.getConnectionRetryCount(oidcConfig);
-        if (connectionRetryCount > 1) {
-            LOG.infof("Connecting to IDP for up to %d times every 2 seconds", connectionRetryCount);
-        }
         return createOidcProvider(oidcConfig, tlsConfig, vertx)
                 .onItem().transform(p -> new TenantConfigContext(p, oidcConfig));
     }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -41,7 +41,7 @@ public class OidcResource {
         final String baseUri = ui.getBaseUriBuilder().path("oidc").build().toString();
         return "{" +
                 "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
-                "   \"token_introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
+                "   \"introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
                 "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
                 "  }";
     }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java
@@ -41,7 +41,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
                                 .withBody("{\n" +
                                         "    \"jwks_uri\": \"" + server.baseUrl()
                                         + "/auth/realms/quarkus/protocol/openid-connect/certs\",\n" +
-                                        "    \"token_introspection_endpoint\": \"" + server.baseUrl()
+                                        "    \"introspection_endpoint\": \"" + server.baseUrl()
                                         + "/auth/realms/quarkus/protocol/openid-connect/token/introspect\",\n"
                                         + "\"issuer\" : \"https://server.example.com\""
                                         + "}")));

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -133,13 +133,21 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
-    public void testDeniedNoBearerToken() {
+    public void testVerificationFailedNoBearerToken() {
         RestAssured.given()
                 .when().get("/api/users/me").then()
                 .statusCode(401);
     }
 
+    @Test
+    public void testVerificationFailedInvalidToken() {
+        RestAssured.given().auth().oauth2("123")
+                .when().get("/api/users/me").then()
+                .statusCode(401);
+    }
+
     //see https://github.com/quarkusio/quarkus/issues/5809
+    @Test
     @RepeatedTest(20)
     public void testOidcAndVertxHandler() {
         RestAssured.given().auth().oauth2(getAccessToken("alice"))


### PR DESCRIPTION
Fixes #15440.

This PR checks not only the legacy `token_introspection_endpoint` but also `introspection_endpoint` discovery property.
How did the tests pass without it ? 1) `integration-tests/oidc_wiremock` uses `token_introspection_endpoint` while `integration-tests/oidc_tenancy` which has a few tests involving the introspection use the test `OidcResource` and a non-discovery option to set the introspection path directly on `OidcTenantConfig`.

This PR also makes sure the extra token verification failures are correctly returned as `AuthenticationFailedException` - after I fixed the `introspection_endpoint` check the `integration-tests/oidc` test which sends a refresh token as a bearer token and expects 401 started failing with 500. The reason it was passing before the fix is because: Keycloak RT is JWT but its verification fails due to `UnresolvedKeyException` as it has no matching JWK - and since the live KC `introspection_endpoint` was missed - it was immediately returning 401. With the fix the RT is successfully introspected but now the code which has always been used before is hit which throws `OIDCException` if the JWT `typ` is `Refresh` - however during the refactoring  wrapping this exception as `AuthenticationFailedException` was lost which is now restored.

I've also added one more test sending an opaque bearer token which is expected to fail with 401. And restored one test which was accidentally disabled during the refactoring

Hope  it clarifies it all.  

CC @Sgitario 