### PR TITLE
Disable live reload instrumentation by default

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
@@ -12,12 +12,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class LiveReloadConfig {
 
     /**
-     * Whether or not Quarkus should disable it's ability to not do a full restart
+     * Whether or not Quarkus should enable its ability to not do a full restart
      * when changes to classes are compatible with JVM instrumentation.
      *
-     * If this is set to false, Quarkus will always restart on changes and never perform class redefinition.
+     * If this is set to true, Quarkus will perform class redefinition when possible.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     boolean instrumentation;
 
     /**

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -220,7 +220,10 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         testDir = initProject("projects/classic-inst", "projects/project-intrumentation-reload");
         runAndCheck();
 
-        //if there is an insturmentation based reload this will stay the same
+        // Enable instrumentation based reload to begin with
+        DevModeTestUtils.getHttpResponse("/app/enable");
+
+        //if there is an instrumentation based reload this will stay the same
         String firstUuid = DevModeTestUtils.getHttpResponse("/app/uuid");
 
         // Edit the "Hello" message.


### PR DESCRIPTION
@stuartwdouglas per our discussion.

I think we should probably document it somewhere but couldn't find a good place for it (it's in the live reload config reference anyway).