### PR TITLE
Avoid unnecessary exception wrapping in NativeTestExtension.throwBootFailureException

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -151,10 +151,15 @@ public class NativeTestExtension
         }
     }
 
-    private void throwBootFailureException() {
+    private void throwBootFailureException() throws Exception {
         if (firstException != null) {
             Throwable throwable = firstException;
             firstException = null;
+
+            if (throwable instanceof Exception) {
+                throw (Exception) throwable;
+            }
+
             throw new RuntimeException(throwable);
         } else {
             throw new TestAbortedException("Boot failed");


### PR DESCRIPTION
Looks like a detail but by doing this we get rid of one level of nesting in most cases.

(noticed while trying to improve the bot situation)