### PR TITLE
Upgrade SmallRye OpenAPI to 2.0.26

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-config.version>1.11.1</smallrye-config.version>
         <smallrye-health.version>2.2.6</smallrye-health.version>
         <smallrye-metrics.version>2.4.6</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.23</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.26</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.22</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.5</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -89,6 +89,13 @@ public class SwaggerUiProcessor {
                         "quarkus.swagger-ui.path was set to \"/\", this is not allowed as it blocks the application from serving anything else.");
             }
 
+            if (openapi.path.equalsIgnoreCase(swaggerUiConfig.path)) {
+                throw new ConfigurationError(
+                        "quarkus.smallrye-openapi.path and quarkus.swagger-ui.path was set to the same value, this is not allowed as the paths needs to be unique ["
+                                + openapi.path + "].");
+
+            }
+
             String openApiPath = nonApplicationRootPathBuildItem.resolvePath(openapi.path);
             String swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path);
 

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/ErroneousConfigTest2.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/ErroneousConfigTest2.java
@@ -1,0 +1,26 @@
+package io.quarkus.swaggerui.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ErroneousConfigTest2 {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(ConfigurationError.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.swagger-ui.path=/api\n"
+                            + "quarkus.smallrye-openapi.path=/api\n"), "application.properties"));
+
+    @Test
+    public void shouldNotStartApplicationIfSwaggerPathIsSameAsOpenAPIPath() {
+        Assertions.fail();
+    }
+}


### PR DESCRIPTION
This PR Upgrades SmallRye OpenAPI to 2.0.26, fixing a few issues

(see https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.26)

Fix #15642
Fix #15714