### PR TITLE
Reorganize Vault internal client

### DIFF
--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
@@ -29,7 +29,17 @@ import io.quarkus.vault.runtime.VaultSystemBackendManager;
 import io.quarkus.vault.runtime.VaultTOTPManager;
 import io.quarkus.vault.runtime.VaultTransitManager;
 import io.quarkus.vault.runtime.client.VertxVaultClient;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalAppRoleAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalKubernetesAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalTokenAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalUserpassAuthMethod;
+import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
 import io.quarkus.vault.runtime.client.dto.VaultModel;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalDatabaseSecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalKvV1SecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalKvV2SecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalTOPTSecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalTransitSecretEngine;
 import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
 import io.quarkus.vault.runtime.health.VaultHealthCheck;
@@ -77,6 +87,16 @@ public class VaultProcessor {
                 .addBeanClass(VaultDbManager.class)
                 .addBeanClass(VertxVaultClient.class)
                 .addBeanClass(VaultConfigHolder.class)
+                .addBeanClass(VaultInternalKvV1SecretEngine.class)
+                .addBeanClass(VaultInternalKvV2SecretEngine.class)
+                .addBeanClass(VaultInternalTransitSecretEngine.class)
+                .addBeanClass(VaultInternalTOPTSecretEngine.class)
+                .addBeanClass(VaultInternalSystemBackend.class)
+                .addBeanClass(VaultInternalAppRoleAuthMethod.class)
+                .addBeanClass(VaultInternalKubernetesAuthMethod.class)
+                .addBeanClass(VaultInternalTokenAuthMethod.class)
+                .addBeanClass(VaultInternalUserpassAuthMethod.class)
+                .addBeanClass(VaultInternalDatabaseSecretEngine.class)
                 .build();
     }
 

--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/kv/VaultKvListSecrets.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/kv/VaultKvListSecrets.java
@@ -1,0 +1,22 @@
+package io.quarkus.vault.runtime.client.dto.kv;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+/**
+ * {
+ * "request_id": "1c4eef43-196a-495c-25d2-f76e1e8c0032",
+ * "lease_id": "",
+ * "renewable": false,
+ * "lease_duration": 0,
+ * "data": {
+ * "keys": [
+ * "world"
+ * ]
+ * },
+ * "wrap_info": null,
+ * "warnings": null,
+ * "auth": null
+ * }
+ */
+public class VaultKvListSecrets extends AbstractVaultDTO<VaultKvListSecretsData, Object> {
+}

