### PR TITLE
RunnerClassLoader#findResources - Return an empty enumeration instead of null if no resource can be found

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -193,7 +193,7 @@ public final class RunnerClassLoader extends ClassLoader {
         }
         ClassLoadingResource[] resources = getClassLoadingResources(name);
         if (resources == null)
-            return null;
+            return Collections.emptyEnumeration();
         List<URL> urls = new ArrayList<>();
         for (ClassLoadingResource resource : resources) {
             accessingResource(resource);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/15625

The implementation of this method already returns an empty enumeration in one part of the method when it can't find the resource. The commit here adds consistency in the rest of this method implementation to return this empty enumeration.
