### PR TITLE
Restructure vertx-cache to allow multiple applications with launched by multiple users

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -246,8 +246,7 @@ public class VertxCoreRecorder {
                 }
             }
 
-            long random = UUID.randomUUID().getMostSignificantBits();
-            File cache = new File(tmp, Long.toString(random));
+            File cache = getRandomDirectory(tmp);
             LOGGER.debugf("Vert.x Cache configured to: %s", cache.getAbsolutePath());
             fileCacheDir = cache.getAbsolutePath();
             if (shutdown != null) {
@@ -289,6 +288,16 @@ public class VertxCoreRecorder {
         options.setPreferNativeTransport(conf.preferNativeTransport);
 
         return options;
+    }
+
+    private static File getRandomDirectory(File tmp) {
+        long random = Math.abs(UUID.randomUUID().getMostSignificantBits());
+        File cache = new File(tmp, Long.toString(random));
+        if (cache.isDirectory()) {
+            // Do not reuse an existing directory.
+            return getRandomDirectory(tmp);
+        }
+        return cache;
     }
 
     private static int calculateDefaultIOThreads() {

--- a/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -55,7 +55,7 @@ public class VertxCoreProducerTest {
         configuration.cluster = cc;
 
         try {
-            VertxCoreRecorder.initialize(configuration, null);
+            VertxCoreRecorder.initialize(configuration, null, null);
             Assertions.fail("It should not have a cluster manager on the classpath, and so fail the creation");
         } catch (IllegalStateException e) {
             Assertions.assertTrue(e.getMessage().contains("No ClusterManagerFactory"),
@@ -82,7 +82,7 @@ public class VertxCoreProducerTest {
                     }
                 }));
 
-        VertxCoreRecorder.initialize(configuration, customizers);
+        VertxCoreRecorder.initialize(configuration, customizers, null);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class VertxCoreProducerTest {
                         called.set(true);
                     }
                 }));
-        Vertx v = VertxCoreRecorder.initialize(createDefaultConfiguration(), customizers);
+        Vertx v = VertxCoreRecorder.initialize(createDefaultConfiguration(), customizers, null);
         Assertions.assertTrue(called.get(), "Customizer should get called during initialization");
     }
 

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -28,7 +28,7 @@ public class VertxProducerTest {
 
     @Test
     public void shouldNotFailWithoutConfig() {
-        verifyProducer(VertxCoreRecorder.initialize(null, null));
+        verifyProducer(VertxCoreRecorder.initialize(null, null, null));
     }
 
     private void verifyProducer(Vertx v) {


### PR DESCRIPTION
Create /tmp/vertx-cache and configure it to be world-readable and writable.
Under that directory, another random directory is created that is only readable and writable from the current user (which is used by the application)).

The vertx-cache directory creation is disabled if:

* the user specifies a cache directory
* the vertx-cache directory already exists

Fix #7678