### PR TITLE
Register parent dirs when deserializing the app

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -125,15 +125,12 @@ public class SerializedApplication {
                 int numDirs = in.readUnsignedShort();
                 for (int i = 0; i < numDirs; ++i) {
                     String dir = in.readUTF();
-                    ClassLoadingResource[] existing = resourceDirectoryMap.get(dir);
-                    if (existing == null) {
-                        resourceDirectoryMap.put(dir, new ClassLoadingResource[] { resource });
-                    } else {
-                        ClassLoadingResource[] newResources = new ClassLoadingResource[existing.length + 1];
-                        System.arraycopy(existing, 0, newResources, 0, existing.length);
-                        newResources[existing.length] = resource;
-                        resourceDirectoryMap.put(dir, newResources);
+                    int j = dir.indexOf('/');
+                    while (j >= 0) {
+                        addResourceDir(dir.substring(0, j), resource, resourceDirectoryMap);
+                        j = dir.indexOf('/', j + 1);
                     }
+                    addResourceDir(dir, resource, resourceDirectoryMap);
                 }
             }
             int packages = in.readUnsignedShort();
@@ -165,6 +162,19 @@ public class SerializedApplication {
                 classLoadingResource.init(runnerClassLoader);
             }
             return new SerializedApplication(runnerClassLoader, mainClass);
+        }
+    }
+
+    private static void addResourceDir(String dir, JarResource resource,
+            Map<String, ClassLoadingResource[]> resourceDirectoryMap) {
+        ClassLoadingResource[] existing = resourceDirectoryMap.get(dir);
+        if (existing == null) {
+            resourceDirectoryMap.put(dir, new ClassLoadingResource[] { resource });
+        } else {
+            ClassLoadingResource[] newResources = new ClassLoadingResource[existing.length + 1];
+            System.arraycopy(existing, 0, newResources, 0, existing.length);
+            newResources[existing.length] = resource;
+            resourceDirectoryMap.put(dir, newResources);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/quarkusio/code.quarkus.io/issues/428

It appears parent directories aren't registered as resources for the RunnerClassLoader. This change appears to fix it. Although this doesn't look like a proper fix, given that multiple instances of JarResource may appear to be providers of the same "parent" dir.