### PR TITLE
Update OIDC client code to retry in case of the connection errors and have OIDC starting without the complete config

### DIFF
--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
@@ -45,7 +45,16 @@ public class OidcClientFilterDevModeTest {
                 .then()
                 .statusCode(401)
                 .body(equalTo("ProtectedResourceService requires a token"));
-        test.modifyResourceFile("application.properties", s -> s.replace("#", ""));
+        test.modifyResourceFile("application.properties", s -> s.replace("#quarkus.oidc-client-filter.register-filter",
+                "quarkus.oidc-client-filter.register-filter"));
+
+        // OidcClient configuration is not complete - Quarkus should start - but 500 returned
+        RestAssured.when().get("/frontend/user-before-registering-provider")
+                .then()
+                .statusCode(500);
+        test.modifyResourceFile("application.properties", s -> s.replace("#quarkus.oidc-client.auth-server-url",
+                "quarkus.oidc-client.auth-server-url"));
+
         // token lifespan (3 secs) is less than the auto-refresh interval so the token should be refreshed immediately 
         RestAssured.when().get("/frontend/user-after-registering-provider")
                 .then()

--- a/extensions/oidc-client-filter/deployment/src/test/resources/application-oidc-client-filter.properties
+++ b/extensions/oidc-client-filter/deployment/src/test/resources/application-oidc-client-filter.properties
@@ -2,7 +2,7 @@ quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 
-quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
+#quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
 quarkus.oidc-client.credentials.client-secret.method=POST

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
@@ -14,6 +14,7 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
+import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
 @Provider
@@ -28,6 +29,8 @@ public class OidcClientRequestFilter extends AbstractTokensProducer implements C
         try {
             final String accessToken = getAccessToken();
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + accessToken);
+        } catch (DisabledOidcClientException ex) {
+            requestContext.abortWith(Response.status(500).build());
         } catch (Exception ex) {
             LOG.debugf("Access token is not available, aborting the request with HTTP 401 error: %s", ex.getMessage());
             requestContext.abortWith(Response.status(401).build());

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DisabledOidcClientException.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DisabledOidcClientException.java
@@ -1,0 +1,20 @@
+package io.quarkus.oidc.client.runtime;
+
+@SuppressWarnings("serial")
+public class DisabledOidcClientException extends RuntimeException {
+    public DisabledOidcClientException() {
+
+    }
+
+    public DisabledOidcClientException(String errorMessage) {
+        this(errorMessage, null);
+    }
+
+    public DisabledOidcClientException(Throwable cause) {
+        this(null, cause);
+    }
+
+    public DisabledOidcClientException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -97,7 +97,13 @@ public class OidcClientRecorder {
             oidcConfig.setId(oidcClientId);
         }
 
-        OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false);
+        try {
+            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false);
+        } catch (Throwable t) {
+            String message = String.format("'%s' client configuration is not initialized", oidcClientId);
+            LOG.debug(message);
+            return Uni.createFrom().item(new DisabledOidcClient(message));
+        }
 
         String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
 
@@ -200,17 +206,17 @@ public class OidcClientRecorder {
 
         @Override
         public Uni<Tokens> getTokens() {
-            throw new OidcClientException(message);
+            throw new DisabledOidcClientException(message);
         }
 
         @Override
         public Uni<Tokens> refreshTokens(String refreshToken) {
-            throw new OidcClientException(message);
+            throw new DisabledOidcClientException(message);
         }
 
         @Override
         public void close() throws IOException {
-            throw new OidcClientException(message);
+            throw new DisabledOidcClientException(message);
         }
     }
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
@@ -1,0 +1,74 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(KeycloakDevModeRealmResourceManager.class)
+public class CodeFlowDevModeDefaultTenantTestCase {
+
+    private static Class<?>[] testClasses = {
+            ProtectedResource.class,
+            UnprotectedResource.class
+    };
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application-dev-mode-default-tenant.properties", "application.properties"));
+
+    @Test
+    public void testAccessAndRefreshTokenInjectionDevMode() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+
+            try {
+                webClient.getPage("http://localhost:8080/protected");
+                fail("Exception is expected because auth-server-url is not available and the authentication can not be completed");
+            } catch (FailingHttpStatusCodeException ex) {
+                // Reported by Quarkus
+                assertEquals(500, ex.getStatusCode());
+            }
+
+            // Enable auth-server-url
+            test.modifyResourceFile("application.properties",
+                    s -> s.replace("#quarkus.oidc.auth-server-url", "quarkus.oidc.auth-server-url"));
+
+            HtmlPage page = webClient.getPage("http://localhost:8080/protected");
+
+            assertEquals("Sign in to devmode", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice-dev-mode");
+            loginForm.getInputByName("password").setValueAttribute("alice-dev-mode");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("alice-dev-mode", page.getBody().asText());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
@@ -1,0 +1,6 @@
+#quarkus.oidc.auth-server-url=${keycloak.url}/realms/devmode
+quarkus.oidc.client-id=client-dev-mode
+quarkus.oidc.application-type=web-app
+
+quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -102,10 +102,17 @@ public class DefaultTenantConfigResolver {
         TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
         if (configContext == null) {
             if (tenantId != null && !tenantId.isEmpty()) {
-                LOG.debugf("No configuration with a tenant id '%s' has been found, using the default configuration");
+                LOG.debugf(
+                        "Registered TenantResolver has not provided the configuration for tenant '%s', using the default tenant",
+                        tenantId);
             }
             configContext = tenantConfigBean.getDefaultTenant();
         }
+        if (!configContext.ready) {
+            LOG.debugf("Tenant '%s' is not initialized", tenantId);
+            configContext = null;
+        }
+
         return configContext;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -14,8 +14,15 @@ class TenantConfigContext {
      */
     final OidcTenantConfig oidcConfig;
 
+    final boolean ready;
+
     public TenantConfigContext(OidcProvider client, OidcTenantConfig config) {
+        this(client, config, true);
+    }
+
+    public TenantConfigContext(OidcProvider client, OidcTenantConfig config, boolean ready) {
         this.provider = client;
         this.oidcConfig = config;
+        this.ready = ready;
     }
 }


### PR DESCRIPTION
Fixes #15599.
Fixes #15933.
Fixes #16061.

This PR:
- Adds the retries to the OIDC client code to minimize the risk of the `connection dropped` exceptions 
- Makes sure `quarkus-oidc` can start without any static configuration without even having to set `tenant-enabled=false` - it has been a blocker for the dev mode (or `code.quarkus.io`) for a while.
(I had to add a `TenantConfigContext` `ready` flag - as recovering from the exception with `null` does not work - but it can be useful to log at the request time that the tenant with a specific id is not initialized)

CC @cescoffier 