### PR TITLE
Support @NonBlocking on ContainerRequestFilters

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1150,6 +1150,19 @@ class Filters {
 }
 ----
 
+[IMPORTANT]
+====
+Request filters are usually executed on the same thread that the method that handles the request will be executed.
+That means that if the method servicing the request is annotated with `@Blocking`, then the filters will also be run
+on the worker thread.
+If the method is annotated with `@NonBlocking` (or is not annotated at all), then the filters will also be run
+on the same event-loop thread.
+
+If however a filter needs to be run on the event-loop despite the fact that the method servicing the request will be
+run on a worker thread, then `@ServerRequestFilter(nonBlocking=true)` can be used.
+Note however, that these filters need to be run before **any** filter that does not use that setting and would run on a worker thread.
+====
+
 Similarly, response filters can be declared with the `@ServerResponseFilter` annotation:
 
 [source,java]
@@ -1827,4 +1840,3 @@ To change this behavior, set the `quarkus.rest.client.scope` property to the ful
 - a few things that don't make sense for a non-blocking implementations, such as setting the `ExecutorService`, don't work
 
 It is important to note that the `quarkus-rest-client` extension may not work properly with RESTEasy Reactive.
-

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -157,6 +157,9 @@ public class ResteasyReactiveCommonProcessor {
         if (priority != null) {
             interceptor.setPriority(priority);
         }
+        if (filterItem instanceof ContainerRequestFilterBuildItem) {
+            interceptor.setNonBlockingRequired(((ContainerRequestFilterBuildItem) filterItem).isNonBlockingRequired());
+        }
         if (interceptors instanceof PreMatchInterceptorContainer
                 && ((ContainerRequestFilterBuildItem) filterItem).isPreMatching()) {
             ((PreMatchInterceptorContainer<T>) interceptors).addPreMatchInterceptor(interceptor);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerRequestFilterBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerRequestFilterBuildItem.java
@@ -3,23 +3,31 @@ package io.quarkus.resteasy.reactive.spi;
 public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBuildItem {
 
     private final boolean preMatching;
+    private final boolean nonBlockingRequired;
 
     protected ContainerRequestFilterBuildItem(Builder builder) {
         super(builder);
         this.preMatching = builder.preMatching;
+        this.nonBlockingRequired = builder.nonBlockingRequired;
     }
 
     public ContainerRequestFilterBuildItem(String className) {
         super(className);
         this.preMatching = false;
+        this.nonBlockingRequired = false;
     }
 
     public boolean isPreMatching() {
         return preMatching;
     }
 
+    public boolean isNonBlockingRequired() {
+        return nonBlockingRequired;
+    }
+
     public static final class Builder extends AbstractInterceptorBuildItem.Builder<ContainerRequestFilterBuildItem, Builder> {
         boolean preMatching = false;
+        boolean nonBlockingRequired = false;
 
         public Builder(String className) {
             super(className);
@@ -27,6 +35,11 @@ public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBu
 
         public Builder setPreMatching(Boolean preMatching) {
             this.preMatching = preMatching;
+            return this;
+        }
+
+        public Builder setNonBlockingRequired(Boolean nonBlockingRequired) {
+            this.nonBlockingRequired = nonBlockingRequired;
             return this;
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -301,6 +301,7 @@ public class ResteasyReactiveProcessor {
         paramConverterProviders.initializeDefaultFactories(factoryFunction);
         paramConverterProviders.sort();
         interceptors.sort();
+        interceptors.getContainerRequestFilters().validateThreadModel();
 
         try (ClassCreator c = new ClassCreator(new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true),
                 QUARKUS_INIT_CLASS, null, Object.class.getName(), ResteasyReactiveInitialiser.class.getName());

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -285,6 +285,10 @@ public class ResteasyReactiveScanningProcessor {
             if (preMatchingValue != null) {
                 builder.setPreMatching(preMatchingValue.asBoolean());
             }
+            AnnotationValue nonBlockingRequiredValue = instance.value("nonBlocking");
+            if (nonBlockingRequiredValue != null) {
+                builder.setNonBlockingRequired(nonBlockingRequiredValue.asBoolean());
+            }
 
             List<AnnotationInstance> annotations = methodInfo.annotations();
             Set<String> nameBindingNames = new HashSet<>();

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/AnotherValidNonBlockingFiltersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/AnotherValidNonBlockingFiltersTest.java
@@ -1,0 +1,176 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import javax.annotation.Priority;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Headers;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class AnotherValidNonBlockingFiltersTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(StandardBlockingRequestFilter.class, AnotherStandardBlockingRequestFilter.class,
+                                    StandardNonBlockingRequestFilter.class, PreMatchingNonBlockingRequestFilter.class,
+                                    CustomFilters.class,
+                                    DummyResource.class);
+                }
+            });
+
+    @Test
+    public void testBlockingEndpoint() {
+        Headers headers = RestAssured.given().get("/dummy/blocking")
+                .then().statusCode(200).extract().headers();
+        assertEquals(
+                "1-pre-matching-non-blocking/2-another-custom-non-blocking/3-standard-non-blocking/4-standard-blocking/5-another-standard-blocking/6-custom-blocking",
+                headers.get("filter-request").getValue());
+        assertEquals(
+                "false/false/false/true/true/true",
+                headers.get("thread").getValue());
+    }
+
+    @Test
+    public void testNonBlockingEndpoint() {
+        Headers headers = RestAssured.given().get("/dummy/nonblocking")
+                .then().statusCode(200).extract().headers();
+        assertEquals(
+                "1-pre-matching-non-blocking/2-another-custom-non-blocking/3-standard-non-blocking/4-standard-blocking/5-another-standard-blocking/6-custom-blocking",
+                headers.get("filter-request").getValue());
+        assertEquals(
+                "false/false/false/false/false/false",
+                headers.get("thread").getValue());
+    }
+
+    @Blocking
+    @Path("dummy")
+    public static class DummyResource {
+
+        @Path("blocking")
+        @GET
+        public Response blocking(@Context HttpHeaders headers) {
+            return getResponse(headers);
+        }
+
+        @NonBlocking
+        @Path("nonblocking")
+        @GET
+        public Response nonblocking(@Context HttpHeaders headers) {
+            return getResponse(headers);
+        }
+
+        private Response getResponse(HttpHeaders headers) {
+            return Response.ok()
+                    .header("filter-request", headers.getHeaderString("filter-request"))
+                    .header("thread", headers.getHeaderString("thread"))
+                    .build();
+        }
+    }
+
+    @Provider
+    @PreMatching
+    @NonBlocking
+    public static class PreMatchingNonBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            headers.putSingle("filter-request", "1-pre-matching-non-blocking");
+            headers.putSingle("thread", "" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 100)
+    public static class StandardBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/4-standard-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 200)
+    public static class AnotherStandardBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/5-another-standard-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 50)
+    @NonBlocking
+    public static class StandardNonBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/3-standard-non-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    public static class CustomFilters {
+
+        @ServerRequestFilter(nonBlocking = true, priority = Priorities.USER + 20)
+        public void anotherNonBlocking(ContainerRequestContext requestContext) {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request",
+                    previousFilterHeaderValue + "/2-another-custom-non-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+
+        @ServerRequestFilter(priority = Priorities.USER + 300)
+        public void blocking(ContainerRequestContext requestContext) {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/6-custom-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/InvalidNonBlockingFiltersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/InvalidNonBlockingFiltersTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import javax.annotation.Priority;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class InvalidNonBlockingFiltersTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(StandardBlockingRequestFilter.class, StandardNonBlockingRequestFilter.class,
+                                    DummyResource.class);
+                }
+            }).assertException(t -> Assertions.assertTrue(t.getMessage().contains("StandardNonBlockingRequestFilter")));
+
+    @Test
+    public void test() {
+        fail("Should never have been called");
+    }
+
+    @Path("dummy")
+    public static class DummyResource {
+
+        @Blocking
+        @Path("blocking")
+        @GET
+        public Response blocking() {
+            return Response.ok().build();
+        }
+    }
+
+    @Provider
+    public static class StandardBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        }
+    }
+
+    @NonBlocking
+    @Provider
+    @Priority(Priorities.USER + 1)
+    public static class StandardNonBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ValidNonBlockingFiltersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ValidNonBlockingFiltersTest.java
@@ -1,0 +1,167 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import javax.annotation.Priority;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Headers;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class ValidNonBlockingFiltersTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(StandardBlockingRequestFilter.class, AnotherStandardBlockingRequestFilter.class,
+                                    StandardNonBlockingRequestFilter.class, DummyResource.class);
+                }
+            });
+
+    @Test
+    public void testBlockingEndpoint() {
+        Headers headers = RestAssured.given().get("/dummy/blocking")
+                .then().statusCode(200).extract().headers();
+        assertEquals(
+                "1-custom-non-blocking/2-another-custom-non-blocking/3-standard-non-blocking/4-standard-blocking/5-another-standard-blocking/6-custom-blocking",
+                headers.get("filter-request").getValue());
+        assertEquals(
+                "false/false/false/true/true/true",
+                headers.get("thread").getValue());
+    }
+
+    @Test
+    public void testNonBlockingEndpoint() {
+        Headers headers = RestAssured.given().get("/dummy/nonblocking")
+                .then().statusCode(200).extract().headers();
+        assertEquals(
+                "1-custom-non-blocking/2-another-custom-non-blocking/3-standard-non-blocking/4-standard-blocking/5-another-standard-blocking/6-custom-blocking",
+                headers.get("filter-request").getValue());
+        assertEquals(
+                "false/false/false/false/false/false",
+                headers.get("thread").getValue());
+    }
+
+    @Path("dummy")
+    public static class DummyResource {
+
+        @Blocking
+        @Path("blocking")
+        @GET
+        public Response blocking(@Context HttpHeaders headers) {
+            return getResponse(headers);
+        }
+
+        @Path("nonblocking")
+        @GET
+        public Response nonblocking(@Context HttpHeaders headers) {
+            return getResponse(headers);
+        }
+
+        private Response getResponse(HttpHeaders headers) {
+            return Response.ok()
+                    .header("filter-request", headers.getHeaderString("filter-request"))
+                    .header("thread", headers.getHeaderString("thread"))
+                    .build();
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 100)
+    public static class StandardBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/4-standard-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 200)
+    public static class AnotherStandardBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/5-another-standard-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.USER + 50)
+    @NonBlocking
+    public static class StandardNonBlockingRequestFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/3-standard-non-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+    public static class CustomFilters {
+
+        @ServerRequestFilter(nonBlocking = true)
+        public void firstNonBlocking(ContainerRequestContext requestContext) {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", "1-custom-non-blocking");
+            headers.putSingle("thread", "" + BlockingOperationControl.isBlockingAllowed());
+        }
+
+        @ServerRequestFilter(nonBlocking = true, priority = Priorities.USER + 20)
+        public void anotherNonBlocking(ContainerRequestContext requestContext) {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request",
+                    previousFilterHeaderValue + "/2-another-custom-non-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+
+        @ServerRequestFilter(priority = Priorities.USER + 300)
+        public void blocking(ContainerRequestContext requestContext) {
+            MultivaluedMap<String, String> headers = requestContext.getHeaders();
+            String previousFilterHeaderValue = headers.getFirst("filter-request");
+            headers.putSingle("filter-request", previousFilterHeaderValue + "/6-custom-blocking");
+            String previousThreadHeaderValue = headers.getFirst("thread");
+            headers.putSingle("thread", previousThreadHeaderValue + "/" + BlockingOperationControl.isBlockingAllowed());
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ApplicationWithBlockingTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ApplicationWithBlockingTest.java
@@ -36,6 +36,12 @@ public class ApplicationWithBlockingTest {
 
         RestAssured.get("/tname/nonblocking")
                 .then().body(Matchers.containsString("loop"), Matchers.not(Matchers.containsString("executor")));
+
+        RestAssured.get("/tname2/blocking")
+                .then().body(Matchers.containsString("executor"), Matchers.not(Matchers.containsString("loop")));
+
+        RestAssured.get("/tname2/nonblocking")
+                .then().body(Matchers.containsString("loop"), Matchers.not(Matchers.containsString("executor")));
     }
 
     @Blocking
@@ -45,6 +51,24 @@ public class ApplicationWithBlockingTest {
 
     @Path("tname")
     public static class ThreadNameResource {
+
+        @Path("blocking")
+        @GET
+        public String threadName() {
+            return Thread.currentThread().getName();
+        }
+
+        @NonBlocking
+        @Path("nonblocking")
+        @GET
+        public String nonBlocking() {
+            return Thread.currentThread().getName();
+        }
+    }
+
+    @Blocking // this should have no effect
+    @Path("tname2")
+    public static class ThreadNameResourceWithBlocking {
 
         @Path("blocking")
         @GET

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -483,14 +483,20 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             }
             Set<String> nameBindingNames = nameBindingNames(info, classNameBindings);
             boolean blocking = defaultBlocking;
-            AnnotationInstance blockingAnnotation = getInheritableAnnotation(info, BLOCKING);
-            if (blockingAnnotation != null) {
-                blocking = true;
-            } else {
-                AnnotationInstance nonBlockingAnnotation = getInheritableAnnotation(info, NON_BLOCKING);
-                if (nonBlockingAnnotation != null) {
+            Map.Entry<AnnotationTarget, AnnotationInstance> blockingAnnotation = getInheritableAnnotation(info, BLOCKING);
+            Map.Entry<AnnotationTarget, AnnotationInstance> nonBlockingAnnotation = getInheritableAnnotation(info, NON_BLOCKING);
+            if ((blockingAnnotation != null) && (nonBlockingAnnotation != null)) {
+                if (blockingAnnotation.getKey().kind() == AnnotationTarget.Kind.METHOD) {
+                    // the most specific annotation was the @Blocking annotation on the method
+                    blocking = true;
+                } else {
+                    // the most specific annotation was the @NonBlocking annotation on the method
                     blocking = false;
                 }
+            } else if ((blockingAnnotation != null) && (nonBlockingAnnotation == null)) {
+                blocking = true;
+            } else if ((nonBlockingAnnotation != null) && (blockingAnnotation == null)) {
+                blocking = false;
             }
 
             ResourceMethod method = createResourceMethod(info, methodContext)
@@ -598,13 +604,15 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         return Objects.requireNonNull(result);
     }
 
-    private static AnnotationInstance getInheritableAnnotation(MethodInfo info, DotName name) {
+    private static Map.Entry<AnnotationTarget, AnnotationInstance> getInheritableAnnotation(MethodInfo info, DotName name) {
         // try method first, class second
         AnnotationInstance annotation = info.annotation(name);
+        AnnotationTarget target = info;
         if (annotation == null) {
             annotation = info.declaringClass().classAnnotation(name);
+            target = info.declaringClass();
         }
-        return annotation;
+        return annotation != null ? new AbstractMap.SimpleEntry<>(target, annotation) : null;
     }
 
     private static String methodDescriptor(MethodInfo info) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -484,7 +484,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             Set<String> nameBindingNames = nameBindingNames(info, classNameBindings);
             boolean blocking = defaultBlocking;
             Map.Entry<AnnotationTarget, AnnotationInstance> blockingAnnotation = getInheritableAnnotation(info, BLOCKING);
-            Map.Entry<AnnotationTarget, AnnotationInstance> nonBlockingAnnotation = getInheritableAnnotation(info, NON_BLOCKING);
+            Map.Entry<AnnotationTarget, AnnotationInstance> nonBlockingAnnotation = getInheritableAnnotation(info,
+                    NON_BLOCKING);
             if ((blockingAnnotation != null) && (nonBlockingAnnotation != null)) {
                 if (blockingAnnotation.getKey().kind() == AnnotationTarget.Kind.METHOD) {
                     // the most specific annotation was the @Blocking annotation on the method

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
@@ -93,6 +93,10 @@ public class ResteasyReactiveInterceptorScanner {
             if (priorityInstance != null) {
                 interceptor.setPriority(priorityInstance.value().asInt());
             }
+            AnnotationInstance nonBlockingInstance = filterClass.classAnnotation(ResteasyReactiveDotNames.NON_BLOCKING);
+            if (nonBlockingInstance != null) {
+                interceptor.setNonBlockingRequired(true);
+            }
             if (interceptorContainer instanceof PreMatchInterceptorContainer
                     && filterClass.classAnnotation(ResteasyReactiveDotNames.PRE_MATCHING) != null) {
                 ((PreMatchInterceptorContainer<T>) interceptorContainer).addPreMatchInterceptor(interceptor);

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
@@ -10,6 +10,7 @@ public class ResourceInterceptor<T>
 
     private BeanFactory<T> factory;
     private Integer priority = Priorities.USER; // default priority as defined by spec
+    private boolean nonBlockingRequired; // whether or not @NonBlocking was specified on the class
 
     /**
      * The class names of the {@code @NameBinding} annotations that the method is annotated with.
@@ -53,6 +54,14 @@ public class ResourceInterceptor<T>
     public ResourceInterceptor<T> setClassName(String className) {
         this.className = className;
         return this;
+    }
+
+    public boolean isNonBlockingRequired() {
+        return nonBlockingRequired;
+    }
+
+    public void setNonBlockingRequired(boolean nonBlockingRequired) {
+        this.nonBlockingRequired = nonBlockingRequired;
     }
 
     // spec says that writer interceptors are sorted in ascending order

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
@@ -1,11 +1,13 @@
 package org.jboss.resteasy.reactive.server;
 
+import io.smallrye.common.annotation.Blocking;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
@@ -83,4 +85,14 @@ public @interface ServerRequestFilter {
      * Whether or not the filter is a pre-matching filter
      */
     boolean preMatching() default false;
+
+    /**
+     * Normally {@link ContainerRequestFilter} classes are run by RESTEasy Reactive on the same thread as the Resource
+     * Method - this means than when a Resource Method is annotated with {@link Blocking}, the filters will also be run
+     * on a worker thread.
+     * This is meant to be set to {@code true} if a filter should be run on the event-loop even if the target Resource
+     * method is going to be run on the worker thread.
+     * For this to work, this filter must be run before any of the filters when non-blocking is not required.
+     */
+    boolean nonBlocking() default false;
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.Feature;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.model.ResourceClass;
 import org.jboss.resteasy.reactive.common.model.ResourceFeature;
+import org.jboss.resteasy.reactive.common.model.ResourceInterceptor;
 import org.jboss.resteasy.reactive.common.model.ResourceInterceptors;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.server.core.Deployment;
@@ -188,9 +189,11 @@ public class RuntimeDeploymentManager {
         }
         if (!interceptors.getContainerRequestFilters().getPreMatchInterceptors().isEmpty()) {
             preMatchHandlers = new ArrayList<>(interceptorDeployment.getPreMatchContainerRequestFilters().size());
-            for (ContainerRequestFilter containerRequestFilter : interceptorDeployment.getPreMatchContainerRequestFilters()
-                    .values()) {
-                preMatchHandlers.add(new ResourceRequestFilterHandler(containerRequestFilter, true));
+            for (Map.Entry<ResourceInterceptor<ContainerRequestFilter>, ContainerRequestFilter> entry : interceptorDeployment
+                    .getPreMatchContainerRequestFilters()
+                    .entrySet()) {
+                preMatchHandlers
+                        .add(new ResourceRequestFilterHandler(entry.getValue(), true, entry.getKey().isNonBlockingRequired()));
             }
         }
         for (int i = 0; i < info.getGlobalHandlerCustomizers().size(); i++) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeInterceptorDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeInterceptorDeployment.java
@@ -91,10 +91,11 @@ public class RuntimeInterceptorDeployment {
         for (ContainerResponseFilter responseFilter : responseFilters) {
             globalResponseInterceptorHandlers.add(new ResourceResponseFilterHandler(responseFilter));
         }
-        Collection<ContainerRequestFilter> requestFilters = globalRequestInterceptorsMap.values();
-        globalRequestInterceptorHandlers = new ArrayList<>(requestFilters.size());
-        for (ContainerRequestFilter requestFilter : requestFilters) {
-            globalRequestInterceptorHandlers.add(new ResourceRequestFilterHandler(requestFilter, false));
+        globalRequestInterceptorHandlers = new ArrayList<>(globalRequestInterceptorsMap.size());
+        for (Map.Entry<ResourceInterceptor<ContainerRequestFilter>, ContainerRequestFilter> entry : globalRequestInterceptorsMap
+                .entrySet()) {
+            globalRequestInterceptorHandlers
+                    .add(new ResourceRequestFilterHandler(entry.getValue(), false, entry.getKey().isNonBlockingRequired()));
         }
 
         InterceptorHandler globalInterceptorHandler = null;
@@ -306,8 +307,8 @@ public class RuntimeInterceptorDeployment {
             return handlers;
         }
 
-        public List<ServerRestHandler> setupRequestFilterHandler() {
-            List<ServerRestHandler> handlers = new ArrayList<>();
+        public List<ResourceRequestFilterHandler> setupRequestFilterHandler() {
+            List<ResourceRequestFilterHandler> handlers = new ArrayList<>();
             // according to the spec, global request filters apply everywhere
             // and named request filters only apply to methods with exactly matching "qualifiers"
             if (method.getNameBindingNames().isEmpty() && methodSpecificRequestInterceptorsMap.isEmpty()) {
@@ -323,12 +324,35 @@ public class RuntimeInterceptorDeployment {
                 TreeMap<ResourceInterceptor<ContainerRequestFilter>, ContainerRequestFilter> interceptorsToUse = buildInterceptorMap(
                         globalRequestInterceptorsMap, nameRequestInterceptorsMap, methodSpecificRequestInterceptorsMap, method,
                         false);
+                // because named filters are different for each Resource method,
+                // we need to make sure that the final set of filters do not alternate the threading model
+                // from blocking to non-blocking
+                validateRequestFilterThreadModel(interceptorsToUse.keySet());
                 for (Map.Entry<ResourceInterceptor<ContainerRequestFilter>, ContainerRequestFilter> entry : interceptorsToUse
                         .entrySet()) {
-                    handlers.add(new ResourceRequestFilterHandler(entry.getValue(), false));
+                    handlers.add(
+                            new ResourceRequestFilterHandler(entry.getValue(), false, entry.getKey().isNonBlockingRequired()));
                 }
             }
             return handlers;
+        }
+    }
+
+    /**
+     * Validates that any {@code ContainerRequestFilter} that has {@code nonBlockingRequired} set, comes before any other filter
+     */
+    public static void validateRequestFilterThreadModel(
+            Collection<ResourceInterceptor<ContainerRequestFilter>> requestFilters) {
+        boolean unsetNonBlockingInterceptorFound = false;
+        for (ResourceInterceptor<ContainerRequestFilter> filter : requestFilters) {
+            if (filter.isNonBlockingRequired()) {
+                if (unsetNonBlockingInterceptorFound) {
+                    throw new RuntimeException(
+                            "ContainerRequestFilters that are marked as '@NonBlocking' must be executed before any other filters.");
+                }
+            } else {
+                unsetNonBlockingInterceptorFound = true;
+            }
         }
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceRequestFilterHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceRequestFilterHandler.java
@@ -9,10 +9,12 @@ public class ResourceRequestFilterHandler implements ServerRestHandler {
 
     private final ContainerRequestFilter filter;
     private final boolean preMatch;
+    private final boolean nonBlockingRequired;
 
-    public ResourceRequestFilterHandler(ContainerRequestFilter filter, boolean preMatch) {
+    public ResourceRequestFilterHandler(ContainerRequestFilter filter, boolean preMatch, boolean nonBlockingRequired) {
         this.filter = filter;
         this.preMatch = preMatch;
+        this.nonBlockingRequired = nonBlockingRequired;
     }
 
     public ContainerRequestFilter getFilter() {
@@ -21,6 +23,10 @@ public class ResourceRequestFilterHandler implements ServerRestHandler {
 
     public boolean isPreMatch() {
         return preMatch;
+    }
+
+    public boolean isNonBlockingRequired() {
+        return nonBlockingRequired;
     }
 
     @Override


### PR DESCRIPTION
The idea is to allow the first filters to run on the event-loop
thread even of the Resource method that will handle the request
is going to be executed on a worker thread

Resolves: #15732