### PR TITLE
Refactor spring-data-jpa integration-test

### DIFF
--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/DataGenerator.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/DataGenerator.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Random;
+
+public class DataGenerator {
+
+    public static final Random RANDOM = new Random();
+
+    public static Date randomDate() {
+        return Date.from(LocalDate.now().minusDays(RANDOM.nextInt(3000)).atStartOfDay()
+                .atZone(ZoneId.systemDefault())
+                .toInstant());
+    }
+
+    public static int randomAge() {
+        return RANDOM.nextInt(100);
+    }
+
+    public static boolean randomBoolean() {
+        return RANDOM.nextBoolean();
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
@@ -1,11 +1,8 @@
 package io.quarkus.it.spring.data.jpa;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 
 import javax.json.bind.annotation.JsonbDateFormat;
@@ -26,8 +23,6 @@ import javax.persistence.Table;
 
 @Entity
 public class Person {
-
-    private static final Random RANDOM = new Random();
 
     @Id
     @SequenceGenerator(name = "personSeqGen", sequenceName = "personSeq", initialValue = 100, allocationSize = 1)
@@ -54,11 +49,9 @@ public class Person {
 
     public Person(String name) {
         this.name = name;
-        this.age = RANDOM.nextInt(100);
-        this.joined = Date.from(LocalDate.now().minusDays(RANDOM.nextInt(3000)).atStartOfDay()
-                .atZone(ZoneId.systemDefault())
-                .toInstant());
-        this.active = RANDOM.nextBoolean();
+        this.age = DataGenerator.randomAge();
+        this.joined = DataGenerator.randomDate();
+        this.active = DataGenerator.randomBoolean();
     }
 
     public Person() {

--- a/integration-tests/spring-data-jpa/src/main/resources/application.properties
+++ b/integration-tests/spring-data-jpa/src/main/resources/application.properties
@@ -5,6 +5,10 @@ quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
+# DataGenerator uses java.util.Random => needs to be runtime initialized
+# as j.u.Random is prohibited in the native image heap. Otherwise
+# random data becomes deterministic
+quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkus.it.spring.data.jpa.DataGenerator
 #quarkus.hibernate-orm.log.sql=true
 
 %prod.quarkus.hibernate-orm.sql-load-script=import.sql


### PR DESCRIPTION
This reworks the test so that Person (an Entity class) no longer uses
j.u.Random directly, but delegates generation of random data to
a separate class which gets runtime-initialized.

Fixes: #16018