### PR TITLE
Minor correction in centralized-log-management doc

### DIFF
--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -307,7 +307,7 @@ networks:
 
 Launch your application, you should see your logs arriving inside EFK: you can use Kibana available at http://localhost:5601/ to access them.
 
-== Fluentd alternative: use Syslog
+== GELF alternative: use Syslog
 
 You can also send your logs to Fluentd using a Syslog input.
 As opposed to the GELF input, the Syslog input will not render multiline logs in one event, that's why we advise to use the GELF input that we implement in Quarkus.


### PR DESCRIPTION
It seems `GELF` is natural to that context.