### PR TITLE
Disable test on Windows

### DIFF
--- a/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesDevModeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesDevModeTest.java
@@ -6,11 +6,14 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@DisabledOnOs(OS.WINDOWS)
 public class AdditionalWatchedResourcesDevModeTest {
 
     private static final String RES_WATCHED = "watched.txt";


### PR DESCRIPTION
This test consistently fails on Windows with:
`java.nio.file.InvalidPathException: Illegal char <*> at index 0: *.sample`