### PR TITLE
Make sure compileClasspath is resolved before quarkusGenerateCode task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -12,8 +12,10 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 
@@ -39,6 +41,16 @@ public class QuarkusGenerateCode extends QuarkusTask {
 
     public QuarkusGenerateCode() {
         super("Performs Quarkus pre-build preparations, such as sources generation");
+    }
+
+    /**
+     * Create a dependency on classpath resolution. This makes sure included build are build this task runs.
+     *
+     * @return resolved compile classpath
+     */
+    @CompileClasspath
+    public FileCollection getClasspath() {
+        return QuarkusGradleUtils.getSourceSet(getProject(), SourceSet.MAIN_SOURCE_SET_NAME).getCompileClasspath();
     }
 
     @TaskAction

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleIncludedBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleIncludedBuildTest.java
@@ -16,7 +16,7 @@ public class MultiModuleIncludedBuildTest extends QuarkusDevGradleTestBase {
 
     @Override
     protected String[] buildArguments() {
-        return new String[] { "clean", "--include-build", "../external-library", "quarkusDev" };
+        return new String[] { "--include-build", "../external-library", "clean", "quarkusDev" };
     }
 
     @Override


### PR DESCRIPTION
This fix add a "dependency" on dependency resolution. This make sure all dependencies are resolved before calling the code generation task. 

This is needed because, when using included build, there was no guarantee that `quarkusGenerateCode` was run after `included-build` build. This was resulting in flaky test reporting a missing jar. 

cc @gsmet there should be less failures with this fix.