### PR TITLE
CI: Fix tcks/resteasy-reactive/update-dependencies.sh failure on no-op incremental build

### DIFF
--- a/tcks/resteasy-reactive/update-dependencies.sh
+++ b/tcks/resteasy-reactive/update-dependencies.sh
@@ -32,6 +32,12 @@ echo ''
 echo 'Building dependencies list from testuite pom.xml...'
 echo ''
 
+if [ "${CI:-}" == true ] && [ ! -f "${PRG_PATH}/target/testsuite/tests/pom.xml" ]
+then
+  echo 'Testsuite pom.xml not found, assuming no-op incremental build.'
+  exit 0
+fi
+
 # get the Quarkus artifact ids from tests/pom.xml of the testsuite repo that is cloned in target
 # pipefail is switched off briefly so that a better error can be logged when nothing is found
 set +o pipefail


### PR DESCRIPTION
When nothing was changed that impacts `tcks/resteasy-reactive`, the script fails with:
```
Building dependencies list from testuite pom.xml...

grep: /home/runner/work/quarkus/quarkus/tcks/resteasy-reactive/target/testsuite/tests/pom.xml: No such file or directory
Error: Could not find any artifact-ids. Please check the grep command. 
Error: Process completed with exit code 1.
```