### PR TITLE
Substitute DefaultMethodFallbackProvider in GraalVM < 21.0

### DIFF
--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/graal/FaultToleranceSubstitutions.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/graal/FaultToleranceSubstitutions.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.faulttolerance.runtime.graal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.home.Version;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+public class FaultToleranceSubstitutions {
+}
+
+@TargetClass(className = "io.smallrye.faulttolerance.DefaultMethodFallbackProvider", onlyWith = GraalVM20OrEarlier.class)
+final class Target_io_smallrye_faulttolerance_DefaultMethodFallbackProvider {
+
+    @TargetClass(className = "io.smallrye.faulttolerance.ExecutionContextWithInvocationContext")
+    static final class Target_io_smallrye_faulttolerance_ExecutionContextWithInvocationContext {
+
+    }
+
+    @Substitute
+    static Object getFallback(Method fallbackMethod,
+            Target_io_smallrye_faulttolerance_ExecutionContextWithInvocationContext ctx)
+            throws IllegalAccessException, InstantiationException, IllegalArgumentException, InvocationTargetException,
+            Throwable {
+        throw new RuntimeException("Not supported in native image when using GraalVM releases prior to 21.0.0");
+    }
+
+}
+
+class GraalVM20OrEarlier implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return Version.getCurrent().compareTo(21) < 0;
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.main;
 
+import static io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion.GRAALVM_21_0;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -175,6 +177,7 @@ public class RestClientTestCase {
     }
 
     @Test
+    @DisableIfBuiltWithGraalVMOlderThan(GRAALVM_21_0)
     public void testFaultTolerance() {
         RestAssured.when().get("/client/fault-tolerance").then()
                 .body(is("Hello fallback!"));


### PR DESCRIPTION
This PR partially reverts #15788 to allow the substitution of DefaultMethodFallbackProvider when using GraalVM < 21.0.
This enables `integration-tests/main`(#16126) and `integration-tests/rest-client` (#16128) to build and not cause failures with GraalVM 20.3.
~In the case of `integration-tests/main`(#16126) however the test `io.quarkus.it.main.RestClientTestCase#testFaultTolerance` still fails and needs to be skipped when using GraalVM 20.3.~

Closes #16126 
Closes #16128 