### PR TITLE
App config parameter support for project creation

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -34,6 +34,10 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
             "--example" }, order = 4, description = "Choose a specific example for the generated Quarkus application.")
     String example;
 
+    @CommandLine.Option(names = { "-c",
+            "--app-config" }, order = 11, description = "Application configs to be set in the application.properties/yml file. (key1=value1,key2=value2)")
+    private String appConfig;
+
     @CommandLine.ArgGroup()
     TargetBuildTool targetBuildTool = new TargetBuildTool();
 
@@ -119,6 +123,7 @@ public class Create extends BaseSubCommand implements Callable<Integer> {
                     .example(example)
                     .extensions(extensions)
                     .noCode(noCode)
+                    .appConfig(appConfig)
                     .execute().isSuccess();
 
             if (status) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
@@ -6,8 +6,11 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -259,6 +262,24 @@ public class CliTest {
         Assertions.assertTrue(pom.contains("<artifactId>my-rest-project</artifactId>"));
         Assertions.assertTrue(pom.contains("<version>4.2</version>"));
         Assertions.assertTrue(pom.contains("<artifactId>quarkus-resteasy</artifactId>"));
+    }
+
+    @Test
+    public void testCreateWithAppConfig() throws Exception {
+        Path project = workspace.resolve("code-with-quarkus");
+
+        List<String> configs = Arrays.asList("custom.app.config1=val1",
+                "custom.app.config2=val2", "lib.config=val3");
+
+        execute("create", "--app-config=" + StringUtils.join(configs, ","));
+
+        Assertions.assertEquals(CommandLine.ExitCode.OK, exitCode);
+        Assertions.assertTrue(screen.contains("Project code-with-quarkus created"));
+
+        Assertions.assertTrue(project.resolve("src/main/resources/application.properties").toFile().exists());
+        String propertiesFile = readString(project.resolve("src/main/resources/application.properties"));
+
+        configs.forEach(conf -> Assertions.assertTrue(propertiesFile.contains(conf)));
     }
 
     @Test

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -187,6 +187,9 @@ public class CreateProjectMojo extends AbstractMojo {
     @Parameter(property = "enableRegistryClient")
     private boolean enableRegistryClient;
 
+    @Parameter(property = "appConfig")
+    private String appConfig;
+
     @Override
     public void execute() throws MojoExecutionException {
 
@@ -290,7 +293,8 @@ public class CreateProjectMojo extends AbstractMojo {
                     .packageName(packageName)
                     .extensions(extensions)
                     .example(example)
-                    .noCode(noCode);
+                    .noCode(noCode)
+                    .appConfig(appConfig);
             if (path != null) {
                 createProject.setValue("path", path);
             }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -20,6 +20,7 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
 
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
             new YAMLFactory().configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false));
+    private static final String APP_CONFIG = "app-config";
 
     @Override
     public String name() {
@@ -32,7 +33,7 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
         checkNotEmptyCodestartFiles(codestartFiles);
 
         final String configType = getConfigType(data);
-        final Map<String, Object> config = new HashMap<>();
+        final Map<String, Object> config = initConfigMap(data);
         for (TargetFile codestartFile : codestartFiles) {
             final String content = codestartFile.getContent();
             if (!content.trim().isEmpty()) {
@@ -87,4 +88,14 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
         final Optional<String> config = CodestartData.getInputCodestartForType(data, CodestartType.CONFIG);
         return config.orElseThrow(() -> new CodestartException("Config type is required"));
     }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> initConfigMap(final Map<String, Object> data) {
+        if (data.get(APP_CONFIG) instanceof Map) {
+            return NestedMaps.unflatten((Map<String, Object>) data.get(APP_CONFIG));
+        }
+
+        return new HashMap<>();
+    }
+
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartData.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartData.java
@@ -43,7 +43,9 @@ public final class QuarkusCodestartData {
         RESTEASY_REACTIVE_CODESTART_RESOURCE_CLASS_NAME("resteasy-reactive-codestart.resource.class-name"),
 
         SPRING_WEB_CODESTART_RESOURCE_PATH("spring-web-codestart.resource.path"),
-        SPRING_WEB_CODESTART_RESOURCE_CLASS_NAME("spring-web-codestart.resource.class-name");
+        SPRING_WEB_CODESTART_RESOURCE_CLASS_NAME("spring-web-codestart.resource.class-name"),
+
+        APP_CONFIG("app-config");
 
         private final String key;
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -1,5 +1,6 @@
 package io.quarkus.devtools.commands;
 
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartData.QuarkusDataKey.APP_CONFIG;
 import static io.quarkus.devtools.project.codegen.ProjectGenerator.*;
 import static java.util.Objects.requireNonNull;
 
@@ -13,6 +14,7 @@ import io.quarkus.devtools.project.codegen.SourceType;
 import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -21,6 +23,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.lang.model.SourceVersion;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Instances of this class are not thread-safe. They are created per invocation.
@@ -102,6 +105,16 @@ public class CreateProject {
 
     public CreateProject resourcePath(String resourcePath) {
         setValue(RESOURCE_PATH, resourcePath);
+        return this;
+    }
+
+    public CreateProject appConfig(String appConfigAsString) {
+        Map<String, String> configMap = Collections.emptyMap();
+
+        if (StringUtils.isNoneBlank(appConfigAsString)) {
+            configMap = ToolsUtils.stringToMap(appConfigAsString, ",", "=");
+        }
+        setValue(APP_CONFIG.key(), configMap);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.devtools.commands.handlers;
 
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartData.QuarkusDataKey.APP_CONFIG;
 import static io.quarkus.devtools.commands.CreateProject.EXAMPLE;
 import static io.quarkus.devtools.commands.CreateProject.EXTRA_CODESTARTS;
 import static io.quarkus.devtools.commands.CreateProject.NO_BUILDTOOL_WRAPPER;
@@ -99,6 +100,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                     .noDockerfiles(invocation.getValue(NO_DOCKERFILES, false))
                     .addData(platformData)
                     .addData(LegacySupport.convertFromLegacy(invocation.getValues()))
+                    .putData(APP_CONFIG.key(), invocation.getValue(APP_CONFIG.key(), Collections.emptyMap()))
                     .messageWriter(invocation.log())
                     .build();
             invocation.log().info("-----------");

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -15,9 +15,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
@@ -37,6 +39,29 @@ public class ToolsUtils {
 
     public static String getProperty(String name, String defaultValue) {
         return System.getProperty(name, defaultValue);
+    }
+
+    public static Map<String, String> stringToMap(
+            String str, String entrySeparator, String keyValueSeparator) {
+        HashMap<String, String> result = new HashMap<>();
+        for (String entry : StringUtils.splitByWholeSeparator(str, entrySeparator)) {
+            String[] pair = StringUtils.splitByWholeSeparator(entry, keyValueSeparator, 2);
+
+            if (pair.length > 0 && StringUtils.isBlank(pair[0])) {
+                throw new IllegalArgumentException("Entry with empty key " + entry);
+            }
+
+            switch (pair.length) {
+                case 1:
+                    result.put(pair[0].trim(), "");
+                    break;
+                case 2:
+                    result.put(pair[0].trim(), pair[1].trim());
+                    break;
+            }
+        }
+
+        return result;
     }
 
     public static boolean isNullOrEmpty(String arg) {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -31,6 +32,7 @@ import org.apache.maven.shared.invoker.PrintStreamLogger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.jboss.logmanager.LogManager;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Charsets;
@@ -357,6 +359,38 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
 
         assertThat(model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("commons-io")
                 && d.getVersion().equalsIgnoreCase("2.5"))).isTrue();
+    }
+
+    @Test
+    public void testProjectGenerationFromScratchWithAppConfigParameter() throws MavenInvocationException, IOException {
+        testDir = initEmptyProject("projects/project-generation-with-config-param");
+        assertThat(testDir).isDirectory();
+        invoker = initInvoker(testDir);
+
+        Properties properties = new Properties();
+        properties.put("projectGroupId", "org.acme");
+        properties.put("projectArtifactId", "acme");
+        properties.put("projectVersion", "1.0.0-SNAPSHOT");
+
+        List<String> configs = Arrays.asList("custom.app.config1=val1",
+                "custom.app.config2=val2", "lib.config=val3");
+        properties.put("appConfig", StringUtils.join(configs, ", "));
+
+        InvocationResult result = setup(properties);
+
+        assertThat(result.getExitCode()).isZero();
+
+        // As the directory is not empty (log) navigate to the artifactID directory
+        testDir = new File(testDir, "acme");
+
+        assertThat(new File(testDir, "pom.xml")).isFile();
+        assertThat(new File(testDir, "src/main/java")).isDirectory();
+
+        String file = Files
+                .asCharSource(new File(testDir, "src/main/resources/application.properties"), Charsets.UTF_8)
+                .read();
+        configs.forEach(conf -> Assertions.assertTrue(file.contains(conf)));
+
     }
 
     /**


### PR DESCRIPTION
Fixes #12924

Draft commit for supporting a new parameter to set config properties that will end up in the application.yml/properties when creating a project either using maven plugin or cli.

Hi there, 

Since this is my first fix I just want to make sure someone have a look before going any further. A couple of questions/notes:

- I'm going to add the same property for CLI, just would be good if you check the property name "configProperties".
- I'm updating documentation because there are some broken links (I'm guessing because of refactoring), I will also document the new parameter.
- I'm creating the constant `APP_CONFIG_PROPERTIES`  in both `SmartConfigMergeCodestartFileStrategyHandler.java `& `ProjectGenerator.java`. I can not see a common file where this definition makes more sense.

- Since there is not support for maps in command line, I'm assuming a string with the below format should be enough.
> prop1Key:prop1value,  prop2Key:prop2value

- I will add testing after the approach validation. 




1- **Should I add other parameter to change the property and key-value separator?** 
2- **Splitter is marked as @Beta, I can change it if that is an issue**
3- I've done some testing with codestarts adding various extensions, I've seen that when writing the .properties there is not a specific order so properties that should be together are not. e.g 

```
quarkus.log.console.json.date-format=YYYY-MM-dd HH:mm:ss
other.log.console.color=false
other.http.port=8700
other.http.cors=true
quarkus.log.console.json.exception-output-type=detailed-and-formatted
quarkus.log.console.json.pretty-print=true
```

**Should I open a new issue for this ? or can I just fix it ?**





