### PR TITLE
Upgrade to Hibernate Reactive 1.0.0.CR1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.29.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.Beta4</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.CR1</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.2.Final</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>


### PR DESCRIPTION
N.B. this requires the current version of Hibernate ORM (5.4.29.Final) and Mutiny (0.14.0)

Changelog:
 - https://github.com/hibernate/hibernate-reactive/milestone/2?closed=1