### PR TITLE
Mark adal4j dependency as optional

### DIFF
--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
+            <optional>true</optional>
             <version>1.6.6</version>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
I would like to see if the com.microsoft.sqlserver:mssql-jdbc can be upgraded, since there have been quite a few new versions after the one used by Quarkus.

As a first step I would like to declare the adal4j dependency as optional. First off this dependency is also declared as optional in mssql-jdbc itself, since it is only required for AD-based authentication. And also, in the newer versions of the driver, the AD-based authentication doesn't use adal4j anymore (which has been discontinued).