### PR TITLE
Automatically register @JsonIdentityInfo generator and resolver in Jackson

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -18,6 +18,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Type;
 
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
@@ -59,6 +60,7 @@ public class JacksonProcessor {
     private static final DotName JSON_SERIALIZE = DotName.createSimple(JsonSerialize.class.getName());
     private static final DotName JSON_CREATOR = DotName.createSimple("com.fasterxml.jackson.annotation.JsonCreator");
     private static final DotName JSON_NAMING = DotName.createSimple("com.fasterxml.jackson.databind.annotation.JsonNaming");
+    private static final DotName JSON_IDENTITY_INFO = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIdentityInfo");
     private static final DotName BUILDER_VOID = DotName.createSimple(Void.class.getName());
 
     private static final String TIME_MODULE = "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule";
@@ -140,6 +142,21 @@ public class JacksonProcessor {
             AnnotationValue strategyValue = jsonNamingInstance.value("value");
             if (strategyValue != null) {
                 reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, strategyValue.asClass().name().toString()));
+            }
+        }
+
+        // register @JsonIdentityInfo strategy implementations for reflection
+        for (AnnotationInstance jsonIdentityInfoInstance : index.getAnnotations(JSON_IDENTITY_INFO)) {
+            AnnotationValue generatorValue = jsonIdentityInfoInstance.value("generator");
+            AnnotationValue resolverValue = jsonIdentityInfoInstance.value("resolver");
+            if (generatorValue != null) {
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, generatorValue.asClass().name().toString()));
+            }
+            if (resolverValue != null) {
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, resolverValue.asClass().name().toString()));
+            } else {
+                // Registering since SimpleObjectIdResolver is the default value of @JsonIdentityInfo.resolver
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, SimpleObjectIdResolver.class));
             }
         }
 

--- a/integration-tests/jackson/src/main/java/io/quarkus/it/jackson/model/RegisteredPojoModel.java
+++ b/integration-tests/jackson/src/main/java/io/quarkus/it/jackson/model/RegisteredPojoModel.java
@@ -2,6 +2,8 @@ package io.quarkus.it.jackson.model;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.Arc;
@@ -11,6 +13,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
  * Simple POJO model class.
  */
 @RegisterForReflection
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class RegisteredPojoModel {
 
     // -------------------------------------------------------------------------
@@ -20,6 +23,9 @@ public class RegisteredPojoModel {
     private int version = 1;
     private String id = null;
     private String value = null;
+
+    private RegisteredPojoModel parent;
+    private RegisteredPojoModel child;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -70,6 +76,22 @@ public class RegisteredPojoModel {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public RegisteredPojoModel getParent() {
+        return parent;
+    }
+
+    public void setParent(RegisteredPojoModel parent) {
+        this.parent = parent;
+    }
+
+    public RegisteredPojoModel getChild() {
+        return child;
+    }
+
+    public void setChild(RegisteredPojoModel child) {
+        this.child = child;
     }
 
     // -------------------------------------------------------------------------

--- a/integration-tests/jackson/src/test/java/io/quarkus/it/jackson/RegisteredPojoModelResourceTest.java
+++ b/integration-tests/jackson/src/test/java/io/quarkus/it/jackson/RegisteredPojoModelResourceTest.java
@@ -16,19 +16,33 @@ public class RegisteredPojoModelResourceTest {
 
     @Test
     public void testSimplePojoModel() throws IOException {
-        RegisteredPojoModel model = new RegisteredPojoModel();
-        model.setId("123");
-        model.setVersion(3);
-        model.setValue("some");
+        RegisteredPojoModel parent = new RegisteredPojoModel();
+        parent.setId("123");
+        parent.setVersion(3);
+        parent.setValue("some");
+
+        RegisteredPojoModel child = new RegisteredPojoModel();
+        child.setId("234");
+        child.setVersion(1);
+        child.setValue("value");
+
+        parent.setChild(child);
+        child.setParent(parent);
 
         given()
                 .contentType("application/json")
-                .body(model.toJson(getObjectMapperForTest()))
+                .body(parent.toJson(getObjectMapperForTest()))
                 .when().post("/registeredpojomodel")
                 .then()
                 .statusCode(201)
                 .body("id", equalTo("123"))
                 .body("version", equalTo(3))
-                .body("value", equalTo("some"));
+                .body("value", equalTo("some"))
+                .body("parent", equalTo(null))
+                .body("child.id", equalTo("234"))
+                .body("child.version", equalTo(1))
+                .body("child.value", equalTo("value"))
+                .body("child.parent", equalTo("123"))
+                .body("child.child", equalTo(null));
     }
 }


### PR DESCRIPTION
Jackson supports entities that refer to one another (perhaps in a recursive loop) via `@JsonIdentityInfo` (where it uses an attribute to determine if two objects in json refer to the same thing). Currently, the generator and resolver of `@JsonIdentityInfo` are not registered for reflective, causing an error at runtime in native mode when jackson try to deserialize an object with the annotation.

This PR registers the generator and resolver of `@JsonIdentityInfo` which fixes the issue (and add an example of it to the jackson integration tests.