### PR TITLE
Prevent QuarkusTestResourceLifecycleManager from being run twice

### DIFF
--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/Counter.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/Counter.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.extension;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Counter {
+
+    public static final AtomicInteger startCounter = new AtomicInteger(0);
+    public static final AtomicInteger endCounter = new AtomicInteger(0);
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/CustomResource.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/CustomResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@QuarkusTestResource(LifecycleManager.class)
+@Stereotype
+public @interface CustomResource {
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/EndTest.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/EndTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.extension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResource
+@QuarkusTest
+public class EndTest {
+
+    @Test
+    public void test1() {
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/LifecycleManager.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/LifecycleManager.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.extension;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class LifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        Counter.startCounter.incrementAndGet();
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        Counter.endCounter.incrementAndGet();
+    }
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/StartTest.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/StartTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.extension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResource
+@QuarkusTest
+public class StartTest {
+
+    @Test
+    public void test1() {
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -30,6 +30,8 @@ import org.jboss.jandex.IndexView;
 
 public class TestResourceManager implements Closeable {
 
+    private static final int ANNOTATION = 0x00002000;
+
     private final List<TestResourceEntry> sequentialTestResourceEntries;
     private final List<TestResourceEntry> parallelTestResourceEntries;
     private final List<TestResourceEntry> allTestResourceEntries;
@@ -387,11 +389,19 @@ public class TestResourceManager implements Closeable {
     }
 
     private boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass, Set<String> testClasses) {
+        if (isAnnotation(targetClass)) {
+            // meta-annotations have already been handled in collectMetaAnnotations
+            return false;
+        }
         AnnotationValue restrict = annotation.value("restrictToAnnotatedClass");
         if (restrict != null && restrict.asBoolean()) {
             return testClasses.contains(targetClass.name().toString('.'));
         }
         return true;
+    }
+
+    private boolean isAnnotation(ClassInfo info) {
+        return (info.flags() & ANNOTATION) != 0;
     }
 
     public static class TestResourceClassEntry {


### PR DESCRIPTION
This happened when the `QuarkusTestResourceLifecycleManager` was
 configured in a `@QuarkusTestResource` that was being used as a
 meta-annotation

Fixes: #16108