### PR TITLE
Fixes quarkus-platform native TS config

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -72,6 +72,30 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
     @Parameter(property = "ignoredEntries")
     private String[] ignoredEntries;
 
+    /**
+     * Coordinates of the Maven artifact containing the original Java application to build the native image for.
+     * If not provided, the current project is assumed to be the original Java application.
+     * <p>
+     * The coordinates are expected to be expressed in the following format:
+     * <p>
+     * groupId:artifactId:classifier:type:version
+     * <p>
+     * With the classifier, type and version being optional.
+     * <p>
+     * If the type is missing, the artifact is assumed to be of type JAR.
+     * <p>
+     * If the version is missing, the artifact is going to be looked up among the project dependencies using the provided
+     * coordinates.
+     *
+     * <p>
+     * However, if the expression consists of only three parts, it is assumed to be groupId:artifactId:version.
+     *
+     * <p>
+     * If the expression consists of only four parts, it is assumed to be groupId:artifactId:classifier:type.
+     */
+    @Parameter(required = false, property = "appArtifact")
+    private String appArtifact;
+
     private AppArtifactKey projectId;
 
     @Override
@@ -104,6 +128,10 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
      * @throws MojoFailureException in case of a failure
      */
     protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
+
+    protected String appArtifactCoords() {
+        return appArtifact;
+    }
 
     protected RepositorySystem repositorySystem() {
         return bootstrapProvider.repositorySystem();
@@ -145,6 +173,8 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
         return projectId == null ? projectId = new AppArtifactKey(project.getGroupId(), project.getArtifactId()) : projectId;
     }
 
+    // @deprecated in 1.14.0.Final
+    @Deprecated
     protected AppArtifact projectArtifact() throws MojoExecutionException {
         return bootstrapProvider.projectArtifact(this);
     }


### PR DESCRIPTION
quarkus-platform TS config was using native-image goal of the quarkus-maven-plugin that was recently removed. `native-image` allowed to configure an alternative artifact as the app artifact in place of the current project. Which is how imported tests are run. With the `native-image` goal removed there is no way to configure the alternative app artifact.
This PR adds `appArtifact` parameter to the QuarkusBootstrapMojo that is equivalent to the removed from the NativeImageMojo one.