### PR TITLE
Add quarkusCoreVersion parameter to generate-platform-descriptor-json goal

### DIFF
--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GeneratePlatformDescriptorJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GeneratePlatformDescriptorJsonMojo.java
@@ -144,6 +144,9 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
     @Parameter(property = "resolveDependencyManagement")
     boolean resolveDependencyManagement;
 
+    @Parameter(required = false)
+    String quarkusCoreVersion;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -250,7 +253,6 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
         final Set<String> referencedCategories = new HashSet<>();
         final List<io.quarkus.registry.catalog.Extension> extListJson = new ArrayList<>();
         platformJson.setExtensions(extListJson);
-        String quarkusCoreVersion = null;
         boolean jsonFoundInBom = false;
         for (Dependency dep : deps) {
             final Artifact artifact = dep.getArtifact();
@@ -281,7 +283,7 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
                 continue;
             }
 
-            if (artifact.getArtifactId().equals(quarkusCoreArtifactId)
+            if (quarkusCoreVersion == null && artifact.getArtifactId().equals(quarkusCoreArtifactId)
                     && artifact.getGroupId().equals(quarkusCoreGroupId)) {
                 quarkusCoreVersion = artifact.getVersion();
             }


### PR DESCRIPTION
This parameter isn't currently used in our setup but it's needed for my platform model prototypes.

@gsmet could we backport this to 1.13.1.Final? I then would be able to release the platform bom generator using it sooner.