### PR TITLE
Ensure that Vert.x runs in its dev-mode when Quarkus is started in dev-mode

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
@@ -22,6 +22,8 @@ public class VertxHttpHotReplacementSetup implements HotReplacementSetup {
 
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
+        // ensure that Vert.x runs in dev mode, this prevents Vert.x from caching static resources
+        System.setProperty("vertxweb.environment", "dev");
         this.hotReplacementContext = context;
         VertxHttpRecorder.setHotReplacement(this::handleHotReplacementRequest, hotReplacementContext);
         hotReplacementContext.addPreScanStep(new Runnable() {


### PR DESCRIPTION
This prevents Vert.x from caching static resources

Fixes: #16524