### PR TITLE
Only warn if there is a missing no-arg ctor

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -357,8 +357,7 @@ public class ResteasyCommonProcessor {
 
     private void checkProperConstructorInProvider(AnnotationInstance i) {
         ClassInfo targetClass = i.target().asClass();
-        if (!targetClass.hasNoArgsConstructor()
-                || targetClass.methods().stream().filter(m -> m.name().equals("<init>")).count() > 1) {
+        if (!targetClass.hasNoArgsConstructor()) {
             LOGGER.warn(
                     "Classes annotated with @Provider should have a single, no-argument constructor, otherwise dependency injection won't work properly. Offending class is "
                             + targetClass);


### PR DESCRIPTION
Its ok to have additional constructors as well.

This prevents warnings like:

[io.qua.res.com.dep.ResteasyCommonProcessor] (build-22) Classes
annotated with @Provider should have a single, no-argument constructor,
otherwise dependency injection won't work properly. Offending class is
org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader