### PR TITLE
Runtime initialize jgit classes using j.u.Random

### DIFF
--- a/extensions/jgit/deployment/src/main/java/io/quarkus/jgit/deployment/JGitProcessor.java
+++ b/extensions/jgit/deployment/src/main/java/io/quarkus/jgit/deployment/JGitProcessor.java
@@ -43,7 +43,10 @@ class JGitProcessor {
     List<RuntimeInitializedClassBuildItem> runtimeInitializedClasses() {
         return Arrays.asList(
                 new RuntimeInitializedClassBuildItem("org.eclipse.jgit.transport.HttpAuthMethod$Digest"),
-                new RuntimeInitializedClassBuildItem("org.eclipse.jgit.lib.GpgSigner"));
+                new RuntimeInitializedClassBuildItem("org.eclipse.jgit.lib.GpgSigner"),
+                // The following classes use j.u.Ramdom, so they need to be runtime-initialized
+                new RuntimeInitializedClassBuildItem("org.eclipse.jgit.internal.storage.file.WindowCache"),
+                new RuntimeInitializedClassBuildItem("org.eclipse.jgit.util.FileUtils"));
     }
 
     @BuildStep


### PR DESCRIPTION
This PR fixes the native `integration-test/jgit` with Graal VM 21.1-dev due to banned `java.util.Random` in the image heap as discussed in #14904.

Example failure:
```
Error: Unsupported features in 2 methods
Detailed message:
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  Object has been initialized by the org.eclipse.jgit.internal.storage.file.WindowCache class initializer with a trace: 
 	at java.util.Random.<init>(Random.java:105)
	at org.eclipse.jgit.internal.storage.file.WindowCache.<clinit>(WindowCache.java:336)
. Try avoiding to initialize the class that caused initialization of the object. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Trace: 
	at parsing org.eclipse.jgit.internal.storage.file.WindowCache.evict(WindowCache.java:656)
Call path from entry point to org.eclipse.jgit.internal.storage.file.WindowCache.evict(): 
	at org.eclipse.jgit.internal.storage.file.WindowCache.evict(WindowCache.java:655)
	at org.eclipse.jgit.internal.storage.file.WindowCache.getOrLoad(WindowCache.java:616)
	at org.eclipse.jgit.internal.storage.file.WindowCache.get(WindowCache.java:385)
	at org.eclipse.jgit.internal.storage.file.WindowCursor.pin(WindowCursor.java:327)
	at org.eclipse.jgit.internal.storage.file.WindowCursor.copy(WindowCursor.java:226)
	at org.eclipse.jgit.internal.storage.file.PackInputStream.read(PackInputStream.java:37)
	at com.jcraft.jsch.ChannelForwardedTCPIP.run(ChannelForwardedTCPIP.java:102)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:553)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  Object has been initialized by the org.eclipse.jgit.util.FileUtils class initializer with a trace: 
 	at java.util.Random.<init>(Random.java:105)
	at org.eclipse.jgit.util.FileUtils.<clinit>(FileUtils.java:60)
. Try avoiding to initialize the class that caused initialization of the object. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Trace: 
	at parsing org.eclipse.jgit.util.FileUtils.delay(FileUtils.java:1017)
Call path from entry point to org.eclipse.jgit.util.FileUtils.delay(long, long, long): 
	at org.eclipse.jgit.util.FileUtils.delay(FileUtils.java:1014)
	at org.eclipse.jgit.internal.storage.file.FileReftableStack.reload(FileReftableStack.java:261)
	at org.eclipse.jgit.internal.storage.file.FileReftableDatabase.addReftable(FileReftableDatabase.java:337)
	at org.eclipse.jgit.internal.storage.file.FileReftableDatabase.access$2(FileReftableDatabase.java:335)
	at org.eclipse.jgit.internal.storage.file.FileReftableDatabase$FileReftableRefUpdate.doLink(FileReftableDatabase.java:538)
	at org.eclipse.jgit.lib.RefUpdate.link(RefUpdate.java:695)
	at org.eclipse.jgit.api.CheckoutCommand.call(CheckoutCommand.java:210)
	at org.eclipse.jgit.api.CheckoutCommand.call(CheckoutCommand.java:1)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:553)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
	at com.oracle.svm.core.code.IsolateEnterStub.PosixJavaThreads_pthreadStartRoutine_e1f4a8c0039f8337338252cd8734f63a79b5e3df(generated:0)
```