### PR TITLE
Add isParentFirst method to QuarkusClassLoader

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -117,6 +117,32 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         return name;
     }
 
+    /**
+     * Returns true if the supplied class is a class that would be loaded parent-first
+     */
+    public boolean isParentFirst(String name) {
+        if (name.startsWith(JAVA)) {
+            return true;
+        }
+
+        //even if the thread is interrupted we still want to be able to load classes
+        //if the interrupt bit is set then we clear it and restore it at the end
+        boolean interrupted = Thread.interrupted();
+        try {
+            ClassLoaderState state = getState();
+            synchronized (getClassLoadingLock(name)) {
+                String resourceName = sanitizeName(name).replace(".", "/") + ".class";
+                return parentFirst(resourceName, state);
+            }
+
+        } finally {
+            if (interrupted) {
+                //restore interrupt state
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     private boolean parentFirst(String name, ClassLoaderState state) {
         return parentFirst || state.parentFirstResources.contains(name);
     }


### PR DESCRIPTION
This can be used by extensions to determine if a class
would be loaded parent first or not.
Relates to: https://github.com/quarkusio/quarkus/issues/16576#issuecomment-822233804

cc @mkouba 