### PR TITLE
Return correct parent when searching executable on PATH

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/core/ExecuteUtil.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/core/ExecuteUtil.java
@@ -9,10 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -78,11 +75,10 @@ public class ExecuteUtil {
     }
 
     private static String findExecutable(String exec) {
-        Optional<Path> mvnPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator)))
-                .map(Paths::get)
-                .filter(path -> Files.exists(path.resolve(exec))).findFirst();
-
-        return mvnPath.map(value -> value.getParent().toString()).orElse(null);
+        return Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator)))
+                .map(Paths::get).map(path -> path.resolve(exec).toFile())
+                .filter(File::exists).findFirst()
+                .map(File::getParent).orElse(null);
     }
 
     private static int executeWrapper(File wrapper, QuarkusCli cli, String... args) throws Exception {


### PR DESCRIPTION
The CLI resolution of the executable file for Maven or Gradle is returning the parent path on PATH when the respective wrapper is absent on work directory. The method `findExecutable(String)` was refactored using a better chain for stream resolution with the correct path containing the executable.

To reproduce, create a project without both Maven and Gradle wrappers and execute a command.

```console
$ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$ which mvn
/usr/local/bin/mvn
$ java -jar quarkus-cli-1.13.0.CR1-runner.jar -e clean
java.io.IOException: Cannot run program "/usr/local/mvn" (in directory "/home/bruno/workspace/quarkus-app"): error=2, No such file or directory
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at io.quarkus.cli.core.ExecuteUtil.executeProcess(ExecuteUtil.java:125)
	at io.quarkus.cli.core.ExecuteUtil.executeMaven(ExecuteUtil.java:77)
	at io.quarkus.cli.core.ExecuteUtil.executeMavenTarget(ExecuteUtil.java:214)
	at io.quarkus.cli.QuarkusCli.executeBuildsystem(QuarkusCli.java:96)
	at io.quarkus.cli.QuarkusCli$ExecutionStrategy.execute(QuarkusCli.java:156)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at io.quarkus.cli.QuarkusCli.run(QuarkusCli.java:86)
	at io.quarkus.cli.QuarkusCli_ClientProxy.run(QuarkusCli_ClientProxy.zig:247)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:122)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:66)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:42)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:30)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:340)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:271)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
	... 13 more
Failure executing build command : mvn clean
```