### PR TITLE
JDK early access job: downgrade jbang

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus
       - name: Report status
-        uses: jbangdev/jbang-action@v0.69.2
+        uses: jbangdev/jbang-action@v0.68.0
         if: "always() && github.repository == 'quarkusio/quarkus' && github.event_name != 'workflow_dispatch'"
         with:
           script: .github/NativeBuildReport.java


### PR DESCRIPTION
Even though I upgraded to 0.69.2 some week ago, the report step still fails with:
```
jbang .github/NativeBuildReport.java
JAVA_HOME is set but does not seem to point to a valid Java JDK
[jbang] Resolving dependencies...
[jbang]     Resolving org.kohsuke:github-api:1.101...Done
[jbang]     Resolving info.picocli:picocli:4.2.0...Done
[jbang] Dependencies resolved
[jbang] Building jar...
Error:  [ERROR] Cannot run program "/opt/hostedtoolcache/jdk/16.0.0/x64/bin/javac": error=2, No such file or directory
[jbang] Run with --verbose for more details
```
https://github.com/quarkusio/quarkus/runs/2292452402?check_suite_focus=true

I don't have time to re-test this in detail, but it was working with 0.68.0 in my fork back then when I created the job initially.