### PR TITLE
Runtime initialize RandomUtil in artemis-core extension

### DIFF
--- a/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
+++ b/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
@@ -49,7 +49,8 @@ public class ArtemisCoreProcessor {
     @BuildStep
     NativeImageConfigBuildItem config() {
         return NativeImageConfigBuildItem.builder()
-                .addRuntimeInitializedClass("org.apache.activemq.artemis.api.core.ActiveMQBuffers").build();
+                .addRuntimeInitializedClass("org.apache.activemq.artemis.api.core.ActiveMQBuffers")
+                .addRuntimeInitializedClass("org.apache.activemq.artemis.utils.RandomUtil").build();
     }
 
     @BuildStep


### PR DESCRIPTION
This fixes native `integration-tests/artemis-core` and `integration-tests/artemis-jms` with Graal VM 21.1-dev due to banned `java.util.Random` in the image heap. Example failure:

```
com.oracle.svm.core.util.UserError$UserException: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Detailed message:
Trace: 
	at parsing org.apache.activemq.artemis.utils.RandomUtil.randomInterval(RandomUtil.java:83)
Call path from entry point to org.apache.activemq.artemis.utils.RandomUtil.randomInterval(int, int): 
	at org.apache.activemq.artemis.utils.RandomUtil.randomInterval(RandomUtil.java:82)
	at org.apache.activemq.artemis.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy.select(RoundRobinConnectionLoadBalancingPolicy.java:42)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl.selectConnector(ServerLocatorImpl.java:446)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl.createSessionFactory(ServerLocatorImpl.java:674)
	at org.apache.activemq.artemis.api.core.client.ServerLocator_b51a6a22694a49d668b2cad8891f3d2f531aa7d1_Synthetic_ClientProxy.createSessionFactory(ServerLocator_b51a6a22694a49d668b2cad8891f3d2f531aa7d1_Synthetic_ClientProxy.zig:1613)
	at io.quarkus.artemis.core.runtime.health.ServerLocatorHealthCheck.call(ServerLocatorHealthCheck.java:23)
	at io.smallrye.health.AsyncHealthCheckFactory$$Lambda$761/0x00000007c1dc6440.get(Unknown Source)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:216)
	at com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:169)
	at com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:291)
	at com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VA_LIST:Ljava_lang_System_2_0002egetProperty_00028Ljava_lang_String_2_00029Ljava_lang_String_2(generated:0)

	at com.oracle.svm.core.util.UserError.abort(UserError.java:82)
	at com.oracle.svm.hosted.FallbackFeature.reportAsFallback(FallbackFeature.java:233)
	at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:796)
	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:580)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$2(NativeImageGenerator.java:493)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```