### PR TITLE
Until the delayed handler is activated, drop anything below INFO level

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
@@ -66,6 +67,10 @@ public class QuarkusDelayedHandler extends ExtHandler {
                     publishToNestedHandlers(record);
                     super.doPublish(record);
                 } else {
+                    // until the handler is fully activated, we drop anything below the info level
+                    if (record.getLevel().intValue() < Level.INFO.intValue()) {
+                        return;
+                    }
                     // Determine whether the queue was overrun
                     if (logRecords.size() >= queueLimit) {
                         reportError(


### PR DESCRIPTION
This is definitely not a perfect solution but keeping all the log
messages in memory sounds worse anyway.

/cc @geoand 

This could fix #16239 if I'm not mistaken.

@mincel any chance you could test this change? You can follow the instructions here https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#checking-an-issue-is-fixed-in-main except you need to get my branch.

If you can come up with a reproducer, I can have a look myself.