### PR TITLE
Improved execution of grouped assertions

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/CapabilityNameTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/CapabilityNameTest.java
@@ -12,8 +12,7 @@ public class CapabilityNameTest {
         assertAll(
                 () -> assertEquals("io.quarkus.agroal", Capability.AGROAL.getName()),
                 () -> assertEquals("io.quarkus.security.jpa", Capability.SECURITY_JPA.getName()),
-                () -> assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName())
-        );
+                () -> assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName()));
     }
 
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/CapabilityNameTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/CapabilityNameTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -8,9 +9,11 @@ public class CapabilityNameTest {
 
     @Test
     public void testName() {
-        assertEquals("io.quarkus.agroal", Capability.AGROAL.getName());
-        assertEquals("io.quarkus.security.jpa", Capability.SECURITY_JPA.getName());
-        assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName());
+        assertAll(
+                () -> assertEquals("io.quarkus.agroal", Capability.AGROAL.getName()),
+                () -> assertEquals("io.quarkus.security.jpa", Capability.SECURITY_JPA.getName()),
+                () -> assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName())
+        );
     }
 
 }


### PR DESCRIPTION
**Problem:**
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution.

**Solution:**
Using JUnit's grouped assertions feature, all assertions are executed, and all failures will be reported together. In this refactoring, no original assertion was changed.

**Result:**
_Before:_
```
assertEquals("io.quarkus.agroal", Capability.AGROAL.getName());
assertEquals("io.quarkus.security.jpa", Capability.SECURITY_JPA.getName());
assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName());
```

_After:_
```
assertAll(
        () -> assertEquals("io.quarkus.agroal", Capability.AGROAL.getName()),
        () -> assertEquals("io.quarkus.security.jpa", Capability.SECURITY_JPA.getName()),
        () -> assertEquals("io.quarkus.container.image.docker", Capability.CONTAINER_IMAGE_DOCKER.getName())
);
```