### PR TITLE
Use -x for --examples in Quarkus CLI (instead of -e)

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -33,7 +33,7 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
             "--no-examples" }, order = 4, description = "Generate without example code.")
     boolean noExamples = false;
 
-    @CommandLine.Option(names = { "-e",
+    @CommandLine.Option(names = { "-x",
             "--examples" }, order = 4, description = "Choose which example(s) you want in the generated Quarkus application.")
     Set<String> examples;
 


### PR DESCRIPTION
It doesn't clash with "--errors"  as it's part of the parent command, but it may be confusing so renaming is best..