### PR TITLE
Update OIDC to accept all RS and ES algorithms

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -33,6 +33,12 @@ import io.vertx.ext.web.RoutingContext;
 public class OidcProvider {
 
     private static final Logger LOG = Logger.getLogger(OidcProvider.class);
+    private static final String[] SUPPORTED_ALGORITHMS = new String[] { SignatureAlgorithm.RS256.getAlgorithm(),
+            SignatureAlgorithm.RS384.getAlgorithm(),
+            SignatureAlgorithm.RS512.getAlgorithm(),
+            SignatureAlgorithm.ES256.getAlgorithm(),
+            SignatureAlgorithm.ES384.getAlgorithm(),
+            SignatureAlgorithm.ES512.getAlgorithm() };
 
     final OidcProviderClient client;
     final RefreshableVerificationKeyResolver keyResolver;
@@ -56,7 +62,7 @@ public class OidcProvider {
         builder.setVerificationKeyResolver(keyResolver);
 
         builder.setJwsAlgorithmConstraints(
-                new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.PERMIT, SignatureAlgorithm.RS256.getAlgorithm()));
+                new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.PERMIT, SUPPORTED_ALGORITHMS));
 
         builder.setRequireExpirationTime();
         builder.setRequireIssuedAt();


### PR DESCRIPTION
This PR effectively restores what was available with Vert.x Auth - where all the asymmetric algorithms are accepted - as a user has reported a problem with migrating to `1.13.0.Final` as their Keycloak test framework uses not only `RS256`.

In a separate PR I'll add a configuration property for the users be able to restrict to a very specific algorithm which is the best practice (supporting N algorithms in a single deployment is not ideal) - it will also mirror the smallrye-jwt approach 