### PR TITLE
Prevent ArrayIndexOutOfBoundsException in AmazonLambdaRecorder

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -84,8 +84,11 @@ public class AmazonLambdaRecorder {
                 }
             }
         }
-        if (method == null) {
+        if (method == null && methods.length > 0) {
             method = methods[0];
+        }
+        if (method == null) {
+            throw new RuntimeException("Unable to find a method which handles request on handler class " + handlerClass);
         }
         return method;
     }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/15502

The commit here prevents the potential ArrayIndexOutOfBoundsException and instead throws an exception with a better error message.