### PR TITLE
Provide Redis hosts programmatically

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.client.RedisHostsProvider;
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
 import io.quarkus.redis.client.runtime.MutinyRedis;
 import io.quarkus.redis.client.runtime.MutinyRedisAPI;
@@ -51,6 +52,14 @@ public class RedisClientProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(Feature.REDIS_CLIENT.getName());
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem registerAdditionalBeans() {
+        return new AdditionalBeanBuildItem.Builder()
+                .setUnremovable()
+                .addBeanClass(RedisHostsProvider.class)
+                .build();
     }
 
     @BuildStep

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/RedisHostsProvider.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/RedisHostsProvider.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.client;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * Programmatically provides redis hosts
+ */
+public interface RedisHostsProvider {
+    /**
+     * Returns the hosts for this provider.
+     * <p>
+     * The host provided uses the following schema `redis://[username:password@][host][:port][/database]`
+     *
+     * @return the hosts
+     */
+    Set<URI> getHosts();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/runtime/RedisConfig.java
@@ -59,11 +59,25 @@ public class RedisConfig {
          * 1 element.
          * <p>
          * The URI provided uses the following schema `redis://[username:password@][host][:port][/database]`
+         * Use `quarkus.redis.hosts-provider-name` to provide the hosts programmatically.
+         * <p>
          * 
          * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
          */
         @ConfigItem(defaultValueDocumentation = "redis://localhost:6379")
         public Optional<Set<URI>> hosts;
+
+        /**
+         * The hosts provider bean name.
+         * <p>
+         * It is the {@code &#64;Named} value of the hosts provider bean. It is used to discriminate if multiple
+         * `io.quarkus.redis.client.RedisHostsProvider` beans are available.
+         *
+         * <p>
+         * Used when `quarkus.redis.hosts` is not set.
+         */
+        @ConfigItem
+        public Optional<String> hostsProviderName = Optional.empty();
 
         /**
          * The maximum delay to wait before a blocking command to redis server times out

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisLocalHostProvider.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisLocalHostProvider.java
@@ -1,0 +1,19 @@
+package io.quarkus.redis.it;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.quarkus.redis.client.RedisHostsProvider;
+
+@ApplicationScoped
+@Named("test-hosts-provider")
+public class RedisLocalHostProvider implements RedisHostsProvider {
+    @Override
+    public Set<URI> getHosts() {
+        return Collections.singleton(URI.create("redis://localhost:6379/3"));
+    }
+}

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithProvidedHostsResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithProvidedHostsResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.redis.it;
+
+import java.util.Arrays;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.quarkus.redis.client.RedisClient;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.client.reactive.ReactiveRedisClient;
+import io.smallrye.mutiny.Uni;
+import io.vertx.redis.client.Response;
+
+@Path("/quarkus-redis-provided-hosts")
+@ApplicationScoped
+public class RedisWithProvidedHostsResource {
+    private RedisClient redisClient;
+    private ReactiveRedisClient reactiveRedisClient;
+
+    @Inject
+    public RedisWithProvidedHostsResource(@RedisClientName("provided-hosts") RedisClient redisClient,
+            @RedisClientName("provided-hosts") ReactiveRedisClient reactiveRedisClient) {
+        this.redisClient = redisClient;
+        this.reactiveRedisClient = reactiveRedisClient;
+    }
+
+    // synchronous
+    @GET
+    @Path("/sync/{key}")
+    public String getSync(@PathParam("key") String key) {
+        Response response = redisClient.get(key);
+        return response == null ? null : response.toString();
+    }
+
+    @POST
+    @Path("/sync/{key}")
+    public void setSync(@PathParam("key") String key, String value) {
+        this.redisClient.set(Arrays.asList(key, value));
+    }
+
+    // reactive
+    @GET
+    @Path("/reactive/{key}")
+    public Uni<String> getReactive(@PathParam("key") String key) {
+        return reactiveRedisClient
+                .get(key)
+                .map(response -> response == null ? null : response.toString());
+    }
+
+    @POST
+    @Path("/reactive/{key}")
+    public Uni<Void> setReactive(@PathParam("key") String key, String value) {
+        return this.reactiveRedisClient
+                .set(Arrays.asList(key, value))
+                .map(response -> null);
+    }
+
+}

--- a/integration-tests/redis-client/src/main/resources/application.properties
+++ b/integration-tests/redis-client/src/main/resources/application.properties
@@ -2,3 +2,4 @@ quarkus.redis.hosts=redis://localhost:6379/0
 quarkus.redis.named-client.hosts=redis://localhost:6379/1
 quarkus.redis.parameter-injection.hosts=redis://localhost:6379/2
 quarkus.redis.named-reactive-client.hosts=redis://localhost:6379/1
+quarkus.redis.provided-hosts.hosts-provider-name=test-hosts-provider

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisWithProvidedHostsIT.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisWithProvidedHostsIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.redis.it;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class QuarkusRedisWithProvidedHostsIT extends QuarkusRedisWithProvidedHostsTest {
+
+}

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisWithProvidedHostsTest.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisWithProvidedHostsTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.redis.it;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+class QuarkusRedisWithProvidedHostsTest {
+    static final String SYNC_KEY = "named-sync-key";
+    static final String SYNC_VALUE = "named-sync-value";
+
+    static final String REACTIVE_KEY = "named-reactive-key";
+    static final String REACTIVE_VALUE = "named-reactive-value";
+
+    @Test
+    public void sync() {
+        RestAssured.given()
+                .when()
+                .get("/quarkus-redis-provided-hosts/sync/" + SYNC_KEY)
+                .then()
+                .statusCode(204); // the key is not set yet
+
+        RestAssured.given()
+                .body(SYNC_VALUE)
+                .when()
+                .post("/quarkus-redis-provided-hosts/sync/" + SYNC_KEY)
+                .then()
+                .statusCode(204);
+
+        RestAssured.given()
+                .when()
+                .get("/quarkus-redis-provided-hosts/sync/" + SYNC_KEY)
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is(SYNC_VALUE));
+    }
+
+    @Test
+    public void reactive() {
+        RestAssured.given()
+                .when()
+                .get("/quarkus-redis-provided-hosts/reactive/" + REACTIVE_KEY)
+                .then()
+                .statusCode(204); // the reactive key is not set yet
+
+        RestAssured.given()
+                .body(REACTIVE_VALUE)
+                .when()
+                .post("/quarkus-redis-provided-hosts/reactive/" + REACTIVE_KEY)
+                .then()
+                .statusCode(204);
+
+        RestAssured.given()
+                .when()
+                .get("/quarkus-redis-provided-hosts/reactive/" + REACTIVE_KEY)
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is(REACTIVE_VALUE));
+    }
+}


### PR DESCRIPTION
This allows for configuration of properties like redis connection password coming from other
sources.

Closes https://github.com/quarkusio/quarkus/issues/16284

The reason I went with configuring the whole host is that the underlying client does not provide a way to override the password. 

/cc @abutic  would you mind having a look at this and give your initial feedback, would something like this work for your case?