### PR TITLE
Revert "Bump zookeeper from 3.5.7 to 3.7.0"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -142,7 +142,7 @@
         <mutiny.version>0.15.0</mutiny.version>
         <mutiny-vertx.version>2.3.0</mutiny-vertx.version>
         <kafka2.version>2.7.0</kafka2.version>
-        <zookeeper.version>3.7.0</zookeeper.version>
+        <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.12.13</scala.version>
         <tika.version>1.26</tika.version>


### PR DESCRIPTION
This reverts commit 3c49c00c120ba73b1db921d08d8bbd3444bde2cc.

It's causing problems for the Kafka Streams quickstart and we have better things to do.