### PR TITLE
Bump kubernetes-client-bom from 5.1.1 to 5.2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -173,7 +173,7 @@
         <sentry.version>4.3.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.1.1</kubernetes-client.version>
+        <kubernetes-client.version>5.2.0</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kubernetes.client;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -65,7 +66,8 @@ public class Pods {
     public Response createNew(@PathParam("namespace") String namespace) {
         return Response
                 .ok(kubernetesClient.pods().inNamespace(namespace)
-                        .create(new PodBuilder().withNewMetadata().withResourceVersion("12345")
+                        .create(new PodBuilder().withNewMetadata()
+                                .withName(UUID.randomUUID().toString()).withResourceVersion("12345")
                                 .endMetadata().build()))
                 .build();
     }


### PR DESCRIPTION
Supersedes #15683 

Updated Pods test Resource create endpoint so that the Pod created contains at least a name and passes new Mock Server validations (see next comment)

_From https://github.com/quarkusio/quarkus/pull/15683#issuecomment-797882003_
We (Fabric8 Kubernetes Client) recently made a change to the MockServer so that it validates create requests, Resource HasMetadata has to pass some conditions now.
- https://github.com/fabric8io/kubernetes-client/issues/2802
- https://github.com/fabric8io/kubernetes-client/pull/2894