### PR TITLE
Make sure the devtools config is initialized for the codestarts tests

### DIFF
--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
@@ -10,10 +10,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import io.quarkus.devtools.PlatformAwareTestBase;
 import io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData;
 import io.quarkus.devtools.testing.SnapshotTesting;
 
-class QuarkusExtensionCodestartGenerationTest {
+class QuarkusExtensionCodestartGenerationTest extends PlatformAwareTestBase {
 
     private static final Path testDirPath = Paths.get("target/extension-codestart-gen-test");
 


### PR DESCRIPTION
Fixes CI failure for https://github.com/quarkusio/quarkus/pull/16136