### PR TITLE
Set the value of extension metadata element built-with-quarkus-core to the version instead of GAV

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -705,7 +705,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
             org.eclipse.aether.artifact.Artifact artifact = dep.getArtifact();
             if (artifact != null && artifact.getArtifactId().equals("quarkus-core")) {
-                coreVersion = artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+                coreVersion = artifact.getVersion();
                 if ("io.quarkus".equals(artifact.getGroupId())) {
                     skipTheRest = true;
                 }


### PR DESCRIPTION
Set the value of extension metadata element built-with-quarkus-core to the version instead of GAV.

Our client-facing devtools haven't yet used it, it's used in the extension registry service (under development), where having a simple version in place of GAV will make it a bit easier.