### PR TITLE
Fix a regression with OIDC ignoring 'tenant-enabled'

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -32,19 +32,21 @@ public class OidcCommonUtils {
         final String configPrefix = isServerConfig ? "quarkus.oidc." : "quarkus.oidc-client.";
         if (!oidcConfig.getAuthServerUrl().isPresent() || !oidcConfig.getClientId().isPresent()) {
             throw new ConfigurationException(
-                    String.format("Both '%sauth-server-url' and '%sclient-id' properties must be configured", configPrefix));
+                    String.format("Both '%1$sauth-server-url' and '%1$sclient-id' properties must be configured",
+                            configPrefix));
         }
 
         Credentials creds = oidcConfig.getCredentials();
         if (creds.secret.isPresent() && creds.clientSecret.value.isPresent()) {
             throw new ConfigurationException(
-                    String.format("'%scredentials.secret' and '%scredentials.client-secret' properties are mutually exclusive",
+                    String.format(
+                            "'%1$scredentials.secret' and '%1$scredentials.client-secret' properties are mutually exclusive",
                             configPrefix));
         }
         if ((creds.secret.isPresent() || creds.clientSecret.value.isPresent()) && creds.jwt.secret.isPresent()) {
             throw new ConfigurationException(
                     String.format(
-                            "Use only '%scredentials.secret' or '%scredentials.client-secret' or '%scredentials.jwt.secret' property",
+                            "Use only '%1$scredentials.secret' or '%1$scredentials.client-secret' or '%1$scredentials.jwt.secret' property",
                             configPrefix));
         }
     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecurityDisabledTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecurityDisabledTestCase.java
@@ -1,0 +1,45 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SecurityDisabledTestCase {
+
+    private static Class<?>[] testClasses = {
+            UnprotectedResource.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application-security-disabled.properties", "application.properties"));
+
+    @Test
+    public void testAccessUnprotectedResource() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage("http://localhost:8081/unprotected");
+            assertEquals("unprotected", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-security-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-security-disabled.properties
@@ -1,0 +1,3 @@
+quarkus.oidc.tenant-enabled=false
+quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.policy=permit

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -107,7 +107,7 @@ public class OidcRecorder {
         }
         if (!oidcConfig.tenantEnabled) {
             LOG.debugf("'%s' tenant configuration is disabled", tenantId);
-            Uni.createFrom().item(new TenantConfigContext(new OidcProvider(null, null, null), oidcConfig));
+            return Uni.createFrom().item(new TenantConfigContext(new OidcProvider(null, null, null), oidcConfig));
         }
 
         if (oidcConfig.getPublicKey().isPresent()) {


### PR DESCRIPTION
Fixes #16014

@gsmet - please backport if 13.0.1.Final will happen as it is really a bad miss from me, sadly. It will affect 1.13.0.Final users who for ex use docker to load the images with the tenant disabled and then re-enable it at runtime - mostly for the test purposes - but it is still not cool at all.

CC @Sgitario