### PR TITLE
Update the section about disabling security with a link to the TestSecurity doc

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -236,7 +236,7 @@ public class DisabledAuthController extends AuthorizationController {
 }
 ----
 
-Please also see link:security-testing#testing-security[TestingSecurity Annotation] section how to disable the security checks using `TestSecurity` annotation.
+Please also see link:security-testing#testing-security[TestingSecurity Annotation] section on how to disable the security checks using `TestSecurity` annotation.
 
 == Registering Security Providers
 

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -236,6 +236,8 @@ public class DisabledAuthController extends AuthorizationController {
 }
 ----
 
+Please also see link:security-testing#testing-security[TestingSecurity Annotation] section how to disable the security checks using `TestSecurity` annotation.
+
 == Registering Security Providers
 
 === Default providers


### PR DESCRIPTION
Fixes #13205.

Add a link to the `TestSecurity` docs where it is well explained how to disable the sec checks - I thought of deleting this section where a custom interceptor is provided - but even if it did not work for OIDC at some point I recall a user was suggesting an improvement to the example code and it worked for them which I followed up with this [PR](https://github.com/quarkusio/quarkus/commit/f9ded7a2414248a189cded30edc693c93a2c5611#diff-6ace812881ef05d41868b02113ea14366f249156fcabcaef18c3bf471eced9a6) so it makes sense to keep this hint.