### PR TITLE
Improve the error message of remote-dev on the client side

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
@@ -134,10 +134,11 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             String session = connection.getHeaderField(RemoteSyncHandler.QUARKUS_SESSION);
             String error = connection.getHeaderField(RemoteSyncHandler.QUARKUS_ERROR);
             if (error != null) {
-                throw new IOException("Server did not start a remote dev session: " + error);
+                throw createIOException("Server did not start a remote dev session: " + error);
             }
             if (session == null) {
-                throw new IOException("Server did not start a remote dev session");
+                throw createIOException(
+                        "Server did not start a remote dev session. Make sure the environment variable 'QUARKUS_LAUNCH_DEVMODE' is set to 'true' when launching the server");
             }
             String result = new String(IoUtil.readBytes(connection.getInputStream()), StandardCharsets.UTF_8);
             Set<String> changed = new HashSet<>();
@@ -162,6 +163,12 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                 log.info("Connected to remote server");
             }
             return session;
+        }
+
+        private IOException createIOException(String message) {
+            IOException result = new IOException(message);
+            result.setStackTrace(new StackTraceElement[] {});
+            return result;
         }
 
         @Override


### PR DESCRIPTION
It used to be:

```
2021-04-08 14:26:16,619 ERROR [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Remote dev request failed: java.io.IOException: Server did not start a remote dev session. Make sure the environment variable 'QUARKUS_LAUNCH_DEVMODE' is set to 'true' when launching the server
        at io.quarkus.vertx.http.deployment.devmode.HttpRemoteDevClient$Session.doConnect(HttpRemoteDevClient.java:140)
        at io.quarkus.vertx.http.deployment.devmode.HttpRemoteDevClient$Session.run(HttpRemoteDevClient.java:182)
        at java.base/java.lang.Thread.run(Thread.java:834)

```

Now it's:

```
2021-04-08 14:29:42,179 ERROR [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Remote dev request failed: java.io.IOException: Server did not start a remote dev session. Make sure the environment variable 'QUARKUS_LAUNCH_DEVMODE' is set to 'true' when launching the server

```