### PR TITLE
Initialize resteasy dependency class using SecureRandom at runtime

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -53,6 +53,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ProxyUnwrapperBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.resteasy.common.runtime.ResteasyInjectorFactoryRecorder;
 import io.quarkus.resteasy.common.runtime.providers.ServerFormUrlEncodedProvider;
@@ -118,6 +119,16 @@ public class ResteasyCommonProcessor {
          */
         @ConfigItem(defaultValue = "10M")
         public MemorySize maxInput;
+    }
+
+    /**
+     * Initialize {@code NTLMEngineImpl} at runtime so as to avoid using a
+     * cached SecureRandom in the image heap.
+     */
+    @BuildStep
+    public RuntimeInitializedClassBuildItem runtimeInitNTLMEngineImpl() {
+        return new RuntimeInitializedClassBuildItem(
+                "org.apache.http.impl.auth.NTLMEngineImpl");
     }
 
     @BuildStep


### PR DESCRIPTION
This fixes another piece of #14904 and is similar to #14908.

This particular fix is for `integration-test/main` and fixes this issue with latest Graal 21.1 dev:

```
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:build (default) @ quarkus-integration-test-main ---
[WARNING] [io.quarkus.deployment] Producing values from constructors and fields is no longer supported and will be removed in a future release: io.quarkus.deployment.annotations.BuildProducer io.quarkus.it.classtransformer.ClassTransformerProcessor.transformers
[INFO] [org.jboss.threads] JBoss Threads version 3.2.0.Final
[INFO] [org.hibernate.Version] HHH000412: Hibernate ORM core version 5.4.29.Final
[WARNING] [io.quarkus.micrometer.deployment.binder.mpmetrics.MicroprofileMetricsProcessor] This application uses the MP Metrics API. The micrometer extension currently provides a compatibility layer that supports the MP Metrics API, but metric names and recorded values will be different. Note that the MP Metrics compatibility layer will move to a different extension in the future.
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/main/target/quarkus-integration-test-main-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-main-999-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/main/target/quarkus-integration-test-main-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-main-999-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM Version 21.1.0-dev (Mandrel Distribution) (Java Version 11.0.11-ea+2)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] /disk/graal/builds/graalvm-21.1-dev-2021-03-17/bin/native-image -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-DCoordinatorEnvironmentBean.transactionStatusManagerEnable=false -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -J-Drx.unsafe-disable=true -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 --trace-object-instantiation=java.security.SecureRandom --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -jar quarkus-integration-test-main-999-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:+AddAllCharsets -H:EnableURLProtocols=http -H:NativeLinkerOption=-no-pie -H:-UseServiceLoaderFeature -H:+StackTrace quarkus-integration-test-main-999-SNAPSHOT-runner
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]    classlist:  15,900.99 ms,  2.71 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]        (cap):     564.61 ms,  2.71 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]        setup:   3,297.67 ms,  2.71 GB
20:27:46,953 INFO  [org.hib.val.int.uti.Version] HV000001: Hibernate Validator 6.2.0.Final
20:27:47,189 INFO  [org.hib.Version] HHH000412: Hibernate ORM core version 5.4.29.Final
20:27:47,232 INFO  [org.hib.ann.com.Version] HCANN000001: Hibernate Commons Annotations {5.1.2.Final}
20:27:47,357 INFO  [org.hib.dia.Dialect] HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL95Dialect
20:27:48,532 WARNING [org.apa.tik.par.PDFParser] J2KImageReader not loaded. JPEG2000 files will not be processed.
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.

20:27:48,577 WARNING [org.apa.tik.par.ocr.TesseractOCRParser] Tesseract OCR is installed and will be automatically applied to image files unless
you've excluded the TesseractOCRParser from the default parser.
Tesseract may dramatically slow down content extraction (TIKA-2359).
As of Tika 1.15 (and prior versions), Tesseract is automatically called.
In future versions of Tika, users may need to turn the TesseractOCRParser on via TikaConfig.
20:28:35,163 INFO  [org.jbo.threads] JBoss Threads version 3.2.0.Final
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]     (clinit):   1,789.77 ms,  6.45 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]   (typeflow):  46,142.88 ms,  6.45 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]    (objects):  75,110.69 ms,  6.45 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]   (features):   2,974.63 ms,  6.45 GB
[quarkus-integration-test-main-999-SNAPSHOT-runner:34914]     analysis: 131,509.97 ms,  6.45 GB
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  Object has been initialized by the org.apache.http.impl.auth.NTLMEngineImpl class initializer with a trace: 
 	at java.security.SecureRandom.<init>(SecureRandom.java:323)
	at java.security.SecureRandom.getInstance(SecureRandom.java:383)
	at org.apache.http.impl.auth.NTLMEngineImpl.<clinit>(NTLMEngineImpl.java:103)
. Try avoiding to initialize the class that caused initialization of the object. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Detailed message:
Trace: 
	at parsing org.apache.http.impl.auth.NTLMEngineImpl.access$000(NTLMEngineImpl.java:51)
Call path from entry point to org.apache.http.impl.auth.NTLMEngineImpl.access$000(): 
	at org.apache.http.impl.auth.NTLMEngineImpl.access$000(NTLMEngineImpl.java:51)
	at org.apache.http.impl.auth.NTLMEngineImpl$Type3Message.<init>(NTLMEngineImpl.java:1505)
	at org.apache.http.impl.auth.NTLMEngineImpl$Type3Message.<init>(NTLMEngineImpl.java:1474)
	at org.apache.http.impl.auth.NTLMEngineImpl.getType3Message(NTLMEngineImpl.java:181)
	at org.apache.http.impl.auth.NTLMEngineImpl.generateType3Msg(NTLMEngineImpl.java:2097)
	at org.apache.http.impl.auth.NTLMScheme.authenticate(NTLMScheme.java:142)
	at org.apache.http.impl.auth.AuthSchemeBase.authenticate(AuthSchemeBase.java:136)
	at org.apache.http.impl.auth.HttpAuthenticator.doAuth(HttpAuthenticator.java:233)
	at org.apache.http.impl.auth.HttpAuthenticator.generateAuthResponse(HttpAuthenticator.java:213)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:262)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine.invoke(ManualClosingApacheHttpClient43Engine.java:268)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:491)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.lambda$executorSubmit$11(ClientInvocation.java:773)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation$$Lambda$2034/0x00000007c4cd7440.get(Unknown Source)
	at app//com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:217)
	at app//com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:170)
	at app//com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:291)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VARARGS:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)

com.oracle.svm.core.util.UserError$UserException: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  Object has been initialized by the org.apache.http.impl.auth.NTLMEngineImpl class initializer with a trace: 
 	at java.security.SecureRandom.<init>(SecureRandom.java:323)
	at java.security.SecureRandom.getInstance(SecureRandom.java:383)
	at org.apache.http.impl.auth.NTLMEngineImpl.<clinit>(NTLMEngineImpl.java:103)
. Try avoiding to initialize the class that caused initialization of the object. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Detailed message:
Trace: 
	at parsing org.apache.http.impl.auth.NTLMEngineImpl.access$000(NTLMEngineImpl.java:51)
Call path from entry point to org.apache.http.impl.auth.NTLMEngineImpl.access$000(): 
	at org.apache.http.impl.auth.NTLMEngineImpl.access$000(NTLMEngineImpl.java:51)
	at org.apache.http.impl.auth.NTLMEngineImpl$Type3Message.<init>(NTLMEngineImpl.java:1505)
	at org.apache.http.impl.auth.NTLMEngineImpl$Type3Message.<init>(NTLMEngineImpl.java:1474)
	at org.apache.http.impl.auth.NTLMEngineImpl.getType3Message(NTLMEngineImpl.java:181)
	at org.apache.http.impl.auth.NTLMEngineImpl.generateType3Msg(NTLMEngineImpl.java:2097)
	at org.apache.http.impl.auth.NTLMScheme.authenticate(NTLMScheme.java:142)
	at org.apache.http.impl.auth.AuthSchemeBase.authenticate(AuthSchemeBase.java:136)
	at org.apache.http.impl.auth.HttpAuthenticator.doAuth(HttpAuthenticator.java:233)
	at org.apache.http.impl.auth.HttpAuthenticator.generateAuthResponse(HttpAuthenticator.java:213)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:262)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine.invoke(ManualClosingApacheHttpClient43Engine.java:268)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:491)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.lambda$executorSubmit$11(ClientInvocation.java:773)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation$$Lambda$2034/0x00000007c4cd7440.get(Unknown Source)
	at app//com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:217)
	at app//com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:170)
	at app//com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:291)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VARARGS:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)

	at com.oracle.svm.core.util.UserError.abort(UserError.java:82)
	at com.oracle.svm.hosted.FallbackFeature.reportAsFallback(FallbackFeature.java:233)
	at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:798)
	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:582)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$2(NativeImageGenerator.java:495)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  Object has been initialized by the org.apache.http.impl.auth.NTLMEngineImpl class initializer with a trace: 
 	at java.security.SecureRandom.<init>(SecureRandom.java:323)
	at java.security.SecureRandom.getInstance(SecureRandom.java:383)
	at org.apache.http.impl.auth.NTLMEngineImpl.<clinit>(NTLMEngineImpl.java:103)
. Try avoiding to initialize the class that caused initialization of the object. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
```

Thoughts?