### PR TITLE
Use fixed port for mailer test

### DIFF
--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/FakeMailerTestResource.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/FakeMailerTestResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.mailer;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -10,8 +11,9 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class FakeMailerTestResource implements QuarkusTestResourceLifecycleManager {
 
-    public GenericContainer<?> server = new GenericContainer<>("reachfive/fake-smtp-server:latest")
-            .withExposedPorts(1080, 1025)
+    public GenericContainer<?> server = new FixedHostPortGenericContainer<>("reachfive/fake-smtp-server:latest")
+            .withFixedExposedPort(9155, 1080)
+            .withFixedExposedPort(9156, 1025)
             .waitingFor(Wait.forHttp("/api/emails"));
 
     @Override


### PR DESCRIPTION
This is done to avoid the flakiness we are seeing in CI (see https://github.com/quarkusio/quarkus/pull/16302#issuecomment-814535161 and https://github.com/quarkusio/quarkus/pull/16285#issuecomment-814295902)