### PR TITLE
Only resolve db kind implicitly if we have no named datasources around

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -261,11 +261,15 @@ class AgroalProcessor {
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesJdbcBuildTimeConfig dataSourcesJdbcBuildTimeConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
-            List<JdbcDriverBuildItem> jdbcDriverBuildItems, List<DefaultDataSourceDbKindBuildItem> defaultDbKinds) {
+            List<JdbcDriverBuildItem> jdbcDriverBuildItems,
+            List<DefaultDataSourceDbKindBuildItem> defaultDbKinds) {
         List<AggregatedDataSourceBuildTimeConfigBuildItem> dataSources = new ArrayList<>();
 
         Optional<String> effectiveDbKind = DefaultDataSourceDbKindBuildItem
-                .resolve(dataSourcesBuildTimeConfig.defaultDataSource.dbKind, defaultDbKinds, curateOutcomeBuildItem);
+                .resolve(dataSourcesBuildTimeConfig.defaultDataSource.dbKind, defaultDbKinds,
+                        dataSourcesBuildTimeConfig.defaultDataSource.devservices.enabled
+                                .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                        curateOutcomeBuildItem);
 
         if (effectiveDbKind.isPresent()) {
             if (dataSourcesJdbcBuildTimeConfig.jdbc.enabled) {
@@ -285,7 +289,9 @@ class AgroalProcessor {
                 continue;
             }
             Optional<String> dbKind = DefaultDataSourceDbKindBuildItem
-                    .resolve(entry.getValue().dbKind, defaultDbKinds, curateOutcomeBuildItem);
+                    .resolve(entry.getValue().dbKind, defaultDbKinds,
+                            true,
+                            curateOutcomeBuildItem);
             if (!dbKind.isPresent()) {
                 continue;
             }

--- a/extensions/agroal/deployment/src/test/resources/application-multiple-devservices-datasources.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-multiple-devservices-datasources.properties
@@ -1,2 +1,3 @@
+quarkus.datasource.devservices=true
 quarkus.datasource.users.devservices=true
 quarkus.datasource.inventory.devservices=true

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DefaultDataSourceDbKindBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DefaultDataSourceDbKindBuildItem.java
@@ -53,18 +53,25 @@ public final class DefaultDataSourceDbKindBuildItem extends MultiBuildItem {
         return scope;
     }
 
-    public static Optional<String> resolve(Optional<String> configured, List<DefaultDataSourceDbKindBuildItem> defaultDbKinds,
+    public static Optional<String> resolve(Optional<String> configured,
+            List<DefaultDataSourceDbKindBuildItem> defaultDbKinds,
+            boolean enableImplicitResolution,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (configured.isPresent()) {
             return Optional.of(DatabaseKind.normalize(configured.get()));
         }
-        return resolve(defaultDbKinds, curateOutcomeBuildItem);
+
+        if (!enableImplicitResolution) {
+            return Optional.empty();
+        }
+
+        return resolveImplicitDbKind(defaultDbKinds, curateOutcomeBuildItem);
     }
 
     /**
-     * Attempts to resolve the default DB kind for the case where none has been specified.
+     * Attempts to resolve the implicit DB kind for the case where none has been specified.
      */
-    public static Optional<String> resolve(List<DefaultDataSourceDbKindBuildItem> defaultDbKinds,
+    private static Optional<String> resolveImplicitDbKind(List<DefaultDataSourceDbKindBuildItem> defaultDbKinds,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (defaultDbKinds.isEmpty()) {
             return Optional.empty();

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/EntitiesInDefaultPUWithImplicitUnconfiguredDatasourceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/EntitiesInDefaultPUWithImplicitUnconfiguredDatasourceTest.java
@@ -19,7 +19,7 @@ public class EntitiesInDefaultPUWithImplicitUnconfiguredDatasourceTest {
                 assertThat(t)
                         .isInstanceOf(ConfigurationException.class)
                         .hasMessageContainingAll(
-                                "Model classes are defined for the default persistence unit <default> but configured datasource <default> not found: the default EntityManagerFactory will not be created. To solve this, configure the default datasource. Refer to https://quarkus.io/guides/datasource for guidance.");
+                                "Model classes are defined for the default persistence unit, but no default datasource was found. The default EntityManagerFactory will not be created. To solve this, configure the default datasource. Refer to https://quarkus.io/guides/datasource for guidance.");
             })
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(MyEntity.class))

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -147,7 +147,11 @@ public final class HibernateReactiveProcessor {
 
         // we only support the default pool for now
         Optional<String> dbKindOptional = DefaultDataSourceDbKindBuildItem.resolve(
-                dataSourcesBuildTimeConfig.defaultDataSource.dbKind, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
+                dataSourcesBuildTimeConfig.defaultDataSource.dbKind,
+                defaultDataSourceDbKindBuildItems,
+                dataSourcesBuildTimeConfig.defaultDataSource.devservices.enabled
+                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                curateOutcomeBuildItem);
         if (dbKindOptional.isPresent()) {
             final String dbKind = dbKindOptional.get();
             ParsedPersistenceXmlDescriptor reactivePU = generateReactivePersistenceUnit(

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/ErroneousConfigHotReloadTestCase.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/ErroneousConfigHotReloadTestCase.java
@@ -22,7 +22,8 @@ public class ErroneousConfigHotReloadTestCase {
 
     @Test
     public void test() {
-        RestAssured.when().get("/unannotatedEntity").then().statusCode(500).body(containsString("No entities were found"))
+        RestAssured.when().get("/unannotatedEntity").then().statusCode(500)
+                .body(containsString("The default datasource has not been properly configured."))
                 .body(not(containsString("NullPointer")));
 
         TEST.modifyResourceFile("application.properties", new Function<String, String>() {

--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
@@ -161,7 +161,11 @@ class ReactiveDB2ClientProcessor {
                 .getDataSourceReactiveBuildTimeConfig(dataSourceName);
 
         Optional<String> dbKind = DefaultDataSourceDbKindBuildItem.resolve(dataSourceBuildTimeConfig.dbKind,
-                defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
+                defaultDataSourceDbKindBuildItems,
+                !DataSourceUtil.isDefault(dataSourceName) || dataSourceBuildTimeConfig.devservices.enabled
+                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                curateOutcomeBuildItem);
+
         if (!dbKind.isPresent()) {
             return false;
         }

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -167,7 +167,10 @@ class ReactiveMySQLClientProcessor {
                 .getDataSourceReactiveBuildTimeConfig(dataSourceName);
 
         Optional<String> dbKind = DefaultDataSourceDbKindBuildItem.resolve(dataSourceBuildTimeConfig.dbKind,
-                defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
+                defaultDataSourceDbKindBuildItems,
+                !DataSourceUtil.isDefault(dataSourceName) || dataSourceBuildTimeConfig.devservices.enabled
+                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                curateOutcomeBuildItem);
         if (!dbKind.isPresent()) {
             return false;
         }

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -179,7 +179,10 @@ class ReactivePgClientProcessor {
                 .getDataSourceReactiveBuildTimeConfig(dataSourceName);
 
         Optional<String> dbKind = DefaultDataSourceDbKindBuildItem.resolve(dataSourceBuildTimeConfig.dbKind,
-                defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
+                defaultDataSourceDbKindBuildItems,
+                !DataSourceUtil.isDefault(dataSourceName) || dataSourceBuildTimeConfig.devservices.enabled
+                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                curateOutcomeBuildItem);
 
         if (!dbKind.isPresent()) {
             return false;


### PR DESCRIPTION
Also explicitly disable automatic resolution if devservices have been explicitly disabled for the default datasource.

@stuartwdouglas could you have a look at this? It's still too much magic for me and I'm pretty sure some other cases are gonna bite us later but I think the behavior should be a bit saner for the time being.

Fixes #16210