### PR TITLE
UIs - Fix case where appArtifact version is null

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
@@ -343,16 +343,22 @@ public class WebJarUtil {
             String contents = new String(IoUtil.readBytes(is));
             contents = contents.replace("{applicationName}",
                     c.getOptionalValue("quarkus.application.name", String.class)
-                            .orElse(appArtifact.getArtifactId()));
+                            .orElseGet(() -> notNullString(appArtifact.getArtifactId())));
 
             contents = contents.replace("{applicationVersion}",
                     c.getOptionalValue("quarkus.application.version", String.class)
-                            .orElse(appArtifact.getVersion()));
+                            .orElseGet(() -> notNullString(appArtifact.getVersion())));
 
             contents = contents.replace("{quarkusVersion}", Version.getVersion());
             is = new ByteArrayInputStream(contents.getBytes());
         }
         return is;
+    }
+
+    private static String notNullString(String in) {
+        if (in == null)
+            return "";
+        return in;
     }
 
     private static InputStream getCustomOverride(PathsCollection paths, String filename, String modulename) {


### PR DESCRIPTION
As discussed here: https://groups.google.com/g/quarkus-dev/c/hT8j5eFPPLA/m/VCZoGG6rAQAJ

I could not find out what changed between 1.13.0 and 1.13.1 that cause this, but it seems like now, in 1.13.1

```
curateOutcomeBuildItem.getEffectiveModel().getAppArtifact().getVersion();
```

version could be null (when running tests)

That was not the case before. This fix the case if it is null.

If we are going to do another release in the 1.x branch, this should be backported.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>