### PR TITLE
Allow to configure HBM2DDL script generation via application.properties

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -340,6 +340,19 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_HALT_ON_ERROR, "true");
         }
 
+        runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_ACTION,
+                persistenceUnitConfig.scripts.generation.generation);
+
+        if (persistenceUnitConfig.scripts.generation.createTarget.isPresent()) {
+            runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_CREATE_TARGET,
+                    persistenceUnitConfig.scripts.generation.createTarget.get());
+        }
+
+        if (persistenceUnitConfig.scripts.generation.dropTarget.isPresent()) {
+            runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_DROP_TARGET,
+                    persistenceUnitConfig.scripts.generation.dropTarget.get());
+        }
+
         // Logging
         if (persistenceUnitConfig.log.sql) {
             runtimeSettingsBuilder.put(AvailableSettings.SHOW_SQL, "true");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -17,6 +17,13 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
     public HibernateOrmConfigPersistenceUnitDatabase database = new HibernateOrmConfigPersistenceUnitDatabase();
 
     /**
+     * Database scripts related configuration.
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public HibernateOrmConfigPersistenceUnitScripts scripts = new HibernateOrmConfigPersistenceUnitScripts();
+
+    /**
      * Logging configuration.
      */
     @ConfigItem
@@ -25,6 +32,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
 
     public boolean isAnyPropertySet() {
         return database.isAnyPropertySet() ||
+                scripts.isAnyPropertySet() ||
                 log.isAnyPropertySet();
     }
 
@@ -36,6 +44,20 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem
         public HibernateOrmConfigPersistenceUnitDatabaseGeneration generation = new HibernateOrmConfigPersistenceUnitDatabaseGeneration();
+
+        public boolean isAnyPropertySet() {
+            return generation.isAnyPropertySet();
+        }
+    }
+
+    @ConfigGroup
+    public static class HibernateOrmConfigPersistenceUnitScripts {
+
+        /**
+         * Schema generation configuration.
+         */
+        @ConfigItem
+        public HibernateOrmConfigPersistenceUnitScriptGeneration generation = new HibernateOrmConfigPersistenceUnitScriptGeneration();
 
         public boolean isAnyPropertySet() {
             return generation.isAnyPropertySet();
@@ -71,6 +93,36 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
             return !"none".equals(generation)
                     || createSchemas
                     || haltOnError;
+        }
+    }
+
+    @ConfigGroup
+    public static class HibernateOrmConfigPersistenceUnitScriptGeneration {
+
+        /**
+         * Select whether the database schema DDL files are generated or not.
+         *
+         * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`.
+         */
+        @ConfigItem(name = ConfigItem.PARENT, defaultValue = "none")
+        public String generation = "none";
+
+        /**
+         * Filename or URL where the database create DDL file should be generated.
+         */
+        @ConfigItem
+        public Optional<String> createTarget = Optional.empty();
+
+        /**
+         * Filename or URL where the database drop DDL file should be generated.
+         */
+        @ConfigItem
+        public Optional<String> dropTarget = Optional.empty();
+
+        public boolean isAnyPropertySet() {
+            return !"none".equals(generation)
+                    || createTarget.isPresent()
+                    || dropTarget.isPresent();
         }
     }
 

--- a/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
@@ -1,0 +1,13 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.jdbc.max-size=8
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-orm.scripts.generation=drop-and-create
+quarkus.hibernate-orm.scripts.generation.create-target=create.sql
+quarkus.hibernate-orm.scripts.generation.drop-target=drop.sql
+
+quarkus.hibernate-orm.statistics=true
+quarkus.hibernate-orm.metrics.enabled=true

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/DDLGenerationPMT.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/DDLGenerationPMT.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.panache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that DDL scripts are generated when script generation is configured in application.properties.
+ */
+public class DDLGenerationPMT {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PageItem.class, TestResources.class, NoPagingTestEndpoint.class))
+            .setApplicationName("ddl-generation")
+            .setApplicationVersion(Version.getVersion())
+            .setRun(true)
+            .setLogFileName("ddl-generation-test.log")
+            .withConfigurationResource("ddlgeneration.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void test() {
+        RestAssured.when().get("/no-paging-test").then().body(is("OK"));
+
+        assertThat(prodModeTestResults.getBuildDir().resolve("quarkus-app/create.sql").toFile()).exists();
+        assertThat(prodModeTestResults.getBuildDir().resolve("quarkus-app/drop.sql").toFile()).exists();
+    }
+
+}


### PR DESCRIPTION
Fixes #14771

This change makes it possible to configure generation of database DDL scripts directly from `application.properties`, so one doesn't have to use a `persistence.xml` file.

The relevant application properties look like:

```
quarkus.hibernate-orm.scripts.generation=drop-and-create
quarkus.hibernate-orm.scripts.generation.create-target=create.sql
quarkus.hibernate-orm.scripts.generation.drop-target=drop.sql
```

Respective JPA properties which are set via above configuration are these:

```
javax.persistence.schema-generation.scripts.action
javax.persistence.schema-generation.scripts.create-target
javax.persistence.schema-generation.scripts.drop-target
```