### PR TITLE
Added processGroupIds parameter to generate-platform-descriptor-json goal

### DIFF
--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -48,13 +48,12 @@
                     <execution>
                         <phase>${pluginPhase}</phase>
                         <goals>
-                            <!-- goal>generate-extensions-json</goal -->
                             <goal>generate-platform-descriptor-json</goal>
                         </goals>
                         <configuration>
-                            <ignoredGroupIds>
-                                <ignoredGroupId>software.amazon.awssdk</ignoredGroupId>
-                            </ignoredGroupIds>
+                            <processGroupIds>
+                                <groupId>io.quarkus</groupId>
+                            </processGroupIds>
                             <bomArtifactId>quarkus-bom</bomArtifactId>
                             <resolveDependencyManagement>true</resolveDependencyManagement>
                             <overridesFile>${basedir}/target/resources/catalog-overrides.json</overridesFile>


### PR DESCRIPTION
This PR adds `processGroupIds` parameter to the `generate-platform-descriptor-json` goal. Including `io.quarkus` in that set (which is what quarkus core is producing) reduces the number of processed artifacts from currently 1187 to 259 with the generated JSON content remaining identical.