### PR TITLE
Workaround for KT-45007, sporadic NPE in kotlin plugin

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,4 @@
 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
 -Dmaven.wagon.http.retryHandler.count=10
+-Dkotlin.environment.keepalive=true


### PR DESCRIPTION
See:
- https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/NPE.20in.20intellij.2Fkotlin.20code
- https://youtrack.jetbrains.com/issue/KT-45007

We should be able to remove the property once it gets fixed in the plugin. I'll try to keep track of it.

I renamed the file because `maven.config` is primarily for `mvn` _args_: http://maven.apache.org/configure.html#mvn-maven-config-file
See also: https://github.com/quarkusio/quarkus-platform/pull/69#issuecomment-812205726 (where AFAICS @geoand got the idea from, initially)