### PR TITLE
Allow to filter dependencies in multi-build mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.pkg;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -55,6 +56,37 @@ public class PackageConfig {
      */
     @ConfigItem
     public Optional<List<String>> userConfiguredIgnoredEntries;
+
+    /**
+     * List of all the dependencies that have been defined as optional to include into the final package of the application.
+     * Each optional dependency needs to be expressed in the following format:
+     * <p>
+     * groupId:artifactId:classifier:type
+     * <p>
+     * With the classifier and type being optional.
+     * <p>
+     * If the type is missing, the artifact is assumed to be of type {@code jar}.
+     * <p>
+     * This parameter is optional, if absent, no optional dependencies will be included into the final package of
+     * the application.
+     * <p>
+     * For backward compatibility reasons, this parameter is ignored by default and can be enabled by setting the
+     * parameter {@code quarkus.package.filter-optional-dependencies} to {@code true}.
+     * <p>
+     * This parameter is meant to be used in modules where multi-builds have been configured to avoid getting a final
+     * package with unused dependencies.
+     */
+    @ConfigItem
+    public Optional<Set<String>> includedOptionalDependencies;
+
+    /**
+     * Flag indicating whether the optional dependencies should be filtered out or not.
+     * <p>
+     * This parameter is meant to be used in modules where multi-builds have been configured to avoid getting a final
+     * package with unused dependencies.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean filterOptionalDependencies;
 
     /**
      * The suffix that is applied to the runner jar and native images

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/OutputTargetBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/OutputTargetBuildItem.java
@@ -1,8 +1,11 @@
 package io.quarkus.deployment.pkg.builditem;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
+import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
@@ -16,12 +19,15 @@ public final class OutputTargetBuildItem extends SimpleBuildItem {
     private final String baseName;
     private final boolean rebuild;
     private final Properties buildSystemProperties;
+    private final Optional<Set<AppArtifactKey>> includedOptionalDependencies;
 
-    public OutputTargetBuildItem(Path outputDirectory, String baseName, boolean rebuild, Properties buildSystemProperties) {
+    public OutputTargetBuildItem(Path outputDirectory, String baseName, boolean rebuild, Properties buildSystemProperties,
+            Optional<Set<AppArtifactKey>> includedOptionalDependencies) {
         this.outputDirectory = outputDirectory;
         this.baseName = baseName;
         this.rebuild = rebuild;
         this.buildSystemProperties = buildSystemProperties;
+        this.includedOptionalDependencies = includedOptionalDependencies;
     }
 
     public Path getOutputDirectory() {
@@ -38,5 +44,9 @@ public final class OutputTargetBuildItem extends SimpleBuildItem {
 
     public Properties getBuildSystemProperties() {
         return buildSystemProperties;
+    }
+
+    public Optional<Set<AppArtifactKey>> getIncludedOptionalDependencies() {
+        return includedOptionalDependencies;
     }
 }

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/pom.xml
@@ -14,6 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <commons.collections.version>4.4</commons.collections.version>
+    <commons.io.version>1.3.2</commons.io.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -43,6 +45,18 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>${commons.collections.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons.io.version}</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -53,7 +67,7 @@
         <extensions>true</extensions>
         <executions>
           <execution>
-            <id>build-foo</id>
+            <id>fast-build-foo</id>
             <goals>
               <goal>generate-code</goal>
               <goal>generate-code-tests</goal>
@@ -61,7 +75,9 @@
             </goals>
             <configuration>
               <properties>
-                <quarkus.package.output-directory>foo-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.output-directory>fast-foo-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar</quarkus.package.included-optional-dependencies>
               </properties>
               <systemProperties>
                 <quarkus.profile>foo</quarkus.profile>
@@ -69,7 +85,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>build-bar</id>
+            <id>fast-build-bar</id>
             <goals>
               <goal>generate-code</goal>
               <goal>generate-code-tests</goal>
@@ -77,7 +93,202 @@
             </goals>
             <configuration>
               <properties>
-                <quarkus.package.output-directory>bar-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.output-directory>fast-bar-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>bar</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>fast-build-foo-full</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-directory>fast-foo-full-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar,commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>foo</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>fast-build-bar-empty</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-directory>fast-bar-empty-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>bar</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>legacy-build-foo</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>legacy</quarkus.package.output-name>
+                <quarkus.package.type>legacy-jar</quarkus.package.type>
+                <quarkus.package.output-directory>legacy-foo-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>foo</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>legacy-build-bar</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>legacy</quarkus.package.output-name>
+                <quarkus.package.type>legacy-jar</quarkus.package.type>
+                <quarkus.package.output-directory>legacy-bar-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>bar</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>legacy-build-foo-full</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>legacy</quarkus.package.output-name>
+                <quarkus.package.type>legacy-jar</quarkus.package.type>
+                <quarkus.package.output-directory>legacy-foo-full-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar,commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>foo</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>legacy-build-bar-empty</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>legacy</quarkus.package.output-name>
+                <quarkus.package.type>legacy-jar</quarkus.package.type>
+                <quarkus.package.output-directory>legacy-bar-empty-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>bar</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>uber-build-foo</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>uber</quarkus.package.output-name>
+                <quarkus.package.type>uber-jar</quarkus.package.type>
+                <quarkus.package.output-directory>uber-foo-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>foo</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>uber-build-bar</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>uber</quarkus.package.output-name>
+                <quarkus.package.type>uber-jar</quarkus.package.type>
+                <quarkus.package.output-directory>uber-bar-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>bar</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>uber-build-foo-full</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>uber</quarkus.package.output-name>
+                <quarkus.package.type>uber-jar</quarkus.package.type>
+                <quarkus.package.output-directory>uber-foo-full-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.apache.commons:commons-collections4::jar,commons-io:commons-io::</quarkus.package.included-optional-dependencies>
+              </properties>
+              <systemProperties>
+                <quarkus.profile>foo</quarkus.profile>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>uber-build-bar-empty</id>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-name>uber</quarkus.package.output-name>
+                <quarkus.package.type>uber-jar</quarkus.package.type>
+                <quarkus.package.output-directory>uber-bar-empty-quarkus-app</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
               </properties>
               <systemProperties>
                 <quarkus.profile>bar</quarkus.profile>

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloResourceBar.java
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloResourceBar.java
@@ -18,6 +18,6 @@ public class HelloResourceBar {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Bar: hello, " + service.name();
+        return "Bar: hello, " + service.name() + "-" + service.classFounds();
     }
 }

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloResourceFoo.java
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloResourceFoo.java
@@ -18,6 +18,6 @@ public class HelloResourceFoo {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Foo: hello, " + service.name();
+        return "Foo: hello, " + service.name() + "-" + service.classFounds();
     }
 }

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloService.java
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/main/java/org/acme/HelloService.java
@@ -3,9 +3,27 @@ package org.acme;
 import io.quarkus.arc.profile.IfBuildProfile;
 
 import javax.enterprise.context.ApplicationScoped;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.collections4.MultiSet;
 
 public interface HelloService {
     String name();
+
+    default String classFounds() {
+        String result = "";
+        try {
+            result += FileUtils.class.getSimpleName();
+        } catch (NoClassDefFoundError e) {
+            result += "?";
+        }
+        result += "/";
+        try {
+            result += MultiSet.class.getSimpleName();
+        } catch (NoClassDefFoundError e) {
+            result += "?";
+        }
+        return result;
+    }
 
     @IfBuildProfile("foo")
     @ApplicationScoped

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/test/java/org/acme/HelloResourceBarTest.java
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/test/java/org/acme/HelloResourceBarTest.java
@@ -16,6 +16,6 @@ public class HelloResourceBarTest {
             .when().get("/hello")
             .then()
             .statusCode(200)
-            .body(is("Bar: hello, from bar"));
+            .body(is("Bar: hello, from bar-FileUtils/MultiSet"));
     }
 }

--- a/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/test/java/org/acme/HelloResourceFooTest.java
+++ b/integration-tests/maven/src/test/resources/projects/multi-build-mode/src/test/java/org/acme/HelloResourceFooTest.java
@@ -16,6 +16,6 @@ public class HelloResourceFooTest {
             .when().get("/hello")
             .then()
             .statusCode(200)
-            .body(is("Foo: hello, from foo"));
+            .body(is("Foo: hello, from foo-FileUtils/MultiSet"));
     }
 }


### PR DESCRIPTION
cc @bcournaud  

fixes #16599

## Motivation

Thanks to #16053, it is now possible to build several artifacts from one module but it is not yet possible to have a way to filter out some dependencies such that we could end up with artifacts containing useless dependencies. The idea of this feature is to go a little bit further by proposing a way to filter out the dependencies.

## Modifications:

* Adds the parameter `optionalDependencies` to the class `PackageConfig` in order to specify the list of optional dependencies that we would like to include into the final package of the application.
* Adds the parameter `filterOptionalDependencies ` to the class `PackageConfig` to enable or not the feature, it is disabled by default for backward compatibility reasons.
*  Adds the field `optionalDependencies ` to the class `OutputTargetBuildItem` corresponding to the parameter `optionalDependencies` but after being post processed to make it absent if the feature is disabled, to make it empty if no optional dependencies were specified and to convert the String representation of the artifacts into the corresponding `AppArtifactKey`'s instances
* Relies on the field `optionalDependencies ` of the class `OutputTargetBuildItem` to filter out all the dependencies of the application that have been marked as optional for all supported package types.
* Adapts the integration test for the multi-build to test this feature for all supported package types (but native one) by adding two optional dependencies to the project and filtering them out using different parameters.

## Result

It is now possible to build several artifacts with specific dependencies, this could be used for example to package the same application for different databases.