### PR TITLE
Codestarts do not need qute-generator but qute-core

### DIFF
--- a/independent-projects/tools/codestarts/pom.xml
+++ b/independent-projects/tools/codestarts/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus.qute</groupId>
-            <artifactId>qute-generator</artifactId>
+            <artifactId>qute-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -42,10 +42,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-codestarts</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus.qute</groupId>
-            <artifactId>qute-generator</artifactId>
-        </dependency>
         <!-- user prompt -->
         <dependency>
             <groupId>jline</groupId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -99,7 +99,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus.qute</groupId>
-                <artifactId>qute-generator</artifactId>
+                <artifactId>qute-core</artifactId>
                 <version>${quarkus.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
- qute-generator brings build time dependencies such as gizmo and ASM