### PR TITLE
Allow to exclude files from deletion when running in remote dev mode …

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -280,6 +280,17 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         }
     }
 
+    private String excludeDeleteFilter() {
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            return ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.live-reload.exclude-delete-filter", String.class).orElse("");
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
     @Override
     public void addPreScanStep(Runnable runnable) {
         preScanSteps.add(runnable);
@@ -307,7 +318,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             for (Map.Entry<String, String> remaining : ourHashes.entrySet()) {
                 String file = remaining.getKey();
                 if (file.endsWith("META-INF/MANIFEST.MF") || file.contains("META-INF/maven")
-                        || !file.contains("/")) {
+                        || !file.contains("/") || file.matches(excludeDeleteFilter())) {
                     //we have some filters, for files that we don't want to delete
                     continue;
                 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
@@ -35,4 +35,12 @@ public class LiveReloadConfig {
      */
     @ConfigItem(defaultValue = "30s")
     public Duration connectTimeout;
+
+    /**
+     * Filter (regular expression format) that allows to exclude files from being deleted by remote dev mode. Usually used
+     * when there are additional files kept within application that are not synchronized but are required for application
+     * to function properly
+     */
+    @ConfigItem
+    public Optional<String> excludeDeleteFilter;
 }


### PR DESCRIPTION
…via configurable filter

When running in remote dev mode the server side of it is quite eager at deleting files that are considered not up to date. In some case it can read to removing files that are not really class files and making the application not runnable anymore due to removed files. This change brings an optional configuration parameter that allows to define an exclude filter (regular expression) to avoid this behaviour
