### PR TITLE
Fix Uni response type handling in quarkus-rest-client-reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
@@ -541,24 +541,14 @@ public class JaxrsClientProcessor {
                         } else {
                             Type type = paramType.arguments().get(0);
                             if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
-                                ResultHandle currentThread = methodCreator
-                                        .invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
-                                ResultHandle tccl = methodCreator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL,
-                                        currentThread);
-                                genericReturnType = Types.getParameterizedType(methodCreator, tccl, type.asParameterizedType());
+                                genericReturnType = createGenericTypeFromParameterizedType(methodCreator,
+                                        type.asParameterizedType());
                             } else {
                                 simpleReturnType = type.toString();
                             }
                         }
                     } else {
-                        ResultHandle currentThread = methodCreator.invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
-                        ResultHandle tccl = methodCreator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
-                        ResultHandle parameterizedType = Types.getParameterizedType(methodCreator, tccl,
-                                paramType);
-
-                        genericReturnType = methodCreator.newInstance(
-                                MethodDescriptor.ofConstructor(GenericType.class, java.lang.reflect.Type.class),
-                                parameterizedType);
+                        genericReturnType = createGenericTypeFromParameterizedType(methodCreator, paramType);
                     }
                 }
 
@@ -706,6 +696,18 @@ public class JaxrsClientProcessor {
         }
         return recorderContext.newInstance(creatorName);
 
