### PR TITLE
CLI - reduce the startup time

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Add.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Add.java
@@ -15,7 +15,7 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "add", usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Add extension(s) to current project.")
+@CommandLine.Command(name = "add", mixinStandardHelpOptions = false, description = "Add extension(s) to current project.")
 public class Add extends BaseSubCommand implements BuildsystemCommand {
 
     @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to project")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Build.java
@@ -9,7 +9,7 @@ import io.quarkus.cli.core.BuildsystemCommand;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "build", usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Build your quarkus project")
+@CommandLine.Command(name = "build", mixinStandardHelpOptions = false, description = "Build your quarkus project")
 public class Build extends BaseSubCommand implements BuildsystemCommand {
 
     @CommandLine.Option(names = { "-n",

--- a/devtools/cli/src/main/java/io/quarkus/cli/Clean.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Clean.java
@@ -9,7 +9,7 @@ import io.quarkus.cli.core.BuildsystemCommand;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "clean", usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Clean current project")
+@CommandLine.Command(name = "clean", mixinStandardHelpOptions = false, description = "Clean current project")
 public class Clean extends BaseSubCommand implements BuildsystemCommand {
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -14,7 +14,7 @@ import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "create", sortOptions = false, usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Create a new quarkus project.")
+@CommandLine.Command(name = "create", sortOptions = false, mixinStandardHelpOptions = false, description = "Create a new quarkus project.")
 public class Create extends BaseSubCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-g",

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -18,7 +18,7 @@ import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.utils.Prompter;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "create-extension", sortOptions = false, usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Creates the base of a Quarkus extension in different layout depending of the options and environment.")
+@CommandLine.Command(name = "create-extension", sortOptions = false, mixinStandardHelpOptions = false, description = "Creates the base of a Quarkus extension in different layout depending of the options and environment.")
 public class CreateExtension extends BaseSubCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-g",

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateJBang.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateJBang.java
@@ -10,7 +10,7 @@ import io.quarkus.devtools.commands.CreateJBangProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "create-jbang", sortOptions = false, usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Create a new quarkus jbang project.")
+@CommandLine.Command(name = "create-jbang", sortOptions = false, mixinStandardHelpOptions = false, description = "Create a new quarkus jbang project.")
 public class CreateJBang extends BaseSubCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = { "-n",

--- a/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
@@ -9,7 +9,7 @@ import io.quarkus.cli.core.BuildsystemCommand;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "dev", usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Execute project in live coding dev mode")
+@CommandLine.Command(name = "dev", mixinStandardHelpOptions = false, description = "Execute project in live coding dev mode")
 public class Dev extends BaseSubCommand implements BuildsystemCommand {
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/List.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/List.java
@@ -12,7 +12,7 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", usageHelpAutoWidth = true, sortOptions = false, mixinStandardHelpOptions = false, description = "List installed (default) or installable extensions.")
+@CommandLine.Command(name = "list", sortOptions = false, mixinStandardHelpOptions = false, description = "List installed (default) or installable extensions.")
 public class List extends BaseSubCommand implements BuildsystemCommand {
 
     @CommandLine.Option(names = { "-i",

--- a/devtools/cli/src/main/java/io/quarkus/cli/Platforms.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Platforms.java
@@ -10,7 +10,7 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "platforms", usageHelpAutoWidth = true, sortOptions = false, mixinStandardHelpOptions = false, description = "List imported (default) or all available Quarkus platforms.")
+@CommandLine.Command(name = "platforms", sortOptions = false, mixinStandardHelpOptions = false, description = "List imported (default) or all available Quarkus platforms.")
 public class Platforms extends BaseSubCommand implements BuildsystemCommand {
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -18,7 +18,7 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 import picocli.CommandLine;
 
 @QuarkusMain
-@CommandLine.Command(name = "qs", versionProvider = QuarkusCliVersion.class, usageHelpAutoWidth = true, subcommandsRepeatable = true, mixinStandardHelpOptions = true, subcommands = {
+@CommandLine.Command(name = "qs", versionProvider = QuarkusCliVersion.class, subcommandsRepeatable = true, mixinStandardHelpOptions = true, subcommands = {
         Build.class,
         Clean.class, Create.class, CreateJBang.class, List.class, Platforms.class, Add.class, Remove.class, Dev.class,
         CreateExtension.class })
@@ -81,7 +81,6 @@ public class QuarkusCli implements QuarkusApplication {
     public int run(String... args) throws Exception {
         CommandLine cmd = factory == null ? new CommandLine(this) : new CommandLine(this, factory);
         return cmd.setExecutionStrategy(new ExecutionStrategy())
-                .setUsageHelpLongOptionsMaxWidth(30)
                 .execute(args);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/Remove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Remove.java
@@ -14,7 +14,7 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "remove", aliases = "rm", usageHelpAutoWidth = true, mixinStandardHelpOptions = false, description = "Remove an extension from this project.")
+@CommandLine.Command(name = "remove", aliases = "rm", mixinStandardHelpOptions = false, description = "Remove an extension from this project.")
 public class Remove extends BaseSubCommand implements BuildsystemCommand {
 
     @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to remove")

--- a/devtools/cli/src/main/resources/application.properties
+++ b/devtools/cli/src/main/resources/application.properties
@@ -3,3 +3,6 @@ quarkus.banner.enabled=false
 quarkus.package.type=uber-jar
 quarkus.native.resources.includes=quarkus.properties
 quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.maven.wagon.shared.http.AbstractHttpClientWagon
+# Do not attempt to detect "unused removed beans" false positives during programmatic lookup 
+# at runtime to conserve some memory
+quarkus.arc.detect-unused-false-positives=false


### PR DESCRIPTION
- do not set CommandLine.setUsageHelpLongOptionsMaxWidth(); a side
effect of this option is that picocli attempts to detect the terminal
size which is quite expensive
- do not detect unused removed beans false posititives at runtime