### PR TITLE
Make update-*dependencies.sh runnable on Mac

### DIFF
--- a/integration-tests/gradle/update-dependencies.sh
+++ b/integration-tests/gradle/update-dependencies.sh
@@ -5,6 +5,9 @@
 set -e -u -o pipefail
 shopt -s failglob
 
+# path of this shell script (note: readlink -f does not work on Mac)
+PRG_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
 DEP_TEMPLATE='        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>XXX</artifactId>
@@ -33,9 +36,9 @@ echo ''
 # pipefail is switched off briefly so that a better error can be logged when nothing is found
 set +o pipefail
 # note on sed: -deployment deps are added explicitly later and bom is upstream anyway
-ARTIFACT_IDS=`grep -hR --include 'build*.gradle' --exclude-dir=build '[iI]mplementation' | \
-              grep -Po '(?<=io\.quarkus:)quarkus-[a-z0-9-]+' | \
-              sed -e '/-deployment/d' -e '/quarkus-bom/d' | sort | uniq`
+ARTIFACT_IDS=$(grep -hR --include 'build*.gradle' --exclude-dir=build '[iI]mplementation' "${PRG_PATH}" | \
+              grep -Eo 'quarkus-[a-z0-9-]+' | \
+              sed -e '/-deployment/d' -e '/quarkus-bom/d' | sort | uniq)
 set -o pipefail
 if [ -z "${ARTIFACT_IDS}" ]
 then
@@ -43,33 +46,42 @@ then
   exit 1
 fi
 
-# to replace newlines with \n so that the final sed calls accept ${DEPS} as input
-SED_EXPR_NEWLINES=':a;N;$!ba;s/\n/\\\n/g'
+# note: that bulky last sed in the following commands replaces newlines with \n so that the final sed calls accept ${DEPS} as input
+# see also: https://stackoverflow.com/a/1252191/9529981
 
