### PR TITLE
Bump gitflow-incremental-builder to 3.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>3.13.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>3.14.0</gitflow-incremental-builder.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Dependabot is having a hard time with a maximum of 3 open PRs, so I'm doing it myself.

Changes: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/version%2F3.14.0