### PR TITLE
Update multistage docker image tag used in doc

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -540,7 +540,7 @@ Sample Dockerfile for building with Gradle:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/centos-quarkus-maven:{graalvm-version}-java8 AS build
+FROM quay.io/quarkus/centos-quarkus-maven:{graalvm-flavor} AS build
 COPY src /usr/src/app/src
 COPY build.gradle /usr/src/app
 COPY settings.gradle /usr/src/app


### PR DESCRIPTION
This replace `21.0.0-java8` to `21.0.0-java11` in documentation. 


close #15904 