### PR TITLE
Disable kafka-snappy tests for versions of GraalVM older than 21.0

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -7,12 +7,48 @@ import io.quarkus.builder.item.SimpleBuildItem;
 public final class NativeImageBuildItem extends SimpleBuildItem {
 
     private final Path path;
+    private final GraalVMVersion graalVMVersion;
 
-    public NativeImageBuildItem(Path path) {
+    public NativeImageBuildItem(Path path, GraalVMVersion graalVMVersion) {
         this.path = path;
+        this.graalVMVersion = graalVMVersion;
     }
 
     public Path getPath() {
         return path;
+    }
+
+    public GraalVMVersion getGraalVMInfo() {
+        return graalVMVersion;
+    }
+
+    public static class GraalVMVersion {
+        private final String fullVersion;
+        private final int major;
+        private final int minor;
+        private final String distribution;
+
+        public GraalVMVersion(String fullVersion, int major, int minor, String distribution) {
+            this.fullVersion = fullVersion;
+            this.major = major;
+            this.minor = minor;
+            this.distribution = distribution;
+        }
+
+        public String getFullVersion() {
+            return fullVersion;
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public String getDistribution() {
+            return distribution;
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -1,0 +1,121 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+final class GraalVM {
+    static final class Version implements Comparable<Version> {
+        private static final Pattern PATTERN = Pattern.compile(
+                "GraalVM Version (([1-9][0-9]*)\\.([0-9]+)\\.[0-9]+|\\p{XDigit}*)[^(\n$]*(\\(Mandrel Distribution\\))?\\s*");
+
+        static final Version UNVERSIONED = new Version("Undefined", -1, -1, Distribution.ORACLE);
+        static final Version SNAPSHOT_ORACLE = new Version("Snapshot", Integer.MAX_VALUE, Integer.MAX_VALUE,
+                Distribution.ORACLE);
+        static final Version SNAPSHOT_MANDREL = new Version("Snapshot", Integer.MAX_VALUE, Integer.MAX_VALUE,
+                Distribution.MANDREL);
+
+        static final Version VERSION_20_3 = new Version("GraalVM 20.3", 20, 3, Distribution.ORACLE);
+        static final Version VERSION_21_0 = new Version("GraalVM 21.0", 21, 0, Distribution.ORACLE);
+
+        static final Version MINIMUM = VERSION_20_3;
+        static final Version CURRENT = VERSION_21_0;
+
+        final String fullVersion;
+        final int major;
+        final int minor;
+        final Distribution distribution;
+
+        Version(String fullVersion, int major, int minor, Distribution distro) {
+            this.fullVersion = fullVersion;
+            this.major = major;
+            this.minor = minor;
+            this.distribution = distro;
+        }
+
+        String getFullVersion() {
+            return fullVersion;
+        }
+
+        boolean isDetected() {
+            return this != UNVERSIONED;
+        }
+
+        boolean isObsolete() {
+            return this.compareTo(MINIMUM) < 0;
+        }
+
+        boolean isMandrel() {
+            return distribution == Distribution.MANDREL;
+        }
+
+        boolean isSnapshot() {
+            return this == SNAPSHOT_ORACLE || this == SNAPSHOT_MANDREL;
+        }
+
+        boolean isNewerThan(Version version) {
+            return this.compareTo(version) > 0;
+        }
+
+        @Override
+        public int compareTo(Version o) {
+            if (major > o.major) {
+                return 1;
+            }
+
+            if (major == o.major) {
+                if (minor > o.minor) {
+                    return 1;
+                } else if (minor == o.minor) {
+                    return 0;
+                }
+            }
+
+            return -1;
+        }
+
+        static Version of(Stream<String> lines) {
+            final Iterator<String> it = lines.iterator();
+            while (it.hasNext()) {
+                final String line = it.next();
+                final Matcher matcher = PATTERN.matcher(line);
+                if (matcher.find() && matcher.groupCount() >= 3) {
+                    final String distro = matcher.group(4);
+                    if (isSnapshot(matcher.group(2))) {
+                        return isMandrel(distro) ? SNAPSHOT_MANDREL : SNAPSHOT_ORACLE;
+                    } else {
+                        return new Version(
+                                line,
+                                Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(3)),
+                                isMandrel(distro) ? Distribution.MANDREL : Distribution.ORACLE);
+                    }
+                }
+            }
+
+            return UNVERSIONED;
+        }
+
+        private static boolean isSnapshot(String s) {
+            return s == null;
+        }
+
+        private static boolean isMandrel(String s) {
+            return "(Mandrel Distribution)".equals(s);
+        }
+
+        @Override
+        public String toString() {
+            return "Version{" +
+                    "major=" + major +
+                    ", minor=" + minor +
+                    ", distribution=" + distribution +
+                    '}';
+        }
+    }
+
+    enum Distribution {
+        ORACLE,
+        MANDREL;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -14,7 +14,6 @@ import java.util.concurrent.Executors;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM;
 import io.quarkus.deployment.util.ProcessUtil;
 
 public abstract class NativeImageBuildRunner {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -12,12 +12,11 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -67,7 +66,12 @@ public class NativeImageBuildStep {
 
     @BuildStep(onlyIf = NativeBuild.class)
     ArtifactResultBuildItem result(NativeImageBuildItem image) {
-        return new ArtifactResultBuildItem(image.getPath(), PackageConfig.NATIVE, Collections.emptyMap());
+        NativeImageBuildItem.GraalVMVersion graalVMVersion = image.getGraalVMInfo();
+        Map<String, Object> graalVMInfoProps = new HashMap<>();
+        graalVMInfoProps.put("graalvm.version.full", graalVMVersion.getFullVersion());
+        graalVMInfoProps.put("graalvm.version.major", "" + graalVMVersion.getMajor());
+        graalVMInfoProps.put("graalvm.version.minor", "" + graalVMVersion.getMinor());
+        return new ArtifactResultBuildItem(image.getPath(), PackageConfig.NATIVE, graalVMInfoProps);
     }
 
     @BuildStep(onlyIf = NativeSourcesBuild.class)
@@ -208,7 +212,10 @@ public class NativeImageBuildStep {
                 log.warn("That will result in a larger native image with debug symbols embedded in it.");
             }
 
-            return new NativeImageBuildItem(finalExecutablePath);
+            return new NativeImageBuildItem(finalExecutablePath,
+                    new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion, graalVMVersion.major,
+                            graalVMVersion.minor,
+                            graalVMVersion.distribution.name()));
         } catch (Exception e) {
             throw new RuntimeException("Failed to build native image", e);
         } finally {
@@ -481,121 +488,6 @@ public class NativeImageBuildStep {
             if (process != null) {
                 process.destroy();
             }
-        }
-    }
-
-    protected static final class GraalVM {
-        static final class Version implements Comparable<Version> {
-            private static final Pattern PATTERN = Pattern.compile(
-                    "GraalVM Version (([1-9][0-9]*)\\.([0-9]+)\\.[0-9]+|\\p{XDigit}*)[^(\n$]*(\\(Mandrel Distribution\\))?\\s*");
-
-            static final Version UNVERSIONED = new Version("Undefined", -1, -1, Distribution.ORACLE);
-            static final Version SNAPSHOT_ORACLE = new Version("Snapshot", Integer.MAX_VALUE, Integer.MAX_VALUE,
-                    Distribution.ORACLE);
-            static final Version SNAPSHOT_MANDREL = new Version("Snapshot", Integer.MAX_VALUE, Integer.MAX_VALUE,
-                    Distribution.MANDREL);
-
-            static final Version VERSION_20_3 = new Version("GraalVM 20.3", 20, 3, Distribution.ORACLE);
-            static final Version VERSION_21_0 = new Version("GraalVM 21.0", 21, 0, Distribution.ORACLE);
-
-            static final Version MINIMUM = VERSION_20_3;
-            static final Version CURRENT = VERSION_21_0;
-
-            final String fullVersion;
-            final int major;
-            final int minor;
-            final Distribution distribution;
-
-            Version(String fullVersion, int major, int minor, Distribution distro) {
-                this.fullVersion = fullVersion;
-                this.major = major;
-                this.minor = minor;
-                this.distribution = distro;
-            }
-
-            String getFullVersion() {
-                return fullVersion;
-            }
-
-            boolean isDetected() {
-                return this != UNVERSIONED;
-            }
-
-            boolean isObsolete() {
-                return this.compareTo(MINIMUM) < 0;
-            }
-
-            boolean isMandrel() {
-                return distribution == Distribution.MANDREL;
-            }
-
-            boolean isSnapshot() {
-                return this == SNAPSHOT_ORACLE || this == SNAPSHOT_MANDREL;
-            }
-
-            boolean isNewerThan(Version version) {
-                return this.compareTo(version) > 0;
-            }
-
-            @Override
-            public int compareTo(Version o) {
-                if (major > o.major) {
-                    return 1;
-                }
-
-                if (major == o.major) {
-                    if (minor > o.minor) {
-                        return 1;
-                    } else if (minor == o.minor) {
-                        return 0;
-                    }
-                }
-
-                return -1;
-            }
-
-            static Version of(Stream<String> lines) {
-                final Iterator<String> it = lines.iterator();
-                while (it.hasNext()) {
-                    final String line = it.next();
-                    final Matcher matcher = PATTERN.matcher(line);
-                    if (matcher.find() && matcher.groupCount() >= 3) {
-                        final String distro = matcher.group(4);
-                        if (isSnapshot(matcher.group(2))) {
-                            return isMandrel(distro) ? SNAPSHOT_MANDREL : SNAPSHOT_ORACLE;
-                        } else {
-                            return new Version(
-                                    line,
-                                    Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(3)),
-                                    isMandrel(distro) ? Distribution.MANDREL : Distribution.ORACLE);
-                        }
-                    }
-                }
-
-                return UNVERSIONED;
-            }
-
-            private static boolean isSnapshot(String s) {
-                return s == null;
-            }
-
-            private static boolean isMandrel(String s) {
-                return "(Mandrel Distribution)".equals(s);
-            }
-
-            @Override
-            public String toString() {
-                return "Version{" +
-                        "major=" + major +
-                        ", minor=" + minor +
-                        ", distribution=" + distribution +
-                        '}';
-            }
-        }
-
-        enum Distribution {
-            ORACLE,
-            MANDREL;
         }
     }
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStepTest.java
@@ -1,15 +1,15 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM.Distribution.MANDREL;
-import static io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM.Distribution.ORACLE;
+import static io.quarkus.deployment.pkg.steps.GraalVM.Distribution.MANDREL;
+import static io.quarkus.deployment.pkg.steps.GraalVM.Distribution.ORACLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM.Distribution;
-import io.quarkus.deployment.pkg.steps.NativeImageBuildStep.GraalVM.Version;
+import io.quarkus.deployment.pkg.steps.GraalVM.Distribution;
+import io.quarkus.deployment.pkg.steps.GraalVM.Version;
 
 public class NativeImageBuildStepTest {
 

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyCodecITCase.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyCodecITCase.java
@@ -1,8 +1,12 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion.GRAALVM_21_0;
+
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
+@DisableIfBuiltWithGraalVMOlderThan(GRAALVM_21_0)
 public class KafkaSnappyCodecITCase extends KafkaSnappyCodecTest {
 
 }

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerITCase.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerITCase.java
@@ -1,8 +1,12 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion.GRAALVM_21_0;
+
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
+@DisableIfBuiltWithGraalVMOlderThan(GRAALVM_21_0)
 public class KafkaSnappyConsumerITCase extends KafkaSnappyConsumerTest {
 
 }

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyProducerITCase.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyProducerITCase.java
@@ -1,8 +1,12 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion.GRAALVM_21_0;
+
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
+@DisableIfBuiltWithGraalVMOlderThan(GRAALVM_21_0)
 public class KafkaSnappyProducerITCase extends KafkaSnappyProducerTest {
 
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThan.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThan.java
@@ -1,0 +1,65 @@
+package io.quarkus.test.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Used to signal that a test class should be disabled if the version of GraalVM used to build the native binary
+ * under test was older than the supplied version.
+ *
+ * This annotation should only be used on a test classes annotated with {@link NativeImageTest} or
+ * {@link QuarkusIntegrationTest}
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisableIfBuiltWithGraalVMOlderThanCondition.class)
+public @interface DisableIfBuiltWithGraalVMOlderThan {
+
+    GraalVMVersion value();
+
+    enum GraalVMVersion {
+        GRAALVM_21_0(21, 0);
+
+        private final int major;
+        private final int minor;
+
+        GraalVMVersion(int major, int minor) {
+            this.major = major;
+            this.minor = minor;
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        /**
+         * Compares this version with a tuple of major and minor parts representing another GraalVM version
+         * 
+         * @return {@code -1} if this version is older than the version represented by the supplied major and minor parts,
+         *         {@code +1} if it's newer and {@code 0} if they represent the same version
+         */
+        public int compareTo(int major, int minor) {
+            int majorComparison = Integer.compare(this.major, major);
+            if (majorComparison != 0) {
+                return majorComparison;
+            }
+            return Integer.compare(this.minor, minor);
+        }
+
+        @Override
+        public String toString() {
+            return "GraalVMVersion{" +
+                    "major=" + major +
+                    ", minor=" + minor +
+                    '}';
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.junit;
+
+import static io.quarkus.test.junit.IntegrationTestUtil.readQuarkusArtifactProperties;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<AnnotatedElement> element = context.getElement();
+        Optional<DisableIfBuiltWithGraalVMOlderThan> optional = findAnnotation(element,
+                DisableIfBuiltWithGraalVMOlderThan.class);
+        if (!optional.isPresent()) {
+            return ConditionEvaluationResult.enabled("@DisableIfBuiltWithGraalVMOlderThan was not found");
+        }
+
+        DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion annotationValue = optional.get().value();
+        Properties quarkusArtifactProperties = readQuarkusArtifactProperties(context);
+        try {
+            int major = Integer.parseInt(quarkusArtifactProperties.getProperty("metadata.graalvm.version.major"));
+            int minor = Integer.parseInt(quarkusArtifactProperties.getProperty("metadata.graalvm.version.minor"));
+            int comparison = annotationValue.compareTo(major, minor);
+            if (comparison > 0) {
+                return ConditionEvaluationResult.disabled("Native binary was built with GraalVM{major=" + major + ", minor= "
+                        + minor + "} but the test is disabled for GraalVM versions older than " + annotationValue);
+            }
+            return ConditionEvaluationResult
+                    .enabled("Native binary was built with a GraalVM version compatible with the required version by the test");
+        } catch (NumberFormatException e) {
+            return ConditionEvaluationResult
+                    .disabled("Unable to determine the GraalVM version with which the native binary was built");
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -4,13 +4,18 @@ import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLo
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.CodeSource;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -217,5 +222,74 @@ final class IntegrationTestUtil {
                     }
                 }, DevServicesDatasourceResultBuildItem.class.getName());
         return propertyMap;
+    }
+
+    static Properties readQuarkusArtifactProperties(ExtensionContext context) {
+        Path buildOutputDirectory = determineBuildOutputDirectory(context);
+        Path artifactProperties = buildOutputDirectory.resolve("quarkus-artifact.properties");
+        if (!Files.exists(artifactProperties)) {
+            throw new IllegalStateException(
+                    "Unable to locate the artifact metadata file created that must be created by Quarkus in order to run integration tests.");
+        }
+        try {
+            Properties properties = new Properties();
+            properties.load(new FileInputStream(artifactProperties.toFile()));
+            return properties;
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Unable to read artifact metadata file created that must be created by Quarkus in order to run integration tests.",
+                    e);
+        }
+    }
+
+    static Path determineBuildOutputDirectory(ExtensionContext context) {
+        String buildOutputDirStr = System.getProperty("build.output.directory");
+        Path result = null;
+        if (buildOutputDirStr != null) {
+            result = Paths.get(buildOutputDirStr);
+        } else {
+            // we need to guess where the artifact properties file is based on the location of the test class
+            Class<?> testClass = context.getRequiredTestClass();
+            final CodeSource codeSource = testClass.getProtectionDomain().getCodeSource();
+            if (codeSource != null) {
+                URL codeSourceLocation = codeSource.getLocation();
+                File artifactPropertiesDirectory = determineBuildOutputDirectory(codeSourceLocation);
+                if (artifactPropertiesDirectory == null) {
+                    throw new IllegalStateException(
+                            "Unable to determine the output of the Quarkus build. Consider setting the 'build.output.directory' system property.");
+                }
+                result = artifactPropertiesDirectory.toPath();
+            }
+        }
+        if (result == null) {
+            throw new IllegalStateException(
+                    "Unable to locate the artifact metadata file created that must be created by Quarkus in order to run tests annotated with '@QuarkusIntegrationTest'.");
+        }
+        if (!Files.isDirectory(result)) {
+            throw new IllegalStateException(
+                    "The determined Quarkus build output '" + result.toAbsolutePath().toString() + "' is not a directory");
+        }
+        return result;
+    }
+
+    private static File determineBuildOutputDirectory(final URL url) {
+        if (url == null) {
+            return null;
+        }
+        if (url.getProtocol().equals("file") && url.getPath().endsWith("test-classes/")) {
+            //we have the maven test classes dir
+            File testClasses = new File(url.getPath());
+            return testClasses.getParentFile();
+        } else if (url.getProtocol().equals("file") && url.getPath().endsWith("test/")) {
+            //we have the gradle test classes dir, build/classes/java/test
+            File testClasses = new File(url.getPath());
+            return testClasses.getParentFile().getParentFile().getParentFile();
+        } else if (url.getProtocol().equals("file") && url.getPath().contains("/target/surefire/")) {
+            //this will make mvn failsafe:integration-test work
+            String path = url.getPath();
+            int index = path.lastIndexOf("/target/");
+            return new File(path.substring(0, index) + "/target/");
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This is done by Introducing the ability to skip native tests if GraalVM version is too old

Essentially the test is skipped if the GraalVM version used to build the
native binary was older than the version specified in the new
`@DisableIfBuiltWithGraalVMOlderThan` annotation.
This is accomplished by recording the GraalVM version in the `quarkus-artifact.properties`
file (this file was introduced to support `@QuarkusIntegrationTest`) and reading
the necessary data in a new JUnit 5 `ExecutionCondition` implementation.

Fixes: #16129