### PR TITLE
Add token audience param to oidc-client

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -30,6 +30,13 @@ quarkus.oidc-client.client-id=quarkus-app
 quarkus.oidc-client.credentials.secret=secret
 ----
 
+The `client_credentials` grant allows to set extra parameters to the token request via `quarkus.oidc-client.grant-options.client.<param-name>=<value>`. Here is how to set the intended token recipient via the `audience` parameter:
+
+[source,properties]
+----
+quarkus.oidc-client.grant-options.client.audience=https://example.com/api
+----
+
 Here is how `OidcClient` can be configured to use the `password` grant:
 
 [source,properties]

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -16,6 +16,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClientConfig.Grant;
+import io.quarkus.oidc.client.OidcClientConfig.Grant.Type;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
@@ -141,13 +142,15 @@ public class OidcClientRecorder {
                                 : OidcConstants.PASSWORD_GRANT;
                         setGrantClientParams(oidcConfig, tokenGrantParams, grantType);
 
+                        Map<String, String> grantOptions = oidcConfig.getGrantOptions()
+                                .get(oidcConfig.grant.getType().name().toLowerCase());
                         if (oidcConfig.grant.getType() == Grant.Type.PASSWORD) {
-                            Map<String, String> passwordGrantOptions = oidcConfig.getGrantOptions()
-                                    .get(OidcConstants.PASSWORD_GRANT);
                             tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_USERNAME,
-                                    passwordGrantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
+                                    grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
                             tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD,
-                                    passwordGrantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
+                                    grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
+                        } else if (grantOptions != null && oidcConfig.grant.getType() == Grant.Type.CLIENT) {
+                            tokenGrantParams.addAll(grantOptions);
                         }
 
                         MultiMap commonRefreshGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());


### PR DESCRIPTION
This PR extends the OIDC Client by adding the token audience param for requesting access tokens with an expected aud claim from the token endpoint.

Background: Some IdPs like Auth0 require the intended audience to be specified when requesting the access token.

