### PR TITLE
Disable -XX:TieredStopAtLevel=1 when GraalVM is used as the JDK

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -279,8 +279,11 @@ public abstract class QuarkusDevModeLauncher {
      */
     protected void prepare() throws Exception {
 
-        // the following flags reduce startup time and are acceptable only for dev purposes
-        args.add("-XX:TieredStopAtLevel=1");
+        if (!JavaVersionUtil.isGraalvmJdk()) {
+            // prevent C2 compiler for kicking in - makes startup a little faster
+            // it only makes sense in dev-mode but it is not available when GraalVM is used as the JDK
+            args.add("-XX:TieredStopAtLevel=1");
+        }
 
         if (suspend != null) {
             switch (suspend.toLowerCase(Locale.ENGLISH)) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -9,6 +9,7 @@ public class JavaVersionUtil {
 
     private static boolean IS_JAVA_11_OR_NEWER;
     private static boolean IS_JAVA_13_OR_NEWER;
+    private static boolean IS_GRAALVM_JDK;
 
     static {
         performChecks();
@@ -25,6 +26,9 @@ public class JavaVersionUtil {
             IS_JAVA_11_OR_NEWER = false;
             IS_JAVA_13_OR_NEWER = false;
         }
+
+        String vmVendor = System.getProperty("java.vm.vendor");
+        IS_GRAALVM_JDK = (vmVendor != null) && vmVendor.startsWith("GraalVM");
     }
 
     public static boolean isJava11OrHigher() {
@@ -33,5 +37,9 @@ public class JavaVersionUtil {
 
     public static boolean isJava13OrHigher() {
         return IS_JAVA_13_OR_NEWER;
+    }
+
+    public static boolean isGraalvmJdk() {
+        return IS_GRAALVM_JDK;
     }
 }


### PR DESCRIPTION
This is done to prevent the following warning:

`OpenJDK 64-Bit Server VM warning: forcing TieredStopAtLevel to full optimization because JVMCI is enabled`