### PR TITLE
Fixes compilation with Mandrel 21.0.0.0.Final

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM20OrEarlier.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM20OrEarlier.java
@@ -1,0 +1,23 @@
+package io.quarkus.runtime.graal;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.home.HomeFinder;
+
+public class GraalVM20OrEarlier implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        String version = HomeFinder.getInstance().getVersion();
+        int dot = version.indexOf('.');
+        if (dot < 0) {
+            return false;
+        }
+        try {
+            int major = Integer.parseInt(version.substring(0, dot));
+            return major < 21;
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JavaIOSubstitutions.java
@@ -1,14 +1,9 @@
 package io.quarkus.runtime.graal;
 
 import java.io.ObjectStreamClass;
-import java.util.function.BooleanSupplier;
-
-import org.graalvm.home.Version;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-
-import io.quarkus.runtime.graal.Target_java_io_ObjectStreamClass.GraalVM20OrEarlier;
 
 @TargetClass(value = java.io.ObjectStreamClass.class, onlyWith = GraalVM20OrEarlier.class)
 @SuppressWarnings({ "unused" })
@@ -27,11 +22,4 @@ final class Target_java_io_ObjectStreamClass {
         throw new UnsupportedOperationException("Not supported");
     }
 
-    static class GraalVM20OrEarlier implements BooleanSupplier {
-
-        @Override
-        public boolean getAsBoolean() {
-            return Version.getCurrent().compareTo(21) < 0;
-        }
-    }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -36,6 +36,7 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.ElasticsearchBackendRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.ElasticsearchIndexRuntimeConfig;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.graal.GraalVM20OrEarlier;
 
 @Recorder
 public class HibernateSearchElasticsearchRecorder {
@@ -138,9 +139,7 @@ public class HibernateSearchElasticsearchRecorder {
         @Override
         public void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
                 BiConsumer<String, Object> propertyCollector) {
-            Version graalVMVersion = Version.getCurrent();
-            boolean isGraalVM20OrBelow = !graalVMVersion.isSnapshot() // isSnapshot() will be true on OpenJDK
-                    && graalVMVersion.compareTo(GRAAL_VM_VERSION_21) < 0;
+            boolean isGraalVM20OrBelow = new GraalVM20OrEarlier().getAsBoolean();
             HibernateOrmIntegrationBooter booter = HibernateOrmIntegrationBooter.builder(metadata, bootstrapContext)
                     .valueReadHandleFactory(
                             // GraalVM 20 or below doesn't support method handles

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/SubstituteSnappy.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/SubstituteSnappy.java
@@ -5,19 +5,19 @@ import static org.apache.kafka.common.record.CompressionType.NONE;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
-import java.util.function.BooleanSupplier;
 
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.utils.AppInfoParser;
-import org.graalvm.home.Version;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.runtime.graal.GraalVM20OrEarlier;
 
 /**
  * Here is where surgery happens
@@ -36,14 +36,6 @@ final class SubstituteSnappy {
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
     static MethodHandle OUTPUT = null;
 
-}
-
-final class GraalVM20OrEarlier implements BooleanSupplier {
-
-    @Override
-    public boolean getAsBoolean() {
-        return Version.getCurrent().compareTo(21) < 0;
-    }
 }
 
 @TargetClass(value = CompressionType.class, onlyWith = GraalVM20OrEarlier.class)


### PR DESCRIPTION
The GraalVM Version class interprets the `21.0.0.0.Final` String as an invalid version. This PR removes the dependency on that GraalVM class.

Fixes #15646