### PR TITLE
Move Google Cloud Functions to preview and update the docs

### DIFF
--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -10,8 +10,6 @@ include::./attributes.adoc[]
 
 The guide walks through quickstart code to show you how you can deploy Funqy functions to Google Cloud Functions.
 
-As the Google Cloud Function Java engine is a new Beta feature of Google Cloud, this extension is flagged as experimental.
-
 include::./status-include.adoc[]
 
 == Prerequisites
@@ -33,13 +31,6 @@ Login to Google Cloud is necessary for deploying the application and it can be d
 gcloud auth login
 ----
 
-At the time of this writing, Cloud Functions are still in beta so make sure to install the `beta` command group.
-
-[source,bash,subs=attributes+]
-----
-gcloud components install beta
-----
-
 == The Quickstart
 
 Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
@@ -58,15 +49,8 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=funqy-google-cloud-functions \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="resteasy,funqy-google-cloud-functions"
+    -Dextensions="funqy-google-cloud-functions"
 ----
-
-Now, let's remove what's not needed inside the generated application:
-
-- Remove the dependency `io.quarkus:quarkus-reasteasy` from your `pom.xml` file.
-- Remove the generated `org.acme.quickstart.GreetingResource` class.
-- Remove the `index.html` from `resources/META-INF/resources` or it will be picked up instead of your Function.
-- Remove the existing tests.
 
 == The Code
 
@@ -158,11 +142,11 @@ Then you will be able to use `gcloud` to deploy your function to Google Cloud, t
 
 [WARNING]
 ====
-The first time you launch the `gcloud beta functions deploy`, you can have the following error message:
+The first time you launch the `gcloud functions deploy`, you can have the following error message:
 
 [source]
 ----
