### PR TITLE
gRPC LoadBalancingPolicy Support

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
@@ -137,4 +137,10 @@ public class GrpcClientConfiguration {
     @ConfigItem
     public Optional<String> userAgent;
 
+    /**
+     * Use a custom load balancing policy.
+     * Accepted values are: {@code pick_value}, {@code round_robin}, {@code grpclb}
+     */
+    @ConfigItem(defaultValue = "pick_first")
+    public String loadBalancingPolicy;
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -86,6 +86,7 @@ public class Channels {
         }
 
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(host, port)
+                .defaultLoadBalancingPolicy(config.loadBalancingPolicy)
                 .flowControlWindow(config.flowControlWindow.orElse(DEFAULT_FLOW_CONTROL_WINDOW))
                 .keepAliveWithoutCalls(config.keepAliveWithoutCalls)
                 .maxHedgedAttempts(config.maxHedgedAttempts)


### PR DESCRIPTION
When using quarkus in kubernetes you currently will run into scaling issues if one service tries to connect to multiple backend grpc services. Kubernetes Headless services can solve this issue but in quarkus the load balancing policy can currently not be changes.

With this pull request it should add the `quarkus.grpc.clients."service-name".load-balancing-policy` field. The field will by default behave like it currently does.

Possible options for the field include `pick_first`(default), `round_robin`, `grpclb`.


refs #9326