### PR TITLE
Build and Runtime fixed properties only from default and built step sources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalStaticInitConfigSourceProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalStaticInitConfigSourceProviderBuildItem.java
@@ -1,0 +1,15 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AdditionalStaticInitConfigSourceProviderBuildItem extends MultiBuildItem {
+    private final String providerClassName;
+
+    public AdditionalStaticInitConfigSourceProviderBuildItem(String providerClassName) {
+        this.providerClassName = providerClassName;
+    }
+
+    public String getProviderClassName() {
+        return providerClassName;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -17,6 +17,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalBootstrapConfigSourceProviderBuildItem;
+import io.quarkus.deployment.builditem.AdditionalStaticInitConfigSourceProviderBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationTypeBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -45,6 +46,7 @@ public class ConfigGenerationBuildStep {
             LaunchModeBuildItem launchModeBuildItem,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             LiveReloadBuildItem liveReloadBuildItem,
+            List<AdditionalStaticInitConfigSourceProviderBuildItem> additionalStaticInitConfigSourceProviders,
             List<AdditionalBootstrapConfigSourceProviderBuildItem> additionalBootstrapConfigSourceProviders) {
         if (liveReloadBuildItem.isLiveReload()) {
             return;
@@ -62,7 +64,20 @@ public class ConfigGenerationBuildStep {
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, false);
         RunTimeConfigurationGenerator.generate(readResult, classOutput,
                 launchModeBuildItem.getLaunchMode() == LaunchMode.DEVELOPMENT, defaults, additionalConfigTypes,
+                getAdditionalStaticInitConfigSourceProviders(additionalStaticInitConfigSourceProviders),
                 getAdditionalBootstrapConfigSourceProviders(additionalBootstrapConfigSourceProviders));
+    }
+
+    private List<String> getAdditionalStaticInitConfigSourceProviders(
+            List<AdditionalStaticInitConfigSourceProviderBuildItem> additionalStaticInitConfigSourceProviders) {
+        if (additionalStaticInitConfigSourceProviders.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<>(additionalStaticInitConfigSourceProviders.size());
+        for (AdditionalStaticInitConfigSourceProviderBuildItem provider : additionalStaticInitConfigSourceProviders) {
+            result.add(provider.getProviderClassName());
+        }
+        return result;
     }
 
     private List<String> getAdditionalBootstrapConfigSourceProviders(

--- a/core/test-extension/deployment/src/main/resources/application.properties
+++ b/core/test-extension/deployment/src/main/resources/application.properties
@@ -51,6 +51,8 @@ quarkus.btrt.all-values.nested-config-map.key2.nested-value=value2
 quarkus.btrt.all-values.nested-config-map.key2.oov=value2.1+value2.2
 quarkus.btrt.all-values.string-list=value1,value2
 quarkus.btrt.all-values.long-list=1,2,3
+# The expansion value is not available in runtime so we need to set it directly.
+quarkus.btrt.all-values.expanded-default=1234
 
 ### Configuration settings for the TestRunTimeConfig config root
 quarkus.rt.rt-string-opt=rtStringOptValue

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/OverrideBuildTimeConfigSource.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/OverrideBuildTimeConfigSource.java
@@ -1,0 +1,43 @@
+package io.quarkus.extest.runtime.config;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.config.common.MapBackedConfigSource;
+
+/**
+ * Override a build time property in runtime.
+ */
+public class OverrideBuildTimeConfigSource extends MapBackedConfigSource {
+    public static AtomicInteger counter = new AtomicInteger(0);
+
+    public OverrideBuildTimeConfigSource() {
+        super(OverrideBuildTimeConfigSource.class.getName(), new HashMap<>(), 1000);
+        counter.incrementAndGet();
+    }
+
+    @Override
+    public String getValue(final String propertyName) {
+        if (!propertyName.endsWith("quarkus.btrt.all-values.long-primitive")) {
+            return super.getValue(propertyName);
+        }
+
+        boolean isBuildTime = false;
+        for (ConfigSource configSource : ConfigProvider.getConfig().getConfigSources()) {
+            if (configSource.getClass().getSimpleName().equals("BuildTimeEnvConfigSource")) {
+                isBuildTime = true;
+                break;
+            }
+        }
+
+        if (isBuildTime) {
+            return super.getValue(propertyName);
+        }
+
+        // Override the value if runtime for quarkus.btrt.all-values.long-primitive.
+        return "0";
+    }
+}

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -69,6 +69,10 @@ To fully enable the close world assumptions that Quarkus can optimize best, it i
 Of course properties like host, port, password should be overridable at runtime.
 But many properties like enable caching or setting the JDBC driver can safely require a rebuild of the application.
 
+==== Static Init Config
+
+If the extension provides additional Config Sources and if these are required during Static Init, these must be registered with `AdditionalStaticInitConfigSourceProviderBuildItem`. Configuration in Static Init does not scan for additional sources to avoid double initialization at application startup time.
+
 ////
 === API
 

--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -50,11 +50,13 @@ import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AdditionalStaticInitConfigSourceProviderBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ProxyUnwrapperBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.resteasy.common.runtime.ResteasyInjectorFactoryRecorder;
+import io.quarkus.resteasy.common.runtime.config.ResteasyConfigSourceProvider;
 import io.quarkus.resteasy.common.runtime.providers.ServerFormUrlEncodedProvider;
 import io.quarkus.resteasy.common.spi.ResteasyConfigBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
@@ -118,6 +120,12 @@ public class ResteasyCommonProcessor {
          */
         @ConfigItem(defaultValue = "10M")
         public MemorySize maxInput;
+    }
+
+    @BuildStep
+    void initConfigSourceProvider(BuildProducer<AdditionalStaticInitConfigSourceProviderBuildItem> initConfigSourceProvider) {
+        initConfigSourceProvider.produce(
+                new AdditionalStaticInitConfigSourceProviderBuildItem(ResteasyConfigSourceProvider.class.getName()));
     }
 
     @BuildStep

--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/config/ResteasyConfigSourceProvider.java
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/config/ResteasyConfigSourceProvider.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.common.runtime.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.jboss.resteasy.microprofile.config.FilterConfigSource;
+import org.jboss.resteasy.microprofile.config.ServletConfigSource;
+import org.jboss.resteasy.microprofile.config.ServletContextConfigSource;
+
+public class ResteasyConfigSourceProvider implements ConfigSourceProvider {
+    @Override
+    public Iterable<ConfigSource> getConfigSources(final ClassLoader forClassLoader) {
+        List<ConfigSource> configSources = new ArrayList<>();
+        configSources.add(new ServletConfigSource());
+        configSources.add(new FilterConfigSource());
+        configSources.add(new ServletContextConfigSource());
+        return configSources;
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ProviderConfigInjectionTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ProviderConfigInjectionTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.test;
 
+import javax.enterprise.inject.Instance;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
@@ -47,11 +48,11 @@ public class ProviderConfigInjectionTest {
     public static class FooProvider implements ContextResolver<String> {
 
         @ConfigProperty(name = "foo")
-        String foo;
+        Instance<String> foo;
 
         @Override
         public String getContext(Class<?> type) {
-            return foo;
+            return foo.get();
         }
     }
 }

--- a/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
+++ b/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
@@ -39,7 +39,9 @@ public class SmallRyeOpenTracingProcessor {
     }
 
     @BuildStep
-    void setupFilter(BuildProducer<ResteasyJaxrsProviderBuildItem> providers,
+    void setupFilter(
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<ResteasyJaxrsProviderBuildItem> providers,
             BuildProducer<FilterBuildItem> filterProducer,
             BuildProducer<FeatureBuildItem> feature,
             BuildProducer<CustomContainerResponseFilterBuildItem> customResponseFilters,
@@ -48,6 +50,7 @@ public class SmallRyeOpenTracingProcessor {
 
         feature.produce(new FeatureBuildItem(Feature.SMALLRYE_OPENTRACING));
 
+        additionalBeans.produce(new AdditionalBeanBuildItem(QuarkusSmallRyeTracingDynamicFeature.class));
         providers.produce(new ResteasyJaxrsProviderBuildItem(QuarkusSmallRyeTracingDynamicFeature.class.getName()));
 
         if (capabilities.isPresent(Capability.SERVLET)) {

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
@@ -1,16 +1,11 @@
 package io.quarkus.smallrye.opentracing.runtime;
 
-import java.util.Optional;
-
 import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
-
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.jaxrs2.server.OperationNameProvider;
@@ -18,37 +13,24 @@ import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 
 @Provider
 public class QuarkusSmallRyeTracingDynamicFeature implements DynamicFeature {
+    @Inject
+    TracingConfig tracingConfig;
 
-    private static final Logger logger = Logger
-            .getLogger(io.smallrye.opentracing.SmallRyeTracingDynamicFeature.class.getName());
-
-    private final ServerTracingDynamicFeature delegate;
-
-    public QuarkusSmallRyeTracingDynamicFeature() {
-        Config config = ConfigProvider.getConfig();
-        Optional<String> skipPattern = config.getOptionalValue("mp.opentracing.server.skip-pattern", String.class);
-        Optional<String> operationNameProvider = config.getOptionalValue("mp.opentracing.server.operation-name-provider",
-                String.class);
-
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
         ServerTracingDynamicFeature.Builder builder = new ServerTracingDynamicFeature.Builder(
                 CDI.current().select(Tracer.class).get())
                         .withOperationNameProvider(OperationNameProvider.ClassNameOperationName.newBuilder())
                         .withTraceSerialization(false);
-        if (skipPattern.isPresent()) {
-            builder.withSkipPattern(skipPattern.get());
-        }
-        if (operationNameProvider.isPresent()) {
-            if ("http-path".equalsIgnoreCase(operationNameProvider.get())) {
+
+        tracingConfig.skipPattern.ifPresent(builder::withSkipPattern);
+        if (tracingConfig.operationNameProvider.isPresent()) {
+            if (tracingConfig.operationNameProvider.get().equals(TracingConfig.OperationNameProvider.HTTP_PATH)) {
                 builder.withOperationNameProvider(OperationNameProvider.WildcardOperationName.newBuilder());
-            } else if (!"class-method".equalsIgnoreCase(operationNameProvider.get())) {
-                logger.warn("Provided operation name does not match http-path or class-method. Using default class-method.");
             }
         }
-        this.delegate = builder.build();
-    }
 
-    @Override
-    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
-        this.delegate.configure(resourceInfo, context);
+        ServerTracingDynamicFeature serverTracing = builder.build();
+        serverTracing.configure(resourceInfo, context);
     }
 }

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/TracingConfig.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/TracingConfig.java
@@ -1,0 +1,27 @@
+package io.quarkus.smallrye.opentracing.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "opentracing", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class TracingConfig {
+    /**
+     *
+     */
+    @ConfigItem(name = "server.skip-pattern")
+    public Optional<String> skipPattern;
+
+    /**
+     *
+     */
+    @ConfigItem(name = "server.operation-name-provider", defaultValue = "class-method")
+    public Optional<OperationNameProvider> operationNameProvider;
+
+    public enum OperationNameProvider {
+        HTTP_PATH,
+        CLASS_METHOD;
+    }
+}

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/TracingConfigRelocateConfigSourceInterceptor.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/TracingConfigRelocateConfigSourceInterceptor.java
@@ -1,0 +1,53 @@
+package io.quarkus.smallrye.opentracing.runtime;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Priority;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+
+@Priority(Priorities.LIBRARY + 600 - 5)
+public class TracingConfigRelocateConfigSourceInterceptor extends RelocateConfigSourceInterceptor {
+    private static final Map<String, String> RELOCATIONS = relocations();
+
+    public TracingConfigRelocateConfigSourceInterceptor() {
+        super(RELOCATIONS);
+    }
+
+    @Override
+    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
+        final Set<String> names = new HashSet<>();
+        final Iterator<String> namesIterator = context.iterateNames();
+        while (namesIterator.hasNext()) {
+            final String name = namesIterator.next();
+            names.add(name);
+            final String mappedName = RELOCATIONS.get(name);
+            if (mappedName != null) {
+                names.add(mappedName);
+            }
+        }
+        return names.iterator();
+    }
+
+    @Override
+    public Iterator<ConfigValue> iterateValues(final ConfigSourceInterceptorContext context) {
+        return context.iterateValues();
+    }
+
+    private static Map<String, String> relocations() {
+        Map<String, String> relocations = new HashMap<>();
+        relocations.put("mp.opentracing.server.skip-pattern", "quarkus.opentracing.server.skip-pattern");
+        relocations.put("quarkus.opentracing.server.skip-pattern", "mp.opentracing.server.skip-pattern");
+        relocations.put("mp.opentracing.server.operation-name-provider", "quarkus.opentracing.server.operation-name-provider");
+        relocations.put("quarkus.opentracing.server.operation-name-provider", "mp.opentracing.server.operation-name-provider");
+        return Collections.unmodifiableMap(relocations);
+    }
+}

--- a/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.opentracing.runtime.TracingConfigRelocateConfigSourceInterceptor


### PR DESCRIPTION
- Fixes #8145

The `Config` instance for static init will only add the `BuildTimeRunTimeDefaultValuesConfigSource`, the default sources from `Config` (system, env and properties) and registered sources with `BuildTimeRunTimeDefaultValuesConfigSource`. This will prevent user discovered sources to be doubled initialised (once for static init and another for run).

The downside of this, is that some libraries that require static init (like RESTEasy) require their sources to be registered with the build step to work properly, so extension developers will need to keep this in mind.

We shouldn't require the default sources of (system, env and properties), but some extensions are relying on specific configuration that are not in the quarkus namespace, so these are not recorded as defaults and they are not available in the `BuildTimeRunTimeDefaultValuesConfigSource`.  We should probably review them. I ended up doing a minor refactor to the Tracing extension because of this, but there are others (SR Messaging).

ConfigRoot objects values that may be overridden by the system, env and properties (when they should only use the `BuildTimeRunTimeDefaultValuesConfigSource`). This needs to be fixed.

Overall, this seems to solve the original issue, but I'm not completely sure if I'm happy with the end result.