### PR TITLE
Fix entirely skipped enforcer in infinispan-client IT and resolve violations

### DIFF
--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -45,6 +45,18 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-hotrod</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- fix dependency convergence with quarkus-junit5 -->
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+                <!-- jboss-transaction-api is banned and not required for the test -->
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- needed so server exposes query based caches -->
         <dependency>
@@ -77,6 +89,13 @@
             <artifactId>infinispan-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <!-- jboss-transaction-api is banned and not required for the test -->
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -90,21 +109,45 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- We override these to satisfy Infinispan server -->
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.11.0</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.11.0</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.11.0</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>
@@ -128,17 +171,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>


### PR DESCRIPTION
This skipped way too many checks:
```
[WARNING]
Dependency convergence error for com.fasterxml.jackson.core:jackson-core:2.12.1 paths to dependency are:
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-io.quarkus:quarkus-resteasy:999-SNAPSHOT
    +-io.quarkus:quarkus-vertx-http:999-SNAPSHOT
      +-io.quarkus:quarkus-vertx-core:999-SNAPSHOT
        +-io.vertx:vertx-core:3.9.5
          +-com.fasterxml.jackson.core:jackson-core:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.fasterxml.jackson.core:jackson-core:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.1
        +-com.fasterxml.jackson.core:jackson-core:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-com.fasterxml.jackson.core:jackson-core:2.11.0

[WARNING]
Dependency convergence error for com.thoughtworks.xstream:xstream:1.4.16 paths to dependency are:
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-io.quarkus:quarkus-junit5:999-SNAPSHOT
    +-com.thoughtworks.xstream:xstream:1.4.16
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.thoughtworks.xstream:xstream:1.4.15

[WARNING]
Dependency convergence error for com.fasterxml.jackson.core:jackson-annotations:2.12.1 paths to dependency are:
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.fasterxml.jackson.core:jackson-annotations:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-com.fasterxml.jackson.core:jackson-annotations:2.11.0

[WARNING]
Dependency convergence error for com.fasterxml.jackson.core:jackson-databind:2.12.1 paths to dependency are:
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.fasterxml.jackson.core:jackson-databind:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-hotrod:12.0.1.Final
    +-org.infinispan:infinispan-server-core:12.0.1.Final
      +-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.1
        +-com.fasterxml.jackson.core:jackson-databind:2.12.1
and
+-io.quarkus:quarkus-integration-test-infinispan-client:999-SNAPSHOT
  +-com.fasterxml.jackson.core:jackson-databind:2.11.0

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:jar:1.1.1.Final
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```
...and (as expected) the minimal deployment dependencies were missing as well.

I don't think the exclusions I added have actually changed the relevant semantics. Everything is still passing.
But then again: I'm not an Infinispan expert and I'm not sure what this "jboss marshalling" comment was about.