### PR TITLE
Registry client: option to cleanup old timestamped catalog artifacts

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -4,7 +4,6 @@
 package io.quarkus.bootstrap.resolver.maven;
 
 import io.quarkus.bootstrap.model.AppArtifactKey;
-import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.util.PropertyUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -208,7 +207,7 @@ public class MavenArtifactResolver {
         }
     }
 
-    public String getLatestVersionFromRange(Artifact artifact, String range) throws AppModelResolverException {
+    public String getLatestVersionFromRange(Artifact artifact, String range) throws BootstrapMavenException {
         return getLatest(resolveVersionRange(new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(),
                 artifact.getClassifier(), artifact.getExtension(), range)));
     }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenNonPlatformExtensionsResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenNonPlatformExtensionsResolver.java
@@ -1,6 +1,5 @@
 package io.quarkus.registry.client.maven;
 
-import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
@@ -18,11 +17,11 @@ public class MavenNonPlatformExtensionsResolver
         implements RegistryNonPlatformExtensionsResolver {
 
     private final RegistryNonPlatformExtensionsConfig config;
-    private final MavenArtifactResolver artifactResolver;
+    private final MavenRegistryArtifactResolver artifactResolver;
     private final MessageWriter log;
 
     public MavenNonPlatformExtensionsResolver(RegistryNonPlatformExtensionsConfig config,
-            MavenArtifactResolver artifactResolver, MessageWriter log) {
+            MavenRegistryArtifactResolver artifactResolver, MessageWriter log) {
         this.config = Objects.requireNonNull(config);
         this.artifactResolver = Objects.requireNonNull(artifactResolver);
         this.log = Objects.requireNonNull(log);
@@ -35,13 +34,15 @@ public class MavenNonPlatformExtensionsResolver
         final Artifact catalogArtifact = new DefaultArtifact(baseCoords.getGroupId(),
                 baseCoords.getArtifactId(), quarkusVersion, baseCoords.getType(), baseCoords.getVersion());
         log.debug("Resolving non-platform extension catalog %s", catalogArtifact);
+
         final Path jsonFile;
         try {
-            jsonFile = artifactResolver.resolve(catalogArtifact).getArtifact().getFile().toPath();
+            jsonFile = artifactResolver.resolve(catalogArtifact);
         } catch (Exception e) {
             log.debug("Failed to resolve non-platform extension catalog %s", catalogArtifact);
             return null;
         }
+
         try {
             return JsonCatalogMapperHelper.deserialize(jsonFile, JsonExtensionCatalog.class);
         } catch (Exception e) {

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
@@ -1,6 +1,5 @@
 package io.quarkus.registry.client.maven;
 
-import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
@@ -17,10 +16,10 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 
 public class MavenPlatformExtensionsResolver implements RegistryPlatformExtensionsResolver {
 
-    private final MavenArtifactResolver artifactResolver;
+    private final MavenRegistryArtifactResolver artifactResolver;
     private final MessageWriter log;
 
-    public MavenPlatformExtensionsResolver(MavenArtifactResolver artifactResolver,
+    public MavenPlatformExtensionsResolver(MavenRegistryArtifactResolver artifactResolver,
             MessageWriter log) {
         this.artifactResolver = Objects.requireNonNull(artifactResolver);
         this.log = Objects.requireNonNull(log);
@@ -43,7 +42,7 @@ public class MavenPlatformExtensionsResolver implements RegistryPlatformExtensio
         log.debug("Resolving platform extension catalog %s", catalogArtifact);
         final Path jsonPath;
         try {
-            jsonPath = artifactResolver.resolve(catalogArtifact).getArtifact().getFile().toPath();
+            jsonPath = artifactResolver.resolve(catalogArtifact);
         } catch (Exception e) {
             throw new RegistryResolutionException("Failed to resolve Quarkus extensions catalog " + catalogArtifact,
                     e);

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformsResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformsResolver.java
@@ -1,6 +1,5 @@
 package io.quarkus.registry.client.maven;
 
-import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
@@ -18,10 +17,10 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 public class MavenPlatformsResolver implements RegistryPlatformsResolver {
 
     private final RegistryPlatformsConfig config;
-    private final MavenArtifactResolver artifactResolver;
+    private final MavenRegistryArtifactResolver artifactResolver;
     private final MessageWriter log;
 
-    public MavenPlatformsResolver(RegistryPlatformsConfig config, MavenArtifactResolver artifactResolver,
+    public MavenPlatformsResolver(RegistryPlatformsConfig config, MavenRegistryArtifactResolver artifactResolver,
             MessageWriter log) {
         this.config = Objects.requireNonNull(config);
         this.artifactResolver = Objects.requireNonNull(artifactResolver);
@@ -36,7 +35,7 @@ public class MavenPlatformsResolver implements RegistryPlatformsResolver {
         log.debug("Resolving platform catalog %s", catalogArtifact);
         final Path jsonFile;
         try {
-            jsonFile = artifactResolver.resolve(catalogArtifact).getArtifact().getFile().toPath();
+            jsonFile = artifactResolver.resolve(catalogArtifact);
         } catch (Exception e) {
             log.debug("Failed to resolve platform catalog %s", catalogArtifact);
             return null;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolver.java
@@ -1,0 +1,12 @@
+package io.quarkus.registry.client.maven;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import java.nio.file.Path;
+import org.eclipse.aether.artifact.Artifact;
+
+public interface MavenRegistryArtifactResolver {
+
+    Path resolve(Artifact artifact) throws BootstrapMavenException;
+
+    String getLatestVersionFromRange(Artifact artifact, String versionRange) throws BootstrapMavenException;
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
@@ -1,0 +1,74 @@
+package io.quarkus.registry.client.maven;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+public class MavenRegistryArtifactResolverWithCleanup implements MavenRegistryArtifactResolver {
+
+    private final MavenArtifactResolver resolver;
+    private final boolean cleanupTimestampedVersions;
+
+    public MavenRegistryArtifactResolverWithCleanup(MavenArtifactResolver resolver, boolean cleanupOldTimestampedVersions) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver can't be null");
+        this.cleanupTimestampedVersions = cleanupOldTimestampedVersions;
+    }
+
+    @Override
+    public Path resolve(Artifact artifact) throws BootstrapMavenException {
+        return resolveAndCleanupOldTimestampedVersions(resolver, artifact, cleanupTimestampedVersions).getArtifact().getFile()
+                .toPath();
+    }
+
+    @Override
+    public String getLatestVersionFromRange(Artifact artifact, String versionRange) throws BootstrapMavenException {
+        return resolver.getLatestVersionFromRange(artifact, versionRange);
+    }
+
+    /**
+     * This method resolves an artifact and then will attempt to remove old timestamped SNAPSHOT versions.
+     *
+     * <p>
+     * IMPORTANT: it does not remove all the timestamped SNAPSHOT versions because otherwise, the artifacts
+     * will always be resolved from a remote repository even if the update policy does not require that.
+     *
+     * @param resolver Maven artifact resolver
+     * @param artifact artifact to resolve
+     * @param cleanupOldTimestampedVersions whether to remove old timestamped SNAPSHOT versions
+     * @return artifact resolution result
+     * @throws BootstrapMavenException in case the artifact could not be resolved
+     */
+    protected static ArtifactResult resolveAndCleanupOldTimestampedVersions(MavenArtifactResolver resolver, Artifact artifact,
+            boolean cleanupOldTimestampedVersions) throws BootstrapMavenException {
+        if (!cleanupOldTimestampedVersions) {
+            return resolver.resolve(artifact);
+        }
+
+        final LocalRepositoryManager localRepoManager = resolver.getSession().getLocalRepositoryManager();
+        final File jsonDir = new File(localRepoManager.getRepository().getBasedir(),
+                localRepoManager.getPathForLocalArtifact(artifact)).getParentFile();
+        final List<String> existingFiles = jsonDir.exists() ? Arrays.asList(jsonDir.list()) : Collections.emptyList();
+
+        final ArtifactResult result = resolver.resolve(artifact);
+
+        final File[] jsonDirContent = jsonDir.listFiles();
+        if (jsonDirContent.length > existingFiles.size()) {
+            final String fileName = result.getArtifact().getFile().getName();
+            for (File c : jsonDirContent) {
+                if (c.getName().length() > fileName.length() && c.getName().startsWith(artifact.getArtifactId())
+                        && existingFiles.contains(c.getName())) {
+                    c.deleteOnExit();
+                }
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Adds a config option to the Maven registry client to clean up old registry artifacts with timestamps from the local repo, which is on by default. It can be disabled in the `.quarkus/config.yaml`, e.g.
````
registries:
- playground.io:
    cleanup-timestamped-artifacts: false
    update-policy: "always"
    maven:
      repository:
        url: http://localhost:8080/registry
````