### PR TITLE
Fix @TestTransaction for self-intercepted invocation

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TestTransactionInterceptor.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TestTransactionInterceptor.java
@@ -7,6 +7,7 @@ import java.util.ServiceLoader;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
+import javax.transaction.Status;
 import javax.transaction.UserTransaction;
 
 import io.quarkus.narayana.jta.runtime.test.TestTransactionCallback;
@@ -28,6 +29,14 @@ public class TestTransactionInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
+        // do nothing in case there is already a transaction (e.g. self-intercepted non-private non-test method in test class)
+        // w/o this check userTransaction.begin() would fail because there is already a tx associated with the current thread
+        if (userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION) {
+            return context.proceed();
+        }
+
+        // an exception from proceed() has to be captured to avoid shadowing it in finally() with a exception from rollback()
+        Throwable caught = null;
         try {
             userTransaction.begin();
             for (TestTransactionCallback i : CALLBACKS) {
@@ -38,9 +47,19 @@ public class TestTransactionInterceptor {
                 i.preRollback();
             }
             return result;
+        } catch (Exception | Error e) { // note: "Error" shall mainly address AssertionError
+            caught = e;
+            throw e;
         } finally {
-            userTransaction.rollback();
+            if (caught == null) {
+                userTransaction.rollback();
+            } else {
+                try {
+                    userTransaction.rollback();
+                } catch (Exception e) {
+                    caught.addSuppressed(e);
+                }
+            }
         }
     }
-
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TestTransactionOnSingleMethodTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TestTransactionOnSingleMethodTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.panache;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
@@ -9,14 +11,14 @@ import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
- * Tests that @TestTransaction works as expected when used for the entire class
+ * Tests that @TestTransaction works as expected when only used for a single test method
  */
 @QuarkusTest
-@TestTransaction
 @TestMethodOrder(MethodName.class)
-public class TestTransactionTest {
+public class TestTransactionOnSingleMethodTest {
 
     @Test
+    @TestTransaction
     public void test1() {
         Assertions.assertEquals(0, Beer.find("name", "Lager").count());
         Beer b = new Beer();
@@ -25,20 +27,18 @@ public class TestTransactionTest {
     }
 
     @Test
+    @Transactional
     public void test2() {
         Assertions.assertEquals(0, Beer.find("name", "Lager").count());
-        // interceptor must not choke on this self-intercepted non-test method invocation
-        intentionallyNonPrivateHelperMethod();
         Beer b = new Beer();
         b.name = "Lager";
         Beer.persist(b);
     }
 
     @Test
+    @Transactional
     public void test3() {
-        Assertions.assertEquals(0, Beer.find("name", "Lager").count());
-    }
-
-    void intentionallyNonPrivateHelperMethod() {
+        Assertions.assertEquals(1, Beer.find("name", "Lager").count());
+        Beer.deleteAll();
     }
 }


### PR DESCRIPTION
This caused quite some confusion in my team as all of our test classes using `@TestTransaction` were working just fine, but for a single one we were getting something like that (this is actually from `TestTransactionTest` after I extended it):
```
[ERROR] io.quarkus.it.panache.TestTransactionTest.test2  Time elapsed: 0.006 s  <<< ERROR!
java.lang.IllegalStateException: BaseTransaction.rollback - ARJUNA016074: no transaction!
        at com.arjuna.ats.internal.jta.transaction.arjunacore.BaseTransaction.rollback(BaseTransaction.java:143)
        at io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_userTransaction_c93608e32f9c017c8aafd0401efc2eb68d35aa4e_ClientProxy.rollback(NarayanaJtaProducers_ProducerMethod_userTransaction_c93608e32f9c017c8aafd0401efc2eb68d35aa4e_ClientProxy.zig:197)
        at io.quarkus.narayana.jta.runtime.interceptor.TestTransactionInterceptor.intercept(TestTransactionInterceptor.java:42)
        at io.quarkus.narayana.jta.runtime.interceptor.TestTransactionInterceptorGenerated_Bean.intercept(TestTransactionInterceptorGenerated_Bean.zig:328)
        at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)
        at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)
        at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)
        at io.quarkus.it.panache.TestTransactionTest_Subclass.test2(TestTransactionTest_Subclass.zig:459)
        [...]
```
which is very confusing because on _rollback_ it has no tx anymore?!

Turns out that by blindly calling rollback(), the `TestTransactionInterceptor` was shadowing the actual problem:
```
Caused by: java.lang.IllegalStateException: BaseTransaction.checkTransactionState - ARJUNA016051: thread is already associated with a transaction!
        at com.arjuna.ats.internal.jta.transaction.arjunacore.BaseTransaction.checkTransactionState(BaseTransaction.java:266)
        at com.arjuna.ats.internal.jta.transaction.arjunacore.BaseTransaction.begin(BaseTransaction.java:70)
        ... 106 more
```
which in turn revealed that the interceptor does not consider self-intercepted invocations of non-private non-test methods from test methods. It was trying to begin a new transaction despite having already done so for the "outer" invocation (the actual test method).

In our case that public helper method was actually an oversight and it should have been private instead. But I don't see why this should be forbidden.
Of course, all this only happens if you use `@TestTransaction` for the entire test class but IMO that is a good DRY-approach.

TL;DR, this PR:
- adds a check to avoid any subsequent `begin()` attempts
- fixes exception shadowing
- adds a second test for the "only method annotated case" (I was actually confused why that one test annotated both test class _and_ methods?!)