### PR TITLE
Oidc-Client: Allow named injections of OidcClients and Tokens

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -168,7 +168,7 @@ Please note that some OpenId Connect Providers will not return a refresh token i
 
 === OidcClients
 
-`io.quarkus.oidc.client.OidcClients` is a container of `OidcClient`s - it includes a default `OidcClient` (which can also be injected directly as described above) and named clients which can be configured like this:
+`io.quarkus.oidc.client.OidcClients` is a container of ``OidcClient``s - it includes a default `OidcClient` (which can also be injected directly as described above) and named clients which can be configured like this:
 
 [source,properties]
 ----
@@ -266,6 +266,52 @@ public class OidcClientResource {
         cfg.getCredentials().setSecret("secret");
         Uni<OidcClient> client = clients.newClient(config);
         // use this client to get the token
+    }
+}
+----
+
+==== Inject named `OidcClient` and `Tokens`
+
+In case of multiple configured ``OidcClient``s you can specify the `OidcClient` injection target by the extra qualifier `@NamedOidcClient` instead of working with `OidcClients`:
+
+[source,java]
+----
+package io.quarkus.oidc.client;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    @NamedOidcClient("jwt-secret")
+    OidcClient client;
+
+    @GET
+    public String getResponse() {
+        // use client to get the token
+    }
+}
+----
+
+The same qualifier can be used to specify the `OidcClient` used for a `Tokens` injection:
+
+[source,java]
+----
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+@RequestScoped
+public class OidcClientRequestCustomFilter implements ClientRequestFilter {
+
+    @Inject
+    @NamedOidcClient("jwt-secret")
+    Tokens tokens;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
     }
 }
 ----

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
@@ -39,6 +39,6 @@ public class OidcClientRequestFilter extends AbstractTokensProducer implements C
 
     private String getAccessToken() {
         // It should be reactive when run with Resteasy Reactive
-        return getTokens().await().indefinitely().getAccessToken();
+        return awaitTokens().getAccessToken();
     }
 }

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -1,24 +1,43 @@
 package io.quarkus.oidc.client.deployment;
 
-import java.util.Arrays;
-import java.util.List;
+import java.lang.reflect.Modifier;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Singleton;
+
+import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.oidc.client.NamedOidcClient;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
 import io.quarkus.oidc.client.runtime.OidcClientBuildTimeConfig;
 import io.quarkus.oidc.client.runtime.OidcClientRecorder;
 import io.quarkus.oidc.client.runtime.OidcClientsConfig;
@@ -49,31 +68,145 @@ public class OidcClientBuildStep {
         runtime.produce(new RuntimeInitializedClassBuildItem(TokensHelper.class.getName()));
     }
 
