### PR TITLE
Use a floating tag for the ubi-quarkus-native-image

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -136,8 +136,8 @@
         <!-- Forbidden API checks -->
         <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
 
-        <!-- platform properties -->
-        <platform.quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11</platform.quarkus.native.builder-image>
+        <!-- platform properties - this is a floating tag -->
+        <platform.quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.0-java11</platform.quarkus.native.builder-image>
 
         <script.extension>sh</script.extension>
         <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -126,7 +126,7 @@ A platform properties file for the example above would contain (the actual value
 
 [source,text]
 ----
-platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java11
+platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:21.0.0.2-java11
 ----
 
 There is also a Maven plugin goal that validates the platform properties content and its artifact coordinates and also checks whether the platform properties artifact is present in the platform's BOM. Here is a sample plugin configuration:


### PR DESCRIPTION
Use a floating tag for the ubi-quarkus-native-image (image providing native-image and used for in-container build).
The mandrel equivalent was already using a floating tag.

