### PR TITLE
Make sure all the project modules are loaded into workspace in case the root pom does not declare any

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/UnresolvedVersionException.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/UnresolvedVersionException.java
@@ -1,13 +1,11 @@
 package io.quarkus.bootstrap.resolver.maven.workspace;
 
-import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
-
 /**
  * Thrown if a "Maven CI Friendly Versions" property in the version could not be resolved.
  *
  * @see <a href="https://maven.apache.org/maven-ci-friendly.html">Maven CI Friendly Versions (maven.apache.org)</a>
  */
-public class UnresolvedVersionException extends BootstrapMavenException {
+public class UnresolvedVersionException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -108,7 +108,7 @@ public class LocalWorkspaceDiscoveryTest {
     @AfterEach
     public void restoreSystemProperties() {
         if (systemPropertiesBackup != null) {
-            System.setProperties(systemPropertiesBackup);
+            System.setProperties((Properties) systemPropertiesBackup.clone());
         }
     }
 
@@ -134,6 +134,26 @@ public class LocalWorkspaceDiscoveryTest {
         assertNotNull(ws.getProject("org.acme", "nested-project-module1"));
         assertNotNull(ws.getProject("org.acme", "nested-project-parent"));
         assertNotNull(ws.getProject("org.acme", "root-module1"));
+        assertNotNull(ws.getProject("org.acme", "root"));
+        assertEquals(4, ws.getProjects().size());
+    }
+
+    @Test
+    public void loadWorkspaceRootWithNoModules() throws Exception {
+        final URL projectUrl = Thread.currentThread().getContextClassLoader().getResource("workspace-root-no-module/root");
+        assertNotNull(projectUrl);
+        final Path rootProjectDir = Paths.get(projectUrl.toURI());
+        assertTrue(Files.exists(rootProjectDir));
+        final Path nestedProjectDir = rootProjectDir.resolve("module1/module2");
+        assertTrue(Files.exists(nestedProjectDir));
+
+        final LocalWorkspace ws = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setCurrentProject(nestedProjectDir.toString()))
+                        .getWorkspace();
+
+        assertNotNull(ws.getProject("org.acme", "module3"));
+        assertNotNull(ws.getProject("org.acme", "module2"));
+        assertNotNull(ws.getProject("org.acme", "module1"));
         assertNotNull(ws.getProject("org.acme", "root"));
         assertEquals(4, ws.getProjects().size());
     }

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/module2/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/module2/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>module1</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>module2</artifactId>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/module3/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/module3/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>module1</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>module3</artifactId>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/module1/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>root</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>module1</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>module2</module>
+        <module>module3</module>
+    </modules>
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/workspace-root-no-module/root/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+</project>


### PR DESCRIPTION
Fixes a bug in the bootstrap Maven workspace discovery when the current project is located deep in the module hierarchy and the root pom doesn't happen to list any modules.