+    @BuildStep(onlyIf = IsEnabled.class)
+    void extractInjectedOidcClientNames(
+            ApplicationArchivesBuildItem beanArchiveIndex,
+            BuildProducer<OidcClientNamesBuildItem> oidcClientNames) {
+
+        oidcClientNames.produce(new OidcClientNamesBuildItem(oidcClientNamesOf(beanArchiveIndex)));
+    }
+
+    private Set<String> oidcClientNamesOf(ApplicationArchivesBuildItem beanArchiveIndex) {
+        return beanArchiveIndex.getAllApplicationArchives().stream()
+                .map(ApplicationArchive::getIndex)
+                .flatMap(archive -> archive.getAnnotations(DotName.createSimple(NamedOidcClient.class.getName())).stream())
+                .map(annotation -> annotation.value().asString())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep(onlyIf = IsEnabled.class)
-    public List<SyntheticBeanBuildItem> setup(
+    public void setup(
             OidcClientsConfig oidcConfig,
             TlsConfig tlsConfig,
             OidcClientRecorder recorder,
-            CoreVertxBuildItem vertxBuildItem) {
+            CoreVertxBuildItem vertxBuildItem,
+            OidcClientNamesBuildItem oidcClientNames,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBean) {
 
         OidcClients clients = recorder.setup(oidcConfig, tlsConfig, vertxBuildItem.getVertx());
 
-        SyntheticBeanBuildItem oidcClientBuildItem = SyntheticBeanBuildItem.configure(OidcClient.class).unremovable()
+        syntheticBean.produce(SyntheticBeanBuildItem.configure(OidcClient.class).unremovable()
                 .types(OidcClient.class)
                 .supplier(recorder.createOidcClientBean(clients))
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .destroyer(BeanDestroyer.CloseableDestroyer.class)
-                .done();
-        SyntheticBeanBuildItem oidcClientsBuildItem = SyntheticBeanBuildItem.configure(OidcClients.class).unremovable()
+                .done());
+
+        syntheticBean.produce(SyntheticBeanBuildItem.configure(OidcClients.class).unremovable()
                 .types(OidcClients.class)
                 .supplier(recorder.createOidcClientsBean(clients))
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .destroyer(BeanDestroyer.CloseableDestroyer.class)
+                .done());
+
+        produceNamedOidcClientBeans(syntheticBean, oidcClientNames.oidcClientNames(), recorder, clients);
+    }
+
+    private void produceNamedOidcClientBeans(BuildProducer<SyntheticBeanBuildItem> syntheticBean,
+            Set<String> injectedOidcClientNames,
+            OidcClientRecorder recorder, OidcClients clients) {
+        injectedOidcClientNames.stream()
+                .map(clientName -> syntheticNamedOidcClientBeanFor(clientName, recorder, clients))
+                .forEach(syntheticBean::produce);
+    }
+
+    private SyntheticBeanBuildItem syntheticNamedOidcClientBeanFor(String clientName, OidcClientRecorder recorder,
+            OidcClients clients) {
+        return SyntheticBeanBuildItem.configure(OidcClient.class).unremovable()
+                .types(OidcClient.class)
+                .supplier(recorder.createOidcClientBean(clients, clientName))
+                .scope(Singleton.class)
+                .addQualifier().annotation(NamedOidcClient.class).addValue("value", clientName).done()
+                .setRuntimeInit()
+                .destroyer(BeanDestroyer.CloseableDestroyer.class)
                 .done();
-        return Arrays.asList(oidcClientBuildItem, oidcClientsBuildItem);
+    }
+
+    @BuildStep(onlyIf = IsEnabled.class)
+    public void createNonDefaultTokensProducers(
+            BuildProducer<GeneratedBeanBuildItem> generatedBean,
+            OidcClientNamesBuildItem oidcClientNames) {
+
+        ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(generatedBean);
+
+        String targetPackage = DotNames
+                .internalPackageNameWithTrailingSlash(DotName.createSimple(TokensProducer.class.getName()));
+
+        for (String oidcClientName : oidcClientNames.oidcClientNames()) {
+            createNamedTokensProducerFor(classOutput, targetPackage, oidcClientName);
+        }
+    }
+
+    /**
+     * Creates a Tokens producer class like follows:
+     * 
+     * <pre>
+     * &#64;Singleton
+     * public class TokensProducer_oidcClientName extends AbstractTokensProducer {
+     *     &#64;Produces
+     *     &#64;NamedOidcClient("oidcClientName")
+     *     &#64;RequestScoped
+     *     public Tokens produceTokens() {
+     *         return awaitTokens();
+     *     }
+     * 
+     *     &#64;Override
+     *     protected Optional<String> clientId() {
+     *         return Optional.of("oidcClientName");
+     *     }
+     * }
+     * </pre>
+     */
+    private String createNamedTokensProducerFor(ClassOutput classOutput, String targetPackage, String oidcClientName) {
+        String generatedName = targetPackage + "TokensProducer_" + sanitize(oidcClientName);
+
+        try (ClassCreator tokensProducer = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+                .superClass(AbstractTokensProducer.class)
+                .build()) {
+            tokensProducer.addAnnotation(DotNames.SINGLETON.toString());
+
+            try (MethodCreator produceMethod = tokensProducer.getMethodCreator("produceTokens", Tokens.class)) {
+                produceMethod.setModifiers(Modifier.PUBLIC);
+
+                produceMethod.addAnnotation(DotNames.PRODUCES.toString());
+                produceMethod.addAnnotation(NamedOidcClient.class.getName()).addValue("value", oidcClientName);
+                produceMethod.addAnnotation(RequestScoped.class.getName());
+
+                ResultHandle tokensResult = produceMethod.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(AbstractTokensProducer.class, "awaitTokens", Tokens.class),
+                        produceMethod.getThis());
+
+                produceMethod.returnValue(tokensResult);
+            }
+
+            try (MethodCreator clientIdMethod = tokensProducer.getMethodCreator("clientId", Optional.class)) {
+                clientIdMethod.setModifiers(Modifier.PROTECTED);
+
+                clientIdMethod.returnValue(clientIdMethod.invokeStaticMethod(
+                        MethodDescriptor.ofMethod(Optional.class, "of", Optional.class, Object.class),
+                        clientIdMethod.load(oidcClientName)));
+            }
+        }
+
+        return generatedName.replace('/', '.');
+    }
+
+    private String sanitize(String oidcClientName) {
+        return oidcClientName.replaceAll("\\W+", "");
     }
 
     public static class IsEnabled implements BooleanSupplier {

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientNamesBuildItem.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientNamesBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.client.deployment;
+
+import java.util.Collections;
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Contains non-default names of OIDC Clients.
+ */
+public final class OidcClientNamesBuildItem extends SimpleBuildItem {
+    private final Set<String> oidcClientNames;
+
+    OidcClientNamesBuildItem(Set<String> oidcClientNames) {
+        this.oidcClientNames = Collections.unmodifiableSet(oidcClientNames);
+    }
+
+    Set<String> oidcClientNames() {
+        return oidcClientNames;
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
@@ -31,6 +31,7 @@ public class KeycloakRealmUserPasswordManager implements QuarkusTestResourceLife
 
             realm.getClients().add(createClient("quarkus-app"));
             realm.getUsers().add(createUser("alice", "user"));
+            realm.getUsers().add(createUser("bob", "user"));
 
             RestAssured
                     .given()

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
@@ -1,0 +1,67 @@
+package io.quarkus.oidc.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.restassured.RestAssured;
+
+@QuarkusTestResource(KeycloakRealmUserPasswordManager.class)
+public class NamedOidcClientInjectionTestCase {
+
+    private static Class<?>[] testClasses = {
+            NamedOidcClientResource.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application-named-oidc-client-credentials.properties", "application.properties"));
+
+    @Test
+    public void testInjectedNamedOidcClients() {
+        String token1 = doTestGetTokenByNamedClient("client1");
+        String token2 = doTestGetTokenByNamedClient("client2");
+        validateTokens(token1, token2);
+    }
+
+    @Test
+    public void testInjectedNamedTokens() {
+        String token1 = doTestGetTokenByNamedTokensProvider("client1");
+        String token2 = doTestGetTokenByNamedTokensProvider("client2");
+        validateTokens(token1, token2);
+    }
+
+    private void validateTokens(String token1, String token2) {
+        assertThat(token1, is(not(equalTo(token2))));
+        assertThat(preferredUserOf(token1), is("alice"));
+        assertThat(preferredUserOf(token2), is("bob"));
+    }
+
+    private String preferredUserOf(String token) {
+        return OidcUtils.decodeJwtContent(token).getString("preferred_username");
+    }
+
+    private String doTestGetTokenByNamedClient(String clientId) {
+        String token = RestAssured.when().get("/" + clientId + "/token").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+
+    private String doTestGetTokenByNamedTokensProvider(String clientId) {
+        String token = RestAssured.when().get("/" + clientId + "/token/singleton").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientResource.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientResource.java
@@ -1,0 +1,51 @@
+package io.quarkus.oidc.client;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/")
+public class NamedOidcClientResource {
+
+    @Inject
+    @NamedOidcClient("client1")
+    OidcClient client1;
+
+    @Inject
+    @NamedOidcClient("client2")
+    OidcClient client2;
+
+    @Inject
+    @NamedOidcClient("client1")
+    Tokens tokens1;
+
+    @Inject
+    @NamedOidcClient("client2")
+    Tokens tokens2;
+
+    @GET
+    @Path("/client1/token")
+    public Uni<String> client1TokenUni() {
+        return client1.getTokens().flatMap(tokens -> Uni.createFrom().item(tokens.getAccessToken()));
+    }
+
+    @GET
+    @Path("/client2/token")
+    public Uni<String> client2TokenUni() {
+        return client2.getTokens().flatMap(tokens -> Uni.createFrom().item(tokens.getAccessToken()));
+    }
+
+    @GET
+    @Path("/client1/token/singleton")
+    public String accessToken1() {
+        return tokens1.getAccessToken();
+    }
+
+    @GET
+    @Path("/client2/token/singleton")
+    public String accessToken2() {
+        return tokens2.getAccessToken();
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/resources/application-named-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-named-oidc-client-credentials.properties
@@ -1,0 +1,17 @@
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=secret
+
+quarkus.oidc-client.client1.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.client1.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.client1.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.client1.grant.type=password
+quarkus.oidc-client.client1.grant-options.password.username=alice
+quarkus.oidc-client.client1.grant-options.password.password=alice
+
+quarkus.oidc-client.client2.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.client2.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.client2.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.client2.grant.type=password
+quarkus.oidc-client.client2.grant-options.password.username=bob
+quarkus.oidc-client.client2.grant-options.password.password=bob

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/NamedOidcClient.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/NamedOidcClient.java
@@ -1,0 +1,27 @@
+package io.quarkus.oidc.client;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Specification of OIDC client to be injected.
+ */
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Retention(RUNTIME)
+@Qualifier
+@Documented
+public @interface NamedOidcClient {
+    /**
+     * @return name of OIDC client to be injected
+     */
+    String value();
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
@@ -1,27 +1,35 @@
 package io.quarkus.oidc.client.runtime;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
 import io.smallrye.mutiny.Uni;
 
 public abstract class AbstractTokensProducer {
-
-    @Inject
-    OidcClient oidcClient;
+    private OidcClient oidcClient;
 
     @Inject
     @ConfigProperty(name = "quarkus.oidc-client.early-tokens-acquisition")
     boolean earlyTokenAcquisition;
 
-    TokensHelper tokensHelper = new TokensHelper();
+    final TokensHelper tokensHelper = new TokensHelper();
 
     @PostConstruct
     public void initTokens() {
+        OidcClients oidcClients = Arc.container().instance(OidcClients.class).get();
+        oidcClient = Objects.requireNonNull(clientId(), "clientId must not be null")
+                .map(oidcClient -> Objects.requireNonNull(oidcClients.getClient(oidcClient), "Unknown client"))
+                .orElseGet(oidcClients::getClient);
+
         if (earlyTokenAcquisition) {
             tokensHelper.initTokens(oidcClient);
         }
@@ -29,5 +37,17 @@ public abstract class AbstractTokensProducer {
 
     public Uni<Tokens> getTokens() {
         return tokensHelper.getTokens(oidcClient);
+    }
+
+    public Tokens awaitTokens() {
+        return getTokens().await().indefinitely();
+    }
+
+    /**
+     * @return optional ID of OIDC client to use for token acquisition.
+     *         Defaults to default OIDC client when {@link Optional#empty() empty}.
+     */
+    protected Optional<String> clientId() {
+        return Optional.empty();
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientBuildTimeConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientBuildTimeConfig.java
@@ -4,12 +4,12 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
- * Build time configuration for OIDC.
+ * Build time configuration for OIDC client.
  */
 @ConfigRoot
 public class OidcClientBuildTimeConfig {
     /**
-     * If the OIDC extension is enabled.
+     * If the OIDC client extension is enabled.
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -16,7 +16,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClientConfig.Grant;
-import io.quarkus.oidc.client.OidcClientConfig.Grant.Type;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
@@ -68,6 +67,16 @@ public class OidcClientRecorder {
             @Override
             public OidcClient get() {
                 return clients.getClient();
+            }
+        };
+    }
+
+    public Supplier<OidcClient> createOidcClientBean(OidcClients clients, String clientName) {
+        return new Supplier<OidcClient>() {
+
+            @Override
+            public OidcClient get() {
+                return clients.getClient(clientName);
             }
         };
     }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensProducer.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensProducer.java
@@ -12,6 +12,6 @@ public class TokensProducer extends AbstractTokensProducer {
     @Produces
     @RequestScoped
     public Tokens produceTokens() {
-        return getTokens().await().indefinitely();
+        return awaitTokens();
     }
 }


### PR DESCRIPTION
Fixes #16393.

`OidcClient` and `Tokens` injections currently only support the default OIDC client. This pull request enables injection of specific named OIDC client by introducing a new Qualifier `NamedOidcClient`.

For every named OIDC client that is referenced by `NamedOidcClient` a new qualified tokens producer and `OidcClient` bean is dynamically synthesized.

Example:

```java
@Inject @NamedOidcClient("foo") OidcClient oidcClient;
@Inject @NamedOidcClient("foo") Tokens tokens;
```