### PR TITLE
Use setter method to derive the type of property

### DIFF
--- a/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
+++ b/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.tika.deployment;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -222,18 +223,24 @@ public class TikaProcessor {
     private static String getParserParamType(String parserName, String paramName) {
         try {
             Class<?> parserClass = loadParserClass(parserName);
-            String paramType = parserClass.getMethod("get" + capitalize(paramName), new Class[] {}).getReturnType()
-                    .getSimpleName().toLowerCase();
-            if (paramType.equals(boolean.class.getSimpleName())) {
-                // TikaConfig Param class does not recognize 'boolean', only 'bool'
-                // This whole reflection code is temporary anyway
-                paramType = "bool";
+            Method[] methods = parserClass.getMethods();
+            String setterMethodName = "set" + capitalize(paramName);
+            String paramType = null;
+            for (Method method : methods) {
+                if (method.getName().equals(setterMethodName) && method.getParameterCount() == 1) {
+                    paramType = method.getParameterTypes()[0].getSimpleName().toLowerCase();
+                    if (paramType.equals(boolean.class.getSimpleName())) {
+                        // TikaConfig Param class does not recognize 'boolean', only 'bool'
+                        // This whole reflection code is temporary anyway
+                        paramType = "bool";
+                    }
+                    return paramType;
+                }
             }
-            return paramType;
         } catch (Throwable t) {
-            final String errorMessage = "Parser " + parserName + " has no " + paramName + " property";
-            throw new TikaParseException(errorMessage);
+            throw new TikaParseException(String.format("Parser %s has no %s property", parserName, paramName));
         }
+        throw new TikaParseException(String.format("Parser %s has no %s property", parserName, paramName));
     }
 
     public static class TikaParserParameter {

--- a/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
+++ b/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
@@ -67,6 +67,35 @@ public class TikaProcessorTest {
     }
 
     @Test
+    public void testTesseractParserConfig() throws Exception {
+        String ocrParserFullName = "org.apache.tika.parser.ocr.TesseractOCRParser";
+        Map<String, List<TikaProcessor.TikaParserParameter>> parserConfig = getParserConfig(null, "ocr",
+                Collections.singletonMap("ocr",
+                        Collections.singletonMap("tesseract-path", "/opt/tesseract/")),
+                Collections.singletonMap("ocr", ocrParserFullName));
+        assertEquals(1, parserConfig.size());
+
+        assertEquals(1, parserConfig.get(ocrParserFullName).size());
+        assertEquals("tesseractPath", parserConfig.get(ocrParserFullName).get(0).getName());
+        assertEquals("/opt/tesseract/", parserConfig.get(ocrParserFullName).get(0).getValue());
+    }
+
+    @Test
+    public void testUnknownParserConfig() throws Exception {
+        String ocrParserFullName = "org.apache.tika.parser.ocr.TesseractOCRParser";
+        try {
+            Map<String, List<TikaProcessor.TikaParserParameter>> parserConfig = getParserConfig(null, "ocr",
+                    Collections.singletonMap("ocr",
+                            Collections.singletonMap("tesseract-unknown-opt", "/opt/tesseract/")),
+                    Collections.singletonMap("ocr", ocrParserFullName));
+        } catch (Exception e) {
+            // expected
+            assertEquals("Parser org.apache.tika.parser.ocr.TesseractOCRParser has no tesseractUnknownOpt property",
+                    e.getMessage());
+        }
+    }
+
+    @Test
     public void testUnresolvableCustomAbbreviation() throws Exception {
         try {
             getParserNames(null, "classparser");


### PR DESCRIPTION
The extension does not allow to set parser config, if the parser implementation does not have a getter method for the config. I came across this limitation while using Tesseract parser and wanted to set tesseractPath and tessdataPath. There were setter methods for both the configurations but no getters and the extension would throw an exception. 

The solution is to get the setter method and get the type of the parameter. 