### PR TITLE
Add basic exception mapping to all REST Data extensions

### DIFF
--- a/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
+++ b/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
@@ -24,8 +24,10 @@ import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.mongodb.rest.data.panache.PanacheMongoEntityResource;
 import io.quarkus.mongodb.rest.data.panache.PanacheMongoRepositoryResource;
+import io.quarkus.mongodb.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 class MongoPanacheRestProcessor {
 
@@ -38,6 +40,11 @@ class MongoPanacheRestProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(MONGODB_REST_DATA_PANACHE);
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     @BuildStep

--- a/extensions/panache/mongodb-rest-data-panache/runtime/src/main/java/io/quarkus/mongodb/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
+++ b/extensions/panache/mongodb-rest-data-panache/runtime/src/main/java/io/quarkus/mongodb/rest/data/panache/runtime/RestDataPanacheExceptionMapper.java
@@ -1,13 +1,18 @@
-package io.quarkus.hibernate.orm.rest.data.panache.runtime;
+package io.quarkus.mongodb.rest.data.panache.runtime;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import org.jboss.logging.Logger;
 
+import com.mongodb.MongoWriteException;
+
 import io.quarkus.rest.data.panache.RestDataPanacheException;
 
 public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+
+    private static final String DUPLICATE_KEY_ERROR_CODE = "E11000";
+
     private static final Logger LOGGER = Logger.getLogger(RestDataPanacheExceptionMapper.class);
 
     @Override
@@ -17,12 +22,8 @@ public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataP
     }
 
     private Response throwableToResponse(Throwable throwable, String message) {
-        if (throwable instanceof org.hibernate.exception.ConstraintViolationException) {
+        if (throwable instanceof MongoWriteException && throwable.getMessage().contains(DUPLICATE_KEY_ERROR_CODE)) {
             return Response.status(Response.Status.CONFLICT.getStatusCode(), message).build();
-        }
-
-        if (throwable instanceof javax.validation.ConstraintViolationException) {
-            return Response.status(Response.Status.BAD_REQUEST.getStatusCode(), message).build();
         }
 
         if (throwable.getCause() != null) {

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
@@ -26,10 +26,12 @@ import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.rest.data.panache.deployment.properties.ResourcePropertiesBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.spring.data.rest.deployment.crud.CrudMethodsImplementor;
 import io.quarkus.spring.data.rest.deployment.crud.CrudPropertiesProvider;
 import io.quarkus.spring.data.rest.deployment.paging.PagingAndSortingMethodsImplementor;
 import io.quarkus.spring.data.rest.deployment.paging.PagingAndSortingPropertiesProvider;
+import io.quarkus.spring.data.rest.runtime.RestDataPanacheExceptionMapper;
 
 class SpringDataRestProcessor {
 
@@ -48,6 +50,11 @@ class SpringDataRestProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(SPRING_DATA_REST);
+    }
+
+    @BuildStep
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     @BuildStep

--- a/extensions/spring-data-rest/runtime/src/main/java/io/quarkus/spring/data/rest/runtime/RestDataPanacheExceptionMapper.java
+++ b/extensions/spring-data-rest/runtime/src/main/java/io/quarkus/spring/data/rest/runtime/RestDataPanacheExceptionMapper.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.rest.data.panache.runtime;
+package io.quarkus.spring.data.rest.runtime;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.rest.data.panache.RestDataPanacheException;
 
 public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+
     private static final Logger LOGGER = Logger.getLogger(RestDataPanacheExceptionMapper.class);
 
     @Override
@@ -17,10 +18,6 @@ public class RestDataPanacheExceptionMapper implements ExceptionMapper<RestDataP
     }
 
     private Response throwableToResponse(Throwable throwable, String message) {
-        if (throwable instanceof org.hibernate.exception.ConstraintViolationException) {
-            return Response.status(Response.Status.CONFLICT.getStatusCode(), message).build();
-        }
-
         if (throwable instanceof javax.validation.ConstraintViolationException) {
             return Response.status(Response.Status.BAD_REQUEST.getStatusCode(), message).build();
         }

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -76,6 +80,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-rest-data-panache/src/main/java/io/quarkus/it/hibernate/orm/rest/data/panache/Book.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/main/java/io/quarkus/it/hibernate/orm/rest/data/panache/Book.java
@@ -4,6 +4,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
 
 @Entity
 public class Book {
@@ -12,6 +13,7 @@ public class Book {
     @GeneratedValue
     private Long id;
 
+    @NotBlank
     private String title;
 
     @ManyToOne

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
@@ -164,6 +164,24 @@ class HibernateOrmRestDataPanacheTest {
     }
 
     @Test
+    void shouldNotCreateBookWithBlankTitle() {
+        JsonObject author = Json.createObjectBuilder()
+                .add("id", DOSTOEVSKY_ID)
+                .add("name", DOSTOEVSKY_NAME)
+                .add("dob", DOSTOEVSKY_DOB)
+                .build();
+        JsonObject book = Json.createObjectBuilder()
+                .add("title", "")
+                .add("author", author)
+                .build();
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body(book.toString())
+                .when().post("/books")
+                .then().statusCode(400);
+    }
+
+    @Test
     void shouldNotUpdateAuthor() {
         JsonObject author = Json.createObjectBuilder()
                 .add("id", DOSTOEVSKY_ID)

--- a/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/Book.java
+++ b/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/Book.java
@@ -1,23 +1,24 @@
 package io.quarkus.it.mongodb.rest.data.panache;
 
-import org.bson.types.ObjectId;
+import org.bson.codecs.pojo.annotations.BsonId;
 
 import io.quarkus.mongodb.panache.MongoEntity;
 
 @MongoEntity
 public class Book {
 
-    private ObjectId id;
+    @BsonId
+    private String id;
 
     private String title;
 
     private Author author;
 
-    public ObjectId getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(ObjectId id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/BookRepository.java
+++ b/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/BookRepository.java
@@ -2,8 +2,8 @@ package io.quarkus.it.mongodb.rest.data.panache;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 
 @ApplicationScoped
-public class BookRepository implements PanacheMongoRepository<Book> {
+public class BookRepository implements PanacheMongoRepositoryBase<Book, String> {
 }

--- a/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/BooksResource.java
+++ b/integration-tests/mongodb-rest-data-panache/src/main/java/io/quarkus/it/mongodb/rest/data/panache/BooksResource.java
@@ -1,10 +1,8 @@
 package io.quarkus.it.mongodb.rest.data.panache;
 
-import org.bson.types.ObjectId;
-
 import io.quarkus.mongodb.rest.data.panache.PanacheMongoRepositoryResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
 @ResourceProperties(hal = true)
-public interface BooksResource extends PanacheMongoRepositoryResource<BookRepository, Book, ObjectId> {
+public interface BooksResource extends PanacheMongoRepositoryResource<BookRepository, Book, String> {
 }

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -76,6 +80,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/Book.java
+++ b/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/Book.java
@@ -4,6 +4,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
 
 @Entity
 public class Book {
@@ -12,6 +13,7 @@ public class Book {
     @GeneratedValue
     private Long id;
 
+    @NotBlank
     private String title;
 
     @ManyToOne

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
@@ -205,4 +205,22 @@ class SpringDataRestTest {
         when().delete(location)
                 .then().statusCode(204);
     }
+
+    @Test
+    void shouldNotCreateBookWithBlankTitle() {
+        JsonObject author = Json.createObjectBuilder()
+                .add("id", DOSTOEVSKY_ID)
+                .add("name", DOSTOEVSKY_NAME)
+                .add("dob", DOSTOEVSKY_DOB)
+                .build();
+        JsonObject book = Json.createObjectBuilder()
+                .add("title", "")
+                .add("author", author)
+                .build();
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body(book.toString())
+                .when().put("/books/100")
+                .then().statusCode(400);
+    }
 }


### PR DESCRIPTION
Added default exception mappers to the REST Data Panache Hibernate, Mongo and Spring Data REST extensions.

Hibernate:

- `javax.validation.ConstraintViolationException` - `400 Bad Request`
- `org.hibernate.exception.ConstraintViolationException` - `409 Conflict`
- Everything else - `500 Internal Server Error`

Mongo:

- `MongoWriteException` ID E11000 - `409 Conflict`
- Everything else - `500 Internal Server Error`

Spring Data REST

- `javax.validation.ConstraintViolationException` - `400 Bad Request`
- Everything else - `500 Internal Server Error`

Fixes https://github.com/quarkusio/quarkus/issues/13307