### PR TITLE
Register the correct native library for Snappy, during native image generation

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -46,6 +46,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
+import org.xerial.snappy.OSInfo;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -199,7 +200,7 @@ public class KafkaProcessor {
             String path = root + dir + "/" + snappyNativeLibraryName;
             nativeLibs.produce(new NativeImageResourceBuildItem(path));
         } else { // otherwise the native lib of the platform this build runs on
-            String dir = getOs() + "/" + getArch();
+            String dir = OSInfo.getNativeLibFolderPathForCurrentOS();
             String snappyNativeLibraryName = System.mapLibraryName("snappyjava");
             if (snappyNativeLibraryName.toLowerCase().endsWith(".dylib")) {
                 snappyNativeLibraryName = snappyNativeLibraryName.replace(".dylib", ".jnilib");
@@ -412,25 +413,6 @@ public class KafkaProcessor {
             serviceProvider.produce(
                     new ServiceProviderBuildItem("io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter",
                             KafkaBindingConverter.class.getName()));
-        }
-    }
-
-    public static String getArch() {
-        String osArch = System.getProperty("os.arch");
-        return osArch.replaceAll("\\W", "");
-    }
-
-    static String getOs() {
-        String osName = System.getProperty("os.name");
-
-        if (osName.contains("Windows")) {
-            return "Windows";
-        } else if (osName.contains("Mac")) {
-            return "Mac";
-        } else if (osName.contains("Linux")) {
-            return "Linux";
-        } else {
-            return osName.replaceAll("\\W", "");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/16042

The commit here fixes the issue where the Snappy native library that was being registered as a native image resource was using the wrong resource path (it was using `org/xerial/snappy/native/Linux/amd64/libsnappyjava.so` instead of `org/xerial/snappy/native/Linux/x86_64/libsnappyjava.so`). The commit here uses the `OSInfo` API from the snappy library to get hold of the correct path (just like we do in the `io.quarkus.kafka.client.runtime.KafkaRecorder#loadSnappy()`) and thus letting that API deal with the details.

P.S: This `integration-tests/kafka-client` fails even with the latest released version of GraalVM, so this isn't related to any GraalVM dev version. It looks like this native-image tests isn't enabled in our CI, which is why this wasn't caught earlier. Perhaps we should enable these tests in our CI (as a separate PR)?