### PR TITLE
CI: Call Gradle ITs via Maven to leverage incremental build setup

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -101,7 +101,8 @@ jobs:
           ./update-extension-dependencies.sh -B --settings .github/mvn-settings.xml
           if [ `git status -s -u no '*pom.xml' | wc -l` -ne 0 ]
           then
-            echo -e '\033[0;31mError:\033[0m Dependencies to extension artifacts are outdated! Run ./update-extension-dependencies.sh and add the modified pom.xml files to your commit.' 1>&2
+            echo -e '\033[0;31mError:\033[0m Dependencies to extension artifacts are outdated!' 1>&2
+            echo -e '\033[0;31mError:\033[0m Run ./update-extension-dependencies.sh and add the modified pom.xml files to your commit.' 1>&2
             exit 1
           fi
       - name: Tar Maven Repo
@@ -357,23 +358,32 @@ jobs:
           name: test-reports-windows-maven-java11
           path: 'test-reports.tgz'
 
-  linux-jvm-gradle-tests:
-    name: Gradle Tests - JDK ${{matrix.java.name}}
-    runs-on: ubuntu-latest
+  gradle-tests-jdk11-jvm:
+    name: Gradle Tests - JDK 11 ${{matrix.os.family}}
+    runs-on: ${{matrix.os.name}}
     # Skip main in forks
     if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk11
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:
-        java:
+        os:
           - {
-            name: "11",
-            java-version: 11
+            name: "ubuntu-latest",
+            family: "Linux"
+          }
+          - {
+            name: "windows-latest",
+            family: "Windows"
           }
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Add quarkusio remote
+        shell: bash
+        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -382,53 +392,27 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Set up JDK ${{ matrix.java.name }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: ${{ matrix.java.java-version }}
-      - name: Build with Gradle
-        uses: eskatos/gradle-command-action@v1
-        env:
-          GRADLE_OPTS: -Xmx1408m
-        with:
-          gradle-version: wrapper
-          wrapper-directory: integration-tests/gradle
-          build-root-directory: integration-tests/gradle
-          arguments: clean test -i -S --stacktrace --no-daemon
-
-  windows-jdk11-jvm-gradle-tests:
-    name: Gradle Tests - JDK 11 Windows
-    needs: build-jdk11
-    # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    runs-on: windows-latest
-    timeout-minutes: 80
-    steps:
-      - uses: actions/checkout@v2
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: 11
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
+      - name: Verify dependencies
+        # runs on Windows as well but would require newline conversion, not worth it
+        if: matrix.os.family == 'Linux'
         shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
-      - name: Build with Gradle
-        uses: eskatos/gradle-command-action@v1
-        timeout-minutes: 60
-        env:
-          GRADLE_OPTS: -Xmx1408m
-        with:
-          gradle-version: wrapper
-          wrapper-directory: integration-tests/gradle
-          build-root-directory: integration-tests/gradle
-          arguments: clean test -i -S --stacktrace --no-daemon
+        run: |
+          ./update-dependencies.sh -B --settings ../../.github/mvn-settings.xml
+          if [ `git status -s -u no '*pom.xml' | wc -l` -ne 0 ]
+          then
+            echo -e '\033[0;31mError:\033[0m Dependencies in integration-tests/gradle/pom.xml are outdated!' 1>&2
+            echo -e '\033[0;31mError:\033[0m Run update-dependencies.sh in integration-tests/gradle and add the modified pom.xml file to your commit.' 1>&2
+            exit 1
+          fi
+        working-directory: integration-tests/gradle
+      - name: Build with Gradle via Maven
+        shell: bash
+        run: mvn $JVM_TEST_MAVEN_OPTS install -pl integration-tests/gradle ${{ needs.build-jdk11.outputs.gib_args }}
 
   linux-jvm-devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -20,6 +20,197 @@
         <maven.test.skip>true</maven.test.skip>
     </properties>
 
+    <dependencies>
+        <!-- All the following dependencies shall enforce the right build order
+             and proper upstream/downstream detection for incremental build.
+             They won't have an actual impact on "inner" gradle execution. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>io.quarkus.gradle.plugin</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+        <!-- The following dependencies are generated in a way that is consistent with other normal IT modules,
+             that is "runtime" deps are defined with scope compile and "minimal extension deployment dependencies"
+             come in the usual form (pom, test, exclusions). This also ensures to keep the enforcer rules happy. -->
+        <!-- START update-dependencies.sh -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devmode-test-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-platform-descriptor-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-devtools</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- END update-dependencies.sh -->
+    </dependencies>
+
     <profiles>
         <profile>
             <id>skip-gradle-build</id>
@@ -60,10 +251,11 @@
                                         <argument>-i</argument> <!-- info logging -->
                                         <argument>-S</argument>
                                         <argument>--stacktrace</argument>
+                                        <argument>--no-daemon</argument>
                                     </arguments>
                                     <environmentVariables>
                                         <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
-                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                        <GRADLE_OPTS>-Xmx1408m</GRADLE_OPTS>
                                     </environmentVariables>
                                     <skip>${skip.gradle.tests}</skip>
                                 </configuration>
@@ -114,10 +306,11 @@
                                         <argument>-Pquarkus.native.builder-image=${quarkus.native.builder-image}</argument>
                                         <argument>-S</argument>
                                         <argument>--stacktrace</argument>
+                                        <argument>--no-daemon</argument>
                                     </arguments>
                                     <environmentVariables>
                                         <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>
-                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                        <GRADLE_OPTS>-Xmx1408m</GRADLE_OPTS>
                                     </environmentVariables>
                                     <skip>${skip.gradle.build}</skip>
                                 </configuration>

--- a/integration-tests/gradle/update-dependencies.sh
+++ b/integration-tests/gradle/update-dependencies.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Purpose: Updates pom.xml with (minimal) dependencies to other modules to enforce a consistent build order.
+
+set -e -u -o pipefail
+shopt -s failglob
+
+DEP_TEMPLATE='        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>XXX</artifactId>
+            <version>\${project.version}</version>
+        </dependency>'
+
+DEP_TEMPLATE_DEPLOYMENT='        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>XXX-deployment</artifactId>
+            <version>\${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>'
+
+echo ''
+echo 'Building dependencies list from gradle build files...'
+echo ''
+
+# get the Quarkus artifact ids from all gradle build files in this repo
+# pipefail is switched off briefly so that a better error can be logged when nothing is found
+set +o pipefail
+# note on sed: -deployment deps are added explicitly later and bom is upstream anyway
+ARTIFACT_IDS=`grep -hR --include 'build*.gradle' --exclude-dir=build '[iI]mplementation' | \
+              grep -Po '(?<=io\.quarkus:)quarkus-[a-z0-9-]+' | \
+              sed -e '/-deployment/d' -e '/quarkus-bom/d' | sort | uniq`
+set -o pipefail
+if [ -z "${ARTIFACT_IDS}" ]
+then
+  echo -e '\033[0;31mError:\033[0m Could not find any artifact-ids. Please check the grep command. ' 1>&2
+  exit 1
+fi
+
+# to replace newlines with \n so that the final sed calls accept ${DEPS} as input
+SED_EXPR_NEWLINES=':a;N;$!ba;s/\n/\\\n/g'
+
+DEPS=`echo "${ARTIFACT_IDS}" \
+  | xargs -i sh -c "echo \"${DEP_TEMPLATE}\" | sed 's/XXX/{}/'" \
+  | sed "${SED_EXPR_NEWLINES}"`
+
+DEPS+='\n'
+
+# note on sed: Remove artifacts that are not extensions (since not -deployment sibling exists).
+#              This is a bit fragile but without this -deployment deps would need to be added by hand.
+DEPS+=`echo "${ARTIFACT_IDS}" \
+  | sed -e '/-bootstrap/d' -e '/-test/d' -e '/-junit/d' -e '/-devtools/d' -e '/-descriptor/d' \
+  | xargs -i sh -c "echo \"${DEP_TEMPLATE_DEPLOYMENT}\" | sed 's/XXX/{}/'" \
+  | sed "${SED_EXPR_NEWLINES}"`
+
+MARK_START='<!-- START update-dependencies.sh -->'
+MARK_END='<!-- END update-dependencies.sh -->'
+SED_EXPR="/${MARK_START}/,/${MARK_END}/c\        ${MARK_START}\n${DEPS}\n        ${MARK_END}"
+
+echo ''
+echo 'Updating pom.xml...'
+echo ''
+sed -i "${SED_EXPR}" pom.xml
+
+echo ''
+echo 'Sanity check...'
+echo ''
+# sanity check; make sure nothing stupid was added like non-existing deps
+mvn dependency:resolve validate -Dsilent -q $*

--- a/update-extension-dependencies.sh
+++ b/update-extension-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Purpose: Updates pom.xml files with symbolic dependencies to extensions to enforce a consistent build order.
+# Purpose: Updates pom.xml files with minimal dependencies to extensions to enforce a consistent build order.
 
 set -e -u -o pipefail
 shopt -s failglob
@@ -8,7 +8,7 @@ shopt -s failglob
 echo ''
 echo 'Building bom-descriptor-json...'
 echo ''
-mvn -e clean package -f devtools/bom-descriptor-json -Denforcer.skip $*
+mvn -q -e clean package -f devtools/bom-descriptor-json -Denforcer.skip $*
 
 # note: OFFSET is replaced later on with an individual amount of spaces
 DEP_TEMPLATE='OFFSET<dependency>
@@ -68,3 +68,9 @@ echo 'Updating docs/pom.xml...'
 echo ''
 sed -i "${SED_EXPR_DEPS_DEPLOYMENT}" docs/pom.xml
 sed -i 's/OFFSET/        /' docs/pom.xml
+
+echo ''
+echo 'Sanity check...'
+echo ''
+# sanity check; make sure nothing stupid was added like non-existing deps
+mvn dependency:resolve validate -Dsilent -q -pl devtools/bom-descriptor-json,docs $*


### PR DESCRIPTION
This resolves the first task of #15686:
> - [ ] CI: execute `integration-tests/gradle` via Maven with enabled GIB
  Needs script-supported mirroring of the dependencies in all gradle build files in that module.

A few notes:
- The new `update-dependencies.sh` is derived from the root `update-extension-dependencies.sh` and some things I came up with (like the sanity check) felt like a good addition to `update-extension-dependencies.sh` as well.
- The script is extracting all Quarkus `implementation` or `testImplementation` entries from all Gradle build file in that module.
  Instead of just generating the "runtime" dependencies, I decided to generate minimal deployment dependencies as well so that you are not faced with a failing enforcer rule and have to do half of the work manually. This comes with some removal heuristics, but I think it's better than not having it at all. Please see the comments in the script for more details.
- I merged the Windows and Linux jobs and introduced a matrix for the operation systems. This feels much more cohesive than before.
  I also changed the job id to be more logical: `gradle-tests-jdk11-jvm`; so `gradle`, the main "area" of the job, is in front.
  I can offer to go through all the other jobs to align their ids as well. This would then also better line up with the job names!
- The exec-plugin setup was aligned to what was set before in CI (`--no-daemon` and `Xmx`).
  Note: The GH Windows runner seems to pre-set `Maven_OPTS` with `-Xms256m`, so I decided to replace `${env.MAVEN_OPTS}` entirely.

@glefloch It would be great if you could have a look. I _think_ I caught all of the dependencies/patterns.
I also tried to compare the output before/after and it LGTM.

