### PR TITLE
Update aws-sdk to 2.16.36

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -151,7 +151,7 @@
         <aws-lambda-java-events.version>3.8.0</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.8.0</aws-xray.version>
-        <awssdk.version>2.16.29</awssdk.version>
+        <awssdk.version>2.16.36</awssdk.version>
         <aws-alexa-sdk.version>2.38.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
         <kotlin.version>1.4.32</kotlin.version>


### PR DESCRIPTION
Updates aws-sdk to 2.16.34 which includes https://github.com/aws/aws-sdk-java-v2/pull/2368 and fixes #16139 (and possibly #15434)

Closes #16139 