--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/kv/VaultKvListSecretsData.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/kv/VaultKvListSecretsData.java
@@ -1,0 +1,11 @@
+package io.quarkus.vault.runtime.client.dto.kv;
+
+import java.util.List;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultKvListSecretsData implements VaultModel {
+
+    public List<String> keys;
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
@@ -1,5 +1,6 @@
 package io.quarkus.vault;
 
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
@@ -23,7 +24,7 @@ public interface VaultKVSecretEngine {
     /**
      * Writes the secret at the given path. If the path does not exist, the secret will
      * be created. If not the new secret will be merged with the existing one.
-     * 
+     *
      * @param path in Vault, without the kv engine mount path
      * @param secret to write at path
      */
@@ -32,9 +33,17 @@ public interface VaultKVSecretEngine {
     /**
      * Deletes the secret at the given path. It has no effect if no secret is currently
      * stored at path.
-     * 
+     *
      * @param path to delete
      */
     void deleteSecret(String path);
+
+    /**
+     * List all paths under the specified path.
+     *
+     * @param path to list
+     * @return list of subpaths
+     */
+    List<String> listSecrets(String path);
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultTOTPManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultTOTPManager.java
@@ -8,11 +8,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.quarkus.vault.VaultTOTPSecretEngine;
-import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPReadKeyResult;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalTOPTSecretEngine;
 import io.quarkus.vault.secrets.totp.CreateKeyParameters;
 import io.quarkus.vault.secrets.totp.KeyConfiguration;
 import io.quarkus.vault.secrets.totp.KeyDefinition;
@@ -21,9 +21,9 @@ import io.quarkus.vault.secrets.totp.KeyDefinition;
 public class VaultTOTPManager implements VaultTOTPSecretEngine {
 
     @Inject
-    VaultAuthManager vaultAuthManager;
+    private VaultAuthManager vaultAuthManager;
     @Inject
-    VaultClient vaultClient;
+    private VaultInternalTOPTSecretEngine vaultInternalTOPTSecretEngine;
 
     @Override
     public Optional<KeyDefinition> createKey(String name, CreateKeyParameters createKeyParameters) {
@@ -42,15 +42,14 @@ public class VaultTOTPManager implements VaultTOTPSecretEngine {
         body.skew = createKeyParameters.getSkew();
         body.url = createKeyParameters.getUrl();
 
-        final VaultTOTPCreateKeyResult result = this.vaultClient
-                .createTOTPKey(getToken(), name, body);
+        final VaultTOTPCreateKeyResult result = vaultInternalTOPTSecretEngine.createTOTPKey(getToken(), name, body);
 
         return result == null ? Optional.empty() : Optional.of(new KeyDefinition(result.data.barcode, result.data.url));
     }
 
     @Override
     public KeyConfiguration readKey(String name) {
-        final VaultTOTPReadKeyResult result = this.vaultClient.readTOTPKey(getToken(), name);
+        final VaultTOTPReadKeyResult result = vaultInternalTOPTSecretEngine.readTOTPKey(getToken(), name);
         return new KeyConfiguration(result.data.accountName,
                 result.data.algorithm, result.data.digits,
                 result.data.issuer, result.data.period);
@@ -59,7 +58,7 @@ public class VaultTOTPManager implements VaultTOTPSecretEngine {
     @Override
     public List<String> listKeys() {
         try {
-            return this.vaultClient.listTOTPKeys(getToken()).data.keys;
+            return vaultInternalTOPTSecretEngine.listTOTPKeys(getToken()).data.keys;
         } catch (VaultClientException e) {
             if (e.getStatus() == 404) {
                 return Collections.emptyList();
@@ -70,17 +69,17 @@ public class VaultTOTPManager implements VaultTOTPSecretEngine {
 
     @Override
     public void deleteKey(String name) {
-        this.vaultClient.deleteTOTPKey(getToken(), name);
+        vaultInternalTOPTSecretEngine.deleteTOTPKey(getToken(), name);
     }
 
     @Override
     public String generateCode(String name) {
-        return this.vaultClient.generateTOTPCode(getToken(), name).data.code;
+        return vaultInternalTOPTSecretEngine.generateTOTPCode(getToken(), name).data.code;
     }
 
     @Override
     public boolean validateCode(String name, String code) {
-        return this.vaultClient.validateTOTPCode(getToken(), name, code).data.valid;
+        return vaultInternalTOPTSecretEngine.validateTOTPCode(getToken(), name, code).data.valid;
     }
 
     private String getToken() {

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -2,151 +2,37 @@ package io.quarkus.vault.runtime.client;
 
 import java.util.Map;
 
-import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthListRolesResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthReadRoleResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
-import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
-import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
-import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
-import io.quarkus.vault.runtime.client.dto.database.VaultDatabaseCredentials;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2WriteBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultHealthResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
-import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
-import io.quarkus.vault.runtime.client.dto.sys.VaultListPolicyResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
-import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultWrapResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPListKeysResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPReadKeyResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPValidateCodeResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitCreateKeyBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecrypt;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecryptBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncrypt;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncryptBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyConfigBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyExport;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitListKeysResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitReadKeyResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitRewrapBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSign;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSignBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerify;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerifyBody;
-
 public interface VaultClient {
 
     String X_VAULT_TOKEN = "X-Vault-Token";
     String X_VAULT_NAMESPACE = "X-Vault-Namespace";
     String API_VERSION = "v1";
 
-    VaultUserPassAuth loginUserPass(String user, String password);
+    <T> T put(String path, String token, Object body, int expectedCode);
 
-    VaultKubernetesAuth loginKubernetes(String role, String jwt);
+    <T> T list(String path, String token, Class<T> resultClass);
 
-    void createKubernetesAuthRole(String token, String name, VaultKubernetesAuthRoleData body);
+    <T> T delete(String path, String token, int expectedCode);
 
-    VaultKubernetesAuthReadRoleResult getVaultKubernetesAuthRole(String token, String name);
+    <T> T post(String path, String token, Object body, Class<T> resultClass, int expectedCode);
 
-    VaultKubernetesAuthListRolesResult listKubernetesAuthRoles(String token);
+    <T> T post(String path, String token, Object body, Class<T> resultClass);
 
-    void deleteKubernetesAuthRoles(String token, String name);
+    <T> T post(String path, String token, Map<String, String> headers, Object body, Class<T> resultClass);
 
-    void configureKubernetesAuth(String token, VaultKubernetesAuthConfigData config);
+    <T> T post(String path, String token, Object body, int expectedCode);
 
-    VaultKubernetesAuthConfigResult readKubernetesAuthConfig(String token);
+    <T> T put(String path, String token, Object body, Class<T> resultClass);
 
-    VaultAppRoleAuth loginAppRole(String roleId, String secretId);
+    <T> T put(String path, Object body, Class<T> resultClass);
 
-    VaultRenewSelf renewSelf(String token, String increment);
+    <T> T get(String path, String token, Class<T> resultClass);
 
-    VaultLookupSelf lookupSelf(String token);
+    <T> T get(String path, Map<String, String> queryParams, Class<T> resultClass);
 
-    VaultLeasesLookup lookupLease(String token, String leaseId);
+    int head(String path);
 
-    VaultRenewLease renewLease(String token, String leaseId);
-
-    VaultKvSecretV1 getSecretV1(String token, String secretEnginePath, String path);
-
-    VaultKvSecretV2 getSecretV2(String token, String secretEnginePath, String path);
-
-    void writeSecretV1(String token, String secretEnginePath, String path, Map<String, String> values);
-
-    void writeSecretV2(String token, String secretEnginePath, String path, VaultKvSecretV2WriteBody body);
-
-    void deleteSecretV1(String token, String secretEnginePath, String path);
-
-    void deleteSecretV2(String token, String secretEnginePath, String path);
-
-    VaultDatabaseCredentials generateDatabaseCredentials(String token, String databaseCredentialsRole);
-
-    void updateTransitKeyConfiguration(String token, String keyName, VaultTransitKeyConfigBody body);
-
-    void createTransitKey(String token, String keyName, VaultTransitCreateKeyBody body);
-
-    void deleteTransitKey(String token, String keyName);
-
-    VaultTransitKeyExport exportTransitKey(String token, String keyType, String keyName, String version);
-
-    VaultTransitReadKeyResult readTransitKey(String token, String keyName);
-
-    VaultTransitListKeysResult listTransitKeys(String token);
-
-    VaultTransitEncrypt encrypt(String token, String keyName, VaultTransitEncryptBody body);
-
-    VaultTransitDecrypt decrypt(String token, String keyName, VaultTransitDecryptBody body);
-
-    VaultTransitSign sign(String token, String keyName, String hashAlgorithm,
-            VaultTransitSignBody body);
-
-    VaultTransitVerify verify(String token, String keyName, String hashAlgorithm,
-            VaultTransitVerifyBody body);
-
-    VaultTransitEncrypt rewrap(String token, String keyName, VaultTransitRewrapBody body);
-
-    VaultTOTPCreateKeyResult createTOTPKey(String token, String keyName, VaultTOTPCreateKeyBody vaultTOTPCreateKeyBody);
-
-    VaultTOTPReadKeyResult readTOTPKey(String token, String keyName);
-
-    VaultTOTPListKeysResult listTOTPKeys(String token);
-
-    void deleteTOTPKey(String token, String keyName);
-
-    VaultTOTPGenerateCodeResult generateTOTPCode(String token, String keyName);
-
-    VaultTOTPValidateCodeResult validateTOTPCode(String token, String keyName, String code);
-
-    int systemHealth(boolean isStandByOk, boolean isPerfStandByOk);
-
-    VaultHealthResult systemHealthStatus(boolean isStandByOk, boolean isPerfStandByOk);
-
-    VaultSealStatusResult systemSealStatus();
-
-    VaultInitResponse init(int secretShares, int secretThreshold);
-
-    VaultWrapResult wrap(String token, long ttl, Object object);
-
-    <T> T unwrap(String wrappingToken, Class<T> resultClass);
-
-    VaultPolicyResult getPolicy(String token, String name);
-
-    void createUpdatePolicy(String token, String name, VaultPolicyBody body);
-
-    VaultListPolicyResult listPolicies(String token);
-
-    void deletePolicy(String token, String name);
+    int head(String path, Map<String, String> queryParams);
 
     void close();
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultInternalBase.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultInternalBase.java
@@ -1,0 +1,14 @@
+package io.quarkus.vault.runtime.client;
+
+import javax.inject.Inject;
+
+public abstract class VaultInternalBase {
+
+    @Inject
+    protected VaultClient vaultClient;
+
+    public VaultInternalBase setVaultClient(VaultClient vaultClient) {
+        this.vaultClient = vaultClient;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VertxVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VertxVaultClient.java
@@ -8,7 +8,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,58 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.VaultConfigHolder;
-import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
-import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuthBody;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthBody;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthListRolesResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthReadRoleResult;
-import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
-import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
-import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
-import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelfBody;
-import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
-import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuthBody;
-import io.quarkus.vault.runtime.client.dto.database.VaultDatabaseCredentials;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2Write;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2WriteBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultHealthResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultInitBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
-import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
-import io.quarkus.vault.runtime.client.dto.sys.VaultListPolicyResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
-import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
-import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapBody;
-import io.quarkus.vault.runtime.client.dto.sys.VaultWrapResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPListKeysResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPReadKeyResult;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPValidateCodeBody;
-import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPValidateCodeResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitCreateKeyBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecrypt;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecryptBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncrypt;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncryptBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyConfigBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyExport;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitListKeysResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitReadKeyResult;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitRewrapBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSign;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSignBody;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerify;
-import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerifyBody;
 import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
@@ -96,7 +43,6 @@ public class VertxVaultClient implements VaultClient {
 
     private final Vertx vertx;
     private URL baseUrl;
-    private String kubernetesAuthMountPath;
     private final TlsConfig tlsConfig;
     private final VaultConfigHolder vaultConfigHolder;
     private WebClient webClient;
@@ -115,7 +61,6 @@ public class VertxVaultClient implements VaultClient {
         VaultBootstrapConfig config = vaultConfigHolder.getVaultBootstrapConfig();
         this.webClient = createHttpClient(vertx, config, tlsConfig);
         this.baseUrl = config.url.orElseThrow(() -> new VaultException("no vault url provided"));
-        this.kubernetesAuthMountPath = config.authentication.kubernetes.authMountPath;
     }
 
     @PreDestroy
@@ -130,331 +75,69 @@ public class VertxVaultClient implements VaultClient {
         }
     }
 
-    @Override
-    public VaultUserPassAuth loginUserPass(String user, String password) {
-        VaultUserPassAuthBody body = new VaultUserPassAuthBody(password);
-        return post("auth/userpass/login/" + user, null, body, VaultUserPassAuth.class);
-    }
-
-    @Override
-    public VaultKubernetesAuth loginKubernetes(String role, String jwt) {
-        VaultKubernetesAuthBody body = new VaultKubernetesAuthBody(role, jwt);
-        return post(kubernetesAuthMountPath + "/login", null, body, VaultKubernetesAuth.class);
-    }
-
-    @Override
-    public void createKubernetesAuthRole(String token, String name, VaultKubernetesAuthRoleData body) {
-        post(kubernetesAuthMountPath + "/role/" + name, token, body, 204);
-    }
-
-    @Override
-    public VaultKubernetesAuthReadRoleResult getVaultKubernetesAuthRole(String token, String name) {
-        return get(kubernetesAuthMountPath + "/role/" + name, token, VaultKubernetesAuthReadRoleResult.class);
-    }
-
-    @Override
-    public VaultKubernetesAuthListRolesResult listKubernetesAuthRoles(String token) {
-        return list(kubernetesAuthMountPath + "/role", token, VaultKubernetesAuthListRolesResult.class);
-    }
-
-    @Override
-    public void deleteKubernetesAuthRoles(String token, String name) {
-        delete(kubernetesAuthMountPath + "/role/" + name, token, 204);
-    }
-
-    @Override
-    public void configureKubernetesAuth(String token, VaultKubernetesAuthConfigData config) {
-        post(kubernetesAuthMountPath + "/config", token, config, 204);
-    }
-
-    @Override
-    public VaultKubernetesAuthConfigResult readKubernetesAuthConfig(String token) {
-        return get(kubernetesAuthMountPath + "/config", token, VaultKubernetesAuthConfigResult.class);
-    }
-
-    @Override
-    public VaultAppRoleAuth loginAppRole(String roleId, String secretId) {
-        VaultAppRoleAuthBody body = new VaultAppRoleAuthBody(roleId, secretId);
-        return post("auth/approle/login", null, body, VaultAppRoleAuth.class);
-    }
-
-    @Override
-    public VaultKvSecretV1 getSecretV1(String token, String secretEnginePath, String path) {
-        return get(secretEnginePath + "/" + path, token, VaultKvSecretV1.class);
-    }
-
-    @Override
-    public VaultKvSecretV2 getSecretV2(String token, String secretEnginePath, String path) {
-        return get(secretEnginePath + "/data/" + path, token, VaultKvSecretV2.class);
-    }
-
-    @Override
-    public void writeSecretV1(String token, String secretEnginePath, String path, Map<String, String> secret) {
-        post(secretEnginePath + "/" + path, token, secret, null, 204);
-    }
-
-    @Override
-    public void writeSecretV2(String token, String secretEnginePath, String path, VaultKvSecretV2WriteBody body) {
-        post(secretEnginePath + "/data/" + path, token, body, VaultKvSecretV2Write.class);
-    }
-
-    @Override
-    public void deleteSecretV1(String token, String secretEnginePath, String path) {
-        delete(secretEnginePath + "/" + path, token, 204);
-    }
-
-    @Override
-    public void deleteSecretV2(String token, String secretEnginePath, String path) {
-        delete(secretEnginePath + "/data/" + path, token, 204);
-    }
-
-    @Override
-    public VaultRenewSelf renewSelf(String token, String increment) {
-        VaultRenewSelfBody body = new VaultRenewSelfBody(increment);
-        return post("auth/token/renew-self", token, body, VaultRenewSelf.class);
-    }
-
-    @Override
-    public VaultLookupSelf lookupSelf(String token) {
-        return get("auth/token/lookup-self", token, VaultLookupSelf.class);
-    }
-
-    @Override
-    public VaultLeasesLookup lookupLease(String token, String leaseId) {
-        VaultLeasesBody body = new VaultLeasesBody(leaseId);
-        return put("sys/leases/lookup", token, body, VaultLeasesLookup.class);
-    }
-
-    @Override
-    public VaultRenewLease renewLease(String token, String leaseId) {
-        VaultLeasesBody body = new VaultLeasesBody(leaseId);
-        return put("sys/leases/renew", token, body, VaultRenewLease.class);
-    }
-
-    @Override
-    public VaultDatabaseCredentials generateDatabaseCredentials(String token, String databaseCredentialsRole) {
-        return get("database/creds/" + databaseCredentialsRole, token, VaultDatabaseCredentials.class);
-    }
-
-    @Override
-    public void updateTransitKeyConfiguration(String token, String keyName, VaultTransitKeyConfigBody body) {
-        post("transit/keys/" + keyName + "/config", token, body, 204);
-    }
-
-    @Override
-    public void createTransitKey(String token, String keyName, VaultTransitCreateKeyBody body) {
-        post("transit/keys/" + keyName, token, body, 204);
-    }
-
-    @Override
-    public void deleteTransitKey(String token, String keyName) {
-        delete("transit/keys/" + keyName, token, 204);
-    }
-
-    @Override
-    public VaultTransitKeyExport exportTransitKey(String token, String keyType, String keyName, String version) {
-        String path = "transit/export/" + keyType + "/" + keyName + (version != null ? "/" + version : "");
-        return get(path, token, VaultTransitKeyExport.class);
-    }
-
-    @Override
-    public VaultTransitReadKeyResult readTransitKey(String token, String keyName) {
-        return get("transit/keys/" + keyName, token, VaultTransitReadKeyResult.class);
-    }
-
-    @Override
-    public VaultTransitListKeysResult listTransitKeys(String token) {
-        return list("transit/keys", token, VaultTransitListKeysResult.class);
-    }
-
-    @Override
-    public VaultTransitEncrypt encrypt(String token, String keyName, VaultTransitEncryptBody body) {
-        return post("transit/encrypt/" + keyName, token, body, VaultTransitEncrypt.class);
-    }
-
-    @Override
-    public VaultTransitDecrypt decrypt(String token, String keyName, VaultTransitDecryptBody body) {
-        return post("transit/decrypt/" + keyName, token, body, VaultTransitDecrypt.class);
-    }
-
-    @Override
-    public VaultTransitSign sign(String token, String keyName, String hashAlgorithm, VaultTransitSignBody body) {
-        String path = "transit/sign/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
-        return post(path, token, body, VaultTransitSign.class);
-    }
-
-    @Override
-    public VaultTransitVerify verify(String token, String keyName, String hashAlgorithm, VaultTransitVerifyBody body) {
-        String path = "transit/verify/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
-        return post(path, token, body, VaultTransitVerify.class);
-    }
-
-    @Override
-    public VaultTransitEncrypt rewrap(String token, String keyName, VaultTransitRewrapBody body) {
-        return post("transit/rewrap/" + keyName, token, body, VaultTransitEncrypt.class);
-    }
-
-    @Override
-    public VaultTOTPCreateKeyResult createTOTPKey(String token, String keyName, VaultTOTPCreateKeyBody body) {
-        String path = "totp/keys/" + keyName;
-
-        // Depending on parameters it might produce an output or not
-        if (body.isProducingOutput()) {
-            return post(path, token, body, VaultTOTPCreateKeyResult.class, 200);
-        } else {
-            post(path, token, body, 204);
-            return null;
-        }
-    }
-
-    @Override
-    public VaultTOTPReadKeyResult readTOTPKey(String token, String keyName) {
-        String path = "totp/keys/" + keyName;
-        return get(path, token, VaultTOTPReadKeyResult.class);
-    }
-
-    @Override
-    public VaultTOTPListKeysResult listTOTPKeys(String token) {
-        return list("totp/keys", token, VaultTOTPListKeysResult.class);
-    }
-
-    @Override
-    public void deleteTOTPKey(String token, String keyName) {
-        String path = "totp/keys/" + keyName;
-        delete(path, token, 204);
-    }
-
-    @Override
-    public VaultTOTPGenerateCodeResult generateTOTPCode(String token, String keyName) {
-        String path = "totp/code/" + keyName;
-        return get(path, token, VaultTOTPGenerateCodeResult.class);
-    }
-
-    @Override
-    public VaultTOTPValidateCodeResult validateTOTPCode(String token, String keyName, String code) {
-        String path = "totp/code/" + keyName;
-        VaultTOTPValidateCodeBody body = new VaultTOTPValidateCodeBody(code);
-        return post(path, token, body, VaultTOTPValidateCodeResult.class);
-    }
-
-    @Override
-    public int systemHealth(boolean isStandByOk, boolean isPerfStandByOk) {
-        Map<String, String> queryParams = getHealthParams(isStandByOk, isPerfStandByOk);
-
-        return head("sys/health", queryParams);
-    }
-
-    @Override
-    public VaultHealthResult systemHealthStatus(boolean isStandByOk, boolean isPerfStandByOk) {
-        Map<String, String> queryParams = getHealthParams(isStandByOk, isPerfStandByOk);
-        return get("sys/health", queryParams, VaultHealthResult.class);
-    }
-
-    @Override
-    public VaultSealStatusResult systemSealStatus() {
-        return get("sys/seal-status", emptyMap(), VaultSealStatusResult.class);
-    }
-
-    @Override
-    public VaultInitResponse init(int secretShares, int secretThreshold) {
-        VaultInitBody body = new VaultInitBody(secretShares, secretThreshold);
-        return put("sys/init", body, VaultInitResponse.class);
-    }
-
-    public VaultWrapResult wrap(String token, long ttl, Object object) {
-        Map<String, String> headers = new HashMap<>();
-        headers.put("X-Vault-Wrap-TTL", "" + ttl);
-        return post("sys/wrapping/wrap", token, headers, object, VaultWrapResult.class);
-    }
-
-    @Override
-    public <T> T unwrap(String wrappingToken, Class<T> resultClass) {
-        return post("sys/wrapping/unwrap", wrappingToken, VaultUnwrapBody.EMPTY, resultClass);
-    }
-
-    @Override
-    public VaultPolicyResult getPolicy(String token, String name) {
-        return get("sys/policy/" + name, token, VaultPolicyResult.class);
-    }
-
-    @Override
-    public void createUpdatePolicy(String token, String name, VaultPolicyBody body) {
-        put("sys/policy/" + name, token, body, 204);
-    }
-
-    @Override
-    public VaultListPolicyResult listPolicies(String token) {
-        return get("sys/policy", token, VaultListPolicyResult.class);
-    }
-
-    @Override
-    public void deletePolicy(String token, String name) {
-        delete("sys/policy/" + name, token, 204);
-    }
-
     // ---
 
-    protected <T> T put(String path, String token, Object body, int expectedCode) {
+    public <T> T put(String path, String token, Object body, int expectedCode) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.PUT);
         return exec(request, body, null, expectedCode);
     }
 
-    protected <T> T list(String path, String token, Class<T> resultClass) {
+    public <T> T list(String path, String token, Class<T> resultClass) {
         HttpRequest<Buffer> request = builder(path, token).rawMethod("LIST");
         return exec(request, resultClass);
     }
 
-    protected <T> T delete(String path, String token, int expectedCode) {
+    public <T> T delete(String path, String token, int expectedCode) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.DELETE);
         return exec(request, expectedCode);
     }
 
-    protected <T> T post(String path, String token, Object body, Class<T> resultClass, int expectedCode) {
+    public <T> T post(String path, String token, Object body, Class<T> resultClass, int expectedCode) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.POST);
         return exec(request, body, resultClass, expectedCode);
     }
 
-    protected <T> T post(String path, String token, Object body, Class<T> resultClass) {
+    public <T> T post(String path, String token, Object body, Class<T> resultClass) {
         return post(path, token, emptyMap(), body, resultClass);
     }
 
-    protected <T> T post(String path, String token, Map<String, String> headers, Object body, Class<T> resultClass) {
+    public <T> T post(String path, String token, Map<String, String> headers, Object body, Class<T> resultClass) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.POST);
         headers.forEach(request::putHeader);
         return exec(request, body, resultClass);
     }
 
-    protected <T> T post(String path, String token, Object body, int expectedCode) {
+    public <T> T post(String path, String token, Object body, int expectedCode) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.POST);
         return exec(request, body, null, expectedCode);
     }
 
-    protected <T> T put(String path, String token, Object body, Class<T> resultClass) {
+    public <T> T put(String path, String token, Object body, Class<T> resultClass) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.PUT);
         return exec(request, body, resultClass);
     }
 
-    protected <T> T put(String path, Object body, Class<T> resultClass) {
+    public <T> T put(String path, Object body, Class<T> resultClass) {
         HttpRequest<Buffer> request = builder(path).method(HttpMethod.PUT);
         return exec(request, body, resultClass);
     }
 
-    protected <T> T get(String path, String token, Class<T> resultClass) {
+    public <T> T get(String path, String token, Class<T> resultClass) {
         HttpRequest<Buffer> request = builder(path, token).method(HttpMethod.GET);
         return exec(request, resultClass);
     }
 
-    protected <T> T get(String path, Map<String, String> queryParams, Class<T> resultClass) {
+    public <T> T get(String path, Map<String, String> queryParams, Class<T> resultClass) {
         final HttpRequest<Buffer> request = builder(path, queryParams).method(HttpMethod.GET);
         return exec(request, resultClass);
     }
 
-    protected int head(String path) {
+    public int head(String path) {
         final HttpRequest<Buffer> request = builder(path).method(HttpMethod.HEAD);
         return exec(request);
     }
 
-    protected int head(String path, Map<String, String> queryParams) {
+    public int head(String path, Map<String, String> queryParams) {
         final HttpRequest<Buffer> request = builder(path, queryParams).method(HttpMethod.HEAD);
         return exec(request);
     }
@@ -551,18 +234,5 @@ public class VertxVaultClient implements VaultClient {
         } catch (MalformedURLException e) {
             throw new VaultException(e);
         }
-    }
-
-    private Map<String, String> getHealthParams(boolean isStandByOk, boolean isPerfStandByOk) {
-        Map<String, String> queryParams = new HashMap<>();
-        if (isStandByOk) {
-            queryParams.put("standbyok", "true");
-        }
-
-        if (isPerfStandByOk) {
-            queryParams.put("perfstandbyok", "true");
-        }
-
-        return queryParams;
     }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAppRoleAuthMethod.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAppRoleAuthMethod.java
@@ -1,0 +1,16 @@
+package io.quarkus.vault.runtime.client.authmethod;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuthBody;
+
+@Singleton
+public class VaultInternalAppRoleAuthMethod extends VaultInternalBase {
+
+    public VaultAppRoleAuth login(String roleId, String secretId) {
+        VaultAppRoleAuthBody body = new VaultAppRoleAuthBody(roleId, secretId);
+        return vaultClient.post("auth/approle/login", null, body, VaultAppRoleAuth.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalKubernetesAuthMethod.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalKubernetesAuthMethod.java
@@ -1,0 +1,59 @@
+package io.quarkus.vault.runtime.client.authmethod;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthBody;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthListRolesResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthReadRoleResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
+
+@Singleton
+public class VaultInternalKubernetesAuthMethod extends VaultInternalBase {
+
+    @Inject
+    private VaultConfigHolder vaultConfigHolder;
+
+    private String getKubernetesAuthMountPath() {
+        return vaultConfigHolder.getVaultBootstrapConfig().authentication.kubernetes.authMountPath;
+    }
+
+    public VaultKubernetesAuth login(String role, String jwt) {
+        VaultKubernetesAuthBody body = new VaultKubernetesAuthBody(role, jwt);
+        return vaultClient.post(getKubernetesAuthMountPath() + "/login", null, body, VaultKubernetesAuth.class);
+    }
+
+    public void createAuthRole(String token, String name, VaultKubernetesAuthRoleData body) {
+        vaultClient.post(getKubernetesAuthMountPath() + "/role/" + name, token, body, 204);
+    }
+
+    public VaultKubernetesAuthReadRoleResult getVaultAuthRole(String token, String name) {
+        return vaultClient.get(getKubernetesAuthMountPath() + "/role/" + name, token, VaultKubernetesAuthReadRoleResult.class);
+    }
+
+    public VaultKubernetesAuthListRolesResult listAuthRoles(String token) {
+        return vaultClient.list(getKubernetesAuthMountPath() + "/role", token, VaultKubernetesAuthListRolesResult.class);
+    }
+
+    public void deleteAuthRoles(String token, String name) {
+        vaultClient.delete(getKubernetesAuthMountPath() + "/role/" + name, token, 204);
+    }
+
+    public void configureAuth(String token, VaultKubernetesAuthConfigData config) {
+        vaultClient.post(getKubernetesAuthMountPath() + "/config", token, config, 204);
+    }
+
+    public VaultKubernetesAuthConfigResult readAuthConfig(String token) {
+        return vaultClient.get(getKubernetesAuthMountPath() + "/config", token, VaultKubernetesAuthConfigResult.class);
+    }
+
+    public VaultInternalKubernetesAuthMethod setVaultConfigHolder(VaultConfigHolder vaultConfigHolder) {
+        this.vaultConfigHolder = vaultConfigHolder;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalTokenAuthMethod.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalTokenAuthMethod.java
@@ -1,0 +1,21 @@
+package io.quarkus.vault.runtime.client.authmethod;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
+import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
+import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelfBody;
+
+@Singleton
+public class VaultInternalTokenAuthMethod extends VaultInternalBase {
+
+    public VaultRenewSelf renewSelf(String token, String increment) {
+        VaultRenewSelfBody body = new VaultRenewSelfBody(increment);
+        return vaultClient.post("auth/token/renew-self", token, body, VaultRenewSelf.class);
+    }
+
+    public VaultLookupSelf lookupSelf(String token) {
+        return vaultClient.get("auth/token/lookup-self", token, VaultLookupSelf.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalUserpassAuthMethod.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalUserpassAuthMethod.java
@@ -1,0 +1,16 @@
+package io.quarkus.vault.runtime.client.authmethod;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuthBody;
+
+@Singleton
+public class VaultInternalUserpassAuthMethod extends VaultInternalBase {
+
+    public VaultUserPassAuth login(String user, String password) {
+        VaultUserPassAuthBody body = new VaultUserPassAuthBody(password);
+        return vaultClient.post("auth/userpass/login/" + user, null, body, VaultUserPassAuth.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/backend/VaultInternalSystemBackend.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/backend/VaultInternalSystemBackend.java
@@ -1,0 +1,96 @@
+package io.quarkus.vault.runtime.client.backend;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.sys.VaultHealthResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultInitBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
+import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
+import io.quarkus.vault.runtime.client.dto.sys.VaultListPolicyResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
+import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultWrapResult;
+
+@Singleton
+public class VaultInternalSystemBackend extends VaultInternalBase {
+
+    public int systemHealth(boolean isStandByOk, boolean isPerfStandByOk) {
+        Map<String, String> queryParams = getHealthParams(isStandByOk, isPerfStandByOk);
+        return vaultClient.head("sys/health", queryParams);
+    }
+
+    public VaultHealthResult systemHealthStatus(boolean isStandByOk, boolean isPerfStandByOk) {
+        Map<String, String> queryParams = getHealthParams(isStandByOk, isPerfStandByOk);
+        return vaultClient.get("sys/health", queryParams, VaultHealthResult.class);
+    }
+
+    public VaultSealStatusResult systemSealStatus() {
+        return vaultClient.get("sys/seal-status", emptyMap(), VaultSealStatusResult.class);
+    }
+
+    public VaultInitResponse init(int secretShares, int secretThreshold) {
+        VaultInitBody body = new VaultInitBody(secretShares, secretThreshold);
+        return vaultClient.put("sys/init", body, VaultInitResponse.class);
+    }
+
+    public VaultWrapResult wrap(String token, long ttl, Object object) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Vault-Wrap-TTL", "" + ttl);
+        return vaultClient.post("sys/wrapping/wrap", token, headers, object, VaultWrapResult.class);
+    }
+
+    public <T> T unwrap(String wrappingToken, Class<T> resultClass) {
+        return vaultClient.post("sys/wrapping/unwrap", wrappingToken, VaultUnwrapBody.EMPTY, resultClass);
+    }
+
+    public VaultPolicyResult getPolicy(String token, String name) {
+        return vaultClient.get("sys/policy/" + name, token, VaultPolicyResult.class);
+    }
+
+    public void createUpdatePolicy(String token, String name, VaultPolicyBody body) {
+        vaultClient.put("sys/policy/" + name, token, body, 204);
+    }
+
+    public VaultListPolicyResult listPolicies(String token) {
+        return vaultClient.get("sys/policy", token, VaultListPolicyResult.class);
+    }
+
+    public void deletePolicy(String token, String name) {
+        vaultClient.delete("sys/policy/" + name, token, 204);
+    }
+
+    public VaultLeasesLookup lookupLease(String token, String leaseId) {
+        VaultLeasesBody body = new VaultLeasesBody(leaseId);
+        return vaultClient.put("sys/leases/lookup", token, body, VaultLeasesLookup.class);
+    }
+
+    public VaultRenewLease renewLease(String token, String leaseId) {
+        VaultLeasesBody body = new VaultLeasesBody(leaseId);
+        return vaultClient.put("sys/leases/renew", token, body, VaultRenewLease.class);
+    }
+
+    // ---
+
+    private Map<String, String> getHealthParams(boolean isStandByOk, boolean isPerfStandByOk) {
+        Map<String, String> queryParams = new HashMap<>();
+        if (isStandByOk) {
+            queryParams.put("standbyok", "true");
+        }
+
+        if (isPerfStandByOk) {
+            queryParams.put("perfstandbyok", "true");
+        }
+
+        return queryParams;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalDatabaseSecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalDatabaseSecretEngine.java
@@ -1,0 +1,14 @@
+package io.quarkus.vault.runtime.client.secretengine;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.database.VaultDatabaseCredentials;
+
+@Singleton
+public class VaultInternalDatabaseSecretEngine extends VaultInternalBase {
+
+    public VaultDatabaseCredentials generateCredentials(String token, String databaseCredentialsRole) {
+        return vaultClient.get("database/creds/" + databaseCredentialsRole, token, VaultDatabaseCredentials.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV1SecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV1SecretEngine.java
@@ -1,0 +1,29 @@
+package io.quarkus.vault.runtime.client.secretengine;
+
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvListSecrets;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
+
+@Singleton
+public class VaultInternalKvV1SecretEngine extends VaultInternalBase {
+
+    public void deleteSecret(String token, String secretEnginePath, String path) {
+        vaultClient.delete(secretEnginePath + "/" + path, token, 204);
+    }
+
+    public void writeSecret(String token, String secretEnginePath, String path, Map<String, String> secret) {
+        vaultClient.post(secretEnginePath + "/" + path, token, secret, null, 204);
+    }
+
+    public VaultKvSecretV1 getSecret(String token, String secretEnginePath, String path) {
+        return vaultClient.get(secretEnginePath + "/" + path, token, VaultKvSecretV1.class);
+    }
+
+    public VaultKvListSecrets listSecrets(String token, String secretEnginePath, String path) {
+        return vaultClient.list(secretEnginePath + "/" + path, token, VaultKvListSecrets.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV2SecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV2SecretEngine.java
@@ -1,0 +1,29 @@
+package io.quarkus.vault.runtime.client.secretengine;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvListSecrets;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2Write;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2WriteBody;
+
+@Singleton
+public class VaultInternalKvV2SecretEngine extends VaultInternalBase {
+
+    public VaultKvSecretV2 getSecret(String token, String secretEnginePath, String path) {
+        return vaultClient.get(secretEnginePath + "/data/" + path, token, VaultKvSecretV2.class);
+    }
+
+    public void writeSecret(String token, String secretEnginePath, String path, VaultKvSecretV2WriteBody body) {
+        vaultClient.post(secretEnginePath + "/data/" + path, token, body, VaultKvSecretV2Write.class);
+    }
+
+    public void deleteSecret(String token, String secretEnginePath, String path) {
+        vaultClient.delete(secretEnginePath + "/data/" + path, token, 204);
+    }
+
+    public VaultKvListSecrets listSecrets(String token, String secretEnginePath, String path) {
+        return vaultClient.list(secretEnginePath + "/metadata/" + path, token, VaultKvListSecrets.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTOPTSecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTOPTSecretEngine.java
@@ -1,0 +1,53 @@
+package io.quarkus.vault.runtime.client.secretengine;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPListKeysResult;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPReadKeyResult;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPValidateCodeBody;
+import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPValidateCodeResult;
+
+@Singleton
+public class VaultInternalTOPTSecretEngine extends VaultInternalBase {
+
+    public VaultTOTPCreateKeyResult createTOTPKey(String token, String keyName, VaultTOTPCreateKeyBody body) {
+        String path = "totp/keys/" + keyName;
+
+        // Depending on parameters it might produce an output or not
+        if (body.isProducingOutput()) {
+            return vaultClient.post(path, token, body, VaultTOTPCreateKeyResult.class, 200);
+        } else {
+            vaultClient.post(path, token, body, 204);
+            return null;
+        }
+    }
+
+    public VaultTOTPReadKeyResult readTOTPKey(String token, String keyName) {
+        String path = "totp/keys/" + keyName;
+        return vaultClient.get(path, token, VaultTOTPReadKeyResult.class);
+    }
+
+    public VaultTOTPListKeysResult listTOTPKeys(String token) {
+        return vaultClient.list("totp/keys", token, VaultTOTPListKeysResult.class);
+    }
+
+    public void deleteTOTPKey(String token, String keyName) {
+        String path = "totp/keys/" + keyName;
+        vaultClient.delete(path, token, 204);
+    }
+
+    public VaultTOTPGenerateCodeResult generateTOTPCode(String token, String keyName) {
+        String path = "totp/code/" + keyName;
+        return vaultClient.get(path, token, VaultTOTPGenerateCodeResult.class);
+    }
+
+    public VaultTOTPValidateCodeResult validateTOTPCode(String token, String keyName, String code) {
+        String path = "totp/code/" + keyName;
+        VaultTOTPValidateCodeBody body = new VaultTOTPValidateCodeBody(code);
+        return vaultClient.post(path, token, body, VaultTOTPValidateCodeResult.class);
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTransitSecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTransitSecretEngine.java
@@ -1,0 +1,70 @@
+package io.quarkus.vault.runtime.client.secretengine;
+
+import javax.inject.Singleton;
+
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitCreateKeyBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecrypt;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecryptBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncrypt;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitEncryptBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyConfigBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitKeyExport;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitListKeysResult;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitReadKeyResult;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitRewrapBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSign;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSignBody;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerify;
+import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerifyBody;
+
+@Singleton
+public class VaultInternalTransitSecretEngine extends VaultInternalBase {
+
+    public void updateTransitKeyConfiguration(String token, String keyName, VaultTransitKeyConfigBody body) {
+        vaultClient.post("transit/keys/" + keyName + "/config", token, body, 204);
+    }
+
+    public void createTransitKey(String token, String keyName, VaultTransitCreateKeyBody body) {
+        vaultClient.post("transit/keys/" + keyName, token, body, 204);
+    }
+
+    public void deleteTransitKey(String token, String keyName) {
+        vaultClient.delete("transit/keys/" + keyName, token, 204);
+    }
+
+    public VaultTransitKeyExport exportTransitKey(String token, String keyType, String keyName, String version) {
+        String path = "transit/export/" + keyType + "/" + keyName + (version != null ? "/" + version : "");
+        return vaultClient.get(path, token, VaultTransitKeyExport.class);
+    }
+
+    public VaultTransitReadKeyResult readTransitKey(String token, String keyName) {
+        return vaultClient.get("transit/keys/" + keyName, token, VaultTransitReadKeyResult.class);
+    }
+
+    public VaultTransitListKeysResult listTransitKeys(String token) {
+        return vaultClient.list("transit/keys", token, VaultTransitListKeysResult.class);
+    }
+
+    public VaultTransitEncrypt encrypt(String token, String keyName, VaultTransitEncryptBody body) {
+        return vaultClient.post("transit/encrypt/" + keyName, token, body, VaultTransitEncrypt.class);
+    }
+
+    public VaultTransitDecrypt decrypt(String token, String keyName, VaultTransitDecryptBody body) {
+        return vaultClient.post("transit/decrypt/" + keyName, token, body, VaultTransitDecrypt.class);
+    }
+
+    public VaultTransitSign sign(String token, String keyName, String hashAlgorithm, VaultTransitSignBody body) {
+        String path = "transit/sign/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
+        return vaultClient.post(path, token, body, VaultTransitSign.class);
+    }
+
+    public VaultTransitVerify verify(String token, String keyName, String hashAlgorithm, VaultTransitVerifyBody body) {
+        String path = "transit/verify/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
+        return vaultClient.post(path, token, body, VaultTransitVerify.class);
+    }
+
+    public VaultTransitEncrypt rewrap(String token, String keyName, VaultTransitRewrapBody body) {
+        return vaultClient.post("transit/rewrap/" + keyName, token, body, VaultTransitEncrypt.class);
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -8,6 +8,8 @@ import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
 import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
 import static io.quarkus.vault.test.VaultTestExtension.DB_PASSWORD;
 import static io.quarkus.vault.test.VaultTestExtension.ENCRYPTION_KEY_NAME;
+import static io.quarkus.vault.test.VaultTestExtension.EXPECTED_SUB_PATHS;
+import static io.quarkus.vault.test.VaultTestExtension.LIST_PATH;
 import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
 import static io.quarkus.vault.test.VaultTestExtension.SECRET_PATH_V1;
 import static io.quarkus.vault.test.VaultTestExtension.SECRET_PATH_V2;
@@ -44,14 +46,18 @@ import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.runtime.Base64String;
-import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalAppRoleAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalTokenAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalUserpassAuthMethod;
+import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
 import io.quarkus.vault.runtime.client.dto.VaultModel;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
 import io.quarkus.vault.runtime.client.dto.database.VaultDatabaseCredentials;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvListSecrets;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
@@ -71,6 +77,10 @@ import io.quarkus.vault.runtime.client.dto.transit.VaultTransitSignBody;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerify;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerifyBatchInput;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitVerifyBody;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalDatabaseSecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalKvV1SecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalKvV2SecretEngine;
+import io.quarkus.vault.runtime.client.secretengine.VaultInternalTransitSecretEngine;
 import io.quarkus.vault.runtime.config.VaultAuthenticationType;
 import io.quarkus.vault.runtime.config.VaultConfigSource;
 import io.quarkus.vault.test.VaultTestExtension;
@@ -86,8 +96,6 @@ public class VaultITCase {
     private static final Logger log = Logger.getLogger(VaultITCase.class);
 
     public static final String MY_PASSWORD = "my-password";
-
-    public static final String CRUD_PATH = "crud";
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -107,7 +115,21 @@ public class VaultITCase {
     String someSecretThroughIndirection;
 
     @Inject
-    VaultClient vaultClient;
+    VaultInternalKvV1SecretEngine vaultInternalKvV1SecretEngine;
+    @Inject
+    VaultInternalKvV2SecretEngine vaultInternalKvV2SecretEngine;
+    @Inject
+    VaultInternalTransitSecretEngine vaultInternalTransitSecretEngine;
+    @Inject
+    VaultInternalSystemBackend vaultInternalSystemBackend;
+    @Inject
+    VaultInternalAppRoleAuthMethod vaultInternalAppRoleAuthMethod;
+    @Inject
+    VaultInternalUserpassAuthMethod vaultInternalUserpassAuthMethod;
+    @Inject
+    VaultInternalTokenAuthMethod vaultInternalTokenAuthMethod;
+    @Inject
+    VaultInternalDatabaseSecretEngine vaultInternalDatabaseSecretEngine;
 
     @Test
     public void credentialsProvider() {
@@ -146,13 +168,13 @@ public class VaultITCase {
     }
 
     @Test
-    public void secretV1() {
+    public void secret() {
         Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
         assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
     }
 
     @Test
-    public void crudSecretV1() {
+    public void crudSecret() {
         VaultTestExtension.assertCrudSecret(kvSecretEngine);
     }
 
@@ -165,10 +187,10 @@ public class VaultITCase {
     public void httpclient() {
 
         String anotherWrappingToken = System.getProperty("vault-test.another-password-kv-v2-wrapping-token");
-        VaultKvSecretV2 unwrap = vaultClient.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
+        VaultKvSecretV2 unwrap = vaultInternalSystemBackend.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
         assertEquals(VAULT_AUTH_USERPASS_PASSWORD, unwrap.data.data.get(USERPASS_WRAPPING_TOKEN_PASSWORD_KEY));
         try {
-            vaultClient.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
+            vaultInternalSystemBackend.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
             fail("expected error 400: wrapping token is not valid or does not exist");
         } catch (VaultClientException e) {
             // fails on second unwrap attempt
@@ -177,52 +199,53 @@ public class VaultITCase {
 
         String appRoleRoleId = System.getProperty("vault-test.role-id");
         String appRoleSecretId = System.getProperty("vault-test.secret-id");
-        VaultAppRoleAuth vaultAppRoleAuth = vaultClient.loginAppRole(appRoleRoleId, appRoleSecretId);
+        VaultAppRoleAuth vaultAppRoleAuth = vaultInternalAppRoleAuthMethod.login(appRoleRoleId, appRoleSecretId);
         String appRoleClientToken = vaultAppRoleAuth.auth.clientToken;
         assertNotNull(appRoleClientToken);
         log.info("appRoleClientToken = " + appRoleClientToken);
 
-        assertTokenAppRole(vaultClient, appRoleClientToken);
-        assertKvSecrets(vaultClient, appRoleClientToken);
-        assertDynamicCredentials(vaultClient, appRoleClientToken, APPROLE);
-        assertWrap(vaultClient, appRoleClientToken);
+        assertTokenAppRole(appRoleClientToken);
+        assertKvSecrets(appRoleClientToken);
+        assertDynamicCredentials(appRoleClientToken, APPROLE);
+        assertWrap(appRoleClientToken);
 
-        VaultUserPassAuth vaultUserPassAuth = vaultClient.loginUserPass(VAULT_AUTH_USERPASS_USER, VAULT_AUTH_USERPASS_PASSWORD);
+        VaultUserPassAuth vaultUserPassAuth = vaultInternalUserpassAuthMethod.login(VAULT_AUTH_USERPASS_USER,
+                VAULT_AUTH_USERPASS_PASSWORD);
         String userPassClientToken = vaultUserPassAuth.auth.clientToken;
         log.info("userPassClientToken = " + userPassClientToken);
         assertNotNull(userPassClientToken);
 
-        assertTransit(vaultClient, appRoleClientToken);
+        assertTransit(appRoleClientToken);
 
-        assertTokenUserPass(vaultClient, userPassClientToken);
-        assertKvSecrets(vaultClient, userPassClientToken);
-        assertDynamicCredentials(vaultClient, userPassClientToken, USERPASS);
-        assertWrap(vaultClient, userPassClientToken);
+        assertTokenUserPass(userPassClientToken);
+        assertKvSecrets(userPassClientToken);
+        assertDynamicCredentials(userPassClientToken, USERPASS);
+        assertWrap(userPassClientToken);
     }
 
-    private void assertWrap(VaultClient vaultClient, String token) {
-        VaultWrapResult wrapResult = vaultClient.wrap(token, 60, new WrapExample());
-        WrapExample unwrapExample = vaultClient.unwrap(wrapResult.wrapInfo.token, WrapExample.class);
+    private void assertWrap(String token) {
+        VaultWrapResult wrapResult = vaultInternalSystemBackend.wrap(token, 60, new WrapExample());
+        WrapExample unwrapExample = vaultInternalSystemBackend.unwrap(wrapResult.wrapInfo.token, WrapExample.class);
         assertEquals("bar", unwrapExample.foo);
         assertEquals("zap", unwrapExample.zip);
     }
 
-    private void assertTransit(VaultClient vaultClient, String token) {
+    private void assertTransit(String token) {
 
         Base64String context = Base64String.from("mycontext");
 
-        assertTransitEncryption(vaultClient, token, ENCRYPTION_KEY_NAME, null);
-        assertTransitEncryption(vaultClient, token, ENCRYPTION_KEY_NAME, context);
+        assertTransitEncryption(token, ENCRYPTION_KEY_NAME, null);
+        assertTransitEncryption(token, ENCRYPTION_KEY_NAME, context);
 
-        assertTransitSign(vaultClient, token, SIGN_KEY_NAME, null);
-        assertTransitSign(vaultClient, token, SIGN_KEY_NAME, context);
+        assertTransitSign(token, SIGN_KEY_NAME, null);
+        assertTransitSign(token, SIGN_KEY_NAME, context);
 
         new TestVaultClient().rotate(token, ENCRYPTION_KEY_NAME);
 
-        assertHash(vaultClient, token);
+        assertHash(token);
     }
 
-    private void assertHash(VaultClient vaultClient, String token) {
+    private void assertHash(String token) {
         VaultTransitHashBody body = new VaultTransitHashBody();
         body.input = Base64String.from("coucou");
         body.format = "base64";
@@ -232,92 +255,98 @@ public class VaultITCase {
         assertEquals(expected, sum.getValue());
     }
 
-    private void assertTransitSign(VaultClient vaultClient, String token, String keyName, Base64String context) {
+    private void assertTransitSign(String token, String keyName, Base64String context) {
 
         String data = "coucou";
 
         VaultTransitSignBody batchBody = new VaultTransitSignBody();
         batchBody.batchInput = singletonList(new VaultTransitSignBatchInput(Base64String.from(data), context));
 
-        VaultTransitSign batchSign = vaultClient.sign(token, keyName, null, batchBody);
+        VaultTransitSign batchSign = vaultInternalTransitSecretEngine.sign(token, keyName, null, batchBody);
 
         VaultTransitVerifyBody verifyBody = new VaultTransitVerifyBody();
         VaultTransitVerifyBatchInput batchInput = new VaultTransitVerifyBatchInput(Base64String.from(data), context);
         batchInput.signature = batchSign.data.batchResults.get(0).signature;
         verifyBody.batchInput = singletonList(batchInput);
 
-        VaultTransitVerify verify = vaultClient.verify(token, keyName, null, verifyBody);
+        VaultTransitVerify verify = vaultInternalTransitSecretEngine.verify(token, keyName, null, verifyBody);
         assertEquals(1, verify.data.batchResults.size());
         assertTrue(verify.data.batchResults.get(0).valid);
-
     }
 
-    private void assertTransitEncryption(VaultClient vaultClient, String token, String keyName, Base64String context) {
+    private void assertTransitEncryption(String token, String keyName, Base64String context) {
 
         String data = "coucou";
 
         VaultTransitEncryptBatchInput encryptBatchInput = new VaultTransitEncryptBatchInput(Base64String.from(data), context);
         VaultTransitEncryptBody encryptBody = new VaultTransitEncryptBody();
         encryptBody.batchInput = singletonList(encryptBatchInput);
-        VaultTransitEncrypt encryptBatchResult = vaultClient.encrypt(token, keyName, encryptBody);
+        VaultTransitEncrypt encryptBatchResult = vaultInternalTransitSecretEngine.encrypt(token, keyName, encryptBody);
         String ciphertext = encryptBatchResult.data.batchResults.get(0).ciphertext;
 
-        String batchDecryptedString = decrypt(vaultClient, token, keyName, ciphertext, context);
+        String batchDecryptedString = decrypt(token, keyName, ciphertext, context);
         assertEquals(data, batchDecryptedString);
 
         VaultTransitRewrapBatchInput rewrapBatchInput = new VaultTransitRewrapBatchInput(ciphertext, context);
         VaultTransitRewrapBody rewrapBody = new VaultTransitRewrapBody();
         rewrapBody.batchInput = singletonList(rewrapBatchInput);
-        VaultTransitEncrypt rewrap = vaultClient.rewrap(token, keyName, rewrapBody);
+        VaultTransitEncrypt rewrap = vaultInternalTransitSecretEngine.rewrap(token, keyName, rewrapBody);
         assertEquals(1, rewrap.data.batchResults.size());
         String rewrappedCiphertext = rewrap.data.batchResults.get(0).ciphertext;
 
-        batchDecryptedString = decrypt(vaultClient, token, keyName, rewrappedCiphertext, context);
+        batchDecryptedString = decrypt(token, keyName, rewrappedCiphertext, context);
         assertEquals(data, batchDecryptedString);
-
     }
 
-    private String decrypt(VaultClient vaultClient, String token, String keyName, String ciphertext, Base64String context) {
+    private String decrypt(String token, String keyName, String ciphertext, Base64String context) {
         VaultTransitDecryptBatchInput decryptBatchInput = new VaultTransitDecryptBatchInput(ciphertext, context);
         VaultTransitDecryptBody decryptBody = new VaultTransitDecryptBody();
         decryptBody.batchInput = singletonList(decryptBatchInput);
-        VaultTransitDecrypt decryptBatchResult = vaultClient.decrypt(token, keyName, decryptBody);
+        VaultTransitDecrypt decryptBatchResult = vaultInternalTransitSecretEngine.decrypt(token, keyName, decryptBody);
         return decryptBatchResult.data.batchResults.get(0).plaintext.decodeAsString();
     }
 
-    private void assertDynamicCredentials(VaultClient vaultClient, String clientToken, VaultAuthenticationType authType) {
-        VaultDatabaseCredentials vaultDatabaseCredentials = vaultClient.generateDatabaseCredentials(clientToken, VAULT_DBROLE);
+    private void assertDynamicCredentials(String clientToken, VaultAuthenticationType authType) {
+        VaultDatabaseCredentials vaultDatabaseCredentials = vaultInternalDatabaseSecretEngine.generateCredentials(clientToken,
+                VAULT_DBROLE);
         String username = vaultDatabaseCredentials.data.username;
         assertTrue(username.startsWith("v-" + authType.name().toLowerCase() + "-" + VAULT_DBROLE + "-"));
 
-        VaultLeasesLookup vaultLeasesLookup = vaultClient.lookupLease(clientToken, vaultDatabaseCredentials.leaseId);
+        VaultLeasesLookup vaultLeasesLookup = vaultInternalSystemBackend.lookupLease(clientToken,
+                vaultDatabaseCredentials.leaseId);
         assertEquals(vaultDatabaseCredentials.leaseId, vaultLeasesLookup.data.id);
 
-        VaultRenewLease vaultRenewLease = vaultClient.renewLease(clientToken, vaultDatabaseCredentials.leaseId);
+        VaultRenewLease vaultRenewLease = vaultInternalSystemBackend.renewLease(clientToken, vaultDatabaseCredentials.leaseId);
         assertEquals(vaultDatabaseCredentials.leaseId, vaultRenewLease.leaseId);
     }
 
-    private void assertKvSecrets(VaultClient vaultClient, String clientToken) {
-        VaultKvSecretV1 secretV1 = vaultClient.getSecretV1(clientToken, SECRET_PATH_V1, APP_SECRET_PATH);
+    private void assertKvSecrets(String clientToken) {
+        VaultKvSecretV1 secretV1 = vaultInternalKvV1SecretEngine.getSecret(clientToken, SECRET_PATH_V1, APP_SECRET_PATH);
         assertEquals(SECRET_VALUE, secretV1.data.get(SECRET_KEY));
+        VaultKvListSecrets vaultKvListSecretsV1 = vaultInternalKvV1SecretEngine.listSecrets(clientToken, SECRET_PATH_V1,
+                LIST_PATH);
+        assertEquals(EXPECTED_SUB_PATHS, vaultKvListSecretsV1.data.keys.toString());
 
-        VaultKvSecretV2 secretV2 = vaultClient.getSecretV2(clientToken, SECRET_PATH_V2, APP_SECRET_PATH);
+        VaultKvSecretV2 secretV2 = vaultInternalKvV2SecretEngine.getSecret(clientToken, SECRET_PATH_V2, APP_SECRET_PATH);
         assertEquals(SECRET_VALUE, secretV2.data.data.get(SECRET_KEY));
+        VaultKvListSecrets vaultKvListSecretsV2 = vaultInternalKvV2SecretEngine.listSecrets(clientToken, SECRET_PATH_V2,
+                LIST_PATH);
+        assertEquals(EXPECTED_SUB_PATHS, vaultKvListSecretsV2.data.keys.toString());
     }
 
-    private void assertTokenUserPass(VaultClient vaultClient, String clientToken) {
-        VaultLookupSelf vaultLookupSelf = vaultClient.lookupSelf(clientToken);
+    private void assertTokenUserPass(String clientToken) {
+        VaultLookupSelf vaultLookupSelf = vaultInternalTokenAuthMethod.lookupSelf(clientToken);
         assertEquals("auth/" + USERPASS.name().toLowerCase() + "/login/" + VAULT_AUTH_USERPASS_USER, vaultLookupSelf.data.path);
 
-        VaultRenewSelf vaultRenewSelf = vaultClient.renewSelf(clientToken, "1h");
+        VaultRenewSelf vaultRenewSelf = vaultInternalTokenAuthMethod.renewSelf(clientToken, "1h");
         assertEquals(VAULT_AUTH_USERPASS_USER, vaultRenewSelf.auth.metadata.get("username"));
     }
 
-    private void assertTokenAppRole(VaultClient vaultClient, String clientToken) {
-        VaultLookupSelf vaultLookupSelf = vaultClient.lookupSelf(clientToken);
+    private void assertTokenAppRole(String clientToken) {
+        VaultLookupSelf vaultLookupSelf = vaultInternalTokenAuthMethod.lookupSelf(clientToken);
         assertEquals("auth/approle/login", vaultLookupSelf.data.path);
 
-        VaultRenewSelf vaultRenewSelf = vaultClient.renewSelf(clientToken, "1h");
+        VaultRenewSelf vaultRenewSelf = vaultInternalTokenAuthMethod.renewSelf(clientToken, "1h");
         assertEquals(VAULT_AUTH_APPROLE, vaultRenewSelf.auth.metadata.get("role_name"));
     }
 

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -49,6 +49,7 @@ import io.quarkus.vault.VaultException;
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.runtime.VaultConfigHolder;
 import io.quarkus.vault.runtime.client.VaultClientException;
+import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
 import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
@@ -74,6 +75,9 @@ public class VaultTestExtension {
     public static final String VAULT_AUTH_APPROLE = "myapprole";
     public static final String SECRET_PATH_V1 = "secret-v1";
     public static final String SECRET_PATH_V2 = "secret";
+    public static final String LIST_PATH = "hello";
+    public static final String LIST_SUB_PATH = "world";
+    public static final String EXPECTED_SUB_PATHS = "[" + LIST_SUB_PATH + "]";
     public static final String VAULT_DBROLE = "mydbrole";
     public static final String APP_SECRET_PATH = "foo";
     static final String APP_CONFIG_PATH = "config";
@@ -128,6 +132,8 @@ public class VaultTestExtension {
     }
 
     public static void assertCrudSecret(VaultKVSecretEngine kvSecretEngine) {
+
+        assertEquals(EXPECTED_SUB_PATHS, kvSecretEngine.listSecrets(LIST_PATH).toString());
 
         assertDeleteSecret(kvSecretEngine);
 
@@ -238,21 +244,23 @@ public class VaultTestExtension {
     }
 
     private String getVaultImage() {
-        return "vault:1.6.0";
+        return "vault:1.6.3";
     }
 
     private void initVault() throws InterruptedException, IOException {
 
         vaultClient = createVaultClient();
+        VaultInternalSystemBackend vaultInternalSystemBackend = new VaultInternalSystemBackend();
+        vaultInternalSystemBackend.setVaultClient(vaultClient);
 
-        VaultInitResponse vaultInit = vaultClient.init(1, 1);
+        VaultInitResponse vaultInit = vaultInternalSystemBackend.init(1, 1);
         String unsealKey = vaultInit.keys.get(0);
         rootToken = vaultInit.rootToken;
 
         waitForContainerToStart();
 
         try {
-            vaultClient.systemHealthStatus(false, false);
+            vaultInternalSystemBackend.systemHealthStatus(false, false);
         } catch (VaultClientException e) {
             // https://www.vaultproject.io/api/system/health.html
             // 503 = sealed
@@ -262,7 +270,7 @@ public class VaultTestExtension {
         // unseal
         execVault("vault operator unseal " + unsealKey);
 
-        VaultSealStatusResult sealStatus = vaultClient.systemSealStatus();
+        VaultSealStatusResult sealStatus = vaultInternalSystemBackend.systemSealStatus();
         assertFalse(sealStatus.sealed);
 
         // userpass auth
@@ -284,16 +292,20 @@ public class VaultTestExtension {
 
         // policy
         String policyContent = readResourceContent("vault.policy");
-        vaultClient.createUpdatePolicy(rootToken, VAULT_POLICY, new VaultPolicyBody(policyContent));
+        vaultInternalSystemBackend.createUpdatePolicy(rootToken, VAULT_POLICY, new VaultPolicyBody(policyContent));
 
         // static secrets kv v1
         execVault(format("vault secrets enable -path=%s kv", SECRET_PATH_V1));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
+        execVault(
+                format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, LIST_PATH + "/" + LIST_SUB_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
 
         // static secrets kv v2
         execVault(format("vault secrets enable -path=%s -version=2 kv", SECRET_PATH_V2));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
+        execVault(
+                format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, LIST_PATH + "/" + LIST_SUB_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
 
         // multi config

--- a/test-framework/vault/src/main/resources/vault.policy
+++ b/test-framework/vault/src/main/resources/vault.policy
@@ -13,6 +13,13 @@ path "secret/data/multi/*" {
   capabilities = ["read"]
 }
 
+path "secret/metadata/hello/*" {
+  capabilities = ["list"]
+}
+path "secret-v1/hello/*" {
+  capabilities = ["list"]
+}
+
 # kv engine v1
 path "secret-v1/foo" {
   capabilities = ["read"]


### PR DESCRIPTION
Splits `VertxVaultClient` into multiple specialized clients located in 3 packages `authmethod`, `backend` and `secretengine`. All new classes are named `VaultInternalXAuthMethod`, `VaultInternalXBackend` or `VaultInternalXSecretEngine`.
This simplifies the `VertxVaultClient` class, which focuses on the low level methods, and strictly adheres to the hashicorp vault api.
This will make it easier to maintain, and evolve. The particular naming has the extra benefit of conveying the _internal_ qualification of these new services.
The image has been updated from 1.6.0 to 1.6.3.
And the listSecrets operation has been implemented on kv v1 and v2.

/cc @sberyozkin 