### PR TITLE
Cache the item emitted by a Uni instead of the Uni itself

### DIFF
--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -26,6 +26,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-caffeine-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny-deployment</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniValueTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniValueTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Tests the {@link CacheResult} annotation on methods returning {@link Uni}.
+ */
+public class UniValueTest {
+
+    private static final String KEY = "key";
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class).addAsResource(
+                    new StringAsset("quarkus.log.category.\"io.quarkus.cache\".level=DEBUG"), "application.properties"));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void test() {
+        // STEP 1
+        // Action: a method annotated with @CacheResult and returning a Uni is called.
+        // Expected effect: the method is invoked and an UnresolvedUniValue is cached.
+        // Verified by: invocations counter and CacheResultInterceptor log.
+        Uni<String> uni1 = cachedService.cachedMethod(KEY);
+        assertEquals(1, cachedService.getInvocations());
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: the method is invoked because the key is associated with a cached UnresolvedUniValue.
+        // Verified by: invocations counter and CacheResultInterceptor log.
+        Uni<String> uni2 = cachedService.cachedMethod(KEY);
+        assertEquals(2, cachedService.getInvocations());
+
+        // STEP 3
+        // Action: the Uni returned in STEP 1 is subscribed to and we wait for an item event to be fired.
+        // Expected effect: the UnresolvedUniValue cached during STEP 1 is replaced with the emitted item from this step in the cache.
+        // Verified by: subscriptions counter and CaffeineCache log.
+        String emittedItem1 = uni1.await().indefinitely();
+        assertEquals("1", emittedItem1); // This checks the subscriptions counter value.
+
+        // STEP 4
+        // Action: the Uni returned in STEP 2 is subscribed to and we wait for an item event to be fired.
+        // Expected effect: the emitted item from STEP 3 is replaced with the emitted item from this step in the cache.
+        // Verified by: subscriptions counter, CaffeineCache log and different objects references between STEPS 3 and 4 emitted items.
+        String emittedItem2 = uni2.await().indefinitely();
+        assertTrue(emittedItem1 != emittedItem2);
+        assertEquals("2", emittedItem2); // This checks the subscriptions counter value.
+
+        // STEP 5
+        // Action: same call as STEP 2 but we immediately subscribe to the returned Uni and wait for an item event to be fired.
+        // Expected effect: the method is not invoked and the emitted item cached during STEP 4 is returned.
+        // Verified by: invocations and subscriptions counters, same object reference between STEPS 4 and 5 emitted items.
+        String emittedItem3 = cachedService.cachedMethod(KEY).await().indefinitely();
+        assertEquals(2, cachedService.getInvocations());
+        assertEquals("2", emittedItem3); // This checks the subscriptions counter value.
+        assertTrue(emittedItem2 == emittedItem3);
+
+        // STEP 6
+        // Action: same call as STEP 5 with a different key.
+        // Expected effect: the method is invoked and an UnresolvedUniValue is cached.
+        // Verified by: invocations and subscriptions counters, CacheResultInterceptor log and different objects references between STEPS 5 and 6 emitted items.
+        String emittedItem4 = cachedService.cachedMethod("another-key").await().indefinitely();
+        assertEquals(3, cachedService.getInvocations());
+        assertEquals("3", emittedItem4); // This checks the subscriptions counter value.
+        assertTrue(emittedItem3 != emittedItem4);
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        private int invocations;
+        private int subscriptions;
+
+        @CacheResult(cacheName = "test-cache")
+        public Uni<String> cachedMethod(String key) {
+            invocations++;
+            return Uni.createFrom().item(() -> {
+                subscriptions++;
+                return "" + subscriptions;
+            });
+        }
+
+        public int getInvocations() {
+            return invocations;
+        }
+    }
+}

--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>quarkus-caffeine</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
             <optional>true</optional>

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/AbstractCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/AbstractCache.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import io.quarkus.cache.Cache;
+import io.smallrye.mutiny.Uni;
 
 public abstract class AbstractCache implements Cache {
 
@@ -32,4 +33,11 @@ public abstract class AbstractCache implements Cache {
     public abstract void invalidate(Object key);
 
     public abstract void invalidateAll();
+
+    /**
+     * Replaces the cache value associated with the given key by an item emitted by a {@link Uni}. This method can be called
+     * several times for the same key, each call will then always replace the existing cache entry with the given emitted
+     * value. If the key no longer identifies a cache entry, this method must not put the emitted item into the cache.
+     */
+    public abstract Uni<Void> replaceUniValue(Object key, Object emittedValue);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/UnresolvedUniValue.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/UnresolvedUniValue.java
@@ -1,0 +1,13 @@
+package io.quarkus.cache.runtime;
+
+/**
+ * This value acts as a placeholder in the cache. It will be eventually replaced by the item emitted by the
+ * {@link io.smallrye.mutiny.Uni Uni} when it has been resolved.
+ */
+public class UnresolvedUniValue {
+
+    public static final UnresolvedUniValue INSTANCE = new UnresolvedUniValue();
+
+    private UnresolvedUniValue() {
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import io.quarkus.cache.runtime.AbstractCache;
+import io.smallrye.mutiny.Uni;
 
 /**
  * This class is an internal Quarkus cache implementation. Do not use it explicitly from your Quarkus application. The public
@@ -36,5 +37,10 @@ public class NoOpCache extends AbstractCache {
 
     @Override
     public void invalidateAll() {
+    }
+
+    @Override
+    public Uni<Void> replaceUniValue(Object key, Object emittedValue) {
+        return Uni.createFrom().voidItem();
     }
 }


### PR DESCRIPTION
Fixes #16607.

cc @cescoffier @geoand