### PR TITLE
ArC - fix the algorithm to find event parameter qualifiers

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
@@ -86,7 +86,7 @@ public class DisposerInfo implements InjectionTargetInfo {
     MethodParameterInfo initDisposedParam(MethodInfo disposerMethod) {
         List<MethodParameterInfo> disposedParams = new ArrayList<>();
         for (AnnotationInstance annotation : disposerMethod.annotations()) {
-            if (Kind.METHOD_PARAMETER.equals(annotation.target().kind()) && annotation.name().equals(DotNames.DISPOSES)) {
+            if (Kind.METHOD_PARAMETER == annotation.target().kind() && annotation.name().equals(DotNames.DISPOSES)) {
                 disposedParams.add(annotation.target().asMethodParameter());
             }
         }


### PR DESCRIPTION
- the Jandex MethodParameterInfo does not implement equals()/hashCode()
and annotations declared on a parameter of the same method may have
different MethodParameterInfo target instances
- resolves #15886