### PR TITLE
Update micrometer guide URL

### DIFF
--- a/extensions/micrometer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   - "metrics"
   - "metric"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "stable"


### PR DESCRIPTION
The current guide url `https://quarkus.io/guides/micrometer-metrics` does not exists, `https://quarkus.io/guides/micrometer` seems to be the good one. 