### PR TITLE
Added ability to define some OpenAPI Security in Config

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -20,4 +20,70 @@ public final class SmallRyeOpenApiConfig {
      */
     @ConfigItem
     public Optional<Path> storeSchemaDirectory;
+
+    /**
+     * Add a certain SecurityScheme with config
+     */
+    public Optional<SecurityScheme> securityScheme;
+
+    /**
+     * Add a Security Scheme name to the generated OpenAPI document
+     */
+    @ConfigItem(defaultValue = "SecurityScheme")
+    public String securitySchemeName;
+
+    /**
+     * Add a description to the Security Scheme
+     */
+    @ConfigItem(defaultValue = "Authentication")
+    public String securitySchemeDescription;
+
+    /**
+     * Add a scheme value to the Basic HTTP Security Scheme
+     */
+    @ConfigItem(defaultValue = "basic")
+    public String basicSecuritySchemeValue;
+
+    /**
+     * Add a scheme value to the JWT Security Scheme
+     */
+    @ConfigItem(defaultValue = "bearer")
+    public String jwtSecuritySchemeValue;
+
+    /**
+     * Add a scheme value to the JWT Security Scheme
+     */
+    @ConfigItem(defaultValue = "JWT")
+    public String jwtBearerFormat;
+
+    /**
+     * Add a openIdConnectUrl value to the OIDC Security Scheme
+     */
+    @ConfigItem
+    public Optional<String> oidcOpenIdConnectUrl;
+
+    /**
+     * Add a implicit flow refreshUrl value to the OAuth2 Security Scheme
+     */
+    @ConfigItem
+    public Optional<String> oauth2ImplicitRefreshUrl;
+
+    /**
+     * Add an implicit flow authorizationUrl value to the OAuth2 Security Scheme
+     */
+    @ConfigItem
+    public Optional<String> oauth2ImplicitAuthorizationUrl;
+
+    /**
+     * Add an implicit flow tokenUrl value to the OAuth2 Security Scheme
+     */
+    @ConfigItem
+    public Optional<String> oauth2ImplicitTokenUrl;
+
+    public enum SecurityScheme {
+        basic,
+        jwt,
+        oidc,
+        oauth2Implicit
+    }
 }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -61,6 +61,7 @@ import io.quarkus.resteasy.server.common.spi.AllowedJaxRsAnnotationPrefixBuildIt
 import io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+import io.quarkus.smallrye.openapi.deployment.security.SecurityConfigFilter;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 import io.quarkus.smallrye.openapi.runtime.OpenApiConstants;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
