### PR TITLE
Add Avro to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,7 +109,9 @@ updates:
       - dependency-name: biz.paluch.logging:logstash-gelf
       - dependency-name: io.sentry:*
       # MongoDB
-      - dependency-name:  org.mongodb:*
+      - dependency-name: org.mongodb:*
+      # Avro
+      - dependency-name: org.apache.avro:*
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/integration-tests/gradle"


### PR DESCRIPTION
We are a bit late on micros of Avro and it's probably worth it to have
Dependabot warning us about new versions even if we don't merge them.