### PR TITLE
Update SmallRye Reactive Messaging to 2.9.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-context-propagation.version>1.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.4.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.8.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.9.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -857,6 +857,7 @@ Some properties have aliases which can be configured globally:
 kafka.bootstrap.servers=...
 ----
 
+.Incoming Attributes of the 'smallrye-kafka' connector
 [cols="25, 30, 15, 20",options="header"]
 |===
 |Attribute (_alias_) | Description | Mandatory | Default
@@ -915,12 +916,7 @@ Type: _string_ | true |
 
 Type: _int_ | false | `1`
 
-| *group.id* | A unique string that identifies the consumer group the application belongs to.
-
-If not set, defaults to the application name as set by the `quarkus.application.name` configuration property.
-
-If that is not set either, a unique, generated id is used.
-It is recommended to always define a `group.id`, the automatic generation is only a convenient feature for development.
+| *group.id* | A unique string that identifies the consumer group the application belongs to. If not set, a unique, generated id is used
 
 Type: _string_ | false |
 
@@ -988,6 +984,10 @@ Type: _string_ | false |
 
 Type: _string_ | false |
 
+| *graceful-shutdown* | Whether or not a graceful shutdown should be attempted when the application terminates.
+
+Type: _boolean_ | false | `true`
+
 |===
 
 === Outgoing channel configuration (writing to Kafka)
@@ -1007,6 +1007,7 @@ Some properties have aliases which can be configured globally:
 kafka.bootstrap.servers=...
 ----
 
+.Outgoing Attributes of the 'smallrye-kafka' connector
 [cols="25, 30, 15, 20",options="header"]
 |===
 |Attribute (_alias_) | Description | Mandatory | Default


### PR DESCRIPTION
Changelog: https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/2.9.0

Noteworthy features:

* Improve graceful shutdown for the Kafka connector
* Added support to enclose the channel name with double quotes
* Fix materialization cycle between emitter and mediator methods

In addition:

* Fix #15058
* Fix #15229


 