+    }
+
+    private ResultHandle createGenericTypeFromParameterizedType(MethodCreator methodCreator,
+            ParameterizedType parameterizedType2) {
+        ResultHandle genericReturnType;
+        ResultHandle currentThread = methodCreator.invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
+        ResultHandle tccl = methodCreator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
+        ResultHandle parameterizedType = Types.getParameterizedType(methodCreator, tccl, parameterizedType2);
+        genericReturnType = methodCreator.newInstance(
+                MethodDescriptor.ofConstructor(GenericType.class, java.lang.reflect.Type.class),
+                parameterizedType);
+        return genericReturnType;
     }
 
     private AssignableResultHandle createWebTargetForMethod(MethodCreator constructor, AssignableResultHandle baseTarget,

--- a/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-jaxrs-client/deployment/src/main/java/io/quarkus/resteasy/reactive/client/deployment/JaxrsClientProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.client.deployment;
 
 import static io.quarkus.deployment.Feature.RESTEASY_REACTIVE_JAXRS_CLIENT;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COMPLETION_STAGE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.WEB_APPLICATION_EXCEPTION;
 
 import java.io.Closeable;
@@ -25,6 +26,7 @@ import javax.ws.rs.client.AsyncInvoker;
 import javax.ws.rs.client.CompletionStageRxInvoker;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.RxInvoker;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
@@ -38,6 +40,7 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.impl.AsyncInvokerImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientImpl;
+import org.jboss.resteasy.reactive.client.impl.UniInvoker;
 import org.jboss.resteasy.reactive.client.impl.WebTargetImpl;
 import org.jboss.resteasy.reactive.common.core.GenericTypeMapping;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
@@ -100,6 +103,7 @@ import io.quarkus.resteasy.reactive.spi.MessageBodyReaderOverrideBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterOverrideBuildItem;
 import io.quarkus.runtime.RuntimeValue;
+import io.smallrye.mutiny.Uni;
 
 public class JaxrsClientProcessor {
 
@@ -525,15 +529,17 @@ public class JaxrsClientProcessor {
                 }
 
                 Type returnType = jandexMethod.returnType();
-                boolean completionStage = false;
-                String simpleReturnType = method.getSimpleReturnType();
+                ReturnCategory returnCategory = ReturnCategory.BLOCKING;
 
+                String simpleReturnType = method.getSimpleReturnType();
                 ResultHandle genericReturnType = null;
+
                 if (returnType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
 
                     ParameterizedType paramType = returnType.asParameterizedType();
-                    if (paramType.name().equals(COMPLETION_STAGE)) {
-                        completionStage = true;
+                    if (paramType.name().equals(COMPLETION_STAGE) || paramType.name().equals(UNI)) {
+                        returnCategory = paramType.name().equals(COMPLETION_STAGE) ? ReturnCategory.COMPLETION_STAGE
+                                : ReturnCategory.UNI;
 
                         // CompletionStage has one type argument:
                         if (paramType.arguments().isEmpty()) {
@@ -600,7 +606,7 @@ public class JaxrsClientProcessor {
                             tryBlock.getMethodParam(bodyParameterIdx),
                             mediaType);
 
-                    if (completionStage) {
+                    if (returnCategory == ReturnCategory.COMPLETION_STAGE) {
                         ResultHandle async = tryBlock.invokeInterfaceMethod(
                                 MethodDescriptor.ofMethod(Invocation.Builder.class, "async", AsyncInvoker.class),
                                 builder);
@@ -620,6 +626,27 @@ public class JaxrsClientProcessor {
                                     async, tryBlock.load(method.getHttpMethod()), entity,
                                     tryBlock.loadClass(simpleReturnType));
                         }
+                    } else if (returnCategory == ReturnCategory.UNI) {
+                        ResultHandle rx = tryBlock.invokeInterfaceMethod(
+                                MethodDescriptor.ofMethod(Invocation.Builder.class, "rx", RxInvoker.class, Class.class),
+                                builder, tryBlock.loadClass(UniInvoker.class));
+                        ResultHandle uniInvoker = tryBlock.checkCast(rx, UniInvoker.class);
+                        // with entity
+                        if (genericReturnType != null) {
+                            result = tryBlock.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(UniInvoker.class, "method",
+                                            Uni.class, String.class,
+                                            Entity.class, GenericType.class),
+                                    uniInvoker, tryBlock.load(method.getHttpMethod()), entity,
+                                    genericReturnType);
+                        } else {
+                            result = tryBlock.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(UniInvoker.class, "method",
+                                            Uni.class, String.class,
+                                            Entity.class, Class.class),
+                                    uniInvoker, tryBlock.load(method.getHttpMethod()), entity,
+                                    tryBlock.loadClass(simpleReturnType));
+                        }
                     } else {
                         if (genericReturnType != null) {
                             result = tryBlock.invokeInterfaceMethod(
@@ -637,7 +664,7 @@ public class JaxrsClientProcessor {
                     }
                 } else {
 
-                    if (completionStage) {
+                    if (returnCategory == ReturnCategory.COMPLETION_STAGE) {
                         ResultHandle async = tryBlock.invokeInterfaceMethod(
                                 MethodDescriptor.ofMethod(Invocation.Builder.class, "async", AsyncInvoker.class),
                                 builder);
@@ -653,6 +680,25 @@ public class JaxrsClientProcessor {
                                             String.class,
                                             Class.class),
                                     async, tryBlock.load(method.getHttpMethod()),
+                                    tryBlock.loadClass(simpleReturnType));
+                        }
+                    } else if (returnCategory == ReturnCategory.UNI) {
+                        ResultHandle rx = tryBlock.invokeInterfaceMethod(
+                                MethodDescriptor.ofMethod(Invocation.Builder.class, "rx", RxInvoker.class, Class.class),
+                                builder, tryBlock.loadClass(UniInvoker.class));
+                        ResultHandle uniInvoker = tryBlock.checkCast(rx, UniInvoker.class);
+                        if (genericReturnType != null) {
+                            result = tryBlock.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(UniInvoker.class, "method",
+                                            Uni.class, String.class,
+                                            GenericType.class),
+                                    uniInvoker, tryBlock.load(method.getHttpMethod()), genericReturnType);
+                        } else {
+                            result = tryBlock.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(UniInvoker.class, "method",
+                                            Uni.class, String.class,
+                                            Class.class),
+                                    uniInvoker, tryBlock.load(method.getHttpMethod()),
                                     tryBlock.loadClass(simpleReturnType));
                         }
                     } else {
@@ -828,6 +874,12 @@ public class JaxrsClientProcessor {
                         MethodDescriptor.ofMethod(Invocation.Builder.class, "cookie", Invocation.Builder.class, String.class,
                                 String.class),
                         invocationBuilder, invoBuilderEnricher.load(paramName), cookieParamHandle));
+    }
+
+    private enum ReturnCategory {
+        BLOCKING,
+        COMPLETION_STAGE,
+        UNI
     }
 
 }

--- a/integration-tests/resteasy-reactive-rest-client/pom.xml
+++ b/integration-tests/resteasy-reactive-rest-client/pom.xml
@@ -90,35 +90,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>uk.co.automatictester</groupId>
-                <artifactId>wiremock-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>wiremock-start</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>stop</goal>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <dir>target/classes</dir>
-                            <params>--port=8765 --verbose --disable-banner</params>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>wiremock-stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/ClientCallingResource.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/ClientCallingResource.java
@@ -1,7 +1,6 @@
 package io.quarkus.it.rest.client;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -13,14 +12,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
 @ApplicationScoped
 public class ClientCallingResource {
     private static final ObjectMapper mapper = new JsonMapper();
 
-    private static final String[] RESPONSES = { "cortland", "cortland2" };
+    private static final String[] RESPONSES = { "cortland", "cortland2", "cortland3" };
     private final AtomicInteger count = new AtomicInteger(0);
 
     void init(@Observes Router router) {
@@ -36,20 +37,41 @@ public class ClientCallingResource {
             String url = rc.getBody().toString();
             SimpleClient client = RestClientBuilder.newBuilder().baseUri(URI.create(url))
                     .build(SimpleClient.class);
-            Apple swappedApple = client.swapApple(new Apple("lobo"));
-            client.completionApple(new Apple("lobo2")).whenComplete((apple2, t) -> {
-                if (t == null) {
-                    try {
-                        rc.response().putHeader("content-type", "application/json")
-                                .end(mapper.writeValueAsString(Arrays.asList(swappedApple, apple2)));
-                        return;
-                    } catch (JsonProcessingException e) {
-                        t = e;
-                    }
-                }
-                rc.response().putHeader("content-type", "text/plain").setStatusCode(500).end(t.getMessage());
-            });
+            Uni<Apple> apple1 = Uni.createFrom().item(client.swapApple(new Apple("lobo")));
+            Uni<Apple> apple2 = Uni.createFrom().completionStage(client.completionSwapApple(new Apple("lobo2")));
+            Uni<Apple> apple3 = client.uniSwapApple(new Apple("lobo3"));
+            Uni<Apple> apple4 = Uni.createFrom().item(client.someApple());
+            Uni<Apple> apple5 = Uni.createFrom().completionStage(client.completionSomeApple());
+            Uni<Apple> apple6 = client.uniSomeApple();
+            Uni<Apple> apple7 = Uni.createFrom().item(client.stringApple()).onItem().transform(this::toApple);
+            Uni<Apple> apple8 = Uni.createFrom().completionStage(client.completionStringApple()).onItem()
+                    .transform(this::toApple);
+            Uni<Apple> apple9 = client.uniStringApple().onItem().transform(this::toApple);
+            Uni.combine().all().unis(apple1, apple2, apple3, apple4, apple5, apple6, apple7, apple8, apple9).asTuple()
+                    .subscribe()
+                    .with(tuple -> {
+                        try {
+                            rc.response().putHeader("content-type", "application/json")
+                                    .end(mapper.writeValueAsString(tuple.asList()));
+                        } catch (JsonProcessingException e) {
+                            fail(rc, e.getMessage());
+                        }
+                    }, t -> {
+                        fail(rc, t.getMessage());
+                    });
         });
+    }
+
+    private void fail(RoutingContext rc, String message) {
+        rc.response().putHeader("content-type", "text/plain").setStatusCode(500).end(message);
+    }
+
+    private Apple toApple(String s) {
+        try {
+            return mapper.readValue(s, Apple.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/SimpleClient.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/SimpleClient.java
@@ -8,6 +8,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.smallrye.mutiny.Uni;
+
 @Path("")
 public interface SimpleClient {
     @POST
@@ -17,6 +19,35 @@ public interface SimpleClient {
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    Apple someApple();
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    String stringApple();
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    CompletionStage<Apple> completionApple(Apple original);
+    CompletionStage<Apple> completionSwapApple(Apple original);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    CompletionStage<Apple> completionSomeApple();
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    CompletionStage<String> completionStringApple();
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Uni<Apple> uniSwapApple(Apple original);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<Apple> uniSomeApple();
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<String> uniStringApple();
 }

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/SimpleClient.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/SimpleClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.rest.client;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -12,4 +14,9 @@ public interface SimpleClient {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     Apple swapApple(Apple original);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    CompletionStage<Apple> completionApple(Apple original);
 }

--- a/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -21,8 +21,15 @@ public class BasicTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
-                .body("size()", is(2))
+                .body("size()", is(9))
                 .body("[0].cultivar", equalTo("cortland"))
-                .body("[1].cultivar", equalTo("cortland2"));
+                .body("[1].cultivar", equalTo("cortland2"))
+                .body("[2].cultivar", equalTo("cortland3"))
+                .body("[3].cultivar", equalTo("cortland"))
+                .body("[4].cultivar", equalTo("cortland2"))
+                .body("[5].cultivar", equalTo("cortland3"))
+                .body("[6].cultivar", equalTo("cortland"))
+                .body("[7].cultivar", equalTo("cortland2"))
+                .body("[8].cultivar", equalTo("cortland3"));
     }
 }

--- a/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -1,13 +1,13 @@
 package io.quarkus.it.rest.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
-import io.restassured.response.Response;
 
 @QuarkusTest
 public class BasicTest {
@@ -17,7 +17,12 @@ public class BasicTest {
 
     @Test
     public void shouldWork() {
-        Response response = RestAssured.with().body(appleUrl).post("/call-client");
-        assertThat(response.jsonPath().getString("cultivar")).isEqualTo("cortland");
+        RestAssured.with().body(appleUrl).post("/call-client")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("size()", is(2))
+                .body("[0].cultivar", equalTo("cortland"))
+                .body("[1].cultivar", equalTo("cortland2"));
     }
 }


### PR DESCRIPTION
Uni was not being treated as an async return type resulting in
the client making blocking calls and trying to deserialize the
result into a Uni

Fixes: #16148