### PR TITLE
Fix Gradle test not using Java 8

### DIFF
--- a/integration-tests/gradle/src/test/resources/multi-module-with-empty-module/build.gradle.kts
+++ b/integration-tests/gradle/src/test/resources/multi-module-with-empty-module/build.gradle.kts
@@ -29,7 +29,7 @@ subprojects {
   val quarkusPlatformArtifactId: String by project
   val quarkusPlatformVersion: String by project
 
-  val javaVersion = "11"
+  val javaVersion = "8"
 
   dependencies {
     "implementation"(enforcedPlatform("$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))


### PR DESCRIPTION
@glefloch could you have another look at this one? I don't understand why CI didn't catch it and only the release build process job did.

Also I wasn't able to run the test anyway (but I tried to do it from the directory itself by fixing a few properties) so I'm not sure if it's just my setup that is incorrect.

Last error I had was:
```
Caused by: java.util.NoSuchElementException
        at io.quarkus.deployment.builditem.ArchiveRootBuildItem.<init>(ArchiveRootBuildItem.java:97)
        at io.quarkus.deployment.builditem.ArchiveRootBuildItem.<init>(ArchiveRootBuildItem.java:17)
        at io.quarkus.deployment.builditem.ArchiveRootBuildItem$Builder.build(ArchiveRootBuildItem.java:50)
        at io.quarkus.deployment.QuarkusAugmentor.run(QuarkusAugmentor.java:141)
        at io.quarkus.runner.bootstrap.AugmentActionImpl.runAugment(AugmentActionImpl.java:394)
```

Is there an easy way to only run one Gradle test?