### PR TITLE
Added netbeans to the supported IDEs in DEV UI's ability to open in IDE

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ide/Ide.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ide/Ide.java
@@ -1,7 +1,23 @@
 package io.quarkus.deployment.ide;
 
 public enum Ide {
-    IDEA,
-    ECLIPSE,
-    VSCODE
+
+    IDEA("idea"),
+    ECLIPSE("eclipse"),
+    VSCODE("code"),
+    NETBEANS("netbeans");
+
+    private String executable;
+
+    private Ide(String executable) {
+        this.executable = executable;
+    }
+
+    public String getExecutable() {
+        return executable;
+    }
+
+    public void setExecutable(String executable) {
+        this.executable = executable;
+    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/ide/IdeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ide/IdeConfig.java
@@ -17,6 +17,7 @@ public class IdeConfig {
         auto,
         idea,
         vscode,
-        eclipse
+        eclipse,
+        netbeans
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/OpenIdeHandler.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/OpenIdeHandler.java
@@ -44,10 +44,8 @@ public class OpenIdeHandler extends DevConsolePostHandler {
             routingContext.fail(400);
         }
 
-        if (ide == Ide.IDEA) {
-            typicalProcessLaunch(routingContext, className, lang, srcMainPath, line, "idea");
-        } else if (ide == Ide.ECLIPSE) {
-            typicalProcessLaunch(routingContext, className, lang, srcMainPath, line, "eclipse");
+        if (ide != null) {
+            typicalProcessLaunch(routingContext, className, lang, srcMainPath, line, ide.getExecutable());
         } else {
             log.debug("Unhandled IDE : " + ide);
             routingContext.fail(500);


### PR DESCRIPTION
This PR adds Netbeans to the IDEs that can be opened by Dev UI. 

Netbeans runs as a java process, so it's a bit more work to figure out, so this PR include:

- looking at a combination of process and arguments to figure out if the IDE is running.
- moved the command to open a file in an IDE to be detected from the arguments (with defaults as it was)


Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>