### PR TITLE
Make class clickable in Log stream (to open in IDE)

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/css/logstream.css
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/css/logstream.css
@@ -85,3 +85,7 @@
 #logstreamViewLogButtonIcon:hover {
     color: #3366ac !important;
 }
+
+.clickable-app-class:hover {
+    cursor:pointer;
+}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/js/logstream.js
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/js/logstream.js
@@ -503,25 +503,45 @@ function getLoggerClassName(loggerClassName){
     return "";
 }
 
-function getClassFullAbbreviatedName(sourceClassNameFull, sourceClassNameFullShort) {
+function getClassFullAbbreviatedName(sourceClassNameFull, lineNumber, sourceClassNameFullShort) {
     if($('#logstreamColumnsModalSourceClassFullAbbreviatedSwitch').is(":checked")){
-        return "<span class='text-secondary' data-toggle='tooltip' data-placement='top' title='" + sourceClassNameFull + "'>[" + sourceClassNameFullShort + "]</span>" + tab;
+        if (isClickableClassName(sourceClassNameFull)) {
+            return makeClickableClassNameLink(sourceClassNameFull, lineNumber, sourceClassNameFullShort);
+        }
+        return "<span class='text-secondary'>[" + sourceClassNameFullShort + "]</span>" + tab;
     }
     return "";
 }
 
-function getFullClassName(sourceClassNameFull) {
+function getFullClassName(sourceClassNameFull, lineNumber) {
     if($('#logstreamColumnsModalSourceClassFullSwitch').is(":checked")){
+        if (isClickableClassName(sourceClassNameFull)) {
+            return makeClickableClassNameLink(sourceClassNameFull, lineNumber, sourceClassNameFull);
+        }
         return "<span class='text-secondary'>[" + sourceClassNameFull + "]</span>" + tab;
     }
     return "";
 }
 
-function getClassName(className) {
+function getClassName(sourceClassNameFull, lineNumber, className) {
     if($('#logstreamColumnsModalSourceClassSwitch').is(":checked")){
+        if (isClickableClassName(sourceClassNameFull)) {
+            return makeClickableClassNameLink(sourceClassNameFull, lineNumber, className);
+        }
         return "<span class='text-secondary'>[" + className + "]</span>" + tab;
     }
     return "";
+}
+
+function isClickableClassName(className){
+    if (className !== undefined && appClassLang(className) && ideKnown()) {
+        return true;
+    }
+    return false;
+}
+
+function makeClickableClassNameLink(className, lineNumber, display){
+    return "<a class='text-secondary clickable-app-class' onclick='openInIDE(\"" + className + "\",\"" + lineNumber + "\");'>[" + display + "]</a>" + tab;
 }
 
 function getMethodName(methodName) {
@@ -596,7 +616,7 @@ function makeLink(message, protocol){
     return message.replace(url, link);    
 }
 
-function enhanceStacktrace(loggerName, stacktrace) {
+function enhanceStacktrace(stacktrace) {
     var enhanceStacktrace = [];
     var lines = stacktrace.split('\n');
     for (var i = 0; i < lines.length; i++) {
@@ -607,9 +627,18 @@ function enhanceStacktrace(loggerName, stacktrace) {
                 var parts = line.split(":");
                 line = "<b>" + parts[0] + ":</b>" + parts[1];
             } else {
-                var isMyClass = line.includes(loggerName);
-                if (isMyClass && loggerName) {
-                    line = '<b>' + line + '</b>';
+                if(!line.includes(".zig")){
+                    var parts = line.split(" ");
+                    // Make it clickable
+                    var classMethodFileNumber = parts[1];
+                    var classMethodFileNumberSplit = classMethodFileNumber.split("(");
+                    var classMethod = classMethodFileNumberSplit[0];
+                    var fileNumber = classMethodFileNumberSplit[1];
+                    givenClassName = classMethod.substring(0, classMethod.lastIndexOf('.'));
+                    if(isClickableClassName(givenClassName)){
+                        lineNumber = fileNumber.substring(fileNumber.lastIndexOf(':') + 1, fileNumber.lastIndexOf(')'));
+                        line = "<a class='text-wrap text-danger clickable-app-class' onclick='openInIDE(\"" + givenClassName + "\",\"" + lineNumber + "\");'><b>" + line + "</b></a>";
+                    }
                 }
                 line = space + space + space + space + space + space + line;
             }
@@ -681,9 +710,9 @@ function openSocket() {
                 + getLoggerNameAbbreviated(json.loggerNameShort)
                 + getLoggerName(json.loggerName)
                 + getLoggerClassName(json.loggerClassName)        
-                + getClassFullAbbreviatedName(json.sourceClassNameFull, json.sourceClassNameFullShort)
-                + getFullClassName(json.sourceClassNameFull)
-                + getClassName(json.sourceClassName)
+                + getClassFullAbbreviatedName(json.sourceClassNameFull, json.sourceLineNumber,json.sourceClassNameFullShort)
+                + getFullClassName(json.sourceClassNameFull,json.sourceLineNumber)
+                + getClassName(json.sourceClassNameFull,json.sourceLineNumber,json.sourceClassName)
                 + getMethodName(json.sourceMethodName)
                 + getFileName(json.sourceFileName)
                 + getLineNumber(json.sourceLineNumber)
@@ -695,7 +724,7 @@ function openSocket() {
                 
         if (json.stacktrace) {
             for (var i in json.stacktrace) {
-                var stacktrace = enhanceStacktrace(json.loggerName, json.stacktrace[i]);
+                var stacktrace = enhanceStacktrace(json.stacktrace[i]);
                 htmlLine = htmlLine + stacktrace;
             }
         }


### PR DESCRIPTION
This PR make the classes in the log file clickable, to open the file, at the correct line number, in the user's IDE (if we could detect it)
It also makes some lines in a stacktrace clickable.

![clickable_log](https://user-images.githubusercontent.com/6836179/111290331-b6f4ce00-864e-11eb-86ea-ba7ce9e3331d.gif)

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>