### PR TITLE
Add DevServices support for DB2 and MSSQL

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -568,6 +568,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices-db2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices-mssql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -51,10 +51,27 @@ is supported for the following open source databases:
 * MariaDB (container)
 * H2 (in-process)
 * Apache Derby (in-process)
+* DB2 (container) (requires license acceptance)
+* MSSQL (container) (requires license acceptance)
+
 
 If you want to use DevServices then all you need to do is include the relevant extension for the type of database you want (either reactive or
 JDBC, or both), and don't configure a database URL, username and password, Quarkus will provide the database and you can just start
 coding without worrying about config.
+
+If you are using a proprietary database such as DB2 or MSSQL you will need to accept the license agreement. To do this
+create a `src/main/resources/container-license-acceptance.txt` files in your project and add a line with the image
+name and tag of the database. By default Quarkus uses the default image for the current version of Testcontainers, if
+you attempt to start Quarkus the resulting failure will tell you the exact image name in use for you to add to the
+file.
+
+An example file is shown below:
+
+.src/main/resources/container-license-acceptance.txt
+----
+ibmcom/db2:11.5.0.0a
+mcr.microsoft.com/mssql/server:2017-CU12
+----
 
 === JDBC datasource
 

--- a/extensions/devservices/db2/pom.xml
+++ b/extensions/devservices/db2/pom.xml
@@ -1,44 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-jdbc-db2-parent</artifactId>
+        <artifactId>quarkus-devservices-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-db2-deployment</artifactId>
-    <name>Quarkus - JDBC - DB2 - Deployment</name>
-
+    <artifactId>quarkus-devservices-db2</artifactId>
+    <name>Quarkus - DevServices - DB2</name>
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal-spi</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-deployment-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-db2</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>db2</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-db2</artifactId>
+            <groupId>com.ibm.db2</groupId>
+            <artifactId>jcc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId> 
+            <artifactId>jboss-logmanager-embedded</artifactId> 
+            <scope>test</scope> 
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -1,0 +1,41 @@
+package io.quarkus.devservices.db2.deployment;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.testcontainers.containers.Db2Container;
+
+import io.quarkus.datasource.common.runtime.DatabaseKind;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public class DB2DevServicesProcessor {
+
+    @BuildStep
+    DevServicesDatasourceProviderBuildItem setupDB2() {
+        return new DevServicesDatasourceProviderBuildItem(DatabaseKind.DB2, new DevServicesDatasourceProvider() {
+            @Override
+            public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
+                    Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
+                Db2Container container = new Db2Container(
+                        imageName.orElse("ibmcom/db2:" + Db2Container.DEFAULT_TAG))
+                                .withPassword(password.orElse("quarkus"))
+                                .withUsername(username.orElse("quarkus"))
+                                .withDatabaseName(datasourceName.orElse("default"));
+                container.start();
+                return new RunningDevServicesDatasource(container.getJdbcUrl(), container.getUsername(),
+                        container.getPassword(),
+                        new Closeable() {
+                            @Override
+                            public void close() throws IOException {
+                                container.stop();
+                            }
+                        });
+            }
+        });
+    }
+
+}

--- a/extensions/devservices/mssql/pom.xml
+++ b/extensions/devservices/mssql/pom.xml
@@ -1,44 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-jdbc-db2-parent</artifactId>
+        <artifactId>quarkus-devservices-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-db2-deployment</artifactId>
-    <name>Quarkus - JDBC - DB2 - Deployment</name>
-
+    <artifactId>quarkus-devservices-mssql</artifactId>
+    <name>Quarkus - DevServices - MSSQL</name>
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal-spi</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-deployment-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-db2</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-db2</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId> 
+            <artifactId>jboss-logmanager-embedded</artifactId> 
+            <scope>test</scope> 
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -1,0 +1,40 @@
+package io.quarkus.devservices.mssql.deployment;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+import io.quarkus.datasource.common.runtime.DatabaseKind;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public class MSSQLDevServicesProcessor {
+
+    @BuildStep
+    DevServicesDatasourceProviderBuildItem setupMSSQL() {
+        return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MSSQL, new DevServicesDatasourceProvider() {
+            @Override
+            public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
+                    Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
+                JdbcDatabaseContainer container = new MSSQLServerContainer(
+                        imageName.orElse(MSSQLServerContainer.IMAGE + ":" + MSSQLServerContainer.DEFAULT_TAG))
+                                .withPassword(password.orElse("Quarkuspassword1"));
+                container.start();
+                return new RunningDevServicesDatasource(container.getJdbcUrl(), container.getUsername(),
+                        container.getPassword(),
+                        new Closeable() {
+                            @Override
+                            public void close() throws IOException {
+                                container.stop();
+                            }
+                        });
+            }
+        });
+    }
+
+}

--- a/extensions/devservices/pom.xml
+++ b/extensions/devservices/pom.xml
@@ -23,6 +23,8 @@
         <module>mariadb</module>
         <module>h2</module>
         <module>derby</module>
+        <module>mssql</module>
+        <module>db2</module>
     </modules>
 
 </project>

--- a/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
@@ -5,6 +5,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -30,6 +31,11 @@ public class JDBCDB2Processor {
             SslNativeConfigBuildItem sslNativeConfigBuildItem) {
         jdbcDriver.produce(new JdbcDriverBuildItem(DatabaseKind.DB2, "com.ibm.db2.jcc.DB2Driver",
                 "com.ibm.db2.jcc.DB2XADataSource"));
+    }
+
+    @BuildStep
+    DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
+        return DevServicesDatasourceConfigurationHandlerBuildItem.jdbc(DatabaseKind.DB2);
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -33,6 +33,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-mssql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-mssql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLProcessor.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -31,6 +32,11 @@ public class MsSQLProcessor {
             SslNativeConfigBuildItem sslNativeConfigBuildItem) {
         jdbcDriver.produce(new JdbcDriverBuildItem(DatabaseKind.MSSQL, "com.microsoft.sqlserver.jdbc.SQLServerDriver",
                 "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"));
+    }
+
+    @BuildStep
+    DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
+        return DevServicesDatasourceConfigurationHandlerBuildItem.jdbc(DatabaseKind.MSSQL);
     }
 
     @BuildStep


### PR DESCRIPTION
This allows them to be automatically started if the license
is accepted.

No tests as I am not sure if we want to be accepting the
license as part of our build.

Fixes: #15540