### PR TITLE
Register hierarchy of io.quarkus.maven.ArtifactKey

### DIFF
--- a/independent-projects/tools/artifact-api/pom.xml
+++ b/independent-projects/tools/artifact-api/pom.xml
@@ -13,6 +13,22 @@
     <artifactId>quarkus-devtools-artifact-api</artifactId>
     <name>Quarkus - Dev tools - Maven Artifact API</name>
 
-    <dependencies>
-    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.0.8</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
This is needed to fix the following warning when compiling to native:
```
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
	- io.quarkus.maven.ArtifactKey (source: JacksonProcessor > io.quarkus.registry.catalog.json.JsonArtifactCoordsMixin)
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.
```