### PR TITLE
Explicitly wait for the broker to be running before executing the test

### DIFF
--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>kafka_2.12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/ssl/SslKafkaEndpoint.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/ssl/SslKafkaEndpoint.java
@@ -52,7 +52,7 @@ public class SslKafkaEndpoint {
 
     public static KafkaConsumer<Integer, String> createConsumer() {
         Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19093");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19099");
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
@@ -1,5 +1,8 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.it.kafka.KafkaTestResource.extract;
+import static org.awaitility.Awaitility.await;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
@@ -10,6 +13,8 @@ import org.apache.kafka.common.config.SaslConfigs;
 import io.debezium.kafka.KafkaCluster;
 import io.debezium.util.Testing;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import kafka.server.KafkaServer;
+import kafka.server.RunningAsBroker;
 
 public class KafkaSASLTestResource implements QuarkusTestResourceLifecycleManager {
 
@@ -45,6 +50,10 @@ public class KafkaSASLTestResource implements QuarkusTestResourceLifecycleManage
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+
+        KafkaServer server = extract(kafka);
+        await().until(() -> server.brokerState().currentState() == RunningAsBroker.state());
+        server.logger().underlying().info("Broker 'kafka-sasl' started");
 
         return Collections.emptyMap();
     }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaTestResource.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaTestResource.java
@@ -1,13 +1,18 @@
 package io.quarkus.it.kafka;
 
+import static org.awaitility.Awaitility.await;
+
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
 import io.debezium.kafka.KafkaCluster;
+import io.debezium.kafka.KafkaServer;
 import io.debezium.util.Testing;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import kafka.server.RunningAsBroker;
 
 public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
 
@@ -29,6 +34,11 @@ public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+
+        kafka.server.KafkaServer server = extract(kafka);
+        await().until(() -> server.brokerState().currentState() == RunningAsBroker.state());
+        server.logger().underlying().info("Broker 'kafka' started");
+
         return Collections.emptyMap();
     }
 
@@ -37,5 +47,23 @@ public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
         if (kafka != null) {
             kafka.shutdown();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    static kafka.server.KafkaServer extract(KafkaCluster cluster) {
+        Field kafkaServersField;
+        Field serverField;
+        try {
+            kafkaServersField = cluster.getClass().getDeclaredField("kafkaServers");
+            kafkaServersField.setAccessible(true);
+            Map<Integer, KafkaServer> map = (Map<Integer, KafkaServer>) kafkaServersField.get(cluster);
+            KafkaServer server = map.get(1);
+            serverField = KafkaServer.class.getDeclaredField("server");
+            serverField.setAccessible(true);
+            return (kafka.server.KafkaServer) serverField.get(server);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
@@ -40,7 +40,7 @@ public class SslKafkaConsumerTest {
 
     public static Producer<Integer, String> createProducer() {
         Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19093");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19099");
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "test-ssl-producer");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());


### PR DESCRIPTION
Also, increase the range between used ports, as a broker may register multiple ports.

Unfortunately, this commit does not fix the conflicting broker ids because Debezium overrides the broker id and set 1 to all of them.

I'm not very happy with the reflection calls, but let's see if it stabilize the CI. If so, we can investigate another approach exposing the Kafka servers directly.