### PR TITLE
Remove unnecessary test dependencies

### DIFF
--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -91,17 +91,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-devtools</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -172,32 +162,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/application/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module-kts/application/build.gradle.kts
@@ -10,8 +10,5 @@ dependencies {
     implementation(project(":common"))
     implementation("io.quarkus:quarkus-resteasy")
 
-    testImplementation("io.quarkus:quarkus-junit5")
-    testImplementation("io.rest-assured:rest-assured")
-
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
 }

--- a/integration-tests/gradle/src/test/resources/add-extension-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/add-extension-multi-module/application/build.gradle
@@ -6,8 +6,5 @@ dependencies {
     implementation project(":common")
     implementation 'io.quarkus:quarkus-resteasy'
 
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
-
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 compileJava {

--- a/integration-tests/gradle/src/test/resources/basic-java-library-module/library/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-library-module/library/build.gradle
@@ -16,10 +16,6 @@ repositories {
 dependencies {
     api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     api 'io.quarkus:quarkus-kubernetes-client'
-    api 'io.quarkus:quarkus-smallrye-health'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 compileJava {

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/application/build.gradle
@@ -15,11 +15,10 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform(project(':platform'))
     implementation 'io.quarkus:quarkus-resteasy'
 
-    implementation platform(project(':platform'))
-
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
 }

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/build.gradle
@@ -18,6 +18,7 @@ allprojects {
 
 subprojects{
      repositories {
+          mavenCentral()
           if (System.properties.containsKey('maven.repo.local')) {
                maven {
                     url System.properties.get('maven.repo.local')
@@ -25,6 +26,5 @@ subprojects{
           } else {
                mavenLocal()
           }
-          mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/test/resources/basic-java-platform-module/platform/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-platform-module/platform/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     constraints {
         api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+        api "io.quarkus:quarkus-resteasy:${quarkusPlatformVersion}"
         api 'io.quarkus:quarkus-kubernetes-client'
     }
 }

--- a/integration-tests/gradle/src/test/resources/builder/multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/builder/multi-module-project/build.gradle
@@ -15,8 +15,6 @@ subprojects {
 
     dependencies {
         implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusPlatformVersion}")
-        implementation 'io.quarkus:quarkus-resteasy'
-        testImplementation 'io.quarkus:quarkus-junit5'
     }
 
 }

--- a/integration-tests/gradle/src/test/resources/builder/simple-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/builder/simple-module-project/build.gradle
@@ -16,7 +16,6 @@ repositories {
 
 dependencies {
     implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusPlatformVersion}")
-    implementation 'io.quarkus:quarkus-resteasy'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/custom-config-java-module/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/dotenv-config-java-module/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/grpc-include-project/build.gradle
@@ -17,11 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.quarkus:quarkus-grpc'
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
+    implementation 'io.quarkus:quarkus-grpc'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/implementation-files/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/implementation-files/application/build.gradle
@@ -4,7 +4,4 @@ plugins {
 
 dependencies {
     implementation files("../common/build/libs/common.jar")
-    
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/build.gradle
@@ -42,13 +42,8 @@ subprojects {
     }
 
     dependencies {
-
         implementation 'io.quarkus:quarkus-resteasy'
 
-        testImplementation 'io.quarkus:quarkus-junit5'
-        testImplementation 'io.rest-assured:rest-assured'
-
         implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-
     }
 }

--- a/integration-tests/gradle/src/test/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/list-extension-single-module/build.gradle
@@ -18,7 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-    implementation 'io.quarkus:quarkus-vertx'
 
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'

--- a/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/domain/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/multi-module-kotlin-project/domain/build.gradle.kts
@@ -1,5 +1,3 @@
 dependencies {
     implementation(project(":port"))
-    implementation("jakarta.enterprise:jakarta.enterprise.cdi-api")
-    implementation("jakarta.transaction:jakarta.transaction-api")
 }

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/common/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/common/build.gradle
@@ -17,9 +17,6 @@ repositories {
 dependencies {
     api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     api 'io.quarkus:quarkus-smallrye-health'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-named-injection/quarkus/build.gradle
@@ -20,9 +20,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 
     implementation project(':common')
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-source-project/build.gradle
@@ -19,7 +19,6 @@ repositories {
 
 dependencies {
     implementation 'io.quarkus:quarkus-kotlin'
-    implementation 'io.quarkus:quarkus-grpc'
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'

--- a/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/test/resources/quarkus-dev-dependency/build.gradle
@@ -21,9 +21,6 @@ dependencies {
 
     implementation 'io.quarkus:quarkus-hibernate-orm-panache'
     quarkusDev 'io.quarkus:quarkus-jdbc-h2'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 compileJava {

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
@@ -17,7 +17,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.quarkus:quarkus-resteasy-jsonb'
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
@@ -16,9 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.quarkus:quarkus-resteasy-jsonb'
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation 'io.quarkus:quarkus-resteasy'
 
     // Library-2 has to be dependency as implementation and test fixture
     implementation(project(':library-2'))

--- a/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/test-that-fast-jar-format-works/src/test/resources/application.properties
@@ -1,7 +1,0 @@
-# Configuration file
-# key = value
-example.message=Hello from Test
-test-only=Test only
-quarkus.package.type=fast-jar
-
-

--- a/integration-tests/gradle/src/test/resources/test-that-legacy-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-that-legacy-jar-format-works/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/test-that-legacy-jar-format-works/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/test-that-legacy-jar-format-works/src/test/resources/application.properties
@@ -1,7 +1,0 @@
-# Configuration file
-# key = value
-example.message=Hello from Test
-test-only=Test only
-quarkus.package.type=fast-jar
-
-

--- a/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-uber-jar-format-works/build.gradle
@@ -18,9 +18,6 @@ repositories {
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/uber-jar-for-multi-module-project/build.gradle
@@ -35,13 +35,8 @@ subprojects {
     }
 
     dependencies {
-
         implementation 'io.quarkus:quarkus-resteasy'
 
-        testImplementation 'io.quarkus:quarkus-junit5'
-        testImplementation 'io.rest-assured:rest-assured'
-
         implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-
     }
 }


### PR DESCRIPTION
This branch leverage all dependencies used in gradle test IT. Addresses task number 2 from #15686.

@famod, let's see how build goes :). I manually updated the `pom.xml`. 
In the `pom.xml`, there are some `-deployment` dependencies that are not used in any gradle project (like `quarkus-grpc-deployment`, `quarkus-kotlin-deployment`) should we keep them? 