### PR TITLE
KeycloakPolicyEnforcerAuthorizer should permit if authentication is not done by OIDC

### DIFF
--- a/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/PolicyEnforcerTest.java
+++ b/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/PolicyEnforcerTest.java
@@ -32,7 +32,8 @@ public class PolicyEnforcerTest {
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
                             .addAsResource("application.properties")
-                            .addClasses(ProtectedResource.class, PublicResource.class, UsersResource.class);
+                            .addClasses(ProtectedResource.class, ProtectedResource2.class, PublicResource.class,
+                                    UsersResource.class);
                 }
             });
 

--- a/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/ProtectedResource2.java
+++ b/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/ProtectedResource2.java
@@ -1,0 +1,17 @@
+package io.quarkus.keycloak.pep.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/api2/resource")
+@Authenticated
+public class ProtectedResource2 {
+
+    @GET
+    public String testResource() {
+        // This method must not be invoked
+        throw new RuntimeException();
+    }
+}

--- a/extensions/keycloak-authorization/deployment/src/test/resources/application.properties
+++ b/extensions/keycloak-authorization/deployment/src/test/resources/application.properties
@@ -28,10 +28,6 @@ quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.method=GET
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.headers.Content-Type=application/x-www-form-urlencoded
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.headers.Authorization=Bearer {keycloak.access_token}
 
-# Disables policy enforcement for a path
-quarkus.keycloak.policy-enforcer.paths.4.path=/api/public
-quarkus.keycloak.policy-enforcer.paths.4.enforcement-mode=DISABLED
-
 # Defines a claim which value is based on the response from an external service
 quarkus.keycloak.policy-enforcer.paths.5.path=/api/permission/body-claim
 quarkus.keycloak.policy-enforcer.paths.5.claim-information-point.claims.from-body={request.body['/from-body']}
@@ -39,16 +35,3 @@ quarkus.keycloak.policy-enforcer.paths.5.claim-information-point.claims.from-bod
 quarkus.keycloak.policy-enforcer.paths.6.name=Root
 quarkus.keycloak.policy-enforcer.paths.6.path=/*
 quarkus.keycloak.policy-enforcer.paths.6.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.7.name=API
-quarkus.keycloak.policy-enforcer.paths.7.path=/api2/*
-quarkus.keycloak.policy-enforcer.paths.7.enforcement-mode=ENFORCING
-
-quarkus.keycloak.policy-enforcer.paths.8.name=Public
-quarkus.keycloak.policy-enforcer.paths.8.path=/hello
-quarkus.keycloak.policy-enforcer.paths.8.enforcement-mode=DISABLED
-
-quarkus.keycloak.policy-enforcer.paths.health.name=Health-check
-quarkus.keycloak.policy-enforcer.paths.health.path=/health/*
-quarkus.keycloak.policy-enforcer.paths.health.enforcement-mode=DISABLED
-

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource2.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource2.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/api2/resource")
+@Authenticated
+public class ProtectedResource2 {
+
+    @GET
+    public String testResource() {
+        // This method must not be invoked
+        throw new RuntimeException();
+    }
+}


### PR DESCRIPTION
Fixes #15988.
Fixes #14619.
The user reported that when both `Basic` and `OIDC` (plus `keycloak-authorization`) mechanisms are enabled, when the user authenticates with the basic credentials the request is denied - because `keycloak-authorization` is trying to enforce its rules.
So I've updated the code a bit to return `PERMIT` if no `AccessTokenCredential` is available (which also avoids a blocking SecurityIdentity check)
I was confused a bit when I got `policyEnforcerTest.testPathConfigurationPrecedenceWhenPathCacheNotDefined` failing - it eas expecting `401` and with my updates it started getting `404`.
I've looked into it and saw that since `api2/resource` had an enforcing mode, with the `main` branch code it is 401 because `KeycloakPolicyEnforcerAuthorizer` itself is checking of the token is available and if not - denies the request.
However `api2/resource`  did not actually exist as the test endpoint resource - and checking the token itself is what `quarkus-oidc` does - so I've added `ProtectedResource2` which requires an authenticated access to `/api2/resource` which makes sure the test gets its `401`
@pedroigor does it look correct ?