### PR TITLE
Fix race condition on reading input in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -217,6 +217,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
 
     @Override
     public ServerHttpResponse setReadListener(ReadCallback callback) {
+        request.pause();
         if (continueState == ContinueState.REQUIRED) {
             continueState = ContinueState.SENT;
             response.writeContinue();
@@ -233,6 +234,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
                 callback.done();
             }
         });
+        request.resume();
         return this;
     }
 


### PR DESCRIPTION
The idea here is to ensure that Vert.x has not completed reading the input because we can install the proper listeners.
Without this change, the is a chance the input ends before we all the listeners thus resulting in an `IllegalStateException` being thrown.

Fixes: #15479
