### PR TITLE
Fix UserCountryNotSetValidatorLocaleTest fail

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/UserCountryNotSetValidatorLocaleTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/UserCountryNotSetValidatorLocaleTest.java
@@ -30,7 +30,9 @@ public class UserCountryNotSetValidatorLocaleTest {
             }).setAfterAllCustomizer(new Runnable() {
                 @Override
                 public void run() {
-                    System.setProperty("user.country", userCountry);
+                    if (userCountry != null) {
+                        System.setProperty("user.country", userCountry);
+                    }
                     System.setProperty("user.language", userLanguage);
                 }
             });


### PR DESCRIPTION
Fix UserCountryNotSetValidatorLocaleTest fail if System.getProperty("user.country") is already null. (when LANG=C and openjdk in linux).

The goal of the test is to ensure that code works when user.country is undefined by removing it artificially by calling System.clearProperty . But if build system already has user.country undefined (e.g. when environment property LANG=C) the test fails.