### PR TITLE
Use ArtifactCoords API in the devtools instead of AppArtifactCoords

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleGroovyProjectBuildFile.java
+++ b/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleGroovyProjectBuildFile.java
@@ -2,8 +2,8 @@ package io.quarkus.devtools.project.buildfile;
 
 import org.gradle.api.Project;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public class GradleGroovyProjectBuildFile extends GradleProjectBuildFile {
@@ -26,7 +26,7 @@ public class GradleGroovyProjectBuildFile extends GradleProjectBuildFile {
     }
 
     @Override
-    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+    protected boolean addDependency(ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(getModel(), coords, managed);
     }
 
@@ -35,7 +35,7 @@ public class GradleGroovyProjectBuildFile extends GradleProjectBuildFile {
         return BuildTool.GRADLE;
     }
 
-    static boolean addDependencyInModel(Model model, AppArtifactCoords coords, boolean managed) {
+    static boolean addDependencyInModel(Model model, ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(model,
                 String.format("    implementation %s%n", createDependencyCoordinatesString(coords, managed, '\'')));
     }

--- a/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleKotlinProjectBuildFile.java
+++ b/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleKotlinProjectBuildFile.java
@@ -2,8 +2,8 @@ package io.quarkus.devtools.project.buildfile;
 
 import org.gradle.api.Project;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public class GradleKotlinProjectBuildFile extends GradleProjectBuildFile {
@@ -26,7 +26,7 @@ public class GradleKotlinProjectBuildFile extends GradleProjectBuildFile {
     }
 
     @Override
-    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+    protected boolean addDependency(ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(getModel(), coords, managed);
     }
 
@@ -35,7 +35,7 @@ public class GradleKotlinProjectBuildFile extends GradleProjectBuildFile {
         return BuildTool.GRADLE_KOTLIN_DSL;
     }
 
-    static boolean addDependencyInModel(Model model, AppArtifactCoords coords, boolean managed) {
+    static boolean addDependencyInModel(Model model, ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(model,
                 String.format("    implementation(%s)%n", createDependencyCoordinatesString(coords, managed, '"')));
     }

--- a/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleProjectBuildFile.java
+++ b/devtools/gradle/src/main/java/io/quarkus/devtools/project/buildfile/GradleProjectBuildFile.java
@@ -15,7 +15,7 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.plugins.JavaPlugin;
 
 import io.quarkus.bootstrap.BootstrapConstants;
-import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.util.PlatformArtifacts;
 
@@ -31,19 +31,19 @@ public abstract class GradleProjectBuildFile extends AbstractGradleBuildFile {
     }
 
     @Override
-    protected List<AppArtifactCoords> getDependencies() throws IOException {
+    protected List<ArtifactCoords> getDependencies() throws IOException {
 
         final List<Dependency> boms = boms();
 
         final Set<ResolvedArtifact> resolvedArtifacts = project.getConfigurations()
                 .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getResolvedConfiguration()
                 .getResolvedArtifacts();
-        final List<AppArtifactCoords> coords = new ArrayList<>(boms.size() + resolvedArtifacts.size());
+        final List<ArtifactCoords> coords = new ArrayList<>(boms.size() + resolvedArtifacts.size());
         boms.forEach(d -> {
-            coords.add(new AppArtifactCoords(d.getGroup(), d.getName(), null, "pom", d.getVersion()));
+            coords.add(new ArtifactCoords(d.getGroup(), d.getName(), null, "pom", d.getVersion()));
         });
         resolvedArtifacts.forEach(a -> {
-            coords.add(new AppArtifactCoords(a.getModuleVersion().getId().getGroup(), a.getName(),
+            coords.add(new ArtifactCoords(a.getModuleVersion().getId().getGroup(), a.getName(),
                     a.getClassifier(), a.getExtension(), a.getModuleVersion().getId().getVersion()));
         });
         return coords;
@@ -69,19 +69,19 @@ public abstract class GradleProjectBuildFile extends AbstractGradleBuildFile {
     }
 
     @Override
-    public List<AppArtifactCoords> getInstalledPlatforms() throws IOException {
+    public List<ArtifactCoords> getInstalledPlatforms() throws IOException {
         final List<Dependency> bomDeps = boms();
         if (bomDeps.isEmpty()) {
             return Collections.emptyList();
         }
         final Configuration boms = project.getConfigurations()
                 .detachedConfiguration(bomDeps.toArray(new org.gradle.api.artifacts.Dependency[0]));
-        final List<AppArtifactCoords> platforms = new ArrayList<>();
+        final List<ArtifactCoords> platforms = new ArrayList<>();
         boms.getResolutionStrategy().eachDependency(d -> {
             if (!d.getTarget().getName().endsWith(BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX)) {
                 return;
             }
-            final AppArtifactCoords platform = new AppArtifactCoords(d.getTarget().getGroup(),
+            final ArtifactCoords platform = new ArtifactCoords(d.getTarget().getGroup(),
                     PlatformArtifacts.ensureBomArtifactId(d.getTarget().getName()), null, "pom", d.getTarget().getVersion());
             platforms.add(platform);
         });

--- a/devtools/maven/src/main/java/io/quarkus/maven/MavenProjectBuildFile.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MavenProjectBuildFile.java
@@ -19,8 +19,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.buildfile.BuildFile;
 import io.quarkus.maven.utilities.MojoUtils;
@@ -36,9 +34,9 @@ public class MavenProjectBuildFile extends BuildFile {
     private Supplier<List<org.eclipse.aether.graph.Dependency>> projectDepsSupplier;
     private Supplier<List<org.eclipse.aether.graph.Dependency>> projectManagedDepsSupplier;
     private Properties projectProps;
-    protected List<AppArtifactCoords> dependencies;
-    protected List<AppArtifactCoords> managedDependencies;
-    protected List<AppArtifactCoords> importedPlatforms;
+    protected List<ArtifactCoords> dependencies;
+    protected List<ArtifactCoords> managedDependencies;
+    protected List<ArtifactCoords> importedPlatforms;
     protected Model model;
 
     public MavenProjectBuildFile(Path projectDirPath, ExtensionCatalog extensionsCatalog, Supplier<Model> model,
@@ -58,7 +56,7 @@ public class MavenProjectBuildFile extends BuildFile {
     }
 
     @Override
-    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+    protected boolean addDependency(ArtifactCoords coords, boolean managed) {
         final Dependency d = new Dependency();
         d.setGroupId(coords.getGroupId());
         d.setArtifactId(coords.getArtifactId());
@@ -101,11 +99,11 @@ public class MavenProjectBuildFile extends BuildFile {
     }
 
     @Override
-    protected void removeDependency(AppArtifactKey key) throws IOException {
+    protected void removeDependency(ArtifactKey key) throws IOException {
         if (model() != null) {
-            final Iterator<AppArtifactCoords> i = getDependencies().iterator();
+            final Iterator<ArtifactCoords> i = getDependencies().iterator();
             while (i.hasNext()) {
-                final AppArtifactCoords a = i.next();
+                final ArtifactCoords a = i.next();
                 if (a.getKey().equals(key)) {
                     i.remove();
                     break;
@@ -116,14 +114,14 @@ public class MavenProjectBuildFile extends BuildFile {
     }
 
     @Override
-    protected List<AppArtifactCoords> getDependencies() {
+    protected List<ArtifactCoords> getDependencies() {
         if (dependencies == null) {
             final List<org.eclipse.aether.graph.Dependency> projectDeps = projectDepsSupplier.get();
             projectDepsSupplier = null;
             dependencies = new ArrayList<>(projectDeps.size());
             for (org.eclipse.aether.graph.Dependency dep : projectDeps) {
                 org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
-                dependencies.add(new AppArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
+                dependencies.add(new ArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
                         a.getExtension(), a.getVersion()));
             }
         }
@@ -131,14 +129,14 @@ public class MavenProjectBuildFile extends BuildFile {
     }
 
     @Override
-    public final Collection<AppArtifactCoords> getInstalledPlatforms() throws IOException {
+    public final Collection<ArtifactCoords> getInstalledPlatforms() throws IOException {
         if (importedPlatforms == null) {
-            final List<AppArtifactCoords> tmp = new ArrayList<>(4);
-            for (AppArtifactCoords c : getManagedDependencies()) {
+            final List<ArtifactCoords> tmp = new ArrayList<>(4);
+            for (ArtifactCoords c : getManagedDependencies()) {
                 if (!PlatformArtifacts.isCatalogArtifactId(c.getArtifactId())) {
                     continue;
                 }
-                tmp.add(new AppArtifactCoords(c.getGroupId(),
+                tmp.add(new ArtifactCoords(c.getGroupId(),
                         c.getArtifactId().substring(0,
                                 c.getArtifactId().length() - Constants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()),
                         null, "pom", c.getVersion()));
@@ -148,14 +146,14 @@ public class MavenProjectBuildFile extends BuildFile {
         return importedPlatforms;
     }
 
-    protected List<AppArtifactCoords> getManagedDependencies() {
+    protected List<ArtifactCoords> getManagedDependencies() {
         if (managedDependencies == null) {
             final List<org.eclipse.aether.graph.Dependency> managedDeps = projectManagedDepsSupplier.get();
             projectManagedDepsSupplier = null;
             managedDependencies = new ArrayList<>(managedDeps.size());
             for (org.eclipse.aether.graph.Dependency dep : managedDeps) {
                 org.eclipse.aether.artifact.Artifact a = dep.getArtifact();
-                managedDependencies.add(new AppArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
+                managedDependencies.add(new ArtifactCoords(a.getGroupId(), a.getArtifactId(), a.getClassifier(),
                         a.getExtension(), a.getVersion()));
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartProjectInput.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartProjectInput.java
@@ -1,11 +1,11 @@
 package io.quarkus.devtools.codestarts.jbang;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.codestarts.CodestartProjectInput;
+import io.quarkus.maven.ArtifactCoords;
 import java.util.Collection;
 
 public final class QuarkusJBangCodestartProjectInput extends CodestartProjectInput {
-    private final Collection<AppArtifactCoords> extensions;
+    private final Collection<ArtifactCoords> extensions;
     private final boolean noJBangWrapper;
 
     public QuarkusJBangCodestartProjectInput(QuarkusJBangCodestartProjectInputBuilder builder) {
@@ -22,7 +22,7 @@ public final class QuarkusJBangCodestartProjectInput extends CodestartProjectInp
         return noJBangWrapper;
     }
 
-    public Collection<AppArtifactCoords> getExtensions() {
+    public Collection<ArtifactCoords> getExtensions() {
         return extensions;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartProjectInputBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartProjectInputBuilder.java
@@ -1,11 +1,11 @@
 package io.quarkus.devtools.codestarts.jbang;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.codestarts.CodestartProjectInputBuilder;
 import io.quarkus.devtools.codestarts.DataKey;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class QuarkusJBangCodestartProjectInputBuilder extends CodestartProjectInputBuilder {
-    public Collection<AppArtifactCoords> extensions = new ArrayList<>();
+    public Collection<ArtifactCoords> extensions = new ArrayList<>();
 
     public QuarkusJBangCodestartProjectInputBuilder setNoJBangWrapper(boolean noJBangWrapper) {
         this.noJBangWrapper = noJBangWrapper;
@@ -26,17 +26,17 @@ public class QuarkusJBangCodestartProjectInputBuilder extends CodestartProjectIn
         super();
     }
 
-    public QuarkusJBangCodestartProjectInputBuilder addExtensions(Collection<AppArtifactCoords> extensions) {
+    public QuarkusJBangCodestartProjectInputBuilder addExtensions(Collection<ArtifactCoords> extensions) {
         this.extensions.addAll(extensions);
         super.addDependencies(extensions.stream().map(Extensions::toGAV).collect(Collectors.toList()));
         return this;
     }
 
-    public QuarkusJBangCodestartProjectInputBuilder addExtension(AppArtifactCoords extension) {
+    public QuarkusJBangCodestartProjectInputBuilder addExtension(ArtifactCoords extension) {
         return this.addExtensions(Collections.singletonList(extension));
     }
 
-    public QuarkusJBangCodestartProjectInputBuilder addExtension(AppArtifactKey extension) {
+    public QuarkusJBangCodestartProjectInputBuilder addExtension(ArtifactKey extension) {
         return this.addExtension(Extensions.toCoords(extension, null));
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInput.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInput.java
@@ -2,15 +2,15 @@ package io.quarkus.devtools.codestarts.quarkus;
 
 import static java.util.Objects.requireNonNull;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.codestarts.CodestartProjectInput;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.maven.ArtifactCoords;
 import java.util.Collection;
 import java.util.Set;
 
 public final class QuarkusCodestartProjectInput extends CodestartProjectInput {
     private final BuildTool buildTool;
-    private final Collection<AppArtifactCoords> extensions;
+    private final Collection<ArtifactCoords> extensions;
     private final Set<String> overrideExamples;
     private final boolean noExamples;
     private final boolean noDockerfiles;
@@ -30,7 +30,7 @@ public final class QuarkusCodestartProjectInput extends CodestartProjectInput {
         return new QuarkusCodestartProjectInputBuilder();
     }
 
-    public Collection<AppArtifactCoords> getExtensions() {
+    public Collection<ArtifactCoords> getExtensions() {
         return extensions;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
@@ -2,12 +2,12 @@ package io.quarkus.devtools.codestarts.quarkus;
 
 import static java.util.Objects.requireNonNull;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.codestarts.CodestartProjectInputBuilder;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,7 +17,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class QuarkusCodestartProjectInputBuilder extends CodestartProjectInputBuilder {
-    Collection<AppArtifactCoords> extensions = new ArrayList<>();
+    Collection<ArtifactCoords> extensions = new ArrayList<>();
     Set<String> overrideExamples = new HashSet<>();
     boolean noExamples;
     boolean noDockerfiles;
@@ -28,17 +28,17 @@ public class QuarkusCodestartProjectInputBuilder extends CodestartProjectInputBu
         super();
     }
 
-    public QuarkusCodestartProjectInputBuilder addExtensions(Collection<AppArtifactCoords> extensions) {
+    public QuarkusCodestartProjectInputBuilder addExtensions(Collection<ArtifactCoords> extensions) {
         this.extensions.addAll(extensions);
         super.addDependencies(extensions.stream().map(Extensions::toGAV).collect(Collectors.toList()));
         return this;
     }
 
-    public QuarkusCodestartProjectInputBuilder addExtension(AppArtifactCoords extension) {
+    public QuarkusCodestartProjectInputBuilder addExtension(ArtifactCoords extension) {
         return this.addExtensions(Collections.singletonList(extension));
     }
 
-    public QuarkusCodestartProjectInputBuilder addExtension(AppArtifactKey extension) {
+    public QuarkusCodestartProjectInputBuilder addExtension(ArtifactKey extension) {
         return this.addExtension(Extensions.toCoords(extension, null));
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
@@ -3,8 +3,6 @@ package io.quarkus.devtools.commands.handlers;
 import static io.quarkus.devtools.commands.AddExtensions.EXTENSION_MANAGER;
 import static io.quarkus.devtools.messagewriter.MessageIcons.NOK_ICON;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.commands.AddExtensions;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
@@ -14,6 +12,7 @@ import io.quarkus.devtools.project.extensions.ExtensionInstallPlan;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
 import io.quarkus.devtools.project.extensions.ExtensionManager.InstallResult;
 import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.platform.catalog.predicate.ExtensionPredicate;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -71,7 +70,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
             throws IOException {
         final ExtensionCatalog catalog = invocation.getExtensionsCatalog();
         final String quarkusCore = catalog.getQuarkusCoreVersion();
-        final Collection<AppArtifactCoords> importedPlatforms = invocation.getQuarkusProject().getExtensionManager()
+        final Collection<ArtifactCoords> importedPlatforms = invocation.getQuarkusProject().getExtensionManager()
                 .getInstalledPlatforms();
         ExtensionInstallPlan.Builder builder = ExtensionInstallPlan.builder();
         boolean multipleKeywords = keywords.size() > 1;
@@ -79,12 +78,12 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
             int countColons = StringUtils.countMatches(keyword, ":");
             // Check if it's just groupId:artifactId
             if (countColons == 1) {
-                AppArtifactKey artifactKey = AppArtifactKey.fromString(keyword);
-                builder.addManagedExtension(new AppArtifactCoords(artifactKey, null));
+                ArtifactKey artifactKey = ArtifactKey.fromString(keyword);
+                builder.addManagedExtension(new ArtifactCoords(artifactKey, null));
                 continue;
             } else if (countColons > 1) {
                 // it's a gav
-                builder.addIndependentExtension(AppArtifactCoords.fromString(keyword));
+                builder.addIndependentExtension(ArtifactCoords.fromString(keyword));
                 continue;
             }
             List<Extension> listed = listInternalExtensions(quarkusCore, keyword, catalog.getExtensions());
@@ -101,7 +100,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                 String groupId = e.getArtifact().getGroupId();
                 String artifactId = e.getArtifact().getArtifactId();
                 String version = e.getArtifact().getVersion();
-                AppArtifactCoords extensionCoords = new AppArtifactCoords(groupId, artifactId, version);
+                ArtifactCoords extensionCoords = new ArtifactCoords(groupId, artifactId, version);
 
                 boolean managed = false;
                 ExtensionOrigin firstPlatform = null;
@@ -109,7 +108,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                     if (!origin.isPlatform()) {
                         continue;
                     }
-                    if (importedPlatforms.contains(new AppArtifactCoords(origin.getBom().getGroupId(),
+                    if (importedPlatforms.contains(new ArtifactCoords(origin.getBom().getGroupId(),
                             origin.getBom().getArtifactId(), null, "pom", origin.getBom().getVersion()))) {
                         managed = true;
                         builder.addManagedExtension(extensionCoords);
@@ -122,9 +121,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                 if (!managed && firstPlatform != null) {
                     // TODO this is not properly picking the platform BOMs
                     builder.addManagedExtension(extensionCoords);
-                    final ArtifactCoords bomCoords = firstPlatform.getBom();
-                    builder.addPlatform(new AppArtifactCoords(bomCoords.getGroupId(), bomCoords.getArtifactId(), null, "pom",
-                            bomCoords.getVersion()));
+                    builder.addPlatform(firstPlatform.getBom());
                     managed = true;
                 }
                 if (!managed) {
@@ -133,7 +130,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
             }
             // TODO
             //if (!listed.isEmpty()) {
-            //    builder.addPlatform(new AppArtifactCoords(catalog.getBomGroupId(), catalog.getBomArtifactId(), null, "pom",
+            //    builder.addPlatform(new ArtifactCoords(catalog.getBomGroupId(), catalog.getBomArtifactId(), null, "pom",
             //            catalog.getBomVersion()));
             //}
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateJBangProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateJBangProjectCommandHandler.java
@@ -2,7 +2,6 @@ package io.quarkus.devtools.commands.handlers;
 
 import static io.quarkus.devtools.commands.handlers.QuarkusCommandHandlers.computeCoordsFromQuery;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.codestarts.jbang.QuarkusJBangCodestartCatalog;
 import io.quarkus.devtools.codestarts.jbang.QuarkusJBangCodestartProjectInput;
 import io.quarkus.devtools.codestarts.jbang.QuarkusJBangCodestartProjectInputBuilder;
@@ -25,7 +24,7 @@ public class CreateJBangProjectCommandHandler implements QuarkusCommandHandler {
     @Override
     public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
         final Set<String> extensionsQuery = invocation.getValue(ProjectGenerator.EXTENSIONS, Collections.emptySet());
-        final List<AppArtifactCoords> extensionsToAdd = computeCoordsFromQuery(invocation, extensionsQuery);
+        final List<ArtifactCoords> extensionsToAdd = computeCoordsFromQuery(invocation, extensionsQuery);
         if (extensionsToAdd == null) {
             throw new QuarkusCommandException("Failed to create project because of invalid extensions");
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -14,7 +14,6 @@ import static io.quarkus.devtools.project.codegen.ProjectGenerator.PACKAGE_NAME;
 import static io.quarkus.devtools.project.codegen.ProjectGenerator.PROJECT_GROUP_ID;
 import static io.quarkus.devtools.project.codegen.ProjectGenerator.QUARKUS_VERSION;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.codestarts.CodestartProjectDefinition;
 import io.quarkus.devtools.codestarts.CodestartType;
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog;
@@ -79,7 +78,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
             }
         }
 
-        final List<AppArtifactCoords> extensionsToAdd = computeCoordsFromQuery(invocation, extensionsQuery);
+        final List<ArtifactCoords> extensionsToAdd = computeCoordsFromQuery(invocation, extensionsQuery);
         if (extensionsToAdd == null) {
             throw new QuarkusCommandException("Failed to create project because of invalid extensions");
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -4,8 +4,6 @@ import static io.quarkus.devtools.project.extensions.Extensions.toKey;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getGuide;
 import static java.util.stream.Collectors.toMap;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.commands.ListExtensions;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
@@ -13,6 +11,8 @@ import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionOrigin;
@@ -79,10 +79,10 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
                 currentFormatter = this::conciseFormatter;
         }
 
-        Map<AppArtifactKey, AppArtifactCoords> installedByKey;
+        Map<ArtifactKey, ArtifactCoords> installedByKey;
         try {
             installedByKey = extensionManager.getInstalled().stream()
-                    .collect(toMap(AppArtifactCoords::getKey, Function.identity()));
+                    .collect(toMap(ArtifactCoords::getKey, Function.identity()));
         } catch (IOException e) {
             throw new QuarkusCommandException("Failed to determine the list of installed extensions", e);
         }
@@ -151,7 +151,7 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
         }
     }
 
-    private void display(MessageWriter messageWriter, final Extension e, final AppArtifactCoords installed,
+    private void display(MessageWriter messageWriter, final Extension e, final ArtifactCoords installed,
             boolean all,
             boolean installedOnly,
             BiConsumer<MessageWriter, Object[]> formatter) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
@@ -6,11 +6,10 @@ import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getExtend
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getShortName;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.isUnlisted;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.SelectionResult;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.maven.ArtifactKey;
 import io.quarkus.registry.catalog.Extension;
 import java.util.ArrayList;
@@ -29,20 +28,20 @@ final class QuarkusCommandHandlers {
     private QuarkusCommandHandlers() {
     }
 
-    static List<AppArtifactCoords> computeCoordsFromQuery(final QuarkusCommandInvocation invocation,
+    static List<ArtifactCoords> computeCoordsFromQuery(final QuarkusCommandInvocation invocation,
             final Set<String> extensionsQuery) {
-        final ArrayList<AppArtifactCoords> builder = new ArrayList<>();
+        final ArrayList<ArtifactCoords> builder = new ArrayList<>();
         for (String query : extensionsQuery) {
             final int countColons = StringUtils.countMatches(query, ":");
             if (countColons == 1) {
-                builder.add(toCoords(AppArtifactKey.fromString(query), null));
+                builder.add(toCoords(ArtifactKey.fromString(query), null));
             } else if (countColons > 1) {
-                builder.add(AppArtifactCoords.fromString(query));
+                builder.add(ArtifactCoords.fromString(query));
             } else {
                 Collection<Extension> extensions = invocation.getExtensionsCatalog().getExtensions();
                 SelectionResult result = select(query, extensions, false);
                 if (result.matches()) {
-                    final Set<AppArtifactCoords> withStrippedVersion = result.getExtensions().stream().map(Extensions::toCoords)
+                    final Set<ArtifactCoords> withStrippedVersion = result.getExtensions().stream().map(Extensions::toCoords)
                             .map(Extensions::stripVersion).collect(Collectors.toSet());
                     // We strip the version because those extensions are managed
                     builder.addAll(withStrippedVersion);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/RemoveExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/RemoveExtensionsCommandHandler.java
@@ -3,8 +3,6 @@ package io.quarkus.devtools.commands.handlers;
 import static io.quarkus.devtools.commands.RemoveExtensions.EXTENSION_MANAGER;
 import static io.quarkus.devtools.commands.handlers.QuarkusCommandHandlers.computeCoordsFromQuery;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.commands.RemoveExtensions;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
@@ -12,6 +10,8 @@ import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.messagewriter.MessageIcons;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
 import io.quarkus.devtools.project.extensions.ExtensionManager.UninstallResult;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -31,14 +31,14 @@ public class RemoveExtensionsCommandHandler implements QuarkusCommandHandler {
             return QuarkusCommandOutcome.success().setValue(RemoveExtensions.OUTCOME_UPDATED, false);
         }
 
-        final List<AppArtifactCoords> extensionsToRemove = computeCoordsFromQuery(invocation, extensionsQuery);
+        final List<ArtifactCoords> extensionsToRemove = computeCoordsFromQuery(invocation, extensionsQuery);
         if (extensionsToRemove == null) {
             return new QuarkusCommandOutcome(false).setValue(RemoveExtensions.OUTCOME_UPDATED, false);
         }
         final ExtensionManager extensionManager = invocation.getValue(EXTENSION_MANAGER,
                 invocation.getQuarkusProject().getExtensionManager());
         try {
-            final Set<AppArtifactKey> keys = extensionsToRemove.stream().map(AppArtifactCoords::getKey)
+            final Set<ArtifactKey> keys = extensionsToRemove.stream().map(ArtifactCoords::getKey)
                     .collect(Collectors.toSet());
             final UninstallResult result = extensionManager.uninstall(keys);
             result.getUninstalled()

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFile.java
@@ -1,7 +1,7 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,7 +60,7 @@ abstract class AbstractGradleBuildFile extends BuildFile {
         writeToProjectFile(getBuildGradlePath(), getModel().getBuildContent().getBytes());
     }
 
-    static String createDependencyCoordinatesString(AppArtifactCoords coords, boolean managed, char quoteChar) {
+    static String createDependencyCoordinatesString(ArtifactCoords coords, boolean managed, char quoteChar) {
         StringBuilder newDependency = new StringBuilder().append(quoteChar)
                 .append(coords.getGroupId()).append(":").append(coords.getArtifactId());
         if (!managed &&
@@ -101,7 +101,7 @@ abstract class AbstractGradleBuildFile extends BuildFile {
     }
 
     @Override
-    protected void removeDependency(AppArtifactKey key) {
+    protected void removeDependency(ArtifactKey key) {
         StringBuilder newBuildContent = new StringBuilder();
         Scanner scanner = new Scanner(getModel().getBuildContent());
         while (scanner.hasNextLine()) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFilesCreator.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFilesCreator.java
@@ -1,6 +1,5 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.buildfile.AbstractGradleBuildFile.Model;
 import io.quarkus.maven.ArtifactCoords;
@@ -36,10 +35,10 @@ abstract class AbstractGradleBuildFilesCreator {
 
     abstract void createSettingsContent(String artifactId) throws IOException;
 
-    abstract void addDependencyInBuildFile(AppArtifactCoords coords) throws IOException;
+    abstract void addDependencyInBuildFile(ArtifactCoords coords) throws IOException;
 
     public void create(String groupId, String artifactId, String version,
-            Properties properties, List<AppArtifactCoords> extensions) throws IOException {
+            Properties properties, List<ArtifactCoords> extensions) throws IOException {
         createSettingsContent(artifactId);
         createBuildContent(groupId, version);
         createProperties();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGroovyGradleBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGroovyGradleBuildFile.java
@@ -1,7 +1,7 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import java.nio.file.Path;
 
@@ -30,7 +30,7 @@ public abstract class AbstractGroovyGradleBuildFile extends AbstractGradleBuildF
     }
 
     @Override
-    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+    protected boolean addDependency(ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(getModel(), coords, managed);
     }
 
@@ -39,7 +39,7 @@ public abstract class AbstractGroovyGradleBuildFile extends AbstractGradleBuildF
         return BuildTool.GRADLE;
     }
 
-    static boolean addDependencyInModel(Model model, AppArtifactCoords coords, boolean managed) {
+    static boolean addDependencyInModel(Model model, ArtifactCoords coords, boolean managed) {
         return addDependencyInModel(model,
                 String.format("    implementation %s%n", createDependencyCoordinatesString(coords, managed, '\'')));
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/BuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/BuildFile.java
@@ -3,11 +3,10 @@ package io.quarkus.devtools.project.buildfile;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.project.extensions.ExtensionInstallPlan;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.maven.ArtifactKey;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -34,9 +33,9 @@ public abstract class BuildFile implements ExtensionManager {
     }
 
     @Override
-    public final InstallResult install(Collection<AppArtifactCoords> coords) throws IOException {
+    public final InstallResult install(Collection<ArtifactCoords> coords) throws IOException {
         this.refreshData();
-        final Collection<AppArtifactCoords> installed = withoutAlreadyInstalled(coords);
+        final Collection<ArtifactCoords> installed = withoutAlreadyInstalled(coords);
         installed.forEach(e -> addDependency(e, e.getVersion() == null));
         this.writeToDisk();
         return new InstallResult(installed);
@@ -44,18 +43,18 @@ public abstract class BuildFile implements ExtensionManager {
 
     @Override
     public InstallResult install(ExtensionInstallPlan plan) throws IOException {
-        List<AppArtifactCoords> installed = new ArrayList<>();
-        for (AppArtifactCoords platform : withoutAlreadyInstalled(plan.getPlatforms())) {
+        List<ArtifactCoords> installed = new ArrayList<>();
+        for (ArtifactCoords platform : withoutAlreadyInstalled(plan.getPlatforms())) {
             if (addDependency(platform, false)) {
                 installed.add(platform);
             }
         }
-        for (AppArtifactCoords managedExtension : withoutAlreadyInstalled(plan.getManagedExtensions())) {
+        for (ArtifactCoords managedExtension : withoutAlreadyInstalled(plan.getManagedExtensions())) {
             if (addDependency(managedExtension, true)) {
                 installed.add(managedExtension);
             }
         }
-        for (AppArtifactCoords independentExtension : withoutAlreadyInstalled(plan.getIndependentExtensions())) {
+        for (ArtifactCoords independentExtension : withoutAlreadyInstalled(plan.getIndependentExtensions())) {
             if (addDependency(independentExtension, false)) {
                 installed.add(independentExtension);
             }
@@ -65,7 +64,7 @@ public abstract class BuildFile implements ExtensionManager {
     }
 
     @Override
-    public final Collection<AppArtifactCoords> getInstalled() throws IOException {
+    public final Collection<ArtifactCoords> getInstalled() throws IOException {
         this.refreshData();
         return this.getDependencies().stream()
                 .filter(d -> this.isQuarkusExtension(d.getKey()))
@@ -73,10 +72,10 @@ public abstract class BuildFile implements ExtensionManager {
     }
 
     @Override
-    public final UninstallResult uninstall(Collection<AppArtifactKey> keys) throws IOException {
+    public final UninstallResult uninstall(Collection<ArtifactKey> keys) throws IOException {
         this.refreshData();
-        final Set<AppArtifactKey> existingKeys = getDependenciesKeys();
-        final List<AppArtifactKey> uninstalled = keys.stream()
+        final Set<ArtifactKey> existingKeys = getDependenciesKeys();
+        final List<ArtifactKey> uninstalled = keys.stream()
                 .distinct()
                 .filter(existingKeys::contains)
                 .filter(k -> {
@@ -91,19 +90,19 @@ public abstract class BuildFile implements ExtensionManager {
         return new UninstallResult(uninstalled);
     }
 
-    private Collection<AppArtifactCoords> withoutAlreadyInstalled(Collection<AppArtifactCoords> extensions) throws IOException {
-        final Set<AppArtifactKey> existingKeys = getDependenciesKeys();
+    private Collection<ArtifactCoords> withoutAlreadyInstalled(Collection<ArtifactCoords> extensions) throws IOException {
+        final Set<ArtifactKey> existingKeys = getDependenciesKeys();
         return extensions.stream()
                 .distinct()
                 .filter(a -> !existingKeys.contains(a.getKey()))
                 .collect(toList());
     }
 
-    protected abstract boolean addDependency(AppArtifactCoords coords, boolean managed);
+    protected abstract boolean addDependency(ArtifactCoords coords, boolean managed);
 
-    protected abstract void removeDependency(AppArtifactKey key) throws IOException;
+    protected abstract void removeDependency(ArtifactKey key) throws IOException;
 
-    protected abstract List<AppArtifactCoords> getDependencies() throws IOException;
+    protected abstract List<ArtifactCoords> getDependencies() throws IOException;
 
     protected abstract void writeToDisk() throws IOException;
 
@@ -129,23 +128,23 @@ public abstract class BuildFile implements ExtensionManager {
         Files.write(projectDirPath.resolve(fileName), content);
     }
 
-    private boolean isQuarkusExtension(final AppArtifactKey key) {
+    private boolean isQuarkusExtension(final ArtifactKey key) {
         if (catalog != null) {
             return findInList(catalog.getExtensions(), key).isPresent();
         }
         return isDefinedInRegistry(catalog.getExtensions(), key);
     }
 
-    private Set<AppArtifactKey> getDependenciesKeys() throws IOException {
-        return getDependencies().stream().map(AppArtifactCoords::getKey).collect(Collectors.toSet());
+    private Set<ArtifactKey> getDependenciesKeys() throws IOException {
+        return getDependencies().stream().map(ArtifactCoords::getKey).collect(Collectors.toSet());
     }
 
-    public static boolean isDefinedInRegistry(Collection<Extension> registry, final AppArtifactKey key) {
+    public static boolean isDefinedInRegistry(Collection<Extension> registry, final ArtifactKey key) {
         return Extensions.findInList(registry, key).isPresent();
     }
 
     private static Optional<io.quarkus.registry.catalog.Extension> findInList(
-            Collection<io.quarkus.registry.catalog.Extension> list, final AppArtifactKey key) {
+            Collection<io.quarkus.registry.catalog.Extension> list, final ArtifactKey key) {
         ArtifactKey k = new ArtifactKey(key.getGroupId(), key.getArtifactId(), key.getClassifier(), key.getType());
         return list.stream().filter(e -> Objects.equals(e.getArtifact().getKey(), k)).findFirst();
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/GenericGradleBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/GenericGradleBuildFile.java
@@ -1,9 +1,9 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.project.extensions.ExtensionInstallPlan;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -13,17 +13,17 @@ import java.util.Collection;
 abstract class GenericGradleBuildFile implements ExtensionManager {
 
     @Override
-    public Collection<AppArtifactCoords> getInstalled() throws IOException {
+    public Collection<ArtifactCoords> getInstalled() throws IOException {
         throw new IllegalStateException("This feature is not yet implemented outside of the Gradle Plugin.");
     }
 
     @Override
-    public Collection<AppArtifactCoords> getInstalledPlatforms() throws IOException {
+    public Collection<ArtifactCoords> getInstalledPlatforms() throws IOException {
         throw new IllegalStateException("This feature is not yet implemented outside of the Gradle Plugin.");
     }
 
     @Override
-    public InstallResult install(Collection<AppArtifactCoords> coords) throws IOException {
+    public InstallResult install(Collection<ArtifactCoords> coords) throws IOException {
         throw new IllegalStateException("This feature is not yet implemented outside of the Gradle Plugin.");
     }
 
@@ -33,7 +33,7 @@ abstract class GenericGradleBuildFile implements ExtensionManager {
     }
 
     @Override
-    public UninstallResult uninstall(Collection<AppArtifactKey> keys) throws IOException {
+    public UninstallResult uninstall(Collection<ArtifactKey> keys) throws IOException {
         throw new IllegalStateException("This feature is not yet implemented outside of the Gradle Plugin.");
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/GroovyGradleBuildFilesCreator.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/GroovyGradleBuildFilesCreator.java
@@ -1,6 +1,5 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.maven.ArtifactCoords;
 import java.io.IOException;
@@ -90,7 +89,7 @@ public final class GroovyGradleBuildFilesCreator extends AbstractGradleBuildFile
     }
 
     @Override
-    void addDependencyInBuildFile(AppArtifactCoords coords) throws IOException {
+    void addDependencyInBuildFile(ArtifactCoords coords) throws IOException {
         AbstractGroovyGradleBuildFile.addDependencyInModel(getModel(), coords, false);
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/KotlinGradleBuildFilesCreator.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/KotlinGradleBuildFilesCreator.java
@@ -1,6 +1,5 @@
 package io.quarkus.devtools.project.buildfile;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.buildfile.AbstractGradleBuildFile.Model;
 import io.quarkus.maven.ArtifactCoords;
@@ -95,11 +94,11 @@ public class KotlinGradleBuildFilesCreator extends AbstractGradleBuildFilesCreat
     }
 
     @Override
-    void addDependencyInBuildFile(AppArtifactCoords coords) throws IOException {
+    void addDependencyInBuildFile(ArtifactCoords coords) throws IOException {
         addDependencyInModel(getModel(), coords, false);
     }
 
-    static boolean addDependencyInModel(Model model, AppArtifactCoords coords, boolean managed) {
+    static boolean addDependencyInModel(Model model, ArtifactCoords coords, boolean managed) {
         return AbstractGradleBuildFile.addDependencyInModel(model,
                 String.format("    implementation(%s)%n",
                         AbstractGradleBuildFile.createDependencyCoordinatesString(coords, managed, '"')));

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
@@ -2,10 +2,10 @@ package io.quarkus.devtools.project.buildfile;
 
 import static io.quarkus.devtools.project.extensions.Extensions.toKey;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.maven.utilities.MojoUtils;
 import io.quarkus.registry.Constants;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -50,7 +50,7 @@ public class MavenBuildFile extends BuildFile {
     }
 
     @Override
-    protected boolean addDependency(AppArtifactCoords coords, boolean managed) {
+    protected boolean addDependency(ArtifactCoords coords, boolean managed) {
         Model model = getModel();
         final Dependency d = new Dependency();
         d.setGroupId(coords.getGroupId());
@@ -89,7 +89,7 @@ public class MavenBuildFile extends BuildFile {
     }
 
     @Override
-    protected void removeDependency(AppArtifactKey key) throws IOException {
+    protected void removeDependency(ArtifactKey key) throws IOException {
         if (getModel() != null) {
             getModel().getDependencies()
                     .removeIf(d -> Objects.equals(toKey(d), key));
@@ -97,23 +97,23 @@ public class MavenBuildFile extends BuildFile {
     }
 
     @Override
-    public List<AppArtifactCoords> getDependencies() throws IOException {
+    public List<ArtifactCoords> getDependencies() throws IOException {
         return getModel() == null ? Collections.emptyList()
                 : getModel().getDependencies().stream().map(Extensions::toCoords).collect(Collectors.toList());
     }
 
     @Override
-    public final Collection<AppArtifactCoords> getInstalledPlatforms() throws IOException {
+    public final Collection<ArtifactCoords> getInstalledPlatforms() throws IOException {
         final Model model = getModel();
         if (model == null || model.getDependencyManagement() == null) {
             return Collections.emptyList();
         }
-        final List<AppArtifactCoords> tmp = new ArrayList<>(4);
+        final List<ArtifactCoords> tmp = new ArrayList<>(4);
         for (Dependency c : model.getDependencyManagement().getDependencies()) {
             if (!PlatformArtifacts.isCatalogArtifactId(c.getArtifactId())) {
                 continue;
             }
-            tmp.add(new AppArtifactCoords(c.getGroupId(),
+            tmp.add(new ArtifactCoords(c.getGroupId(),
                     c.getArtifactId().substring(0,
                             c.getArtifactId().length() - Constants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()),
                     null, "pom", c.getVersion()));

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
@@ -1,6 +1,6 @@
 package io.quarkus.devtools.project.extensions;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.maven.ArtifactCoords;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -13,13 +13,13 @@ public class ExtensionInstallPlan {
             Collections.emptySet(),
             Collections.emptySet());
 
-    private final Set<AppArtifactCoords> platforms;
-    private final Set<AppArtifactCoords> managedExtensions;
-    private final Set<AppArtifactCoords> independentExtensions;
+    private final Set<ArtifactCoords> platforms;
+    private final Set<ArtifactCoords> managedExtensions;
+    private final Set<ArtifactCoords> independentExtensions;
 
-    private ExtensionInstallPlan(Set<AppArtifactCoords> platforms,
-            Set<AppArtifactCoords> managedExtensions,
-            Set<AppArtifactCoords> independentExtensions) {
+    private ExtensionInstallPlan(Set<ArtifactCoords> platforms,
+            Set<ArtifactCoords> managedExtensions,
+            Set<ArtifactCoords> independentExtensions) {
         this.platforms = platforms;
         this.managedExtensions = managedExtensions;
         this.independentExtensions = independentExtensions;
@@ -33,8 +33,8 @@ public class ExtensionInstallPlan {
     /**
      * @return a {@link Collection} of all extensions contained in this object
      */
-    public Collection<AppArtifactCoords> toCollection() {
-        Set<AppArtifactCoords> result = new LinkedHashSet<>();
+    public Collection<ArtifactCoords> toCollection() {
+        Set<ArtifactCoords> result = new LinkedHashSet<>();
         result.addAll(getPlatforms());
         result.addAll(getManagedExtensions());
         result.addAll(getIndependentExtensions());
@@ -44,7 +44,7 @@ public class ExtensionInstallPlan {
     /**
      * @return Platforms (BOMs) to be added to the build descriptor
      */
-    public Collection<AppArtifactCoords> getPlatforms() {
+    public Collection<ArtifactCoords> getPlatforms() {
         return platforms;
     }
 
@@ -52,14 +52,14 @@ public class ExtensionInstallPlan {
      * @return Extensions that are included in the platforms returned in {@link #getPlatforms()},
      *         therefore setting the version is not required.
      */
-    public Collection<AppArtifactCoords> getManagedExtensions() {
+    public Collection<ArtifactCoords> getManagedExtensions() {
         return managedExtensions;
     }
 
     /**
      * @return Extensions that do not exist in any platform, the version MUST be set in the build descriptor
      */
-    public Collection<AppArtifactCoords> getIndependentExtensions() {
+    public Collection<ArtifactCoords> getIndependentExtensions() {
         return independentExtensions;
     }
 
@@ -78,26 +78,26 @@ public class ExtensionInstallPlan {
 
     public static class Builder {
 
-        private final Set<AppArtifactCoords> platforms = new LinkedHashSet<>();
-        private final Set<AppArtifactCoords> extensionsInPlatforms = new LinkedHashSet<>();
-        private final Set<AppArtifactCoords> independentExtensions = new LinkedHashSet<>();
+        private final Set<ArtifactCoords> platforms = new LinkedHashSet<>();
+        private final Set<ArtifactCoords> extensionsInPlatforms = new LinkedHashSet<>();
+        private final Set<ArtifactCoords> independentExtensions = new LinkedHashSet<>();
 
         public ExtensionInstallPlan build() {
             return new ExtensionInstallPlan(platforms, extensionsInPlatforms, independentExtensions);
         }
 
-        public Builder addIndependentExtension(AppArtifactCoords appArtifactCoords) {
-            this.independentExtensions.add(appArtifactCoords);
+        public Builder addIndependentExtension(ArtifactCoords artifactCoords) {
+            this.independentExtensions.add(artifactCoords);
             return this;
         }
 
-        public Builder addManagedExtension(AppArtifactCoords appArtifactCoords) {
-            this.extensionsInPlatforms.add(appArtifactCoords);
+        public Builder addManagedExtension(ArtifactCoords artifactCoords) {
+            this.extensionsInPlatforms.add(artifactCoords);
             return this;
         }
 
-        public Builder addPlatform(AppArtifactCoords appArtifactCoords) {
-            this.platforms.add(appArtifactCoords);
+        public Builder addPlatform(ArtifactCoords artifactCoords) {
+            this.platforms.add(artifactCoords);
             return this;
         }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionManager.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionManager.java
@@ -1,8 +1,8 @@
 package io.quarkus.devtools.project.extensions;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
@@ -23,24 +23,24 @@ public interface ExtensionManager {
      * @return current list of imported platforms
      * @throws IOException if a problem occurs while reading the project build file(s)
      */
-    Collection<AppArtifactCoords> getInstalledPlatforms() throws IOException;
+    Collection<ArtifactCoords> getInstalledPlatforms() throws IOException;
 
     /**
      * Read the build file(s) to get the list of installed extensions in this Quarkus project.
      *
-     * @return The list of {@link AppArtifactCoords} installed in the project build file(s).
+     * @return The list of {@link ArtifactCoords} installed in the project build file(s).
      * @throws IOException if a problem occurs while reading the project build file(s)
      */
-    Collection<AppArtifactCoords> getInstalled() throws IOException;
+    Collection<ArtifactCoords> getInstalled() throws IOException;
 
     /**
      * Read build file(s) to check if an extension is installed in this Quarkus project.
      *
-     * @param key the {@link AppArtifactKey} of the extension to check
+     * @param key the {@link ArtifactKey} of the extension to check
      * @return true if it's installed
      * @throws IOException if a problem occurs while reading the project build file(s)
      */
-    default boolean isInstalled(AppArtifactKey key) throws IOException {
+    default boolean isInstalled(ArtifactKey key) throws IOException {
         return getInstalled().stream().anyMatch(i -> Objects.equals(i.getKey(), key));
     }
 
@@ -52,11 +52,11 @@ public interface ExtensionManager {
      *   - The provided version will be used if it wasn't already installed
      * </pre>
      *
-     * @param coords the list of {@link AppArtifactCoords} for the extensions to install
+     * @param coords the list of {@link ArtifactCoords} for the extensions to install
      * @return the {@link InstallResult}
      * @throws IOException if a problem occurs while reading/writing the project build file(s)
      */
-    InstallResult install(Collection<AppArtifactCoords> coords) throws IOException;
+    InstallResult install(Collection<ArtifactCoords> coords) throws IOException;
 
     /**
      * This is going to install/add all the specified extensions to the project build file(s).
@@ -67,7 +67,7 @@ public interface ExtensionManager {
      *   - The provided version will be used if wasn't already installed
      * </pre>
      *
-     * @param request the list of {@link AppArtifactCoords} for the extensions to install
+     * @param request the list of {@link ArtifactCoords} for the extensions to install
      * @return the {@link InstallResult}
      * @throws IOException if a problem occurs while reading/writing the project build file(s)
      */
@@ -78,20 +78,20 @@ public interface ExtensionManager {
      *
      * This is ignoring the {@link Extension} version
      *
-     * @param keys the set of {@link AppArtifactKey} for the extensions to uninstall
+     * @param keys the set of {@link ArtifactKey} for the extensions to uninstall
      * @return the {@link InstallResult}
      * @throws IOException if a problem occurs while reading/writing the project build file(s)
      */
-    UninstallResult uninstall(Collection<AppArtifactKey> keys) throws IOException;
+    UninstallResult uninstall(Collection<ArtifactKey> keys) throws IOException;
 
     class InstallResult {
-        private final Collection<AppArtifactCoords> installed;
+        private final Collection<ArtifactCoords> installed;
 
-        public InstallResult(Collection<AppArtifactCoords> installed) {
+        public InstallResult(Collection<ArtifactCoords> installed) {
             this.installed = installed;
         }
 
-        public Collection<AppArtifactCoords> getInstalled() {
+        public Collection<ArtifactCoords> getInstalled() {
             return installed;
         }
 
@@ -101,13 +101,13 @@ public interface ExtensionManager {
     }
 
     class UninstallResult {
-        private final Collection<AppArtifactKey> uninstalled;
+        private final Collection<ArtifactKey> uninstalled;
 
-        public UninstallResult(Collection<AppArtifactKey> uninstalled) {
+        public UninstallResult(Collection<ArtifactKey> uninstalled) {
             this.uninstalled = uninstalled;
         }
 
-        public Collection<AppArtifactKey> getUninstalled() {
+        public Collection<ArtifactKey> getUninstalled() {
             return uninstalled;
         }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/Extensions.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/Extensions.java
@@ -1,7 +1,7 @@
 package io.quarkus.devtools.project.extensions;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.registry.catalog.Extension;
 import java.util.Collection;
 import java.util.Objects;
@@ -12,50 +12,50 @@ public final class Extensions {
     private Extensions() {
     }
 
-    public static AppArtifactKey toKey(final Extension extension) {
-        return new AppArtifactKey(extension.getArtifact().getGroupId(),
+    public static ArtifactKey toKey(final Extension extension) {
+        return new ArtifactKey(extension.getArtifact().getGroupId(),
                 extension.getArtifact().getArtifactId(),
                 extension.getArtifact().getClassifier(),
                 extension.getArtifact().getType());
     }
 
-    public static AppArtifactKey toKey(final Dependency dependency) {
-        return new AppArtifactKey(dependency.getGroupId(), dependency.getArtifactId(), dependency.getClassifier(),
+    public static ArtifactKey toKey(final Dependency dependency) {
+        return new ArtifactKey(dependency.getGroupId(), dependency.getArtifactId(), dependency.getClassifier(),
                 dependency.getType());
     }
 
-    public static Optional<Extension> findInList(Collection<Extension> list, final AppArtifactKey key) {
+    public static Optional<Extension> findInList(Collection<Extension> list, final ArtifactKey key) {
         return list.stream().filter(e -> Objects.equals(toCoords(e).getKey(), key)).findFirst();
     }
 
-    public static AppArtifactCoords toCoords(final AppArtifactKey k, final String version) {
-        return new AppArtifactCoords(k, version);
+    public static ArtifactCoords toCoords(final ArtifactKey k, final String version) {
+        return new ArtifactCoords(k, version);
     }
 
-    public static AppArtifactCoords toCoords(final Extension e) {
-        return new AppArtifactCoords(e.getArtifact().getGroupId(),
+    public static ArtifactCoords toCoords(final Extension e) {
+        return new ArtifactCoords(e.getArtifact().getGroupId(),
                 e.getArtifact().getArtifactId(),
                 e.getArtifact().getClassifier(),
                 e.getArtifact().getType(),
                 e.getArtifact().getVersion());
     }
 
-    public static AppArtifactCoords toCoords(final Dependency d, final String overrideVersion) {
+    public static ArtifactCoords toCoords(final Dependency d, final String overrideVersion) {
         return overrideVersion(toCoords(d), overrideVersion);
     }
 
-    public static String toGAV(AppArtifactCoords c) {
+    public static String toGAV(ArtifactCoords c) {
         if (c.getVersion() == null) {
             return toGA(c);
         }
         return c.getGroupId() + ":" + c.getArtifactId() + ":" + c.getVersion();
     }
 
-    public static String toGA(AppArtifactCoords c) {
+    public static String toGA(ArtifactCoords c) {
         return c.getGroupId() + ":" + c.getArtifactId();
     }
 
-    public static String toGA(AppArtifactKey c) {
+    public static String toGA(ArtifactKey c) {
         return c.getGroupId() + ":" + c.getArtifactId();
     }
 
@@ -63,17 +63,17 @@ public final class Extensions {
         return e.getArtifact().getGroupId() + ":" + e.getArtifact().getArtifactId();
     }
 
-    public static AppArtifactCoords stripVersion(final AppArtifactCoords coords) {
+    public static ArtifactCoords stripVersion(final ArtifactCoords coords) {
         return overrideVersion(coords, null);
     }
 
-    public static AppArtifactCoords overrideVersion(final AppArtifactCoords coords, final String overrideVersion) {
-        return new AppArtifactCoords(coords.getGroupId(), coords.getArtifactId(), coords.getClassifier(), coords.getType(),
+    public static ArtifactCoords overrideVersion(final ArtifactCoords coords, final String overrideVersion) {
+        return new ArtifactCoords(coords.getGroupId(), coords.getArtifactId(), coords.getClassifier(), coords.getType(),
                 overrideVersion);
     }
 
-    public static AppArtifactCoords toCoords(final Dependency d) {
-        return new AppArtifactCoords(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion());
+    public static ArtifactCoords toCoords(final Dependency d) {
+        return new ArtifactCoords(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion());
     }
 
 }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/buildfile/MavenBuildFileTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/buildfile/MavenBuildFileTest.java
@@ -2,7 +2,7 @@ package io.quarkus.devtools.project.buildfile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.maven.utilities.MojoUtils;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import java.io.IOException;
@@ -45,7 +45,7 @@ class MavenBuildFileTest {
 
     @Test
     void shouldNotAddManagedDependencyWithProperties() throws IOException {
-        AppArtifactCoords addedDep = new AppArtifactCoords("bar", "pops", "pom", "1");
+        ArtifactCoords addedDep = new ArtifactCoords("bar", "pops", "pom", "1");
         assertThat(mavenBuildFile.addDependency(addedDep, false)).isFalse();
     }
 

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
@@ -9,13 +9,13 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.PlatformAwareTestBase;
 import io.quarkus.devtools.codestarts.Codestart;
 import io.quarkus.devtools.codestarts.CodestartProjectDefinition;
 import io.quarkus.devtools.codestarts.CodestartType;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.testing.SnapshotTesting;
+import io.quarkus.maven.ArtifactKey;
 
 class QuarkusCodestartCatalogTest extends PlatformAwareTestBase {
 
@@ -104,7 +104,7 @@ class QuarkusCodestartCatalogTest extends PlatformAwareTestBase {
     @Test
     void createProjectTestKotlin() throws IOException {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .build();
         final CodestartProjectDefinition projectDefinition = getCatalog().createProject(input);
         assertThat(projectDefinition.getRequiredCodestart(CodestartType.LANGUAGE)).extracting(Codestart::getName)
@@ -114,7 +114,7 @@ class QuarkusCodestartCatalogTest extends PlatformAwareTestBase {
     @Test
     void prepareProjectTestScala() throws IOException {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-scala"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-scala"))
                 .build();
         final CodestartProjectDefinition projectDefinition = getCatalog().createProject(input);
         assertThat(projectDefinition.getRequiredCodestart(CodestartType.LANGUAGE)).extracting(Codestart::getName)
@@ -124,7 +124,7 @@ class QuarkusCodestartCatalogTest extends PlatformAwareTestBase {
     @Test
     void prepareProjectTestConfigYaml() throws IOException {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-config-yaml"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-config-yaml"))
                 .build();
         final CodestartProjectDefinition projectDefinition = getCatalog().createProject(input);
         assertThat(projectDefinition.getRequiredCodestart(CodestartType.CONFIG)).extracting(Codestart::getName)
@@ -134,7 +134,7 @@ class QuarkusCodestartCatalogTest extends PlatformAwareTestBase {
     @Test
     void prepareProjectTestResteasy() throws IOException {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
                 .build();
         final CodestartProjectDefinition projectDefinition = getCatalog().createProject(input);
         assertThat(projectDefinition.getBaseCodestarts()).extracting(Codestart::getName)

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.PlatformAwareTestBase;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.testing.SnapshotTesting;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 
 class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
 
@@ -124,7 +124,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateRESTEasyJavaCustom(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
                 .putData(PROJECT_PACKAGE_NAME.key(), "com.andy")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_CLASS_NAME.key(), "BonjourResource")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_PATH.key(), "/bonjour")
@@ -146,8 +146,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateRESTEasySpringWeb(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-spring-web"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-spring-web"))
                 .build();
         final Path projectDir = testDirPath.resolve("resteasy-springweb");
         getCatalog().createProject(input).generate(projectDir);
@@ -179,8 +179,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateMavenWithCustomDep(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactCoords.fromString("commons-io:commons-io:2.5"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactCoords.fromString("commons-io:commons-io:2.5"))
 
                 .build();
         final Path projectDir = testDirPath.resolve("maven-custom-dep");
@@ -203,8 +203,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateRESTEasyKotlinCustom(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .putData(PROJECT_PACKAGE_NAME.key(), "com.andy")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_CLASS_NAME.key(), "BonjourResource")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_PATH.key(), "/bonjour")
@@ -236,8 +236,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateRESTEasyScalaCustom(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-scala"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-scala"))
                 .putData(PROJECT_PACKAGE_NAME.key(), "com.andy")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_CLASS_NAME.key(), "BonjourResource")
                 .putData(RESTEASY_EXAMPLE_RESOURCE_PATH.key(), "/bonjour")
@@ -286,7 +286,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenResteasyJava(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-resteasy-java");
@@ -305,7 +305,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenPicocliJava(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-picocli"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-picocli"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-picocli-java");
@@ -328,8 +328,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenPicocliKotlin(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-picocli"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-picocli"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-picocli-kotlin");
@@ -349,7 +349,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenPicocliGradle(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-picocli"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-picocli"))
                 .buildTool(BuildTool.GRADLE)
                 .addData(getGenerationTestInputData())
                 .build();
@@ -368,7 +368,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenConfigYamlJava(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-config-yaml"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-config-yaml"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-yaml-java");
@@ -385,8 +385,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenResteasyKotlin(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-resteasy-kotlin");
@@ -405,8 +405,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateMavenResteasyScala(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-scala"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-scala"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-resteasy-scala");
@@ -427,7 +427,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE)
                 .addCodestart("gradle")
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("gradle-resteasy-java");
@@ -447,8 +447,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateGradleResteasyKotlin(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE)
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .addCodestart("gradle")
                 .addData(getGenerationTestInputData())
                 .build();
@@ -469,8 +469,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateGradleResteasyScala(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE)
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-scala"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-scala"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("gradle-resteasy-scala");
@@ -490,7 +490,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateGradleWithKotlinDslResteasyJava(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE_KOTLIN_DSL)
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("gradle-kotlin-dsl-resteasy-java");
@@ -508,8 +508,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateGradleWithKotlinDslResteasyKotlin(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE_KOTLIN_DSL)
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-kotlin"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("gradle-kotlin-dsl-resteasy-kotlin");
@@ -527,8 +527,8 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     void generateGradleWithKotlinDslResteasyScala(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE_KOTLIN_DSL)
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-scala"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-scala"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("gradle-kotlin-dsl-resteasy-scala");
@@ -545,7 +545,7 @@ class QuarkusCodestartGenerationTest extends PlatformAwareTestBase {
     @Test
     void generateRESTEasyQute(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                .addExtension(AppArtifactKey.fromString("io.quarkus:quarkus-resteasy-qute"))
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy-qute"))
                 .addData(getGenerationTestInputData())
                 .build();
         final Path projectDir = testDirPath.resolve("maven-resteasy-qute");

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/AddGradleExtensionsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/AddGradleExtensionsTest.java
@@ -11,13 +11,13 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.buildfile.AbstractGroovyGradleBuildFile;
 import io.quarkus.devtools.testing.SnapshotTesting;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
@@ -76,10 +76,10 @@ class AddGradleExtensionsTest extends AbstractAddExtensionsTest<List<String>> {
         }
 
         @Override
-        protected List<AppArtifactCoords> getDependencies() throws IOException {
+        protected List<ArtifactCoords> getDependencies() throws IOException {
             final Matcher matcher = Pattern.compile("\\s*implementation\\s+'([^\\v:]+):([^\\v:]+)(:[^:\\v]+)?'")
                     .matcher(getBuildContent());
-            final ArrayList<AppArtifactCoords> builder = new ArrayList<>();
+            final ArrayList<ArtifactCoords> builder = new ArrayList<>();
             while (matcher.find()) {
                 builder.add(createDependency(matcher.group(1), matcher.group(2), matcher.group(3), "jar"));
             }
@@ -94,12 +94,12 @@ class AddGradleExtensionsTest extends AbstractAddExtensionsTest<List<String>> {
             return builder;
         }
 
-        private AppArtifactCoords createDependency(String groupId, String artifactId, String version, String type) {
-            return new AppArtifactCoords(groupId, artifactId, type, version);
+        private ArtifactCoords createDependency(String groupId, String artifactId, String version, String type) {
+            return new ArtifactCoords(groupId, artifactId, type, version);
         }
 
         @Override
-        public Collection<AppArtifactCoords> getInstalledPlatforms() throws IOException {
+        public Collection<ArtifactCoords> getInstalledPlatforms() throws IOException {
             return Collections.emptyList();
         }
     }

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
@@ -21,8 +21,6 @@ import org.apache.maven.model.Model;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.devtools.PlatformAwareTestBase;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -30,6 +28,8 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.testing.SnapshotTesting;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.maven.ArtifactKey;
 import io.quarkus.maven.utilities.MojoUtils;
 import io.quarkus.maven.utilities.QuarkusDependencyPredicate;
 
@@ -42,9 +42,9 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
 
         final ListExtensions listExtensions = new ListExtensions(project);
 
-        final Map<AppArtifactKey, AppArtifactCoords> installed = readByKey(project);
+        final Map<ArtifactKey, ArtifactCoords> installed = readByKey(project);
 
-        Assertions.assertNotNull(installed.get(AppArtifactKey.fromString(IO_QUARKUS + ":quarkus-agroal")));
+        Assertions.assertNotNull(installed.get(ArtifactKey.fromString(IO_QUARKUS + ":quarkus-agroal")));
     }
 
     /**
@@ -60,11 +60,11 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
 
         final ListExtensions listExtensions = new ListExtensions(quarkusProject);
 
-        final Map<AppArtifactKey, AppArtifactCoords> installed = readByKey(quarkusProject);
+        final Map<ArtifactKey, ArtifactCoords> installed = readByKey(quarkusProject);
 
-        Assertions.assertNotNull(installed.get(AppArtifactKey.fromString(IO_QUARKUS + ":quarkus-resteasy")));
+        Assertions.assertNotNull(installed.get(ArtifactKey.fromString(IO_QUARKUS + ":quarkus-resteasy")));
         Assertions.assertNotNull(
-                installed.get(AppArtifactKey.fromString(IO_QUARKUS + ":quarkus-hibernate-validator")));
+                installed.get(ArtifactKey.fromString(IO_QUARKUS + ":quarkus-hibernate-validator")));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
     void testListExtensionsWithoutAPomFile() throws Exception {
         final Path tempDirectory = Files.createTempDirectory("proj");
         final QuarkusProject project = QuarkusProjectHelper.getProject(tempDirectory, BuildTool.MAVEN);
-        final Map<AppArtifactKey, AppArtifactCoords> installed = readByKey(project);
+        final Map<ArtifactKey, ArtifactCoords> installed = readByKey(project);
         assertTrue(installed.isEmpty());
         assertFalse(project.getExtensionsCatalog().getExtensions().isEmpty());
 
@@ -200,8 +200,8 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
         return project;
     }
 
-    private static Map<AppArtifactKey, AppArtifactCoords> readByKey(QuarkusProject project) throws IOException {
+    private static Map<ArtifactKey, ArtifactCoords> readByKey(QuarkusProject project) throws IOException {
         return project.getExtensionManager().getInstalled().stream()
-                .collect(toMap(AppArtifactCoords::getKey, Function.identity()));
+                .collect(toMap(ArtifactCoords::getKey, Function.identity()));
     }
 }


### PR DESCRIPTION
There is a mix of artifact related API in devtools. The `AppArtifact*` API is used in Quarkus bootstrap. The `Artifact*` API was introduced for the registry client and is at the core of devtools now.
