### PR TITLE
Upgrade Jackson to 2.12.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -87,7 +87,7 @@
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>21.0.0</graal-sdk.version>
         <gizmo.version>1.0.7.Final</gizmo.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.2</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>


### PR DESCRIPTION
They fixed the deployment of the missing artifacts.