### PR TITLE
Added class files should trigger a full reload

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -203,7 +203,9 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             //attempt to do an instrumentation based reload
             //if only code has changed and not the class structure, then we can do a reload
             //using the JDK instrumentation API (assuming we were started with the javaagent)
-            if (changedClassResults.deletedClasses.isEmpty() && !changedClassResults.changedClasses.isEmpty()) {
+            if (changedClassResults.deletedClasses.isEmpty()
+                    && changedClassResults.addedClasses.isEmpty()
+                    && !changedClassResults.changedClasses.isEmpty()) {
                 try {
                     Indexer indexer = new Indexer();
                     //attempt to use the instrumentation API

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -14,6 +14,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -276,6 +277,25 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         //verify that this was an instrumentation based reload
         Assertions.assertEquals(secondUUid, DevModeTestUtils.getHttpResponse("/app/uuid"));
+
+        // verify that add + change results in full reload
+        // add a new class
+        Files.write(Paths.get(testDir.toString(), "src/main/java/org/acme/AnotherClass.java"),
+                "package org.acme;\nclass ItDoesntMatter{}".getBytes());
+
+        // change back to hello
+        source = new File(testDir, "src/main/java/org/acme/HelloResource.java");
+        filter(source, Collections.singletonMap("return \"" + uuid + "\";", "return \"hello\";"));
+
+        // Wait until we get "hello"
+        await()
+                .pollDelay(100, TimeUnit.MILLISECONDS)
+                .atMost(1, TimeUnit.MINUTES).until(() -> DevModeTestUtils.getHttpResponse("/app/hello").contains("hello"));
+
+        //verify that this was not instrumentation based reload
+        Assertions.assertNotEquals(secondUUid, DevModeTestUtils.getHttpResponse("/app/uuid"));
+        secondUUid = DevModeTestUtils.getHttpResponse("/app/uuid");
+
     }
 
     @Test


### PR DESCRIPTION
With instrumentation enabled, If there are updated classes AND new classes, instrumentation will occur, but the new "ADDED" classes won't be loaded.

In fact, consider the case:

                    changedClassResults.addedClasses.isEmpty() == false
                    && changedClassResults.changedClasses.isEmpty() == false

in `RuntimeUpdatesProcessor` the following `if` condition will be `true`, causing the body to execute, setting `instrumentationChange = true`

```
if (changedClassResults.deletedClasses.isEmpty() && !changedClassResults.changedClasses.isEmpty()) {
```

however, the check a few lines later:

```
        boolean restartNeeded = !instrumentationChange && (changedClassResults.isChanged()
                || (IsolatedDevModeMain.deploymentProblem != null && userInitiated) || configFileRestartNeeded);
```

will always be false, skipping over `changedClassResults.isChanged()` which expands to: 

```
!changedClasses.isEmpty() || !deletedClasses.isEmpty() || !addedClasses.isEmpty();
```

so either (1) instrumentation should be skipped over when there are ADDED class files, or (2) the check below should read something along the lines of:


```
        boolean restartNeeded = !changedClassResults.addedClasses.isEmpty() || 
                !instrumentationChange && 
                ((IsolatedDevModeMain.deploymentProblem != null && userInitiated) || configFileRestartNeeded);
```

this patch is for (1).

(This should be backported to 1.11)

EDIT: This is draft as I am still verifying this works locally with both `main` and `1.11`
related: https://github.com/kiegroup/kogito-runtimes/pull/1123
