### PR TITLE
Add annotation to enable native build for QuarkusProdModeTest

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/EnableNativeBuildOnQuarkusProdMode.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/EnableNativeBuildOnQuarkusProdMode.java
@@ -1,0 +1,15 @@
+package io.quarkus.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that indicates that this test should enable the Native build for the {@link @QuarkusProdModeTest} extension.
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableNativeBuildOnQuarkusProdMode {
+}


### PR DESCRIPTION
This PR adds a new annotation for allowing to enable the native build when using QuarkusProdModeTest.
Usage:

- Normal test:
```
public class GreetingResourceTest {

    @RegisterExtension
    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
            .setArchiveProducer(
                    () -> ShrinkWrap.create(JavaArchive.class)
                            .addClass(GreetingResource.class))
            .setRun(true);

    @Test
    public void shouldVerifySomething() {
        // ...
    }
}
```

Before, to enable the native build, we had to set the property `.setBuildNative(true)`:

```
@RegisterExtension
    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
            .setArchiveProducer(
                    () -> ShrinkWrap.create(JavaArchive.class)
                            .addClass(GreetingResource.class))
            .setRun(true)
            .setBuildNative(true);
```

Note that this was not working properly because the property `quarkus.package.type` has to be propagated at build time. This is also addressed in this PR.

In order to reuse and to mimic how `@NativeImageTest` works, we used to extend the test class (where the test cases are defined) and make it to be run as integration test, something like:

```
public class NativeGreetingResourceIT extends GreetingResourceTest {

}
```

The problem is that the only way to enable the build native for QuarkusProdModeTest is via the `setBuildNative` and this can be only done if we duplicate the whole definition of our Quarkus app:

```
public class NativeGreetingResourceIT extends GreetingResourceTest {
    @RegisterExtension
    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
            .setArchiveProducer(
                    () -> ShrinkWrap.create(JavaArchive.class)
                            .addClass(GreetingResource.class))
            .setRun(true)
            .setBuildNative(true);
}
```

In order to avoid this duplication of code, the suggestion of this PR is to add another annotation called `@EnableNativeBuildOnQuarkusProdMode` and annotate the IT test accordingly:

```
@EnableNativeBuildOnQuarkusProdMode
public class NativeGreetingResourceIT extends GreetingResourceTest {
}
```

Note that we can't reuse `@NativeImageTest` as it would start the native app from the build Maven phase and what we want is to create a custom Native image using the settings provided in our QuarkusProdModeTest scenario.