### PR TITLE
Fix kotlin-plugin build warning

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>


### PR DESCRIPTION
Fixes:
```
Warning:  
Warning:  Some problems were encountered while building the effective model for io.quarkus:quarkus-resteasy-reactive:jar:999-SNAPSHOT
Warning:  'build.plugins.plugin.version' for org.jetbrains.kotlin:kotlin-maven-plugin is missing. @ line 66, column 21
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
```

/cc @evanchooly