### PR TITLE
Introduce tcks/resteasy-reactive, wrapping the testsuite repo

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Verify extension dependencies
         shell: bash
         run: |
-          ./update-extension-dependencies.sh -B --settings .github/mvn-settings.xml
+          ./update-extension-dependencies.sh $COMMON_MAVEN_ARGS
           if [ `git status -s -u no '*pom.xml' | wc -l` -ne 0 ]
           then
             echo -e '\033[0;31mError:\033[0m Dependencies to extension artifacts are outdated!' 1>&2
@@ -453,7 +453,7 @@ jobs:
         if: matrix.os.family == 'Linux'
         shell: bash
         run: |
-          ./update-dependencies.sh -B --settings ../../.github/mvn-settings.xml
+          ./integration-tests/gradle/update-dependencies.sh $COMMON_MAVEN_ARGS
           if [ `git status -s -u no '*pom.xml' | wc -l` -ne 0 ]
           then
             echo -e '\033[0;31mError:\033[0m Dependencies in integration-tests/gradle/pom.xml are outdated!' 1>&2
@@ -462,7 +462,6 @@ jobs:
             git --no-pager diff '*pom.xml' 1>&2
             exit 1
           fi
-        working-directory: integration-tests/gradle
       - name: Build
         shell: bash
         run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl integration-tests/gradle ${{ needs.build-jdk11.outputs.gib_args }}
@@ -591,19 +590,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          path: tcks
       - name: Add quarkusio remote
         shell: bash
         run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
-        working-directory: ./tcks
-      - name: Download RESTEasy Reactive Testsuite
-        uses: actions/checkout@v2
-        with:
-          repository: quarkusio/resteasy-reactive-testsuite
-          path: resteasy-reactive-testsuite
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
-        working-directory: ./tcks
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
@@ -617,13 +608,22 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Run RESTEasy Reactive TCK
-        # Note: No gib_args here because resteasy-reactive-testsuite is a different repo
-        run: mvn -B --settings ../tcks/.github/mvn-settings.xml install
-        working-directory: ./resteasy-reactive-testsuite
       - name: Verify
         run: ./mvnw $COMMON_MAVEN_ARGS -Dtcks -pl tcks -amd install ${{ needs.build-jdk11.outputs.gib_args }}
-        working-directory: ./tcks
+      - name: Verify resteasy-reative dependencies
+        # note: ideally, this would be run _before_ mvnw but that would required building tcks/resteasy-reactive in two steps
+        shell: bash
+        run: |
+          ./tcks/resteasy-reactive/update-dependencies.sh $COMMON_MAVEN_ARGS
+          if [ `git status -s -u no '*pom.xml' | wc -l` -ne 0 ]
+          then
+            echo -e '\033[0;31mError:\033[0m Dependencies in tcks/resteasy-reactive/pom.xml are outdated!' 1>&2
+            echo -e '\033[0;31mError:\033[0m Run './mvnw clean process-test-resources -f tcks/resteasy-reactive && tcks/resteasy-reactive/update-dependencies.sh' \
+              and add the modified pom.xml file to your commit.' 1>&2
+            echo -e '\033[0;31mError:\033[0m Diff is:' 1>&2
+            git --no-pager diff '*pom.xml' 1>&2
+            exit 1
+          fi
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -30,6 +30,7 @@
         -->
         <module>microprofile-openapi</module>
         <module>microprofile-opentracing</module>
+        <module>resteasy-reactive</module>
     </modules>
 
     <properties>

--- a/tcks/resteasy-reactive/README.md
+++ b/tcks/resteasy-reactive/README.md
@@ -1,0 +1,20 @@
+# Resteasy Reactive Testuite Wrapper
+
+This Maven module wraps the execution of https://github.com/quarkusio/resteasy-reactive-testsuite
+to leverage incremental build mechanics and to make it easier to run locally.
+
+That repo will be cloned and executed via a separate mvn call when running `mvn test`.
+
+The Git ref is pinned in `pom.xml` and can be changed conveniently via `./update-ref.sh <new-ref>`.
+
+If dependencies were changed in the testuite repo make sure to run `./update-dependencies.sh`
+to ensure proper build order.
+
+`mvn clean ...` will remove the cloned repo so better use `mvn test -Dresteasy-reactive-testsuite.clone.skip`
+to save some time in case you want to run the suite multiple times.
+
+More properties:
+- `resteasy-reactive-testsuite.checkout.skip` skips (re-)checking out the respective ref
+- `resteasy-reactive-testsuite.test.skip` skips the execution of the suite
+- `resteasy-reactive-testsuite.repo.org` can be used to target a fork
+- `resteasy-reactive-testsuite.repo.ref` defines the ref to check out

