### PR TITLE
Fix dependency gaps in container-image & k8s ITs

### DIFF
--- a/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/ext1/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/ext1/pom.xml
@@ -36,10 +36,28 @@
     <profiles>
         <profile>
             <id>SuperfluousDeploymentDep</id>
+            <properties>
+                <enforcer.requiresMinimalDeploymentDependency.nonSuperfluous>
+                    quarkus-enforcer-rules-smoketest-ext3-deployment
+                </enforcer.requiresMinimalDeploymentDependency.nonSuperfluous>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-enforcer-rules-smoketest-ext2-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-enforcer-rules-smoketest-ext3-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/integration-tests/container-image/maven-invoker-way/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/pom.xml
@@ -22,6 +22,19 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+
+        <!-- made test scope only to force Maven to build these dependencies before running the tests-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
@@ -47,6 +60,34 @@
                  </exclusion>
             </exclusions>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/integration-tests/kubernetes/maven-invoker-way/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/pom.xml
@@ -15,6 +15,18 @@
     <description>Kubernetes integration tests that need to use the maven invoker because they test various dependency related scenarios</description>
 
     <dependencies>
+        <!-- made test scope only to force Maven to build these dependencies before running the tests-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-maven</artifactId>
@@ -45,6 +57,32 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -14,6 +14,19 @@
     <name>Quarkus - Integration Tests - Kubernetes - Standard</name>
     <description>Kubernetes integration tests that use @QuarkusProdModeTest</description>
 
+    <properties>
+        <!-- quarkus-container-image-*-deployment deps (see dependencies section) are important for proper build order.
+             But due to the nature of the tests in this module, the runtime siblings must not be on the classpath.
+             Therefore the following property instructs RequiresMinimalDeploymentDependency enforcer rule to _not_
+             consider the respective deployment deps "superfluous" (because their runtime siblings are not present). -->
+        <enforcer.requiresMinimalDeploymentDependency.nonSuperfluous>
+            quarkus-container-image-docker-deployment,
+            quarkus-container-image-jib-deployment,
+            quarkus-container-image-openshift-deployment,
+            quarkus-container-image-s2i-deployment
+        </enforcer.requiresMinimalDeploymentDependency.nonSuperfluous>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -120,6 +133,58 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-openshift-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-s2i-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/pull/15946#issuecomment-804730185

```
mvn validate -pl extensions/container-image/container-image-openshift/deployment -amd
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] Quarkus - Container Image - OpenShift - Deployment                 [jar]
[INFO] Quarkus - Kubernetes - Openshift - Deployment                      [jar]
[INFO] Quarkus - Integration Tests - Kubernetes - Standard                [jar]
[INFO] Quarkus - Documentation                                            [jar]
[INFO]
```

That new `enforcer.requiresMinimalDeploymentDependency.nonSuperfluous` property is pretty verbose, but I wanted to make it clear where it belongs to.

/cc @geoand @iocanel @aloubyansky