### PR TITLE
Make the kafka streams extension to read the default kafka broker configuration

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
@@ -23,7 +23,7 @@ public class KafkaRuntimeConfigProducer {
     @Produces
     @DefaultBean
     @Singleton
-    @Named("default-kafka-broker")
+    @Named("default-kafka-broker") // TODO Should use @Identifier soon
     public Map<String, Object> createKafkaRuntimeConfig(Config config, ApplicationConfig app) {
         Map<String, Object> result = new HashMap<>();
 

--- a/integration-tests/kafka-streams/src/main/resources/application.properties
+++ b/integration-tests/kafka-streams/src/main/resources/application.properties
@@ -8,10 +8,11 @@ quarkus.kafka-streams.topics=streams-test-categories,streams-test-customers
 quarkus.kafka-streams.schema-registry-key=apicurio.registry.url
 quarkus.kafka-streams.schema-registry-url=http://localhost:8080
 
-quarkus.kafka-streams.security.protocol=SSL
-quarkus.kafka-streams.ssl.truststore.location=./target/classes/ks-truststore.p12
-quarkus.kafka-streams.ssl.truststore.password=Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L
-quarkus.kafka-streams.ssl.truststore.type=PKCS12
+# Mix properties provided by the quarkus-kafka-client extension and kafka-streams specific ones.
+kafka.security.protocol=SSL
+kafka.ssl.truststore.location=./target/classes/ks-truststore.p12
+kafka.ssl.truststore.password=Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L
+kafka.ssl.truststore.type=PKCS12
 quarkus.kafka-streams.ssl.endpoint-identification-algorithm=
 
 quarkus.kafka-streams.sasl.kerberos-ticket-renew-jitter=0.06
@@ -21,7 +22,7 @@ quarkus.kafka-streams.sasl.login-refresh-buffer=PT20S
 kafka-streams.cache.max.bytes.buffering=10240
 kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
-kafka-streams.auto.offset.reset=earliest
+kafka.auto.offset.reset=earliest
 
 # Set explicitly as for tests the quarkus.application.name does not default to the name of the project
 %test.quarkus.application.name=streams-test-pipeline


### PR DESCRIPTION
Fix #15845 

As a consequence, it will read the configuration produced using service bindings.