### PR TITLE
Fixes Jackson serialization issues in native

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -57,14 +57,21 @@ import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 public class JacksonProcessor {
 
     private static final DotName JSON_DESERIALIZE = DotName.createSimple(JsonDeserialize.class.getName());
+
     private static final DotName JSON_SERIALIZE = DotName.createSimple(JsonSerialize.class.getName());
+
     private static final DotName JSON_CREATOR = DotName.createSimple("com.fasterxml.jackson.annotation.JsonCreator");
+
     private static final DotName JSON_NAMING = DotName.createSimple("com.fasterxml.jackson.databind.annotation.JsonNaming");
+
     private static final DotName JSON_IDENTITY_INFO = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIdentityInfo");
+
     private static final DotName BUILDER_VOID = DotName.createSimple(Void.class.getName());
 
     private static final String TIME_MODULE = "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule";
+
     private static final String JDK8_MODULE = "com.fasterxml.jackson.datatype.jdk8.Jdk8Module";
+
     private static final String PARAMETER_NAMES_MODULE = "com.fasterxml.jackson.module.paramnames.ParameterNamesModule";
 
     // this list can probably be enriched with more modules
@@ -86,7 +93,8 @@ public class JacksonProcessor {
         reflectiveClass.produce(
                 new ReflectiveClassBuildItem(true, false, "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
                         "com.fasterxml.jackson.databind.ser.std.SqlDateSerializer",
-                        "com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer"));
+                        "com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer",
+                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver"));
 
         IndexView index = combinedIndexBuildItem.getIndex();
 

--- a/independent-projects/tools/registry-client/pom.xml
+++ b/independent-projects/tools/registry-client/pom.xml
@@ -45,4 +45,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.0.8</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This fixes the following errors when running a native application:

```
    com.fasterxml.jackson.databind.JsonMappingException: Class com.fasterxml.jackson.annotation.SimpleObjectIdResolver has no default (no arg) constructor
     at [Source: (io.quarkus.vertx.http.runtime.VertxInputStream); line: 1, column: 1]
```
and 

```
    com.fasterxml.jackson.databind.JsonMappingException: Class io.quarkus.registry.catalog.json.JsonArtifactCoordsDeserializer has no default (no arg) constructor
     at [Source: (io.quarkus.vertx.http.runtime.VertxInputStream); line: 1, column: 1]
```