### PR TITLE
Support main branches while releasing Quarkiverse Extensions

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release.yml
+++ b/independent-projects/tools/devtools-common/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release.yml
@@ -66,3 +66,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
+          branch: ${{github.base_ref}}


### PR DESCRIPTION
Because `master` is the default value for that action