### PR TITLE
Fixed the codestarts artifactId

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,4 +12,4 @@ metadata:
     name: "amazon-lambda"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/azure-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,4 +12,4 @@ metadata:
     name: "azure-functions-http"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/config-yaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/config-yaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -14,4 +14,4 @@ metadata:
     languages:
       - "java"
       - "kotlin"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -14,4 +14,4 @@ metadata:
     name: "funqy-amazon-lambda"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -15,4 +15,4 @@ metadata:
     name: "funqy-google-cloud-functions-example"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/funqy/funqy-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,4 +12,4 @@ metadata:
     name: "funqy-http"
     kind: "example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -13,4 +13,4 @@ metadata:
     name: "funqy-knative-events"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -14,4 +14,4 @@ metadata:
     name: "google-cloud-functions-http"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -13,4 +13,4 @@ metadata:
     name: "google-cloud-functions"
     kind: "singleton-example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   codestart:
     name: "kotlin"
     kind: "core"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/logging-json/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/logging-json/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -15,4 +15,4 @@ metadata:
     languages:
       - "java"
       - "kotlin"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/picocli/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/picocli/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -13,4 +13,4 @@ metadata:
     languages:
       - "java"
       - "kotlin"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -18,4 +18,4 @@ metadata:
     languages:
       - "java"
       - "kotlin"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -15,4 +15,4 @@ metadata:
     languages:
       - "java"
       - "kotlin"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,4 +16,4 @@ metadata:
       - "java"
       - "kotlin"
       - "scala"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,4 +17,4 @@ metadata:
       - "java"
       - "kotlin"
       - "scala"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   codestart:
     name: "scala"
     kind: "core"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -14,5 +14,5 @@ metadata:
       - "java"
       - "kotlin"
       - "scala"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"
 

--- a/extensions/websockets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/websockets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -15,4 +15,4 @@ metadata:
     name: "undertow-websockets"
     kind: "example"
     languages: "java"
-    artifact: "io.quarkus:quarkus-descriptor-json"
+    artifact: "io.quarkus:quarkus-platform-descriptor-json"

--- a/independent-projects/tools/codestarts/README.adoc
+++ b/independent-projects/tools/codestarts/README.adoc
@@ -104,10 +104,10 @@ metadata:
       - "java"
       - "kotlin"
       - "scala"
-    artifact: "io.quarkus:quarkus-descriptor-json" # The artifact in which the codestart is located
+    artifact: "io.quarkus:quarkus-platform-descriptor-json" # The artifact in which the codestart is located
 ----
 
-*NOTE* Using "io.quarkus:quarkus-descriptor-json" as artifact is temporary, extension codestarts will soon live alongside the extension.
+*NOTE* Using "io.quarkus:quarkus-platform-descriptor-json" as artifact is temporary, extension codestarts will soon live alongside the extension.
 
 === Tests
 

--- a/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
@@ -24,7 +24,8 @@ public class ExtensionProcessorTest extends PlatformAwareTestBase {
         assertThat(extensionProcessor.getCategories()).contains("web");
         assertThat(extensionProcessor.getCodestartKind()).isEqualTo(ExtensionProcessor.CodestartKind.EXAMPLE);
         assertThat(extensionProcessor.getCodestartName()).isEqualTo("resteasy");
-        assertThat(extensionProcessor.getCodestartArtifact()).isEqualTo("io.quarkus:quarkus-descriptor-json");
+        assertThat(extensionProcessor.getCodestartArtifact())
+                .isEqualTo("io.quarkus:quarkus-platform-descriptor-json::jar:" + getQuarkusCoreVersion());
         assertThat(extensionProcessor.getCodestartLanguages()).contains("java", "kotlin", "scala");
         assertThat(extensionProcessor.getKeywords()).contains("resteasy", "jaxrs", "web", "rest");
         assertThat(extensionProcessor.getExtendedKeywords()).contains("resteasy", "jaxrs", "web", "rest");
@@ -42,7 +43,8 @@ public class ExtensionProcessorTest extends PlatformAwareTestBase {
         assertThat(extensionProcessor.getCodestartKind()).isEqualTo(ExtensionProcessor.CodestartKind.CORE);
         assertThat(extensionProcessor.getCodestartName()).isEqualTo("kotlin");
         assertThat(extensionProcessor.getCodestartLanguages()).isEmpty();
-        assertThat(extensionProcessor.getCodestartArtifact()).isEqualTo("io.quarkus:quarkus-descriptor-json");
+        assertThat(extensionProcessor.getCodestartArtifact())
+                .isEqualTo("io.quarkus:quarkus-platform-descriptor-json::jar:" + getQuarkusCoreVersion());
         assertThat(extensionProcessor.getKeywords()).contains("kotlin");
         assertThat(extensionProcessor.getExtendedKeywords()).contains("kotlin", "quarkus-kotlin", "services", "write");
         assertThat(extensionProcessor.getGuide()).isEqualTo("https://quarkus.io/guides/kotlin");


### PR DESCRIPTION
This fixes the artifactId containing the codestarts templates which is referenced from the extension descriptors.
And also adds code to the extension descriptor generator to complete and validate the configured codestarts artifact coordinates.