### PR TITLE
Resolve Quarkus version from the runtime dependencies instead of the deployment ones

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -367,7 +367,15 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private void setBuiltWithQuarkusCoreVersion(ObjectMapper mapper, ObjectNode extObject) throws MojoExecutionException {
         final QuarkusCoreDeploymentVersionLocator coreVersionLocator = new QuarkusCoreDeploymentVersionLocator();
-        collectDeploymentDeps().getRoot().accept(coreVersionLocator);
+        final DependencyNode root;
+        try {
+            root = repoSystem.collectDependencies(repoSession, newCollectRuntimeDepsRequest()).getRoot();
+        } catch (MojoExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to collect runtime dependencies of " + project.getArtifact(), e);
+        }
+        root.accept(coreVersionLocator);
         if (coreVersionLocator.coreVersion != null) {
             ObjectNode metadata;
             JsonNode mvalue = extObject.get(METADATA);
@@ -399,12 +407,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
         try {
             resolvedDeps = repoSystem.resolveDependencies(repoSession,
-                    new DependencyRequest()
-                            .setCollectRequest(newCollectRequest(new DefaultArtifact(project.getArtifact().getGroupId(),
-                                    project.getArtifact().getArtifactId(),
-                                    project.getArtifact().getClassifier(),
-                                    project.getArtifact().getArtifactHandler().getExtension(),
-                                    project.getArtifact().getVersion()))));
+                    new DependencyRequest().setCollectRequest(newCollectRuntimeDepsRequest()));
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to resolve dependencies of " + project.getArtifact(), e);
         }
@@ -677,6 +680,14 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private AppArtifactCoords getDeploymentCoords() {
         return deploymentCoords == null ? deploymentCoords = AppArtifactCoords.fromString(deployment) : deploymentCoords;
+    }
+
+    private CollectRequest newCollectRuntimeDepsRequest() throws MojoExecutionException {
+        return newCollectRequest(new DefaultArtifact(project.getArtifact().getGroupId(),
+                project.getArtifact().getArtifactId(),
+                project.getArtifact().getClassifier(),
+                project.getArtifact().getArtifactHandler().getExtension(),
+                project.getArtifact().getVersion()));
     }
 
     private CollectRequest newCollectRequest(DefaultArtifact projectArtifact) throws MojoExecutionException {


### PR DESCRIPTION
When generating extension descriptors, if the deployment artifacts haven't been built locally (e.g. explicitly excluded from the reactor) and aren't available in the local repo and `skipExtensionValidation=true`, the Quarkus version that's added to the `quarkus-extension.yaml` should be resolved from the runtime dependencies instead of the deployment ones. Otherwise, it will fail to resolve it.