### PR TITLE
Flatten quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5115,4 +5115,22 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten-platform-bom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,18 @@
     <version>999-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <description>Quarkus - Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM</description>
+    <url>https://github.com/quarkusio/quarkus</url>
+
+    <developers>
+        <developer>
+            <id>quarkus</id>
+            <name>Quarkus Community</name>
+            <organization>Quarkus</organization>
+            <organizationUrl>https://quarkus.io</organizationUrl>
+        </developer>
+    </developers>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -29,6 +41,11 @@
         <developerConnection>scm:git:git@github.com:quarkusio/quarkus.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/quarkusio/quarkus/issues/</url>
+    </issueManagement>
 
     <properties>
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>


### PR DESCRIPTION
Flatten quarkus-bom with `io.quarkus:quarkus-platform-bom-maven-plugin`'s `flatten-platform-bom` goal. This goal generates a POM file containing the effective set of the managed dependencies of the original BOM ordered alphabetically (although there is a parameter to preserve the original ordering) with the exception of the Quarkus platform artifacts (such as the json descriptor and properties) that are moved to the top of the BOM.