### PR TITLE
Avoid race condition when creating the Dev UI routes

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -305,21 +305,37 @@ public class DevConsoleProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(LoggingSetupBuildItem.class)
     @BuildStep(onlyIf = IsDevelopment.class)
-    public void setupDevConsoleRoutes(List<DevConsoleRouteBuildItem> routes,
-            BuildProducer<RouteBuildItem> routeBuildItemBuildProducer,
-            LogStreamRecorder recorder,
+    public void setupDevConsoleRoutes(
+            DevConsoleRecorder recorder,
+            LogStreamRecorder logStreamRecorder,
+            List<DevConsoleRouteBuildItem> routes,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             HistoryHandlerBuildItem historyHandlerBuildItem,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            LaunchModeBuildItem launchModeBuildItem) {
+            LaunchModeBuildItem launchModeBuildItem,
+            ShutdownContextBuildItem shutdownContext,
+            BuildProducer<RouteBuildItem> routeBuildItemBuildProducer) throws IOException {
         if (launchModeBuildItem.getDevModeType().orElse(null) != DevModeType.LOCAL) {
             return;
         }
 
+        // Add the static resources
+        AppArtifact devConsoleResourcesArtifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, "io.quarkus",
+                "quarkus-vertx-http-deployment");
+
+        Path devConsoleStaticResourcesDeploymentPath = WebJarUtil.copyResourcesForDevOrTest(curateOutcomeBuildItem,
+                launchModeBuildItem,
+                devConsoleResourcesArtifact, STATIC_RESOURCES_PATH);
+
+        routeBuildItemBuildProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                .route("dev/resources/*")
+                .handler(recorder.devConsoleHandler(devConsoleStaticResourcesDeploymentPath.toString(), shutdownContext))
+                .build());
+
         // Add the log stream
         routeBuildItemBuildProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                 .route("dev/logstream")
-                .handler(recorder.websocketHandler(historyHandlerBuildItem.value))
+                .handler(logStreamRecorder.websocketHandler(historyHandlerBuildItem.value))
                 .build());
 
         for (DevConsoleRouteBuildItem i : routes) {
@@ -346,29 +362,6 @@ public class DevConsoleProcessor {
                 .route("dev")
                 .displayOnNotFoundPage("Dev UI")
                 .handler(new RedirectHandler())
-                .build());
-    }
-
-    @BuildStep(onlyIf = IsDevelopment.class)
-    @Record(ExecutionTime.RUNTIME_INIT)
-    public void deployStaticResources(DevConsoleRecorder recorder, CurateOutcomeBuildItem curateOutcomeBuildItem,
-            LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdownContext,
-            BuildProducer<RouteBuildItem> routeBuildItemBuildProducer,
-            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            LaunchModeBuildItem launchModeBuildItem) throws IOException {
-
-        if (launchModeBuildItem.getDevModeType().orElse(DevModeType.LOCAL) != DevModeType.LOCAL) {
-            return;
-        }
-        AppArtifact devConsoleResourcesArtifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, "io.quarkus",
-                "quarkus-vertx-http-deployment");
-
-        Path devConsoleStaticResourcesDeploymentPath = WebJarUtil.copyResourcesForDevOrTest(curateOutcomeBuildItem, launchMode,
-                devConsoleResourcesArtifact, STATIC_RESOURCES_PATH);
-
-        routeBuildItemBuildProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .route("dev/resources/*")
-                .handler(recorder.devConsoleHandler(devConsoleStaticResourcesDeploymentPath.toString(), shutdownContext))
                 .build());
     }
 


### PR DESCRIPTION
We need the static resources route to be defined before /dev/* and this
wasn't guaranteed with two concurrent methods.