### PR TITLE
Fixed missing Import in security-openid-connect doc

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -168,7 +168,7 @@ If you need to access `JsonWebToken` claims, you may simply inject the token its
 package org.acme.security.openid.connect;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
-
+import javax.inject.Inject;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;


### PR DESCRIPTION
Added:
`import javax.inject.Inject;`
to the "Accessing JWT claims" sample code