### PR TITLE
Load configurations recursively from Consul KV store

### DIFF
--- a/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/ConsulConfig.java
+++ b/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/ConsulConfig.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -37,7 +39,7 @@ public class ConsulConfig {
 
     /**
      * Keys whose value is a raw string.
-     * When this is used, the keys that end up in the user configuration are the keys specified her with '/' replaced by '.'
+     * When this is used, the keys that end up in the user configuration are the keys specified here with '/' replaced by '.'
      */
     @ConfigItem
     Optional<List<String>> rawValueKeys;
@@ -49,6 +51,15 @@ public class ConsulConfig {
      */
     @ConfigItem
     Optional<List<String>> propertiesValueKeys;
+
+    /**
+     * A folder which will be recursively searched for raw string values.
+     * When this is used, the keys that end up in the user configuration are all the raw keys found under the specified folders
+     * and their sub-folders.
+     * The folder and sub-folder names are also part of the keys, separated by '.'
+     */
+    @ConfigItem
+    Optional<List<String>> rawValueFolders;
 
     /**
      * If set to true, the application will not start if any of the configured config sources cannot be located
@@ -69,6 +80,13 @@ public class ConsulConfig {
             }
         }
         return result;
+    }
+
+    Map<String, ValueType> foldersAsMap() {
+        return rawValueFolders
+                .map(folders -> folders.stream()
+                        .collect(Collectors.toMap(Function.identity(), s -> ValueType.RAW)))
+                .orElse(new LinkedHashMap<>());
     }
 
     @ConfigGroup

--- a/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/ConsulConfigGateway.java
+++ b/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/ConsulConfigGateway.java
@@ -9,5 +9,7 @@ interface ConsulConfigGateway {
      */
     Uni<Response> getValue(String key);
 
+    Uni<MultiResponse> getValueRecursive(String key);
+
     void close();
 }

--- a/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/MultiResponse.java
+++ b/extensions/consul-config/runtime/src/main/java/io/quarkus/consul/config/runtime/MultiResponse.java
@@ -1,0 +1,18 @@
+package io.quarkus.consul.config.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiResponse {
+
+    private final List<Response> responses = new ArrayList<>();
+
+    public MultiResponse addResponse(Response response) {
+        responses.add(response);
+        return this;
+    }
+
+    public List<Response> getResponses() {
+        return responses;
+    }
+}

--- a/extensions/consul-config/runtime/src/test/java/io/quarkus/consul/config/runtime/ResponseUtil.java
+++ b/extensions/consul-config/runtime/src/test/java/io/quarkus/consul/config/runtime/ResponseUtil.java
@@ -1,6 +1,7 @@
 package io.quarkus.consul.config.runtime;
 
 import java.util.Base64;
+import java.util.List;
 
 import io.smallrye.mutiny.Uni;
 
@@ -10,7 +11,19 @@ final class ResponseUtil {
     }
 
     static Uni<Response> validResponse(String key, String rawValue) {
-        return Uni.createFrom().item(new Response(key, Base64.getEncoder().encodeToString(rawValue.getBytes())));
+        return Uni.createFrom().item(encodeResponse(key, rawValue));
+    }
+
+    static Uni<MultiResponse> validMultiResponse(List<String> keys, List<String> rawValues) {
+        MultiResponse multiResponse = new MultiResponse();
+        for (int i = 0; i < keys.size(); i++) {
+            multiResponse.addResponse(encodeResponse(keys.get(i), rawValues.get(i)));
+        }
+        return Uni.createFrom().item(multiResponse);
+    }
+
+    private static Response encodeResponse(String key, String rawValue) {
+        return new Response(key, Base64.getEncoder().encodeToString(rawValue.getBytes()));
     }
 
     static Uni<Response> emptyResponse() {


### PR DESCRIPTION
Let users list several Consul KV store "folders" and make all the raw configuration values "below" config sources as if they were listed explicitly in the `rawValueKeys` Quarkus property

Closes #16095
