### PR TITLE
Upgrade to Hibernate Reactive 1.0.0.CR3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -94,7 +94,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.4.30.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.CR2</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.CR3</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.3.Final</hibernate-search.version>
         <narayana.version>5.11.1.Final</narayana.version>


### PR DESCRIPTION
This release fixes a [bug related to the id generation](https://github.com/hibernate/hibernate-reactive/issues/707).