### PR TITLE
Revert "Register all profile properties in the default config source."

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -296,7 +296,7 @@ public final class BuildTimeConfigurationReader {
                 nameBuilder.setLength(len);
             }
             // sweep-up
-            for (String propertyName : getAllProperties()) {
+            for (String propertyName : config.getPropertyNames()) {
                 if (propertyName.equals(ConfigSource.CONFIG_ORDINAL)) {
                     continue;
                 }
@@ -717,19 +717,6 @@ public final class BuildTimeConfigurationReader {
             }
             convByType.put(valueType, converter);
             return converter;
-        }
-
-        /**
-         * We collect all properties from ConfigSources, because Config#getPropertyNames exclude the active profiled
-         * properties, meaning that the property is written in the default config source unprofiled. This may cause
-         * issues if we run with a different profile and fallback to defaults.
-         */
-        private Set<String> getAllProperties() {
-            Set<String> properties = new HashSet<>();
-            for (ConfigSource configSource : config.getConfigSources()) {
-                properties.addAll(configSource.getPropertyNames());
-            }
-            return properties;
         }
     }
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/ConfigDefaultValues.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/ConfigDefaultValues.java
@@ -15,17 +15,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ConfigDefaultValuesTest {
+public class ConfigDefaultValues {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "config_ordinal=1000\n" +
-                                    "my.prop=1234\n" +
-                                    "%prod.my.prop=1234\n" +
-                                    "%dev.my.prop=5678\n" +
-                                    "%test.my.prop=1234"),
-                            "application.properties"));
+                    .addAsResource(new StringAsset("config_ordinal=1000\n" +
+                            "my.prop=1234\n"), "application.properties"));
     @Inject
     Config config;
 
@@ -42,17 +37,6 @@ public class ConfigDefaultValuesTest {
 
         assertEquals("1234", defaultValues.getValue("my.prop"));
         assertEquals("1234", applicationProperties.getValue("my.prop"));
-    }
-
-    @Test
-    void profileDefaultValues() {
-        ConfigSource defaultValues = getConfigSourceByName("PropertiesConfigSource[source=Specified default values]");
-        assertNotNull(defaultValues);
-        assertEquals("1234", defaultValues.getValue("my.prop"));
-        assertEquals("1234", defaultValues.getValue("%prod.my.prop"));
-        assertEquals("5678", defaultValues.getValue("%dev.my.prop"));
-        assertEquals("1234", defaultValues.getValue("%test.my.prop"));
-        assertEquals("1234", config.getValue("my.prop", String.class));
     }
 
     private ConfigSource getConfigSourceByName(String name) {


### PR DESCRIPTION
This reverts commit 8d85f2299f4b0565fee348bed5bba5a711032a1e.

As discussed here: https://github.com/quarkusio/quarkus/issues/15919#issuecomment-805314355 .

I already reverted it in the 1.13 branch, this PR is to get master on par with 1.13.

We can work on a better fix for 1.13.1.Final.