### PR TITLE
Add maven-resolver-api as parentFirstArtifact

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -131,6 +131,7 @@
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager-embedded</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logging:jboss-logging</parentFirstArtifact>
                         <parentFirstArtifact>org.apache.maven:maven-model</parentFirstArtifact>
+                        <parentFirstArtifact>org.apache.maven.resolver:maven-resolver-api</parentFirstArtifact>
                         <parentFirstArtifact>org.codehaus.plexus:plexus-utils</parentFirstArtifact>
                         <parentFirstArtifact>xml-apis:xml-apis</parentFirstArtifact>
                         <!--


### PR DESCRIPTION
This fixes devmode for code.quarkus.io.

fyi @ia3andy 