### PR TITLE
Fix Thread-safe issue and memory leak with Log History Handler

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -263,11 +263,11 @@ public class DevConsoleProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = IsDevelopment.class)
     @Record(ExecutionTime.STATIC_INIT)
     public HistoryHandlerBuildItem handler(BuildProducer<LogHandlerBuildItem> logHandlerBuildItemBuildProducer,
-            LogStreamRecorder recorder) {
-        RuntimeValue<Optional<HistoryHandler>> handler = recorder.handler();
+            LogStreamRecorder recorder, DevUIConfig devUiConfig) {
+        RuntimeValue<Optional<HistoryHandler>> handler = recorder.handler(devUiConfig.historySize);
         logHandlerBuildItemBuildProducer.produce(new LogHandlerBuildItem((RuntimeValue) handler));
         return new HistoryHandlerBuildItem(handler);
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevUIConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.vertx.http.deployment.devmode.console;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "dev-ui")
+public class DevUIConfig {
+
+    /**
+     * The number of history log entries to remember.
+     */
+    @ConfigItem(defaultValue = "50")
+    public int historySize;
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogStreamRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogStreamRecorder.java
@@ -10,8 +10,8 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class LogStreamRecorder {
 
-    public RuntimeValue<Optional<HistoryHandler>> handler() {
-        return new RuntimeValue<>(Optional.of(new HistoryHandler()));
+    public RuntimeValue<Optional<HistoryHandler>> handler(int size) {
+        return new RuntimeValue<>(Optional.of(new HistoryHandler(size)));
     }
 
     public Handler<RoutingContext> websocketHandler(RuntimeValue<Optional<HistoryHandler>> historyHandler) {


### PR DESCRIPTION
This PR fixes a thread safe issue with the HistoryHandler (Logging) in the Dev UI.

Because the history is stored in an unsafe manner currently, the list can build up.

This PR change:

1) Only include the HistoryHandler in Dev mode (only needed for the Dev UI)
2) Do the insert in a thread safe way
3) Allow config to set the number of History Entries to remember.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>