### PR TITLE
Don't pass --enable-all-security-services to GraalVM >= 21.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -13,6 +13,7 @@ final class GraalVM {
         static final Version UNVERSIONED = new Version("Undefined", -1, -1, Distribution.ORACLE);
         static final Version VERSION_20_3 = new Version("GraalVM 20.3", 20, 3, Distribution.ORACLE);
         static final Version VERSION_21_0 = new Version("GraalVM 21.0", 21, 0, Distribution.ORACLE);
+        static final Version VERSION_21_1 = new Version("GraalVM 21.1", 21, 1, Distribution.ORACLE);
 
         static final Version MINIMUM = VERSION_20_3;
         static final Version CURRENT = VERSION_21_0;
@@ -47,6 +48,10 @@ final class GraalVM {
 
         boolean isNewerThan(Version version) {
             return this.compareTo(version) > 0;
+        }
+
+        boolean isOlderThan(Version version) {
+            return this.compareTo(version) < 0;
         }
 
         @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -656,7 +656,8 @@ public class NativeImageBuildStep {
                 if (!protocols.isEmpty()) {
                     nativeImageArgs.add("-H:EnableURLProtocols=" + String.join(",", protocols));
                 }
-                if (enableAllSecurityServices) {
+                if (enableAllSecurityServices && graalVMVersion.isOlderThan(GraalVM.Version.VERSION_21_1)) {
+                    // This option was removed in GraalVM 21.1 https://github.com/oracle/graal/pull/3258
                     nativeImageArgs.add("--enable-all-security-services");
                 }
                 if (inlineBeforeAnalysis) {


### PR DESCRIPTION
The option was removed in GraalVM 21.1
https://github.com/oracle/graal/pull/3258
