### PR TITLE
Remote dev mode fails on missing project directory

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassLoaderCompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassLoaderCompiler.java
@@ -146,7 +146,7 @@ public class ClassLoaderCompiler implements Closeable {
                             new CompilationProvider.Context(
                                     i.getName(),
                                     classPathElements,
-                                    new File(i.getProjectDirectory()),
+                                    i.getProjectDirectory() == null ? null : new File(i.getProjectDirectory()),
                                     new File(sourcePath),
                                     new File(i.getClassesPath()),
                                     context.getSourceEncoding(),


### PR DESCRIPTION
this addresses the issue #15494 as the project directory is explicitly set to null [here](https://github.com/quarkusio/quarkus/blob/master/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java#L84) 

@geoand you might be interested in this :)

with that remote dev mode starts and works!