### PR TITLE
Update OidcConfigurationMetadata to return the scopes and minor error log updates

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -105,9 +105,11 @@ public class OidcClientImpl implements OidcClient {
             }
             return new Tokens(accessToken, accessTokenExpiresAt, oidcConfig.refreshTokenTimeSkew.orElse(null), refreshToken);
         } else {
-            LOG.debugf("%s OidcClient has failed to complete the %s grant request: %s", oidcConfig.getId().get(),
-                    (refresh ? OidcConstants.REFRESH_TOKEN_GRANT : grantType), resp.bodyAsString());
-            throw new OidcClientException();
+            String errorMessage = resp.bodyAsString();
+            LOG.debugf("%s OidcClient has failed to complete the %s grant request:  status: %d, error message: %s",
+                    oidcConfig.getId().get(), (refresh ? OidcConstants.REFRESH_TOKEN_GRANT : grantType), resp.statusCode(),
+                    errorMessage);
+            throw new OidcClientException(errorMessage);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -1,8 +1,10 @@
 package io.quarkus.oidc;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class OidcConfigurationMetadata {
@@ -13,6 +15,7 @@ public class OidcConfigurationMetadata {
     private static final String JWKS_ENDPOINT = "jwks_uri";
     private static final String USERINFO_ENDPOINT = "userinfo_endpoint";
     private static final String END_SESSION_ENDPOINT = "end_session_endpoint";
+    private static final String SCOPES_SUPPORTED = "scopes_supported";
 
     private final String tokenUri;
     private final String introspectionUri;
@@ -74,12 +77,27 @@ public class OidcConfigurationMetadata {
         return endSessionUri;
     }
 
+    public List<String> getSupportedScopes() {
+        return getStringList(SCOPES_SUPPORTED);
+    }
+
     public String getIssuer() {
         return issuer;
     }
 
     public String get(String propertyName) {
-        return json != null ? null : json.getString(propertyName);
+        return json == null ? null : json.getString(propertyName);
+    }
+
+    public List<String> getStringList(String propertyName) {
+        JsonArray array = json == null ? null : json.getJsonArray(propertyName);
+        if (array != null) {
+            @SuppressWarnings("unchecked")
+            List<String> values = array.getList();
+            return Collections.unmodifiableList(values);
+        } else {
+            return null;
+        }
     }
 
     public boolean contains(String propertyName) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -127,11 +127,9 @@ public class OidcProviderClient {
         if (resp.statusCode() == 200) {
             return resp.bodyAsJsonObject();
         } else {
-            String error = resp.bodyAsString();
-            if (error != null) {
-                LOG.debugf("Request has failed: %s", error);
-            }
-            throw new OIDCException();
+            String errorMessage = resp.bodyAsString();
+            LOG.debugf("Request has failed: status: %d, error message: %s", resp.statusCode(), errorMessage);
+            throw new OIDCException(errorMessage);
         }
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.keycloak;
 
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
@@ -59,6 +61,12 @@ public class ProtectedResource {
     @Path("configMetadataIssuer")
     public String configMetadataIssuer() {
         return configMetadata.getIssuer();
+    }
+
+    @GET
+    @Path("configMetadataScopes")
+    public String configMetadataScopes() {
+        return configMetadata.getSupportedScopes().stream().collect(Collectors.joining(","));
     }
 
     @GET

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -73,6 +73,11 @@ public class CodeFlowTest {
                     KeycloakRealmResourceManager.KEYCLOAK_SERVER_URL + "/realms/" + KeycloakRealmResourceManager.KEYCLOAK_REALM,
                     page.asText());
 
+            page = webClient.getPage("http://localhost:8081/web-app/configMetadataScopes");
+
+            assertTrue(page.asText().contains("openid"));
+            assertTrue(page.asText().contains("profile"));
+
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #15880.
(Not as originally suggested in the description but only by adding an option to check these scopes, see the last comment)

Also:
- minor updates to the way the OIDC HTTP response errors are logged - right now, if for example, the code grant fails, one sees something like `Exception during the code to token exchange: null` - the error is logged at the lower level `OidcProviderClient` but not propagated since it is only an HTTP status failure.
So I've updated the code to propagate the message - while trying to avoid duplicating the complete error message.