### PR TITLE
Declare all test source directories in gradle model

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -3,6 +3,7 @@ package io.quarkus.gradle.extension;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -65,7 +66,7 @@ public class QuarkusPluginExtension {
             props.put(BootstrapConstants.SERIALIZED_APP_MODEL, serializedModel.toString());
 
             StringJoiner outputSourcesDir = new StringJoiner(",");
-            for (File outputSourceDir : outputSourcesDir()) {
+            for (File outputSourceDir : combinedOutputSourceDirs()) {
                 outputSourcesDir.add(outputSourceDir.getAbsolutePath());
             }
             props.put(BootstrapConstants.OUTPUT_SOURCES_DIR, outputSourcesDir.toString());
@@ -193,8 +194,11 @@ public class QuarkusPluginExtension {
         return getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getResources().getSrcDirs();
     }
 
-    public Set<File> outputSourcesDir() {
-        return getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDirs().getFiles();
+    public Set<File> combinedOutputSourceDirs() {
+        Set<File> sourcesDirs = new LinkedHashSet<>();
+        sourcesDirs.addAll(getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDirs().getFiles());
+        sourcesDirs.addAll(getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME).getOutput().getClassesDirs().getFiles());
+        return sourcesDirs;
     }
 
     public AppArtifact getAppArtifact() {

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -68,10 +68,12 @@ public class QuarkusPluginTest {
 
         final QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
 
-        final Set<File> outputSourceDirs = extension.outputSourcesDir();
-        assertThat(outputSourceDirs).hasSize(2);
+        final Set<File> outputSourceDirs = extension.combinedOutputSourceDirs();
+        assertThat(outputSourceDirs).hasSize(4);
         assertThat(outputSourceDirs).contains(new File(project.getBuildDir(), "classes/java/main"),
-                new File(project.getBuildDir(), "classes/scala/main"));
+                new File(project.getBuildDir(), "classes/java/test"),
+                new File(project.getBuildDir(), "classes/scala/main"),
+                new File(project.getBuildDir(), "classes/scala/test"));
 
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BeanInTestSourcesTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BeanInTestSourcesTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class BeanInTestSourcesTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testBasicMultiModuleBuild() throws Exception {
+        final File projectDir = getProjectDir("bean-in-testsources-project");
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "test");
+        assertThat(build.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.gradle.builder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -70,8 +71,8 @@ class QuarkusModelBuilderTest {
         final SourceSet sourceSet = workspaceModule.getSourceSet();
         assertNotNull(sourceSet);
         assertNull(sourceSet.getResourceDirectory());
-        assertEquals(1, sourceSet.getSourceDirectories().size());
-        assertEquals(new File(projectDir, "build/classes/java/main"), sourceSet.getSourceDirectories().iterator().next());
+        assertThat(sourceSet.getSourceDirectories()).containsAnyOf(new File(projectDir, "build/classes/java/main"),
+                new File(projectDir, "build/classes/java/test"));
         final SourceSet sourceSourceSet = workspaceModule.getSourceSourceSet();
         assertEquals(new File(projectDir, "src/main/resources"), sourceSourceSet.getResourceDirectory());
         assertEquals(1, sourceSourceSet.getSourceDirectories().size());

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'org.jetbrains.kotlin.jvm' version "1.3.72"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.3.72"
+}
+
+repositories {
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-kotlin'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+allOpen {
+    annotation("javax.ws.rs.Path")
+    annotation("javax.enterprise.context.ApplicationScoped")
+    annotation("io.quarkus.test.junit.QuarkusTest")
+}
+
+compileKotlin {
+    kotlinOptions.javaParameters = true
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,17 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Test";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/test-resources")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from Test"));
+    }
+}

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/kotlin/org/acme/test/TestExampleResource.kt
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/kotlin/org/acme/test/TestExampleResource.kt
@@ -1,0 +1,14 @@
+package org.acme.test
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("/test-resources")
+class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello() = "Hello from Test"
+}

--- a/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/bean-in-testsources-project/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+# Configuration file
+# key = value
+


### PR DESCRIPTION
By default, we look for CDI beans in the directory that contains de test. In multi language project, CDI beans in `src/test/java` are not loaded if run a test from `src/test/kotlin`. 

This branch add all test dirs in the model when we are in test mode.

close #15618 