### PR TITLE
Reactive datasource idle-timeout for pooled connections

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -616,9 +616,10 @@ In `application.properties` add:
 quarkus.datasource.reactive.url=mysql:///quarkus_test?host=/var/run/mysqld/mysqld.sock
 ----
 
-== TCP Connection `idle-timeout`
+== Pooled Connection `idle-timeout`
 
-Reactive datasources can be configured with an `idle-timeout` (in milliseconds) that applies at the TCP connection level.
+Reactive datasources can be configured with an `idle-timeout` (in milliseconds).
+It is the maximum time a connection remains unused in the pool before it is closed.
 
 NOTE: The `idle-timeout` is disabled by default.
 
@@ -628,26 +629,6 @@ For example, you could expire idle connections after 60 minutes:
 ----
 quarkus.datasource.reactive.idle-timeout=PT60M
 ----
-
-[WARNING]
-====
-This timeout does not apply to the pool, but to the TCP connection.
-
-If it expires while the connection is idle in the pool, the connection is closed and removed from the pool.
-
-If it expires immediately after your borrowed the connection from the pool and before you execute a query, you will get an error.
-
-
-While this is unlikely to happen, you must be prepared for such eventuality:
-
-[source,java]
-----
-// Run a query, retry at most 3 times if it fails
-Uni<RowSet<Row>> rowSet = client.query("SELECT id, name FROM fruits ORDER BY name ASC")
-                            .execute()
-                            .onFailure().retry().atMost(3);
-----
-====
 
 == Configuration Reference
 

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -110,7 +110,7 @@ public class DataSourceReactiveRuntimeConfig {
     public Duration reconnectInterval = Duration.ofSeconds(1L);
 
     /**
-     * The maximum time without data written to or read from a connection before it is closed.
+     * The maximum time a connection remains unused in the pool before it is closed.
      */
     @ConfigItem(defaultValueDocumentation = "no timeout")
     public Optional<Duration> idleTimeout = Optional.empty();

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -77,6 +77,11 @@ public class DB2PoolRecorder {
             poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize.getAsInt());
         }
 
+        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
+            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
+            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+        }
+
         return poolOptions;
     }
 
@@ -143,11 +148,6 @@ public class DB2PoolRecorder {
         connectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts);
 
         connectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval.toMillis());
-
-        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
-            connectOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
-        }
 
         return connectOptions;
     }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -78,6 +78,11 @@ public class MySQLPoolRecorder {
             poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize.getAsInt());
         }
 
+        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
+            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
+            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+        }
+
         return poolOptions;
     }
 
@@ -152,11 +157,6 @@ public class MySQLPoolRecorder {
         mysqlConnectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts);
 
         mysqlConnectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval.toMillis());
-
-        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
-            mysqlConnectOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
-        }
 
         return mysqlConnectOptions;
     }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -78,6 +78,11 @@ public class PgPoolRecorder {
             poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize.getAsInt());
         }
 
+        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
+            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
+            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+        }
+
         return poolOptions;
     }
 
@@ -150,11 +155,6 @@ public class PgPoolRecorder {
         pgConnectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts);
 
         pgConnectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval.toMillis());
-
-        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
-            pgConnectOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
-        }
 
         return pgConnectOptions;
     }


### PR DESCRIPTION
Before Vert.x 3.9.6, the reactive SQL client pool implementation did not support idle-timeout.

So we temporarily used the TCP connection idle-timeout config to achieve the same effect (with the caveat that the connection could be closed as idle after it was borrowed but not yet used for request execution).

With https://github.com/quarkusio/quarkus/pull/16100, Quarkus uses Vert.x 3.9.6 so we can now apply the idle-timeout config at the pool level and get rid of the warnings in the doc.