### PR TITLE
GRPC port 9001 for tests

### DIFF
--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -224,7 +224,8 @@ annotated method on a worker thread instead of the I/O thread (event-loop).
 The services are _served_ by a _server_.
 Available services (_CDI beans_) are automatically registered and exposed.
 
-By default, the server is exposed on `localhost:9000`, and uses _plain-text_ (so no TLS).
+By default, the server is exposed on `localhost:9000`, and uses _plain-text_ (so no TLS) when
+running normally, and `localhost:9001` for tests.
 
 Run the application using: `mvn quarkus:dev`.
 

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -95,6 +96,7 @@ public class GrpcServerProcessor {
     @Record(value = ExecutionTime.RUNTIME_INIT)
     ServiceStartBuildItem build(GrpcServerRecorder recorder, GrpcConfiguration config,
             ShutdownContextBuildItem shutdown, List<BindableServiceBuildItem> bindables,
+            LaunchModeBuildItem launchModeBuildItem,
             VertxBuildItem vertx) {
 
         // Build the list of blocking methods per service implementation
@@ -106,7 +108,7 @@ public class GrpcServerProcessor {
         }
 
         if (!bindables.isEmpty()) {
-            recorder.initializeGrpcServer(vertx.getVertx(), config, shutdown, blocking);
+            recorder.initializeGrpcServer(vertx.getVertx(), config, shutdown, blocking, launchModeBuildItem.getLaunchMode());
             return new ServiceStartBuildItem(GRPC_SERVER);
         }
         return null;

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/GrpcServiceTestBase.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/GrpcServiceTestBase.java
@@ -37,7 +37,7 @@ public class GrpcServiceTestBase {
 
     @BeforeEach
     public void init() throws Exception {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                 .usePlaintext()
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithSSLTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithSSLTest.java
@@ -52,7 +52,7 @@ public class MutinyGrpcServiceWithSSLTest extends GrpcServiceTestBase {
         SslContext sslcontext = GrpcSslContexts.forClient()
                 .trustManager(createTrustAllTrustManager())
                 .build();
-        channel = NettyChannelBuilder.forAddress("localhost", 9000)
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
                 .sslContext(sslcontext)
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLFromClasspathTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLFromClasspathTest.java
@@ -54,7 +54,7 @@ public class RegularGrpcServiceWithSSLFromClasspathTest extends GrpcServiceTestB
         SslContext sslcontext = GrpcSslContexts.forClient()
                 .trustManager(createTrustAllTrustManager())
                 .build();
-        channel = NettyChannelBuilder.forAddress("localhost", 9000)
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
                 .sslContext(sslcontext)
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLTest.java
@@ -52,7 +52,7 @@ public class RegularGrpcServiceWithSSLTest extends GrpcServiceTestBase {
         SslContext sslcontext = GrpcSslContexts.forClient()
                 .trustManager(createTrustAllTrustManager())
                 .build();
-        channel = NettyChannelBuilder.forAddress("localhost", 9000)
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
                 .sslContext(sslcontext)
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
@@ -52,7 +52,7 @@ public class BlockingServiceTest {
 
     @BeforeEach
     public void init() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                 .usePlaintext()
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityReversedTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityReversedTest.java
@@ -40,7 +40,7 @@ public class ServerInterceptorPriorityReversedTest {
 
     @BeforeEach
     public void init() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                 .usePlaintext()
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityTest.java
@@ -40,7 +40,7 @@ public class ServerInterceptorPriorityTest {
 
     @BeforeEach
     public void init() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                 .usePlaintext()
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorRegistrationTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorRegistrationTest.java
@@ -38,7 +38,7 @@ public class ServerInterceptorRegistrationTest {
 
     @BeforeEach
     public void init() throws Exception {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                 .usePlaintext()
                 .build();
     }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/scaling/ScalingTestBase.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/scaling/ScalingTestBase.java
@@ -24,7 +24,7 @@ public class ScalingTestBase {
         List<Callable<String>> calls = new ArrayList<>();
         for (int i = 0; i < requestNo; i++) {
             calls.add(() -> {
-                ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9000)
+                ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9001)
                         .usePlaintext()
                         .build();
                 HelloReply reply = GreeterGrpc.newBlockingStub(channel)

--- a/extensions/grpc/deployment/src/test/resources/blocking-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/blocking-config.properties
@@ -1,4 +1,7 @@
 quarkus.grpc.clients.reflection-service.host=localhost
+quarkus.grpc.clients.reflection-service.port=9001
 quarkus.grpc.clients.test-service.host=localhost
+quarkus.grpc.clients.test-service.port=9001
 quarkus.grpc.clients.greeter-service.host=localhost
+quarkus.grpc.clients.greeter-service.port=9001
 quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/deployment/src/test/resources/blocking-test-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/blocking-test-config.properties
@@ -1,2 +1,3 @@
 quarkus.grpc.clients.blocking-test.host=localhost
+quarkus.grpc.clients.blocking-test.port=9001
 quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/deployment/src/test/resources/call-from-blocking-service.properties
+++ b/extensions/grpc/deployment/src/test/resources/call-from-blocking-service.properties
@@ -1,2 +1,4 @@
 quarkus.grpc.clients.greeter.host=localhost
+quarkus.grpc.clients.greeter.port=9001
 quarkus.grpc.clients.service3.host=localhost
+quarkus.grpc.clients.service3.port=9001

--- a/extensions/grpc/deployment/src/test/resources/grpc-client-tls-configuration.properties
+++ b/extensions/grpc/deployment/src/test/resources/grpc-client-tls-configuration.properties
@@ -1,4 +1,5 @@
 quarkus.grpc.clients.hello.host=localhost
+quarkus.grpc.clients.hello.port=9001
 quarkus.grpc.clients.hello.ssl.trust-store=src/test/resources/tls-from-file/ca.pem
 
 quarkus.grpc.server.ssl.certificate=src/test/resources/tls-from-file/server.pem

--- a/extensions/grpc/deployment/src/test/resources/health-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/health-config.properties
@@ -1,3 +1,4 @@
 quarkus.grpc.clients.health-service.host=localhost
+quarkus.grpc.clients.health-service.port=9001
 quarkus.grpc.clients.foo.host=localhost
 quarkus.grpc.server.port=9000

--- a/extensions/grpc/deployment/src/test/resources/hello-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/hello-config.properties
@@ -1,4 +1,5 @@
 quarkus.grpc.clients.hello-service.host=localhost
+quarkus.grpc.clients.hello-service.port=9001
 quarkus.grpc.clients.hello-service.keep-alive-timeout=1s
 quarkus.grpc.clients.hello-service-2.host=localhost
 quarkus.grpc.clients.hello-service-2.retry=true

--- a/extensions/grpc/deployment/src/test/resources/multiple-instances-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/multiple-instances-config.properties
@@ -1,3 +1,4 @@
 quarkus.grpc.server.instances=3
 quarkus.grpc.clients.hello-service.host=localhost
+quarkus.grpc.clients.hello-service.port=9001
 quarkus.grpc.clients.hello-service.keep-alive-timeout=1s

--- a/extensions/grpc/deployment/src/test/resources/reflection-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/reflection-config.properties
@@ -1,2 +1,3 @@
 quarkus.grpc.clients.reflection-service.host=localhost
+quarkus.grpc.clients.reflection-service.port=9001
 quarkus.grpc.server.enable-reflection-service=true

--- a/extensions/grpc/deployment/src/test/resources/single-instance-config.properties
+++ b/extensions/grpc/deployment/src/test/resources/single-instance-config.properties
@@ -1,3 +1,4 @@
 quarkus.grpc.server.instances=1
 quarkus.grpc.clients.hello-service.host=localhost
+quarkus.grpc.clients.hello-service.port=9001
 quarkus.grpc.clients.hello-service.keep-alive-timeout=1s

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -18,6 +18,12 @@ public class GrpcServerConfiguration {
     public int port;
 
     /**
+     * The gRPC Server port used for tests.
+     */
+    @ConfigItem(defaultValue = "9001")
+    public int testPort;
+
+    /**
      * The gRPC server host.
      */
     @ConfigItem(defaultValue = "0.0.0.0")

--- a/integration-tests/grpc-health/src/test/resources/health-config.properties
+++ b/integration-tests/grpc-health/src/test/resources/health-config.properties
@@ -1,1 +1,2 @@
 quarkus.grpc.clients.health-service.host=localhost
+quarkus.grpc.clients.health-service.port=9001

--- a/integration-tests/grpc-health/src/test/resources/no-mp-health-config.properties
+++ b/integration-tests/grpc-health/src/test/resources/no-mp-health-config.properties
@@ -1,2 +1,3 @@
 quarkus.grpc.clients.health-service.host=localhost
+quarkus.grpc.clients.health-service.port=9001
 quarkus.grpc.server.health.enabled=false

--- a/integration-tests/grpc-interceptors/src/main/resources/application.properties
+++ b/integration-tests/grpc-interceptors/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001

--- a/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
+++ b/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001
 quarkus.grpc.clients.hello.ssl.certificate=src/main/resources/tls/client.pem
 quarkus.grpc.clients.hello.ssl.key=src/main/resources/tls/client.key
 quarkus.grpc.clients.hello.ssl.trust-store=src/main/resources/tls/ca.pem

--- a/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTest.java
+++ b/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTest.java
@@ -35,7 +35,7 @@ class HelloWorldMutualTlsServiceTest {
                 new File("src/main/resources/tls/client.key"));
         SslContext context = builder.build();
 
-        channel = NettyChannelBuilder.forAddress("localhost", 9000)
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
                 .sslContext(context)
                 .build();
     }

--- a/integration-tests/grpc-plain-text-gzip/src/main/resources/application.properties
+++ b/integration-tests/grpc-plain-text-gzip/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001
 quarkus.grpc.server.compression=gzip

--- a/integration-tests/grpc-plain-text-gzip/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
+++ b/integration-tests/grpc-plain-text-gzip/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
@@ -24,7 +24,7 @@ class HelloWorldServiceTest {
 
     @BeforeEach
     public void init() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001).usePlaintext().build();
     }
 
     @AfterEach

--- a/integration-tests/grpc-plain-text-mutiny/src/main/resources/application.properties
+++ b/integration-tests/grpc-plain-text-mutiny/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001

--- a/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
+++ b/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
@@ -24,7 +24,7 @@ class HelloWorldServiceTest {
 
     @BeforeEach
     public void init() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001).usePlaintext().build();
     }
 
     @AfterEach

--- a/integration-tests/grpc-proto-v2/src/main/resources/application.properties
+++ b/integration-tests/grpc-proto-v2/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001

--- a/integration-tests/grpc-proto-v2/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
+++ b/integration-tests/grpc-proto-v2/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
@@ -24,7 +24,7 @@ class HelloWorldServiceTest {
 
     @BeforeEach
     void setUp() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001).usePlaintext().build();
     }
 
     @AfterEach

--- a/integration-tests/grpc-streaming/src/main/resources/application.properties
+++ b/integration-tests/grpc-streaming/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.grpc.clients.streaming.host=localhost
+%test.quarkus.grpc.clients.streaming.port=9001

--- a/integration-tests/grpc-streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingServiceTest.java
+++ b/integration-tests/grpc-streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingServiceTest.java
@@ -29,7 +29,7 @@ public class StreamingServiceTest {
 
     @BeforeEach
     public void getChannel() {
-        channel = ManagedChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", 9001).usePlaintext().build();
     }
 
     @AfterEach

--- a/integration-tests/grpc-tls/src/main/resources/application.properties
+++ b/integration-tests/grpc-tls/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001
 quarkus.grpc.clients.hello.ssl.trust-store=tls/ca.pem
 
 quarkus.grpc.server.ssl.certificate=tls/server.pem

--- a/integration-tests/grpc-tls/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldTlsServiceTest.java
+++ b/integration-tests/grpc-tls/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldTlsServiceTest.java
@@ -33,7 +33,7 @@ class HelloWorldTlsServiceTest {
         builder.trustManager(new File("src/main/resources/tls/ca.pem"));
         SslContext context = builder.build();
 
-        channel = NettyChannelBuilder.forAddress("localhost", 9000)
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
                 .sslContext(context)
                 .build();
     }


### PR DESCRIPTION
GRPC does not bind to a different port for testing,
which stops you running tests while the app is running.

This will cause problems for continous testing.