### PR TITLE
Improve Mongo health checks

### DIFF
--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
@@ -1,11 +1,14 @@
 package io.quarkus.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +20,7 @@ import com.mongodb.client.internal.MongoClientImpl;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.ClientProxyUnwrapper;
+import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.mongodb.runtime.MongoClientName;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -33,6 +37,10 @@ public class DefaultAndNamedMongoClientConfigTest extends MongoWithReplicasTestB
     @Inject
     @MongoClientName("cluster2")
     MongoClient client2;
+
+    @Inject
+    @Any
+    MongoHealthCheck health;
 
     private final ClientProxyUnwrapper unwrapper = new ClientProxyUnwrapper();
 
@@ -58,6 +66,14 @@ public class DefaultAndNamedMongoClientConfigTest extends MongoWithReplicasTestB
         assertThat(Arc.container().instance(MongoClient.class, Default.Literal.INSTANCE).get()).isNotNull();
         assertThat(Arc.container().instance(MongoClient.class, NamedLiteral.of("cluster2")).get()).isNotNull();
         assertThat(Arc.container().instance(MongoClient.class, NamedLiteral.of("cluster3")).get()).isNull();
+
+        org.eclipse.microprofile.health.HealthCheckResponse response = health.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2).contains(
+                entry("<default>", "OK"),
+                entry("cluster2", "OK"));
+
     }
 
     private void assertProperConnection(MongoClient client, int expectedPort) {

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultMongoClientConfigTest.java
@@ -1,9 +1,14 @@
 package io.quarkus.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
+import java.util.function.BiConsumer;
+
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
 
+import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -28,6 +34,10 @@ public class DefaultMongoClientConfigTest extends MongoWithReplicasTestBase {
     @Inject
     ReactiveMongoClient reactiveClient;
 
+    @Inject
+    @Any
+    MongoHealthCheck health;
+
     @AfterEach
     void cleanup() {
         if (reactiveClient != null) {
@@ -42,5 +52,25 @@ public class DefaultMongoClientConfigTest extends MongoWithReplicasTestBase {
     public void testClientInjection() {
         assertThat(client.listDatabaseNames().first()).isNotEmpty();
         assertThat(reactiveClient.listDatabases().collectItems().first().await().indefinitely()).isNotEmpty();
+
+        org.eclipse.microprofile.health.HealthCheckResponse response = health.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2).contains(entry("<default-reactive>", "OK"),
+                entry("<default>", "OK"));
+
+        // Stop the database and recheck the health
+        stopMongoDatabase();
+
+        response = health.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2)
+                .allSatisfy(new BiConsumer<String, Object>() {
+                    @Override
+                    public void accept(String s, Object o) {
+                        assertThat(o.toString()).startsWith("KO, reason:");
+                    }
+                });
     }
 }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedMongoClientConfigTest.java
@@ -1,12 +1,15 @@
 package io.quarkus.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.lang.annotation.Annotation;
 
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
@@ -19,6 +22,7 @@ import com.mongodb.client.MongoClient;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class NamedMongoClientConfigTest extends MongoWithReplicasTestBase {
@@ -36,6 +40,10 @@ public class NamedMongoClientConfigTest extends MongoWithReplicasTestBase {
     @MongoClientName("cluster2")
     MongoClient client2;
 
+    @Inject
+    @Any
+    MongoHealthCheck health;
+
     @AfterEach
     void cleanup() {
         if (client != null) {
@@ -52,6 +60,15 @@ public class NamedMongoClientConfigTest extends MongoWithReplicasTestBase {
         assertThat(client2.listDatabases().first()).isNotEmpty();
 
         assertNoDefaultClient();
+
+        checkHealth();
+    }
+
+    public void checkHealth() {
+        org.eclipse.microprofile.health.HealthCheckResponse response = health.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2).contains(entry("cluster1", "OK"), entry("cluster2", "OK"));
     }
 
     private void assertNoDefaultClient() {

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
@@ -1,9 +1,13 @@
 package io.quarkus.mongodb.health;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.Bean;
@@ -20,6 +24,11 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.mongodb.MongoClientName;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.mongodb.runtime.MongoClientConfig;
+import io.quarkus.mongodb.runtime.MongodbConfig;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.tuples.Tuple2;
 
 @Readiness
 @ApplicationScoped
@@ -27,32 +36,92 @@ public class MongoHealthCheck implements HealthCheck {
 
     public static final String CLIENT_DEFAULT = "<default>";
     public static final String CLIENT_DEFAULT_REACTIVE = "<default-reactive>";
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 
-    private Map<String, MongoClient> clients = new HashMap<>();
-    private Map<String, ReactiveMongoClient> reactiveClients = new HashMap<>();
+    private final List<Supplier<Uni<Tuple2<String, String>>>> checks = new ArrayList<>();
 
-    @PostConstruct
-    protected void init() {
-        for (InstanceHandle<MongoClient> handle : Arc.container().select(MongoClient.class, Any.Literal.INSTANCE).handles()) {
-            String clientName = getMongoClientName(handle.getBean());
-            clients.put(clientName == null ? CLIENT_DEFAULT : clientName, handle.get());
+    private static final Document COMMAND = new Document("ping", 1);
+
+    public void configure(MongodbConfig config) {
+        Iterable<InstanceHandle<MongoClient>> handle = Arc.container().select(MongoClient.class, Any.Literal.INSTANCE)
+                .handles();
+        Iterable<InstanceHandle<ReactiveMongoClient>> reactiveHandlers = Arc.container()
+                .select(ReactiveMongoClient.class, Any.Literal.INSTANCE).handles();
+
+        if (config.defaultMongoClientConfig != null) {
+            MongoClient client = getClient(handle, null);
+            ReactiveMongoClient reactiveClient = getReactiveClient(reactiveHandlers, null);
+            if (client != null) {
+                checks.add(new MongoClientCheck(CLIENT_DEFAULT, client, config.defaultMongoClientConfig));
+            }
+            if (reactiveClient != null) {
+                checks.add(new ReactiveMongoClientCheck(CLIENT_DEFAULT_REACTIVE,
+                        reactiveClient,
+                        config.defaultMongoClientConfig));
+            }
         }
-        // reactive clients
-        for (InstanceHandle<ReactiveMongoClient> handle : Arc.container()
-                .select(ReactiveMongoClient.class, Any.Literal.INSTANCE).handles()) {
-            String clientName = getMongoClientName(handle.getBean());
-            reactiveClients.put(clientName == null ? CLIENT_DEFAULT_REACTIVE : clientName, handle.get());
+
+        config.mongoClientConfigs.forEach(new BiConsumer<String, MongoClientConfig>() {
+            @Override
+            public void accept(String name, MongoClientConfig cfg) {
+                MongoClient client = getClient(handle, name);
+                ReactiveMongoClient reactiveClient = getReactiveClient(reactiveHandlers, name);
+                if (client != null) {
+                    checks.add(new MongoClientCheck(name, client,
+                            config.defaultMongoClientConfig));
+                }
+                if (reactiveClient != null) {
+                    checks.add(new ReactiveMongoClientCheck(name, reactiveClient,
+                            config.defaultMongoClientConfig));
+                }
+            }
+        });
+
+    }
+
+    private MongoClient getClient(Iterable<InstanceHandle<MongoClient>> handle, String name) {
+        for (InstanceHandle<MongoClient> client : handle) {
+            String n = getMongoClientName(client.getBean());
+            if (name == null && n == null) {
+                return client.get();
+            }
+            if (name != null && name.equals(n)) {
+                return client.get();
+            }
         }
+        return null;
+    }
+
+    private ReactiveMongoClient getReactiveClient(Iterable<InstanceHandle<ReactiveMongoClient>> handle, String name) {
+        for (InstanceHandle<ReactiveMongoClient> client : handle) {
+            String n = getMongoClientName(client.getBean());
+            if (name == null && n == null) {
+                return client.get();
+            }
+            if (name != null && name.equals(n)) {
+                return client.get();
+            }
+        }
+        return null;
+    }
+
+    private BiFunction<Document, Throwable, Tuple2<String, String>> toResult(String name) {
+        return new BiFunction<Document, Throwable, Tuple2<String, String>>() {
+            @Override
+            public Tuple2<String, String> apply(Document ignored, Throwable failure) {
+                return Tuple2.of(name, failure == null ? "OK" : failure.getMessage());
+            }
+        };
     }
 
     /**
      * Get mongoClient name if defined.
      *
-     * @param bean
+     * @param bean the bean from which the name will be extracted.
      * @return mongoClient name or null if not defined
      * @see MongoClientName
      */
-    private String getMongoClientName(Bean bean) {
+    private String getMongoClientName(Bean<?> bean) {
         for (Object qualifier : bean.getQualifiers()) {
             if (qualifier instanceof MongoClientName) {
                 return ((MongoClientName) qualifier).value();
@@ -64,24 +133,79 @@ public class MongoHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("MongoDB connection health check").up();
-        Document command = new Document("ping", 1);
-        for (Map.Entry<String, MongoClient> client : clients.entrySet()) {
-            try {
-                Document document = client.getValue().getDatabase("admin").runCommand(command);
-                builder.up().withData(client.getKey(), document.toJson());
-            } catch (Exception e) {
-                return builder.down().withData("reason", "client [" + client.getKey() + "]: " + e.getMessage()).build();
-            }
+        List<Uni<Tuple2<String, String>>> unis = new ArrayList<>();
+        for (Supplier<Uni<Tuple2<String, String>>> client : checks) {
+            unis.add(client.get());
         }
-        for (Map.Entry<String, ReactiveMongoClient> client : reactiveClients.entrySet()) {
-            try {
-                Document document = client.getValue().getDatabase("admin").runCommand(command).await().indefinitely();
-                builder.up().withData(client.getKey(), document.toJson());
-            } catch (Exception e) {
-                return builder.down().withData("reason", "reactive client [" + client.getKey() + "]: " + e.getMessage())
-                        .build();
+
+        if (unis.isEmpty()) {
+            return builder.build();
+        }
+
+        return Uni.combine().all().unis(unis)
+                .collectFailures() // We collect all failures to avoid partial responses.
+                .combinedWith(new Function<List<?>, HealthCheckResponse>() {
+                    @Override
+                    public HealthCheckResponse apply(List<?> list) {
+                        return MongoHealthCheck.this.combine(list, builder);
+                    }
+                }).await().indefinitely(); // All checks fails after a timeout, so if won't be forever.
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private HealthCheckResponse combine(List<?> results, HealthCheckResponseBuilder builder) {
+        for (Object result : results) {
+            Tuple2<String, String> tuple = (Tuple2<String, String>) result;
+            if ("OK".equalsIgnoreCase(tuple.getItem2())) {
+                builder.withData(tuple.getItem1(), "OK");
+            } else {
+                builder.down()
+                        .withData(tuple.getItem1(), "KO, reason: " + tuple.getItem2());
             }
         }
         return builder.build();
+    }
+
+    private class MongoClientCheck implements Supplier<Uni<Tuple2<String, String>>> {
+        final String name;
+        final MongoClient client;
+        final MongoClientConfig config;
+
+        MongoClientCheck(String name, MongoClient client, MongoClientConfig config) {
+            this.name = name;
+            this.client = client;
+            this.config = config;
+        }
+
+        public Uni<Tuple2<String, String>> get() {
+            return Uni.createFrom().item(new Supplier<Document>() {
+                @Override
+                public Document get() {
+                    return client.getDatabase(config.healthDatabase).runCommand(COMMAND);
+                }
+            })
+                    .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                    .ifNoItem().after(config.readTimeout.orElse(DEFAULT_TIMEOUT)).fail()
+                    .onItemOrFailure().transform(toResult(name));
+        }
+    }
+
+    private class ReactiveMongoClientCheck implements Supplier<Uni<Tuple2<String, String>>> {
+        final String name;
+        final ReactiveMongoClient client;
+        final MongoClientConfig config;
+
+        ReactiveMongoClientCheck(String name, ReactiveMongoClient client, MongoClientConfig config) {
+            this.name = name;
+            this.client = client;
+            this.config = config;
+        }
+
+        public Uni<Tuple2<String, String>> get() {
+            return client.getDatabase(config.healthDatabase).runCommand(COMMAND)
+                    .ifNoItem().after(config.readTimeout.orElse(DEFAULT_TIMEOUT)).fail()
+                    .onItemOrFailure().transform(toResult(name));
+        }
     }
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -183,4 +183,11 @@ public class MongoClientConfig {
      */
     @ConfigDocSection
     public CredentialConfig credentials;
+
+    /**
+     * The database used during the readiness health checks
+     */
+    @ConfigItem(name = "health.database", defaultValue = "admin")
+    public String healthDatabase;
+
 }


### PR DESCRIPTION
- use parallel composition to avoid cumulative timeouts
- allows the user to set the checked database