@@ -178,6 +179,14 @@ public class SmallRyeOpenApiProcessor {
                 .requiresLegacyRedirect()
                 .blockingRoute()
                 .build();
+    }
+
+    @BuildStep
+    void addSecurityFilter(BuildProducer<AddToOpenAPIDefinitionBuildItem> addToOpenAPIDefinitionProducer,
+            SmallRyeOpenApiConfig config) {
+
+        addToOpenAPIDefinitionProducer
+                .produce(new AddToOpenAPIDefinitionBuildItem(new SecurityConfigFilter(config)));
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/security/SecurityConfigFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/security/SecurityConfigFilter.java
@@ -1,0 +1,97 @@
+package io.quarkus.smallrye.openapi.deployment.security;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.jboss.logging.Logger;
+
+import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+
+/**
+ * Add Basic Security via Config
+ */
+public class SecurityConfigFilter implements OASFilter {
+    private static final Logger log = Logger.getLogger("io.quarkus.smallrye.openapi");
+
+    private final SmallRyeOpenApiConfig config;
+
+    public SecurityConfigFilter(SmallRyeOpenApiConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+
+        if (config.securityScheme.isPresent()) {
+
+            // Make sure components are created
+            if (openAPI.getComponents() == null) {
+                openAPI.setComponents(OASFactory.createComponents());
+            }
+
+            Map<String, SecurityScheme> securitySchemes = new HashMap();
+
+            // Add any existing security
+            if (openAPI.getComponents().getSecuritySchemes() != null
+                    && !openAPI.getComponents().getSecuritySchemes().isEmpty()) {
+                securitySchemes.putAll(openAPI.getComponents().getSecuritySchemes());
+            }
+
+            SmallRyeOpenApiConfig.SecurityScheme securitySchemeOption = config.securityScheme.get();
+
+            SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+            securityScheme.setDescription(config.securitySchemeDescription);
+
+            switch (securitySchemeOption) {
+                case basic:
+                    securityScheme.setType(SecurityScheme.Type.HTTP);
+                    securityScheme.setScheme(config.basicSecuritySchemeValue);
+                    break;
+                case jwt:
+                    securityScheme.setType(SecurityScheme.Type.HTTP);
+                    securityScheme.setScheme(config.jwtSecuritySchemeValue);
+                    securityScheme.setBearerFormat(config.jwtBearerFormat);
+                    break;
+                case oidc:
+                    securityScheme.setType(SecurityScheme.Type.OPENIDCONNECT);
+                    securityScheme.setOpenIdConnectUrl(config.oidcOpenIdConnectUrl.orElse(null));
+                    break;
+                case oauth2Implicit:
+                    securityScheme.setType(SecurityScheme.Type.OAUTH2);
+                    OAuthFlows oAuthFlows = OASFactory.createOAuthFlows();
+                    OAuthFlow oAuthFlow = OASFactory.createOAuthFlow();
+                    if (config.oauth2ImplicitAuthorizationUrl.isPresent()) {
+                        oAuthFlow.authorizationUrl(config.oauth2ImplicitAuthorizationUrl.get());
+                    }
+                    if (config.oauth2ImplicitRefreshUrl.isPresent()) {
+                        oAuthFlow.authorizationUrl(config.oauth2ImplicitRefreshUrl.get());
+                    }
+                    if (config.oauth2ImplicitTokenUrl.isPresent()) {
+                        oAuthFlow.tokenUrl(config.oauth2ImplicitTokenUrl.get());
+                    }
+                    oAuthFlow.setScopes(OASFactory.createScopes());
+                    oAuthFlows.setImplicit(oAuthFlow);
+                    securityScheme.setType(SecurityScheme.Type.OAUTH2);
+                    securityScheme.setFlows(oAuthFlows);
+                    break;
+            }
+            securitySchemes.put(config.securitySchemeName, securityScheme);
+            openAPI.getComponents().setSecuritySchemes(securitySchemes);
+        }
+
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null) {
+
+            Map<String, SecurityScheme> securitySchemes = openAPI.getComponents().getSecuritySchemes();
+            if (securitySchemes.size() > 1) {
+                log.warn("Detected multiple Security Schemes, only one scheme is supported at the moment "
+                        + securitySchemes.keySet().toString());
+            }
+        }
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/BasicSecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/BasicSecurityWithConfigTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class BasicSecurityWithConfigTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=basic\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=CompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=Basic Authentication"),
+
+                            "application.properties"));
+
+    @Test
+    public void testBasicAuthentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("components.securitySchemes.CompanyAuthentication", Matchers.hasEntry("type", "http"))
+                .and()
+                .body("components.securitySchemes.CompanyAuthentication",
+                        Matchers.hasEntry("description", "Basic Authentication"))
+                .and().body("components.securitySchemes.CompanyAuthentication", Matchers.hasEntry("scheme", "basic"));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/JWTSecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/JWTSecurityWithConfigTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class JWTSecurityWithConfigTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=jwt\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=JWT Authentication"),
+
+                            "application.properties"));
+
+    @Test
+    public void testJWTAuthentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("type", "http"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication",
+                        Matchers.hasEntry("description", "JWT Authentication"))
+                .and().body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("scheme", "bearer"))
+                .and().body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("bearerFormat", "JWT"));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityWithConfigTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OIDCSecurityWithConfigTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=oidc\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=OIDCCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=OIDC Authentication\n"
+                                    + "quarkus.smallrye-openapi.oidc-open-id-connect-url=http://localhost:8081/auth/realms/OpenAPIOIDC/.well-known/openid-configuration"),
+
+                            "application.properties"));
+
+    @Test
+    public void testOIDCAuthentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("components.securitySchemes.OIDCCompanyAuthentication", Matchers.hasEntry("type", "openIdConnect"))
+                .and()
+                .body("components.securitySchemes.OIDCCompanyAuthentication",
+                        Matchers.hasEntry("description", "OIDC Authentication"))
+                .and().body("components.securitySchemes.OIDCCompanyAuthentication", Matchers.hasEntry("openIdConnectUrl",
+                        "http://localhost:8081/auth/realms/OpenAPIOIDC/.well-known/openid-configuration"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/Oauth2ImplicitSecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/Oauth2ImplicitSecurityWithConfigTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class Oauth2ImplicitSecurityWithConfigTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=oauth2Implicit\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=OAuth2CompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=OAuth2 Authentication"),
+
+                            "application.properties"));
+
+    @Test
+    public void testOAuth2Authentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("components.securitySchemes.OAuth2CompanyAuthentication", Matchers.hasEntry("type", "oauth2"))
+                .and()
+                .body("components.securitySchemes.OAuth2CompanyAuthentication",
+                        Matchers.hasEntry("description", "OAuth2 Authentication"));
+    }
+}


### PR DESCRIPTION
As discussed in the OpenAPI Quarkus Insights session.

This allows adding basic, JWT, OIDC and Implicit flow OAuth2 security via config. 

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>