-DEPS=`echo "${ARTIFACT_IDS}" \
-  | xargs -i sh -c "echo \"${DEP_TEMPLATE}\" | sed 's/XXX/{}/'" \
-  | sed "${SED_EXPR_NEWLINES}"`
+DEPS=$(echo "${ARTIFACT_IDS}" \
+  | while read AID; do echo "${DEP_TEMPLATE/XXX/${AID}}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
 
-DEPS+='\n'
+# https://superuser.com/a/307486
+LF=$'\n'
+
+DEPS+="\\${LF}"
 
 # note on sed: Remove artifacts that are not extensions (since not -deployment sibling exists).
 #              This is a bit fragile but without this -deployment deps would need to be added by hand.
-DEPS+=`echo "${ARTIFACT_IDS}" \
+DEPS+=$(echo "${ARTIFACT_IDS}" \
   | sed -e '/-bootstrap/d' -e '/-test/d' -e '/-junit/d' -e '/-devtools/d' -e '/-descriptor/d' -e '/-extension-codestarts/d' \
-  | xargs -i sh -c "echo \"${DEP_TEMPLATE_DEPLOYMENT}\" | sed 's/XXX/{}/'" \
-  | sed "${SED_EXPR_NEWLINES}"`
+  | while read AID; do echo "${DEP_TEMPLATE_DEPLOYMENT/XXX/${AID}}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
 
 MARK_START='<!-- START update-dependencies.sh -->'
 MARK_END='<!-- END update-dependencies.sh -->'
-SED_EXPR="/${MARK_START}/,/${MARK_END}/c\        ${MARK_START}\n${DEPS}\n        ${MARK_END}"
+# note: line break after c command is required for MacOS compatibility: https://unix.stackexchange.com/a/52141
+SED_EXPR="/${MARK_START}/,/${MARK_END}/c\\
+        ${MARK_START}\\${LF}${DEPS}\\${LF}        ${MARK_END}"
+# BSD sed (on MacOS) consumes one line break too much which will be fixed by the following additional expression:
+SED_EXPR_BSD_FIXUP="s/${MARK_END}    <\/dependencies>/${MARK_END}\\${LF}    <\/dependencies>/"
 
 echo ''
 echo 'Updating pom.xml...'
 echo ''
-sed -i "${SED_EXPR}" pom.xml
+# note: the following sed command does not use -i because behavior on MacOS is different than on Linux
+sed -e "${SED_EXPR}" -e "${SED_EXPR_BSD_FIXUP}" "${PRG_PATH}/pom.xml" > /tmp/gradle-pom.xml
+mv /tmp/gradle-pom.xml "${PRG_PATH}/pom.xml"
 
 echo ''
 echo 'Sanity check...'
 echo ''
 # sanity check; make sure nothing stupid was added like non-existing deps
-mvn dependency:resolve validate -Dsilent -q $*
+mvn dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*

--- a/update-extension-dependencies.sh
+++ b/update-extension-dependencies.sh
@@ -5,10 +5,27 @@
 set -e -u -o pipefail
 shopt -s failglob
 
-echo ''
-echo 'Building bom-descriptor-json...'
-echo ''
-mvn -q -e clean package -f devtools/bom-descriptor-json -Denforcer.skip $*
+# path of this shell script (note: readlink -f does not work on Mac)
+PRG_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+# CI env var => https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+if [ "${CI:-}" == true ]
+then
+  echo ''
+  echo 'Building bom-descriptor-json...'
+  echo ''
+  mvn -q -e clean package -f "${PRG_PATH}/devtools/bom-descriptor-json" -Denforcer.skip $*
+else
+  read -n1 -p 'Did you build the entire project? [y/n] ' ANSWER
+  echo ''
+  if [ "${ANSWER}" != y ]
+  then
+    echo ''
+    echo 'Building entire project...'
+    echo ''
+    mvn -q -e -Dquickly -T0.8C -f "${PRG_PATH}" $*
+  fi
+fi
 
 # note: OFFSET is replaced later on with an individual amount of spaces
 DEP_TEMPLATE='OFFSET<dependency>
@@ -32,7 +49,7 @@ echo ''
 # get all "artifact-id" values from the generated json file
 # pipefail is switched off briefly so that a better error can be logged when nothing is found
 set +o pipefail
-ARTIFACT_IDS=`grep '^    "artifact"' devtools/bom-descriptor-json/target/*.json | grep -Po '(?<=io.quarkus:)(?!quarkus-bom)[^:]+' | sort`
+ARTIFACT_IDS=$(cd "${PRG_PATH}" && grep '^    "artifact"' devtools/bom-descriptor-json/target/*.json | grep -Eo 'quarkus-[a-z0-9-]+' | sort)
 set -o pipefail
 if [ -z "${ARTIFACT_IDS}" ]
 then
@@ -40,37 +57,48 @@ then
   exit 1
 fi
 
-# to replace newlines with \n so that the final sed calls accept ${DEPS_*} as input
-SED_EXPR_NEWLINES=':a;N;$!ba;s/\n/\\\n/g'
+# note: that bulky last sed in the following commands replaces newlines with \n so that the final sed calls accept ${DEPS_*} as input
+# see also: https://stackoverflow.com/a/1252191/9529981
 
-DEPS_RUNTIME=`echo "${ARTIFACT_IDS}" \
-  | xargs -i sh -c "echo \"${DEP_TEMPLATE}\" | sed 's/XXX/{}/'" \
-  | sed "${SED_EXPR_NEWLINES}"`
+DEPS_RUNTIME=$(echo "${ARTIFACT_IDS}" \
+  | while read AID; do echo "${DEP_TEMPLATE/XXX/${AID}}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
 
-DEPS_DEPLOYMENT=`echo "${ARTIFACT_IDS}" \
-  | xargs -i sh -c "echo \"${DEP_TEMPLATE}\" | sed 's/XXX/{}-deployment/'" \
-  | sed "${SED_EXPR_NEWLINES}"`
+DEPS_DEPLOYMENT=$(echo "${ARTIFACT_IDS}" \
+  | while read AID; do echo "${DEP_TEMPLATE/XXX/${AID}-deployment}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
 
 MARK_START='<!-- START update-extension-dependencies.sh -->'
 MARK_END='<!-- END update-extension-dependencies.sh -->'
-SED_EXPR_DEPS_RUNTIME="/${MARK_START}/,/${MARK_END}/cOFFSET${MARK_START}\n${DEPS_RUNTIME}\nOFFSET${MARK_END}"
-SED_EXPR_DEPS_DEPLOYMENT="/${MARK_START}/,/${MARK_END}/cOFFSET${MARK_START}\n${DEPS_DEPLOYMENT}\nOFFSET${MARK_END}"
+# https://superuser.com/a/307486
+LF=$'\n'
+# note: line breaks after c command are required for MacOS compatibility: https://unix.stackexchange.com/a/52141
+SED_EXPR_DEPS_RUNTIME="/${MARK_START}/,/${MARK_END}/c\\
+OFFSET${MARK_START}\\${LF}${DEPS_RUNTIME}\\${LF}OFFSET${MARK_END}"
+SED_EXPR_DEPS_DEPLOYMENT="/${MARK_START}/,/${MARK_END}/c\\
+OFFSET${MARK_START}\\${LF}${DEPS_DEPLOYMENT}\\${LF}OFFSET${MARK_END}"
+# BSD sed (on MacOS) consumes one line break too much which will be fixed by the following additional expression:
+SED_EXPR_BSD_FIXUP="s/${MARK_END}([ ]*)<\/dependencies>/${MARK_END}\\${LF}\1<\/dependencies>/"
+
+# note: the following sed commands do not use -i because behavior on MacOS is different than on Linux
 
 echo ''
 echo 'Updating devtools/bom-descriptor-json/pom.xml...'
 echo ''
-sed -i "${SED_EXPR_DEPS_RUNTIME}" devtools/bom-descriptor-json/pom.xml
-# note: more indetation here since bom-descriptor-json has a profile for the deps
-sed -i 's/OFFSET/                /' devtools/bom-descriptor-json/pom.xml
+sed "${SED_EXPR_DEPS_RUNTIME}" "${PRG_PATH}/devtools/bom-descriptor-json/pom.xml" > /tmp/bom-descriptor-json-pom.xml
+# note: more indentation here since bom-descriptor-json has a profile for the deps
+sed -r -e 's/OFFSET/                /' -e "${SED_EXPR_BSD_FIXUP}" /tmp/bom-descriptor-json-pom.xml > "${PRG_PATH}/devtools/bom-descriptor-json/pom.xml"
+rm -f /tmp/bom-descriptor-json-pom.xml
 
 echo ''
 echo 'Updating docs/pom.xml...'
 echo ''
-sed -i "${SED_EXPR_DEPS_DEPLOYMENT}" docs/pom.xml
-sed -i 's/OFFSET/        /' docs/pom.xml
+sed "${SED_EXPR_DEPS_DEPLOYMENT}" "${PRG_PATH}/docs/pom.xml" > /tmp/docs-pom.xml
+sed -r -e 's/OFFSET/        /' -e "${SED_EXPR_BSD_FIXUP}" /tmp/docs-pom.xml > "${PRG_PATH}/docs/pom.xml"
+rm -f /tmp/docs-pom.xml
 
 echo ''
 echo 'Sanity check...'
 echo ''
 # sanity check; make sure nothing stupid was added like non-existing deps
-mvn dependency:resolve validate -Dsilent -q -pl devtools/bom-descriptor-json,docs $*
+mvn dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" -pl devtools/bom-descriptor-json,docs $*


### PR DESCRIPTION
Change tested on Ubuntu 20.04 and Windows 10 (Git Bash).

@kenfinnigan I'd appreciate if you could test those two scripts on Mac. Thanks!

/cc @gsmet

FTR: Came up here: https://github.com/quarkusio/quarkus/pull/15016#issuecomment-801319454