### PR TITLE
Disable DevUI for remote dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -365,6 +365,7 @@ public class AugmentActionImpl implements AugmentAction {
             }
 
             builder.setLaunchMode(launchMode);
+            builder.setDevModeType(devModeType);
             builder.setRebuild(quarkusBootstrap.isRebuild());
             if (firstRun) {
                 builder.setLiveReloadState(

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -56,6 +56,7 @@ import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 import io.quarkus.deployment.util.ArtifactInfoUtil;
 import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
@@ -280,7 +281,11 @@ public class DevConsoleProcessor {
             LogStreamRecorder recorder,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             HistoryHandlerBuildItem historyHandlerBuildItem,
-            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
+            LaunchModeBuildItem launchModeBuildItem) {
+        if (launchModeBuildItem.getDevModeType().orElse(null) != DevModeType.LOCAL) {
+            return;
+        }
         initializeVirtual();
 
         newRouter(buildEngine(devTemplatePaths), nonApplicationRootPathBuildItem);
@@ -326,7 +331,12 @@ public class DevConsoleProcessor {
     public void deployStaticResources(DevConsoleRecorder recorder, CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdownContext,
             BuildProducer<RouteBuildItem> routeBuildItemBuildProducer,
-            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) throws IOException {
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
+            LaunchModeBuildItem launchModeBuildItem) throws IOException {
+
+        if (launchModeBuildItem.getDevModeType().orElse(DevModeType.LOCAL) != DevModeType.LOCAL) {
+            return;
+        }
         AppArtifact devConsoleResourcesArtifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, "io.quarkus",
                 "quarkus-vertx-http-deployment");
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -54,6 +54,9 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
                 .atMost(1, TimeUnit.MINUTES).until(() -> DevModeTestUtils.getHttpResponse("/app/hello").contains("carambar"));
+
+        //also verify that the dev ui console is disabled
+        DevModeTestUtils.getHttpResponse("/q/dev", 404, 10, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
This is being disabled for hardening reasons. It will likely be re-added in future in a more secure manner.