### PR TITLE
Remove duplicate method in code example of reactive documentation

### DIFF
--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -608,16 +608,6 @@ public class FruitResource {
         this.client = client;
     }
 
-    private void initdb() {
-        client.query("DROP TABLE IF EXISTS fruits").execute()
-                .flatMap(r -> client.query("CREATE TABLE fruits (id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute())
-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Kiwi')").execute())
-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Durian')").execute())
-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Pomelo')").execute())
-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Lychee')").execute())
-                .await().indefinitely();
-    }
-
     @GET
     public Multi<Fruit> get() {
         return Fruit.findAll(client);


### PR DESCRIPTION
In the example code both `DBInit` and `FruitResource` include the `initdb()`-method, but only the one in `DBInit` is used.