### PR TITLE
Substitute MappedByteBuffer#force0 only in JDK 15 or earlier

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/MappedByteBufferReplacement.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/MappedByteBufferReplacement.java
@@ -5,8 +5,9 @@ import java.nio.MappedByteBuffer;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK15OrEarlier;
 
-@TargetClass(MappedByteBuffer.class)
+@TargetClass(value = MappedByteBuffer.class, onlyWith = JDK15OrEarlier.class)
 final class MappedByteBufferReplacement {
 
     @Substitute


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/15903

I haven't tested this against JDK 16, since Graal VM needs to be built from source and I need to refresh my current setup a bit to get that building.

/cc @cstancu