### PR TITLE
Copy Content-Type from Netty HttpResponse to APIGatewayV2HTTPResponse

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -6,7 +6,10 @@ import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -92,12 +95,21 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                     HttpResponse res = (HttpResponse) msg;
                     responseBuilder.setStatusCode(res.status().code());
 
-                    Headers multiValueHeaders = new Headers();
-                    responseBuilder.setMultiValueHeaders(multiValueHeaders);
+                    final Map<String, String> headers = new HashMap<>();
+                    responseBuilder.setHeaders(headers);
                     for (String name : res.headers().names()) {
-                        for (String v : res.headers().getAll(name)) {
-                            multiValueHeaders.add(name, v);
+                        final List<String> allForName = res.headers().getAll(name);
+                        if (allForName == null || allForName.isEmpty()) {
+                            continue;
                         }
+                        final StringBuilder sb = new StringBuilder();
+                        for (Iterator<String> valueIterator = allForName.iterator(); valueIterator.hasNext();) {
+                            sb.append(valueIterator.next());
+                            if (valueIterator.hasNext()) {
+                                sb.append(",");
+                            }
+                        }
+                        headers.put(name, sb.toString());
                     }
                 }
                 if (msg instanceof HttpContent) {
@@ -122,7 +134,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                 }
                 if (msg instanceof LastHttpContent) {
                     if (baos != null) {
-                        if (isBinary(((Headers) responseBuilder.getMultiValueHeaders()).getFirst("Content-Type"))) {
+                        if (isBinary(responseBuilder.getHeaders().get("Content-Type"))) {
                             responseBuilder.setIsBase64Encoded(true);
                             responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
                         } else {

--- a/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -44,7 +44,7 @@ public class AmazonLambdaSimpleTestCase {
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello");
-        Assertions.assertTrue(out.getMultiValueHeaders().get("Content-Type").get(0).startsWith("text/plain"));
+        Assertions.assertTrue(out.getHeaders().get("Content-Type").startsWith("text/plain"));
     }
 
     private APIGatewayV2HTTPEvent request(String path) {
@@ -77,7 +77,7 @@ public class AmazonLambdaSimpleTestCase {
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello Bill");
-        Assertions.assertTrue(out.getMultiValueHeaders().get("Content-Type").get(0).startsWith("text/plain"));
+        Assertions.assertTrue(out.getHeaders().get("Content-Type").startsWith("text/plain"));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class AmazonLambdaSimpleTestCase {
         request.setIsBase64Encoded(true);
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
-        Assertions.assertEquals(out.getMultiValueHeaders().get("Content-Type").get(0),
+        Assertions.assertEquals(out.getHeaders().get("Content-Type"),
                 MediaType.APPLICATION_OCTET_STREAM);
         Assertions.assertTrue(out.getIsBase64Encoded());
         byte[] rtn = Base64.decodeBase64(out.getBody());

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -58,7 +58,7 @@ public class AmazonLambdaSimpleTestCase {
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello");
-        Assertions.assertTrue(out.getMultiValueHeaders().get("Content-Type").get(0).startsWith("text/plain"));
+        Assertions.assertTrue(out.getHeaders().get("Content-Type").startsWith("text/plain"));
     }
 
     private APIGatewayV2HTTPEvent request(String path) {
@@ -93,7 +93,7 @@ public class AmazonLambdaSimpleTestCase {
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello Bill");
-        Assertions.assertTrue(out.getMultiValueHeaders().get("Content-Type").get(0).startsWith("text/plain"));
+        Assertions.assertTrue(out.getHeaders().get("Content-Type").startsWith("text/plain"));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class AmazonLambdaSimpleTestCase {
         request.setIsBase64Encoded(true);
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
-        Assertions.assertEquals(out.getMultiValueHeaders().get("Content-Type").get(0),
+        Assertions.assertEquals(out.getHeaders().get("Content-Type"),
                 MediaType.APPLICATION_OCTET_STREAM);
         Assertions.assertTrue(out.getIsBase64Encoded());
         byte[] rtn = Base64.decodeBase64(out.getBody());
@@ -138,7 +138,7 @@ public class AmazonLambdaSimpleTestCase {
         APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "\"Make it funqy Bill\"");
-        Assertions.assertTrue(out.getMultiValueHeaders().get("Content-Type").get(0).startsWith("application/json"));
+        Assertions.assertTrue(out.getHeaders().get("Content-Type").startsWith("application/json"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #15909 

If the Netty response is an HttpResponse, retrieve its Content-Type and set it on the APIGatewayV2HTTPResponse.

(my first pull request for a long time, a lot has changed, please don't hesitate to fix/squash if necessary)