### PR TITLE
Add extension categories to the quarkus-bom platform

### DIFF
--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -1,4 +1,120 @@
 {
+  "categories": [
+    {
+      "name": "Web",
+      "id": "web",
+      "description": "Everything you need for REST endpoints, HTTP and web formats like JSON",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-resteasy",
+          "io.quarkus:quarkus-resteasy-jackson",
+          "io.quarkus:quarkus-resteasy-jsonb"
+        ]
+      }
+    },
+    {
+      "name": "Data",
+      "id": "data",
+      "description": "Accessing and managing your data (RDBMS, NoSQL, caching, transaction management, etc)",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-hibernate-orm",
+          "io.quarkus:quarkus-hibernate-orm-panache",
+          "io.quarkus:quarkus-jdbc-postgresql",
+          "io.quarkus:quarkus-jdbc-mariadb",
+          "io.quarkus:quarkus-jdbc-mysql",
+          "io.quarkus:quarkus-jdbc-mssql",
+          "io.quarkus:quarkus-jdbc-db2",
+          "io.quarkus:quarkus-jdbc-h2",
+          "io.quarkus:quarkus-jdbc-derby"
+        ]
+      }
+    },
+    {
+      "name": "Messaging",
+      "id": "messaging",
+      "description": "Send and receives message to various messaging systems (AMQP, KAfka etc)",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-smallrye-reactive-messaging",
+          "io.quarkus:quarkus-smallrye-reactive-messaging-amqp",
+          "io.quarkus:quarkus-smallrye-reactive-messaging-kafka",
+          "io.quarkus:quarkus-smallrye-reactive-messaging-mqtt"
+        ]
+      }
+    },
+    {
+      "name": "Core",
+      "id": "core",
+      "description": "Core Quarkus components: engine, logging, etc.",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-config-yaml",
+          "io.quarkus:quarkus-logging-json"
+        ]
+      }
+    },
+    {
+      "name": "Reactive",
+      "id": "reactive",
+      "description": "Non blocking stack and connectors",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-vertx",
+          "io.quarkus:quarkus-mutiny"
+        ]
+      }
+    },
+    {
+      "name": "Cloud",
+      "id": "cloud",
+      "description": "Useful for Cloud Native deployments platforms like Kubernetes and cloud providers",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-kubernetes",
+          "io.quarkus:quarkus-openshift",
+          "io.quarkus:quarkus-smallrye-health",
+          "io.quarkus:quarkus-smallrye-fault-tolerance"
+        ]
+      }
+    },
+    {
+      "name": "Observability",
+      "id": "observability",
+      "description": "Metrics, tracing, etc"
+    },
+    {
+      "name": "Security",
+      "id": "security",
+      "description": "Everything you need to secure your application",
+      "metadata": {
+        "pinned": [
+          "io.quarkus:quarkus-oidc",
+          "io.quarkus:quarkus-smallrye-jwt"
+        ]
+      }
+    },
+    {
+      "name": "Serialization",
+      "id": "serialization",
+      "description": "Serializing and deserializing various formats"
+    },
+    {
+      "name": "Miscellaneous",
+      "id": "miscellaneous",
+      "description": "Mixed bag of good stuff"
+    },
+    {
+      "name": "Compatibility",
+      "id": "compatibility",
+      "description": "Support for alternative programming models on Quarkus"
+    },
+    {
+      "name": "Alternative languages",
+      "id": "alt-languages",
+      "description": "Support for other JVM based languages"
+    }
+  ],
   "metadata":{
     "project": {
       "properties": {

--- a/extensions/consul-config/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/consul-config/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,5 +7,5 @@ metadata:
   - "configuration"
   - "consul"
   categories:
-  - "configuration"
+  - "core"
   status: "preview"

--- a/extensions/reactive-messaging-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/reactive-messaging-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,10 +3,10 @@ name: "Reactive HTTP and WebSocket Connector"
 metadata:
   keywords:
     - "http-connector"
-  categories:
-    - "web"
     - "http"
     - "websockets"
+  categories:
+    - "web"
     - "reactive"
     - "messaging"
   status: "experimental"

--- a/extensions/redis-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/redis-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,6 @@ metadata:
     - "reactive"
   guide: "https://quarkus.io/guides/redis"
   categories:
-    - "persistence"
+    - "data"
     - "reactive"
   status: "preview"

--- a/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   keywords:
   - "undertow"
   - "servlet"
+  - "http"
   categories:
   - "web"
-  - "http"
   status: "stable"

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/descriptor/ProjectPlatformDescriptorJsonUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/descriptor/ProjectPlatformDescriptorJsonUtil.java
@@ -28,7 +28,7 @@ public class ProjectPlatformDescriptorJsonUtil {
             throws AppModelResolverException {
         final List<JsonExtensionCatalog> platforms = new ArrayList<>(2);
         final Set<AppArtifactKey> processedPlatforms = new HashSet<>();
-        for (int i = depConstraints.size() - 1; i >= 0; --i) {
+        for (int i = 0; i < depConstraints.size(); ++i) {
             final AppArtifact artifact = depConstraints.get(i);
             if (!artifact.getArtifactId().endsWith(BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX)
                     && !artifact.getType().equals("json")) {
@@ -69,7 +69,7 @@ public class ProjectPlatformDescriptorJsonUtil {
         catalog.setQuarkusCoreVersion(dominatingPlatform.getQuarkusCoreVersion());
         catalog.setUpstreamQuarkusCoreVersion(dominatingPlatform.getUpstreamQuarkusCoreVersion());
 
-        for (int i = platforms.size() - 1; i >= 0; --i) {
+        for (int i = 0; i < platforms.size(); ++i) {
             final JsonExtensionCatalog platform = platforms.get(i);
             if (platform.getBom() != null) {
                 catalog.setBom(platform.getBom());
@@ -86,19 +86,15 @@ public class ProjectPlatformDescriptorJsonUtil {
                 }
             }
 
-            if (platform.getCategories().isEmpty()) {
-                for (Category c : platform.getCategories()) {
-                    if (categoryIds.add(c.getId())) {
-                        categories.add(c);
-                    }
+            for (Category c : platform.getCategories()) {
+                if (categoryIds.add(c.getId())) {
+                    categories.add(c);
                 }
             }
 
-            if (!platform.getMetadata().isEmpty()) {
-                for (Map.Entry<String, Object> entry : platform.getMetadata().entrySet()) {
-                    if (!metadata.containsKey(entry.getKey())) {
-                        metadata.put(entry.getKey(), entry.getValue());
-                    }
+            for (Map.Entry<String, Object> entry : platform.getMetadata().entrySet()) {
+                if (!metadata.containsKey(entry.getKey())) {
+                    metadata.put(entry.getKey(), entry.getValue());
                 }
             }
         }

--- a/test-framework/jacoco/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/test-framework/jacoco/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,5 +6,5 @@ metadata:
   - "coverage"
   guide: "https://quarkus.io/guides/tests-with-coverage"
   categories:
-  - "testing"
+  - "miscellaneous"
   status: "experimental"


### PR DESCRIPTION
This PR copies relevant categories from the quarkus-platform to the quarkus-bom platform. These categories won't be duplicated in quarkus-platform but be inherited from the quarkus-bom platform with the possibility to override them.
What's missing though is a possibility to "unlist" or exclude categories inherited from the base platforms.

Fixes #15528