### PR TITLE
Upgrade LogManager to 1.0.9

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -157,7 +157,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.0.3</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.6</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
         <jgit.version>5.11.0.202103091610-r</jgit.version>
         <flyway.version>7.7.0</flyway.version>
         <yasson.version>1.0.8</yasson.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LoggingSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LoggingSubstitutions.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.graal;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Handler;
 
 import org.jboss.logmanager.LogContext;
@@ -20,8 +21,8 @@ import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 final class Target_org_jboss_logmanager_LoggerNode {
 
     @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
-    volatile Handler[] handlers;
+    @RecomputeFieldValue(declClass = AtomicReference.class, kind = RecomputeFieldValue.Kind.NewInstance)
+    AtomicReference<Handler[]> handlersRef;
 }
 
 @TargetClass(className = "org.slf4j.LoggerFactory")

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -42,7 +42,7 @@
         <commons-lang.version>3.12.0</commons-lang.version>
         <guava.version>30.1-jre</guava.version>
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager-embedded.version>1.0.5</jboss-logmanager-embedded.version>
+        <jboss-logmanager-embedded.version>1.0.9</jboss-logmanager-embedded.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <graal-sdk.version>21.0.0</graal-sdk.version>


### PR DESCRIPTION
Fixes potential NPE in `AtomicArray` updates on native images.

Fixes #6954