-ERROR: (gcloud.beta.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
+ERROR: (gcloud.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
 ----
 This means that Cloud Build is not activated yet. To overcome this error, open the URL shown in the error, follow the instructions and then wait a few minutes before retrying the command.
 ====
@@ -173,7 +157,7 @@ Use this command to deploy to Google Cloud Functions:
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-funky-pubsub \
+gcloud functions deploy quarkus-example-funky-pubsub \
   --entry-point=io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction \
   --runtime=java11 --trigger-resource hello_topic --trigger-event google.pubsub.topic.publish \
   --source=target/deployment
@@ -207,7 +191,7 @@ Then, use this command to deploy to Google Cloud Functions:
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-funky-storage \
+gcloud functions deploy quarkus-example-funky-storage \
   --entry-point=io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction \
   --runtime=java11 --trigger-resource quarkus-hello --trigger-event google.storage.object.finalize \
   --source=target/deployment
@@ -239,7 +223,7 @@ You can download it via Maven using the following command:
 [source,bash]
 ----
 mvn dependency:copy \
-  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.0-beta1' \
+  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.2' \
   -DoutputDirectory=.
 ----
 
@@ -253,7 +237,7 @@ For background functions, you launch the invoker with a target class of `io.quar
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/funqy-google-cloud-functions-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction
 ----
@@ -275,7 +259,7 @@ For background functions, you launch the invoker with a target class of `io.quar
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/funqy-google-cloud-functions-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction
 ----

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
-:extension-status: experimental
+:extension-status: preview
 
 include::./attributes.adoc[]
 
@@ -12,8 +12,6 @@ The `quarkus-google-cloud-functions-http` extension allows you to write microser
 Undertow (Servlet), Vert.x Web, or link:funqy-http[Funqy HTTP], and make these microservices deployable to the Google Cloud Functions runtime.
 
 One Google Cloud Functions deployment can represent any number of JAX-RS, Servlet, Vert.x Web, or link:funqy-http[Funqy HTTP] endpoints.
-
-As the Google Cloud Function Java engine is a new Beta feature of Google Cloud, this extension is flagged as experimental.
 
 include::./status-include.adoc[]
 
@@ -61,13 +59,6 @@ Login to Google Cloud is necessary for deploying the application and it can be d
 [source,bash,subs=attributes+]
 ----
 gcloud auth login
-----
-
-At the time of this writing, Cloud Functions are still in beta so make sure to install the `beta` command group.
-
-[source,bash,subs=attributes+]
-----
-gcloud components install beta
 ----
 
 == Creating the endpoints
@@ -171,7 +162,7 @@ Then you will be able to use `gcloud` to deploy your function to Google Cloud.
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-http \
+gcloud functions deploy quarkus-example-http \
   --entry-point=io.quarkus.gcp.functions.http.QuarkusHttpFunction \
   --runtime=java11 --trigger-http --source=target/deployment
 ----
@@ -186,7 +177,7 @@ The entry point must always be set to `io.quarkus.gcp.functions.http.QuarkusHttp
 The first time you launch this command, you can have the following error message:
 [source]
 ----
-ERROR: (gcloud.beta.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
+ERROR: (gcloud.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
 ----
 This means that Cloud Build is not activated yet. To overcome this error, open the URL shown in the error, follow the instructions and then wait a few minutes before retrying the command.
 ====
@@ -210,7 +201,7 @@ You can download it via Maven using the following command:
 [source,bash]
 ----
 mvn dependency:copy \
-  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.0-beta1' \
+  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.2' \
   -DoutputDirectory=.
 ----
 
@@ -220,7 +211,7 @@ Then you can use it to launch your function locally.
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/deployment/google-cloud-functions-http-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.gcp.functions.http.QuarkusHttpFunction
 ----

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -4,14 +4,12 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless)
-:extension-status: experimental
+:extension-status: preview
 
 include::./attributes.adoc[]
 
 The `quarkus-google-cloud-functions` extension allows you to use Quarkus to build your Google Cloud Functions.
 Your functions can use injection annotations from CDI or Spring and other Quarkus facilities as you need them.
-
-As the Google Cloud Function Java engine is a new Beta feature of Google Cloud, this extension is flagged as experimental.
 
 include::./status-include.adoc[]
 
@@ -66,13 +64,6 @@ Login to Google Cloud is necessary for deploying the application and it can be d
 [source,bash,subs=attributes+]
 ----
 gcloud auth login
-----
-
-At the time of this writing, Cloud Functions are still in beta so make sure to install the `beta` command group.
-
-[source,bash,subs=attributes+]
-----
-gcloud components install beta
 ----
 
 == Creating the functions
@@ -223,14 +214,14 @@ To build your application, you can package it using the standard `mvn clean pack
 
 The result of the previous command is a single JAR file inside the `target/deployment` repository that contains classes and dependencies of the project.
 
-Then you will be able to use `gcloud beta functions deploy` command to deploy your function to Google Cloud.
+Then you will be able to use `gcloud functions deploy` command to deploy your function to Google Cloud.
 
 [WARNING]
 ====
 The first time you launch this command, you can have the following error message:
 [source]
 ----
-ERROR: (gcloud.beta.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
+ERROR: (gcloud.functions.deploy) OperationError: code=7, message=Build Failed: Cloud Build has not been used in project <project_name> before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<my-project> then retry.
 ----
 This means that Cloud Build is not activated yet. To overcome this error, open the URL shown in the error, follow the instructions and then wait a few minutes before retrying the command.
 ====
@@ -241,7 +232,7 @@ This is an example command to deploy your `HttpFunction` to Google Cloud:
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-http \
+gcloud functions deploy quarkus-example-http \
   --entry-point=io.quarkus.gcp.functions.QuarkusHttpFunction \
   --runtime=java11 --trigger-http --source=target/deployment
 ----
@@ -267,7 +258,7 @@ it needs to use `--trigger-event google.storage.object.finalize` and the `--trig
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-storage \
+gcloud functions deploy quarkus-example-storage \
     --entry-point=io.quarkus.gcp.functions.QuarkusBackgroundFunction \
     --trigger-resource quarkus-hello --trigger-event google.storage.object.finalize \
     --runtime=java11 --source=target/deployment
@@ -294,7 +285,7 @@ it needs to use `--trigger-event google.pubsub.topic.publish` and the `--trigger
 
 [source,bash]
 ----
-gcloud beta functions deploy quarkus-example-pubsub \
+gcloud functions deploy quarkus-example-pubsub \
   --entry-point=io.quarkus.gcp.functions.QuarkusBackgroundFunction \
   --runtime=java11 --trigger-resource hello_topic --trigger-event google.pubsub.topic.publish --source=target/deployment
 ----
@@ -320,7 +311,7 @@ You can download it via Maven using the following command:
 [source,bash]
 ----
 mvn dependency:copy \
-  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.0-beta1' \
+  -Dartifact='com.google.cloud.functions.invoker:java-function-invoker:1.0.2' \
   -DoutputDirectory=.
 ----
 
@@ -332,7 +323,7 @@ To test an `HttpFunction`, you can use this command to launch your function loca
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/google-cloud-functions-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.gcp.functions.QuarkusHttpFunction
 ----
@@ -347,7 +338,7 @@ For background functions, you launch the invoker with a target class of `io.quar
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/google-cloud-functions-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.gcp.functions.QuarkusBackgroundFunction
 ----
@@ -369,7 +360,7 @@ For background functions, you launch the invoker with a target class of `io.quar
 
 [source,bash]
 ----
-java -jar java-function-invoker-1.0.0-beta1.jar \
+java -jar java-function-invoker-1.0.2.jar \
   --classpath target/google-cloud-functions-1.0.0-SNAPSHOT-runner.jar \
   --target io.quarkus.gcp.functions.QuarkusBackgroundFunction
 ----

--- a/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
   categories:
   - "cloud"
   guide: "https://quarkus.io/guides/gcp-functions-http"
-  status: "experimental"
+  status: "preview"
   codestart:
     name: "google-cloud-functions-http"
     kind: "singleton-example"

--- a/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,7 +8,7 @@ metadata:
   categories:
   - "cloud"
   guide: "https://quarkus.io/guides/gcp-functions"
-  status: "experimental"
+  status: "preview"
   codestart:
     name: "google-cloud-functions"
     kind: "singleton-example"


### PR DESCRIPTION
Move Google Cloud to preview as it exists since almost a year, we had some feedback from users, and the support of Java on Google Cloud Function is not yet in Beta.

Funqy is still experimental as all funqy exensions are.