### PR TITLE
Upgrade to Hibernate Search 6.0.3.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -96,7 +96,7 @@
         <hibernate-orm.version>5.4.30.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR1.Vertx4</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.2.Final</hibernate-search.version>
+        <hibernate-search.version>6.0.3.Final</hibernate-search.version>
         <narayana.version>5.11.1.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.11</agroal.version>

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -138,15 +138,9 @@ public class HibernateSearchElasticsearchRecorder {
         @Override
         public void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
                 BiConsumer<String, Object> propertyCollector) {
-            Version graalVMVersion = Version.getCurrent();
-            final boolean isAOT = Boolean.getBoolean("com.oracle.graalvm.isaot");
-            boolean isGraalVM20OrBelow = isAOT && graalVMVersion.compareTo(GRAAL_VM_VERSION_21) < 0;
             HibernateOrmIntegrationBooter booter = HibernateOrmIntegrationBooter.builder(metadata, bootstrapContext)
-                    .valueReadHandleFactory(
-                            // GraalVM 20 or below doesn't support method handles
-                            isGraalVM20OrBelow ? ValueReadHandleFactory.usingJavaLangReflect()
-                                    // GraalVM 21+ and OpenJDK can handle the default (method handles)
-                                    : null)
+                    // MethodHandles don't work at all in GraalVM 20 and below, and seem unreliable on GraalVM 21
+                    .valueReadHandleFactory(ValueReadHandleFactory.usingJavaLangReflect())
                     .build();
             booter.preBoot(propertyCollector);
         }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
@@ -30,6 +30,12 @@ public class HibernateSearchTestResource {
         createPerson("David Lodge", "London");
         createPerson("Paul Auster", "New York");
         createPerson("John Grisham", "Oxford");
+
+        // Add many other entities, so that mass indexing has something to do.
+        // DO NOT REMOVE, it's important to have many entities to fully test mass indexing.
+        for (int i = 0; i < 2000; i++) {
+            createPerson("Other Person #" + i, "Other City #" + i);
+        }
     }
 
     @GET
@@ -55,6 +61,10 @@ public class HibernateSearchTestResource {
 
         assertEquals(1, person.size());
         assertEquals("David Lodge", person.get(0).getName());
+
+        assertEquals(4 + 2000, searchSession.search(Person.class)
+                .where(f -> f.matchAll())
+                .fetchTotalHitCount());
 
         return "OK";
     }


### PR DESCRIPTION
Relates to #16463, and provides a workaround for Hibernate Search, but does not fix the problem entirely: we would need a fix in ORM for that.

CC @gsmet 

Creating as draft: we need a release of Hibernate Search first; one that includes https://github.com/hibernate/hibernate-search/pull/2544 ([HSEARCH-4211](https://hibernate.atlassian.net/browse/HSEARCH-4211)) . I tested that the upgrade fixes the problem locally.