### PR TITLE
Use the thread-safe version of flatten-platform-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5205,7 +5205,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GeneratePlatformDescriptorJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/GeneratePlatformDescriptorJsonMojo.java
@@ -65,7 +65,7 @@ import io.quarkus.registry.catalog.json.JsonExtensionCatalog;
 /**
  * This goal generates a platform JSON descriptor for a given platform BOM.
  */
-@Mojo(name = "generate-platform-descriptor-json")
+@Mojo(name = "generate-platform-descriptor-json", threadSafe = true)
 public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
 
     @Parameter(property = "quarkusCoreGroupId", defaultValue = ToolsConstants.QUARKUS_CORE_GROUP_ID)


### PR DESCRIPTION
Upgrade the `quarkus-platform-bom-maven-plugin` to version 0.0.9 with `flatten-platform-bom` marked as thread-safe.