### PR TITLE
Register for reflection the hierarchy of the entity in MongoDB with Panache

### DIFF
--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug13301Repository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug13301Repository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+
+@ApplicationScoped
+public class Bug13301Repository implements PanacheMongoRepository<NeedReflectionChild> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -22,6 +23,9 @@ public class BugResource {
 
     @Inject
     Bug5274EntityRepository bug5274EntityRepository;
+
+    @Inject
+    Bug13301Repository bug13301Repository;
 
     @GET
     @Path("5274")
@@ -96,5 +100,17 @@ public class BugResource {
         // we should be able to retrieve `entity` from the foreignId ...
         LinkedEntity.find("myForeignId", link.id).firstResultOptional().orElseThrow(() -> new NotFoundException());
         return Response.ok().build();
+    }
+
+    @GET
+    @Path("13301")
+    public Response testReflectiveHierarchy() {
+        NeedReflectionChild me = new NeedReflectionChild();
+        me.parent = "François";
+        me.child = "Loïc";
+        bug13301Repository.persist(me);
+
+        Optional<NeedReflectionChild> result = bug13301Repository.find("parent", "François").firstResultOptional();
+        return result.isPresent() ? Response.ok().build() : Response.serverError().build();
     }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflectionChild.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflectionChild.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+public class NeedReflectionChild extends NeedReflectionParent {
+    public String child;
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflectionParent.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflectionParent.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+public class NeedReflectionParent {
+    public String parent;
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -384,4 +384,9 @@ class MongodbPanacheResourceTest {
     public void testMoreRepositoryFunctionalities() {
         get("/test/imperative/repository").then().statusCode(200);
     }
+
+    @Test
+    public void testBug13301() {
+        get("/bugs/13301").then().statusCode(200);
+    }
 }


### PR DESCRIPTION
Fixes #13301

I register for reflection the hierarchy of the entity and not juste the entity itself.

I didn't add any test yet as I wanted to have some feedback on the usage of the `ReflectiveHierarchyBuildItem` as it's the first time I used it. Is my usage correct ?
I notice that Hibernate ORM didn't use it and instead use a rather complex way of climbing the hierarchy of types: https://github.com/quarkusio/quarkus/blob/master/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java#L228