### PR TITLE
Graceful shutdown fixes

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -94,7 +94,7 @@ public class ExecutorRecorder {
                 long start = System.nanoTime();
                 for (;;)
                     try {
-                        if (!executor.awaitTermination(Math.min(remaining, intervalRemaining), TimeUnit.MILLISECONDS)) {
+                        if (!executor.awaitTermination(Math.min(remaining, intervalRemaining), TimeUnit.NANOSECONDS)) {
                             long elapsed = System.nanoTime() - start;
                             intervalRemaining -= elapsed;
                             remaining -= elapsed;

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -281,10 +281,11 @@ public class QuartzScheduler implements Scheduler {
      *
      * @param event ignored
      */
-    void destroy(@BeforeDestroyed(ApplicationScoped.class) Object event) { //
+    void destroy(@Observes @BeforeDestroyed(ApplicationScoped.class) Object event) {
         if (scheduler != null) {
             try {
-                scheduler.shutdown(true); // gracefully shutdown
+                // Note that this method does not return until all currently executing jobs have completed
+                scheduler.shutdown(true);
             } catch (SchedulerException e) {
                 LOGGER.warnf("Unable to gracefully shutdown the scheduler", e);
             }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/shutdown/ShutdownTimeoutDefaultExecutorTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/shutdown/ShutdownTimeoutDefaultExecutorTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.vertx.http.shutdown;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.ObservesAsync;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Tests that shutdown will wait for current requests to finish, up to the timeout specified.
+ * 
+ * This test records the current time, then sends a request to an endpoint that will take 50s to finish.
+ * 
+ * After undeploy we verify that less than 50s has elapsed, as the shutdown should have proceeded anyway once
+ * the timeout of 100ms was reached.
+ */
+public class ShutdownTimeoutDefaultExecutorTest {
+
+    protected static final int HANDLER_WAIT_TIME = 50000;
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setAllowTestClassOutsideDeployment(true)
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(ShutdownTimeoutDefaultExecutorTest.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.shutdown.timeout=PT0.1S\nquarkus.thread-pool.shutdown-check-interval=PT0.2S"),
+                                    "application.properties");
+                }
+            })
+            .setAfterUndeployListener(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ShutdownTimer.socket.close();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    Assertions.assertTrue(System.currentTimeMillis() - ShutdownTimer.requestStarted < HANDLER_WAIT_TIME);
+                }
+            });
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testShutdownBehaviour() throws Exception {
+        ShutdownTimer.requestStarted = System.currentTimeMillis();
+        ShutdownTimer.socket = new Socket(url.getHost(), url.getPort());
+        ShutdownTimer.socket.getOutputStream()
+                .write("GET /shutdown HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+        Thread.sleep(1000);
+    }
+
+    @ApplicationScoped
+    public static class ShutdownHandler {
+
+        public void setup(@Observes Router router, Event<ShutdownHandler> event) {
+            ShutdownHandler thisHandler = this;
+            router.get("/shutdown").handler(new Handler<RoutingContext>() {
+                @Override
+                public void handle(RoutingContext routingContext) {
+                    event.fireAsync(thisHandler).thenRun(new Runnable() {
+                        @Override
+                        public void run() {
+                            routingContext.response().end();
+                        }
+                    });
+                }
+            });
+        }
+
+        // This observer is executed on a thread from the default executor
+        void blockExecutor(@ObservesAsync ShutdownHandler ignoreMe) throws InterruptedException {
+            TimeUnit.MILLISECONDS.sleep(HANDLER_WAIT_TIME);
+        }
+
+    }
+}


### PR DESCRIPTION
- fix ExecutorRecorder to interpret the shutdown timeout property
correctly + test
- fix the graceful shutdown logic in QuartzScheduler
- resolves #15908