### PR TITLE
Remove warn message in KubernetesProcessor that shouldn't be there

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -106,8 +106,6 @@ class KubernetesProcessor {
             throw new RuntimeException("Unable to setup environment for generating Kubernetes resources", e);
         }
 
-        log.warn("exposition openshift=" + openshiftConfig.route.host);
-
         Map<String, Object> config = KubernetesConfigUtil.toMap(kubernetesConfig, openshiftConfig, knativeConfig);
         Set<String> deploymentTargets = kubernetesDeploymentTargets.getEntriesSortedByPriority().stream()
                 .map(DeploymentTargetEntry::getName)


### PR DESCRIPTION
I think it was added to debug things, let's remove it. If it has any
value, it needs to be handled a lot better.

Fixes #15607