--- a/tcks/resteasy-reactive/pom.xml
+++ b/tcks/resteasy-reactive/pom.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-tck-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-tck-resteasy-reactive</artifactId>
+    <name>Quarkus - TCK - RestEasy Reactive</name>
+
+    <properties>
+
+        <!-- to avoid sudden surprises, checkout is pinned to a specific commit -->
+        <resteasy-reactive-testsuite.repo.ref>531734d28f1fcb39d369c1d2fae0a0f90a4ab9dc</resteasy-reactive-testsuite.repo.ref>
+
+        <exec.skip>${skipTests}</exec.skip>
+        <resteasy-reactive-testsuite.clone.skip>${exec.skip}</resteasy-reactive-testsuite.clone.skip>
+        <resteasy-reactive-testsuite.checkout.skip>${exec.skip}</resteasy-reactive-testsuite.checkout.skip>
+        <resteasy-reactive-testsuite.test.skip>${exec.skip}</resteasy-reactive-testsuite.test.skip>
+
+        <!-- careful when changing the workdir, it's referenced in update-dependencies.sh as well -->
+        <resteasy-reactive-testsuite.workdir>${project.build.directory}/testsuite</resteasy-reactive-testsuite.workdir>
+        <resteasy-reactive-testsuite.repo.org>quarkusio</resteasy-reactive-testsuite.repo.org>
+        <resteasy-reactive-testsuite.repo.url>https://github.com/${resteasy-reactive-testsuite.repo.org}/resteasy-reactive-testsuite</resteasy-reactive-testsuite.repo.url>
+
+        <resteasy-reactive-testsuite.mvn.args></resteasy-reactive-testsuite.mvn.args>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <workingDirectory>${resteasy-reactive-testsuite.workdir}</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>clone</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <commandlineArgs>clone ${resteasy-reactive-testsuite.repo.url} ${resteasy-reactive-testsuite.workdir}</commandlineArgs>
+                            <skip>${resteasy-reactive-testsuite.clone.skip}</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>checkout</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <commandlineArgs>checkout ${resteasy-reactive-testsuite.repo.ref}</commandlineArgs>
+                            <skip>${resteasy-reactive-testsuite.checkout.skip}</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>mvn</executable>
+                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args}</commandlineArgs>
+                            <skip>${resteasy-reactive-testsuite.test.skip}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- All the following dependencies shall enforce the right build order
+             and proper upstream/downstream detection for incremental build.
+             They won't have an actual impact on "inner" gradle execution. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+        <!-- The following dependencies are generated in a way that is consistent with other normal IT modules,
+             that is "runtime" deps are defined with scope compile and "minimal extension deployment dependencies"
+             come in the usual form (pom, test, exclusions). This also ensures to keep the enforcer rules happy. -->
+        <!-- START update-dependencies.sh -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxrs-client-reactive</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- END update-dependencies.sh -->
+    </dependencies>
+</project>

