### PR TITLE
Fix wrong location of Micrometer Prometheus extension descriptor

### DIFF
--- a/extensions/micrometer-registry-prometheus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer-registry-prometheus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: "Micrometer registry: Prometheus"
+name: "Micrometer Registry Prometheus"
 metadata:
   keywords:
   - "micrometer"


### PR DESCRIPTION
This extension was not visible in all the tooling (including code.quarkus.io) because of this..