### PR TITLE
Optimise ArC 's generated implementation of bean equals()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1612,22 +1612,24 @@ public class BeanGenerator extends AbstractGenerator {
 
     protected void implementEquals(BeanInfo bean, ClassCreator beanCreator) {
         MethodCreator equals = beanCreator.getMethodCreator("equals", boolean.class, Object.class).setModifiers(ACC_PUBLIC);
+        final ResultHandle obj = equals.getMethodParam(0);
         // if (this == obj) {
         //    return true;
         // }
-        equals.ifTrue(equals.invokeStaticMethod(MethodDescriptors.OBJECTS_REFERENCE_EQUALS, equals.getThis(),
-                equals.getMethodParam(0))).trueBranch().returnValue(equals.load(true));
+        equals.ifReferencesEqual(equals.getThis(), obj)
+                .trueBranch().returnValue(equals.load(true));
+
         // if (obj == null) {
         //    return false;
         // }
-        equals.ifNull(equals.getMethodParam(0)).trueBranch().returnValue(equals.load(false));
+        equals.ifNull(obj).trueBranch().returnValue(equals.load(false));
         // if (!(obj instanceof InjectableBean)) {
         //    return false;
         // }
-        equals.ifFalse(equals.instanceOf(equals.getMethodParam(0), InjectableBean.class)).trueBranch()
+        equals.ifFalse(equals.instanceOf(obj, InjectableBean.class)).trueBranch()
                 .returnValue(equals.load(false));
         // return identifier.equals(((InjectableBean) obj).getIdentifier());
-        ResultHandle injectableBean = equals.checkCast(equals.getMethodParam(0), InjectableBean.class);
+        ResultHandle injectableBean = equals.checkCast(obj, InjectableBean.class);
         ResultHandle otherIdentifier = equals.invokeInterfaceMethod(MethodDescriptors.GET_IDENTIFIER, injectableBean);
         equals.returnValue(equals.invokeVirtualMethod(MethodDescriptors.OBJECT_EQUALS, equals.load(bean.getIdentifier()),
                 otherIdentifier));

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -79,12 +79,30 @@ public final class MethodDescriptors {
     public static final MethodDescriptor OBJECT_EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
             Object.class);
 
+    /**
+     * No longer used - will be deleted
+     * 
+     * @deprecated
+     */
+    @Deprecated
     public static final MethodDescriptor OBJECT_HASH_CODE = MethodDescriptor.ofMethod(Object.class, "hashCode", int.class);
 
+    /**
+     * No longer used - will be deleted
+     * 
+     * @deprecated
+     */
+    @Deprecated
     public static final MethodDescriptor OBJECT_TO_STRING = MethodDescriptor.ofMethod(Object.class, "toString", String.class);
 
     public static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
 
+    /**
+     * No longer used - will be deleted
+     * 
+     * @deprecated
+     */
+    @Deprecated
     public static final MethodDescriptor OBJECTS_REFERENCE_EQUALS = MethodDescriptor.ofMethod(Objects.class, "referenceEquals",
             boolean.class, Object.class, Object.class);
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Objects.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Objects.java
@@ -1,5 +1,9 @@
 package io.quarkus.arc.impl;
 
+/**
+ * @deprecated will be removed. Use Gizmo's ifReferencesEqual instead.
+ */
+@Deprecated
 public final class Objects {
 
     private Objects() {


### PR DESCRIPTION

Original code:

    public String getIdentifier() {
        return "af92c027c2ee73cb5a9eda77a40bc4f296965f25";
    }

    public boolean equals(Object var1) {
        if (!Objects.referenceEquals(this, var1)) {
            if (var1 != null) {
                if (var1 instanceof InjectableBean) {
                    String var2 = ((InjectableBean)var1).getIdentifier();
                    return "af92c027c2ee73cb5a9eda77a40bc4f296965f25".equals(var2);
                } else {
                    return false;
                }
            } else {
                return false;
            }
        } else {
            return true;
        }
    }


1. introduce the static constant, to a)avoid repeating it b) help with identity based comparisons
2. avoid the no longer needed `Objects.referenceEquals` method
3. adapt the `getIdentifier()` method, for same reasons as 1#

New code:

    private static final String IDENTIFIER = "af92c027c2ee73cb5a9eda77a40bc4f296965f25";

    public String getIdentifier() {
        return IDENTIFIER;
    }

    public boolean equals(Object var1) {
        if (this != var1) {
            if (var1 != null) {
                if (var1 instanceof InjectableBean) {
                    String var2 = ((InjectableBean)var1).getIdentifier();
                    String var3 = IDENTIFIER;
                    return (var2 != var3 ? var3.equals(var2) : true);
                } else {
                    return false;
                }
            } else {
                return false;
            }
        } else {
            return true;
        }
    }


I believe it should also be safe to remove the full-depth check on the string `var3.equals(var2)`, but this assumption might break with classloaders so I'll leave that alone for now.