--- a/tcks/resteasy-reactive/update-dependencies.sh
+++ b/tcks/resteasy-reactive/update-dependencies.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Purpose: Updates pom.xml with (minimal) dependencies to other modules to enforce a consistent build order.
+
+set -e -u -o pipefail
+shopt -s failglob
+
+# path of this shell script (note: readlink -f does not work on Mac)
+PRG_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+DEP_TEMPLATE='        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>XXX</artifactId>
+            <version>\${project.version}</version>
+        </dependency>'
+
+DEP_TEMPLATE_DEPLOYMENT='        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>XXX-deployment</artifactId>
+            <version>\${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>'
+
+echo ''
+echo 'Building dependencies list from testuite pom.xml...'
+echo ''
+
+# get the Quarkus artifact ids from tests/pom.xml of the testsuite repo that is cloned in target
+# pipefail is switched off briefly so that a better error can be logged when nothing is found
+set +o pipefail
+# note on sed: -deployment deps are added with their runtime counterparts later, so treat each -deployment dep as a runtime dep
+ARTIFACT_IDS=$(grep -h '<artifactId>' "${PRG_PATH}/target/testsuite/tests/pom.xml" | \
+              grep -Eo 'quarkus-[a-z0-9-]+' | \
+              sed -e '/-maven-plugin/d' -e 's/-deployment//' | sort | uniq)
+set -o pipefail
+if [ -z "${ARTIFACT_IDS}" ]
+then
+  echo -e '\033[0;31mError:\033[0m Could not find any artifact-ids. Please check the grep command. ' 1>&2
+  exit 1
+fi
+
+# note: that bulky last sed in the following commands replaces newlines with \n so that the final sed calls accept ${DEPS} as input
+# see also: https://stackoverflow.com/a/1252191/9529981
+
+DEPS=$(echo "${ARTIFACT_IDS}" \
+  | while read AID; do echo "${DEP_TEMPLATE/XXX/${AID}}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
+
+# https://superuser.com/a/307486
+LF=$'\n'
+
+DEPS+="\\${LF}"
+
+# note on sed: Remove artifacts that are not extensions (since no -deployment sibling exists).
+#              This is a bit fragile but without this -deployment deps would need to be added by hand.
+DEPS+=$(echo "${ARTIFACT_IDS}" \
+  | sed -e '/-junit/d' \
+  | while read AID; do echo "${DEP_TEMPLATE_DEPLOYMENT/XXX/${AID}}"; done \
+  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\n/g')
+
+MARK_START='<!-- START update-dependencies.sh -->'
+MARK_END='<!-- END update-dependencies.sh -->'
+# note: line break after c command is required for MacOS compatibility: https://unix.stackexchange.com/a/52141
+SED_EXPR="/${MARK_START}/,/${MARK_END}/c\\
+        ${MARK_START}\\${LF}${DEPS}\\${LF}        ${MARK_END}"
+# BSD sed (on MacOS) consumes one line break too much which will be fixed by the following additional expression:
+SED_EXPR_BSD_FIXUP="s/${MARK_END}    <\/dependencies>/${MARK_END}\\${LF}    <\/dependencies>/"
+
+echo ''
+echo 'Updating pom.xml...'
+echo ''
+# note: the following sed command does not use -i because behavior on MacOS is different than on Linux
+sed -e "${SED_EXPR}" -e "${SED_EXPR_BSD_FIXUP}" "${PRG_PATH}/pom.xml" > /tmp/tcks-resteasy-reactive-pom.xml
+mv /tmp/tcks-resteasy-reactive-pom.xml "${PRG_PATH}/pom.xml"
+
+echo ''
+echo 'Sanity check...'
+echo ''
+# sanity check; make sure nothing stupid was added like non-existing deps
+mvn dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*

--- a/tcks/resteasy-reactive/update-ref.sh
+++ b/tcks/resteasy-reactive/update-ref.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Purpose: Updates resteasy-reactive-testsuite.repo.ref in pom.xmls (after changes were pushed to the testuite repo).
+#          First parameter is the new ref (mandatory).
+
+set -e -u -o pipefail
+shopt -s failglob
+
+# path of this shell script (note: readlink -f does not work on Mac)
+PRG_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+# note: the following sed command does not use -i because behavior on MacOS is different than on Linux
+sed -e "s/<resteasy-reactive-testsuite.repo.ref>.*</<resteasy-reactive-testsuite.repo.ref>$1</" \
+  "${PRG_PATH}/pom.xml" > /tmp/tcks-resteasy-reactive-pom.xml
+mv /tmp/tcks-resteasy-reactive-pom.xml "${PRG_PATH}/pom.xml"


### PR DESCRIPTION
Addresses point 3 of #15686:
> - [ ] Mostly CI, but could also help locally: Wrap clone and execution of `resteasy-reactive-testsuite` in e.g. `tcks/resteasy-reactive`, with `exec-maven-plugin` and those few deps the testsuite is (indirectly) dependening on

Some remarks:
- **Git ref of the testsuite is now pinned to a commit hash! Updates of the suite repo will now have to be accompanied with a PR bumping the hash.**
- I could add a README.md to the module in case you find that helpful
- Yes, another one of those dreaded scripts but this should be the last one for now, AFAICS. The testsuite is probably the least chaged one in terms of dependencies.
- I was thinking about moving that diff check into the script (and do the same for the other two existing ones) and trigger it with a special argument. This would reduce the noise in the workflow file.
- The reactive testsuite is now run _after_ the other TCKs modules. Theoretically, it could still be a separate step if that's what you want (but means more "noise").