### PR TITLE
JDK EA job: drop jbang action

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -104,14 +104,14 @@ jobs:
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus
       - name: Report status
-        uses: jbangdev/jbang-action@v0.68.0
         if: "always() && github.repository == 'quarkusio/quarkus' && github.event_name != 'workflow_dispatch'"
-        with:
-          script: .github/NativeBuildReport.java
-          scriptargs: |
-            issueNumber=15867
-            runId=${{ github.run_id }}
-            status=${{ job.status }}
-            token=${{ secrets.GITHUB_API_TOKEN }}
-            issueRepo=${{ github.repository }}
+        shell: bash
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          ~/.jbang/bin/jbang .github/NativeBuildReport.java \
+            issueNumber=15867 \
+            runId=${{ github.run_id }} \
+            status=${{ job.status }} \
+            token=${{ secrets.GITHUB_API_TOKEN }} \
+            issueRepo=${{ github.repository }} \
             thisRepo=${{ github.repository }}


### PR DESCRIPTION
Should fix the reporting for good.

This is the result of a longer chat with @maxandersen:
We cannot use the jbang action here because GH does not mount `/opt/hostedtoolcache` into the container and so the host's JDK is not visible to jbang.
Letting jbang install it's own JDK would have been the (less efficient) alternative.