### PR TITLE
Precompute hashcodes as bytecode constants for ArC beans

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1635,9 +1635,8 @@ public class BeanGenerator extends AbstractGenerator {
 
     protected void implementHashCode(BeanInfo bean, ClassCreator beanCreator) {
         MethodCreator hashCode = beanCreator.getMethodCreator("hashCode", int.class).setModifiers(ACC_PUBLIC);
-        // return identifier.hashCode()
-        hashCode.returnValue(
-                hashCode.invokeVirtualMethod(MethodDescriptors.OBJECT_HASH_CODE, hashCode.load(bean.getIdentifier())));
+        final ResultHandle constantHashCodeResult = hashCode.load(bean.getIdentifier().hashCode());
+        hashCode.returnValue(constantHashCodeResult);
     }
 
     /**


### PR DESCRIPTION
This enhances hashcode for all syntethic generated beans.

Original code:

    public int hashCode() {
        return "3449be42e1180a2e7cb1cb54b5217fa1fb279532".hashCode();
    }

New code:

    public int hashCode() {
        return 1892960708;
    }