### PR TITLE
Make sure the proper TCCL isn't lost in dev mode when static resource exist

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
@@ -52,6 +52,7 @@ public class StaticResourcesRecorder {
             }
         }
         if (!knownPaths.isEmpty()) {
+            ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
             StaticHandler staticHandler = StaticHandler.create(META_INF_RESOURCES).setDefaultContentEncoding("UTF-8");
             handlers.add(ctx -> {
                 String rel = ctx.mountPoint() == null ? ctx.normalisedPath()
@@ -59,6 +60,8 @@ public class StaticResourcesRecorder {
                 if (knownPaths.contains(rel)) {
                     staticHandler.handle(ctx);
                 } else {
+                    // make sure we don't lose the correct TCCL to Vert.x...
+                    Thread.currentThread().setContextClassLoader(currentCl);
                     ctx.next();
                 }
             });


### PR DESCRIPTION
Fixes: #15763
Fixes: #15164