### PR TITLE
Add NVD related information to security.adoc

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -231,3 +231,12 @@ See link:security-testing[Security Testing] for more information about testing Q
 == Secret Engines
 === Vault
 Quarkus provides a very comprehensive HashiCorp Vault support, please see the link:vault[Quarkus and HashiCorp Vault] documentation for more information.
+
+== National Vulnerability Database
+
+Most of Quarkus tags have been registered in link:https://nvd.nist.gov[National Vulnerability Database] (NVD) using a Common Platform Enumeration (CPE) name format.
+All registered Quarkus CPE names can be found using link:https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=quarkus[this search query].
+If a Quarkus tag represented by the given CPE name entry is affected by some CVE then you'll be able to follow a provided link to that CVE.
+
+We will be asking the NVD CPE team to update the list as well as link Quarkus CPE name entries with the related CVEs on a regular basis.
+If you work with a plugin like OWASP plugin which is using NVD feeds to detect the vulnerabilities at the application build time and you see a false positive reported then please re-open link:https://github.com/quarkusio/quarkus/issues/2611[this issue] and provide the details.


### PR DESCRIPTION
Fixes #2611.

The time has come to resolve this issue :-). Most of Quarkus tags have been registered and linked to the related CVEs so this doc update is the final step.
Going forward we will be looking at the false positives if any on an individual basis