### PR TITLE
Fix thread safe issue with history logger

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUI.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUI.java
@@ -29,7 +29,7 @@ import io.vertx.ext.web.RoutingContext;
  * This is a Handler running in the Dev Vert.x instance (which is loaded by the Augmentation ClassLoader)
  * and has access to build time stuff
  */
-public class DevConsole implements Handler<RoutingContext> {
+public class DevUI implements Handler<RoutingContext> {
 
     static final ThreadLocal<String> currentExtension = new ThreadLocal<>();
     private static final Comparator<Map<String, Object>> EXTENSION_COMPARATOR = Comparator
@@ -42,7 +42,7 @@ public class DevConsole implements Handler<RoutingContext> {
 
     final Config config = ConfigProvider.getConfig();
 
-    DevConsole(Engine engine, String httpRootPath, String frameworkRootPath) {
+    DevUI(Engine engine, String httpRootPath, String frameworkRootPath) {
         this.engine = engine;
         this.globalData.put("httpRootPath", httpRootPath);
         this.globalData.put("frameworkRootPath", frameworkRootPath);

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.vertx.http.deployment.devmode.console;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "dev-ui")
+public class DevUIConfig {
+
+    /**
+     * The number of history log entries to remember.
+     */
+    @ConfigItem(defaultValue = "50")
+    public int historySize;
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIHttpHandler.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIHttpHandler.java
@@ -38,8 +38,8 @@ import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
  * is a parent first dependency thus also loaded by the System ClassLoader).
  */
 @SuppressWarnings("unused")
-public class DevConsoleHttpHandler implements Consumer<DevConsoleRequest> {
-    private static final Logger log = Logger.getLogger(DevConsoleHttpHandler.class);
+public class DevUIHttpHandler implements Consumer<DevConsoleRequest> {
+    private static final Logger log = Logger.getLogger(DevUIHttpHandler.class);
     public static VirtualAddress QUARKUS_DEV_CONSOLE = new VirtualAddress("quarkus-dev-console");
 
     private static final int BUFFER_SIZE = 8096;

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devconsole/JavaDocResolverTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devconsole/JavaDocResolverTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qute.Engine;
-import io.quarkus.vertx.http.deployment.devmode.console.DevConsoleProcessor.JavaDocResolver;
+import io.quarkus.vertx.http.deployment.devmode.console.DevUIProcessor.JavaDocResolver;
 
 public class JavaDocResolverTest {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogStreamRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogStreamRecorder.java
@@ -10,8 +10,8 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class LogStreamRecorder {
 
-    public RuntimeValue<Optional<HistoryHandler>> handler() {
-        return new RuntimeValue<>(Optional.of(new HistoryHandler()));
+    public RuntimeValue<Optional<HistoryHandler>> handler(int size) {
+        return new RuntimeValue<>(Optional.of(new HistoryHandler(size)));
     }
 
     public Handler<RoutingContext> websocketHandler(RuntimeValue<Optional<HistoryHandler>> historyHandler) {


### PR DESCRIPTION
This PR fixes a thread safe issue with the HistoryHandler (Logging) in the Dev UI.

Because the history is stored in an unsafe manner currently, the list can build up.

This PR change:

1) Only include the HistoryHandler in Dev mode (only needed for the Dev UI)
2) Do the insert in a thread safe way
3) Allow config to set the number of History Entries to remember.
4) Renamed to confusingly name DevConsole* to DevUI*


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>