### PR TITLE
Add missing throw statement

### DIFF
--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProtocolCodeGenProvider.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProtocolCodeGenProvider.java
@@ -48,7 +48,7 @@ public class AvroProtocolCodeGenProvider extends AvroCodeGenProviderBase impleme
             compiler.setOutputCharacterEncoding("UTF-8");
             compiler.compileToDestination(filePath.toFile(), outputDirectory.toFile());
         } catch (IOException e) {
-            new CodeGenException("Failed to compile avro protocole file: " + filePath.toString() + " to Java", e);
+            throw new CodeGenException("Failed to compile avro protocole file: " + filePath.toString() + " to Java", e);
         }
     }
 }


### PR DESCRIPTION
While looking at the avro code, I found this catch without throw.. I think it's missing. 