### PR TITLE
Support setting quarkus.log.level in lowercase

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LevelConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LevelConverter.java
@@ -3,6 +3,7 @@ package io.quarkus.runtime.logging;
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.logging.Level;
 
 import javax.annotation.Priority;
@@ -22,6 +23,6 @@ public final class LevelConverter implements Converter<Level>, Serializable {
         if (value == null || value.isEmpty()) {
             return null;
         }
-        return LogContext.getLogContext().getLevelForName(value);
+        return LogContext.getLogContext().getLevelForName(value.toUpperCase(Locale.ROOT));
     }
 }

--- a/core/test-extension/deployment/src/main/resources/application.properties
+++ b/core/test-extension/deployment/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Log settings
-quarkus.log.level=INFO
+# log level in lower case for testing
+quarkus.log.level=info
 quarkus.log.file.enable=true
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n


### PR DESCRIPTION
Fixes #15495

Doesn't cost much and make things a bit more user friendly.