### PR TITLE
Reintroduce RouteBuildItem#Builder() public ctor

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -151,13 +151,13 @@ public final class RouteBuildItem extends MultiBuildItem {
         /**
          * Use HttpRootPathBuildItem and NonApplicationRootPathBuildItem to
          * ensure paths are constructed/normalized correctly
-         * 
+         *
          * @deprecated
          * @see HttpRootPathBuildItem#routeBuilder()
          * @see NonApplicationRootPathBuildItem#routeBuilder()
          */
         @Deprecated
-        Builder() {
+        public Builder() {
         }
 
         /**


### PR DESCRIPTION
It used to be public and was made private when it was marked as
deprecated (the default constructor is public).
It is used by extensions out there so we need to maintain it.