### PR TITLE
Qute - fix validation of type-safe message expressions

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -315,6 +315,7 @@ public class MessageBundleProcessor {
             List<TypeCheckExcludeBuildItem> excludes,
             List<MessageBundleBuildItem> messageBundles,
             List<MessageBundleMethodBuildItem> messageBundleMethods,
+            List<TemplateExpressionMatchesBuildItem> expressionMatches,
             BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
             BuildProducer<ImplicitValueResolverBuildItem> implicitClasses) {
 
@@ -356,7 +357,13 @@ public class MessageBundleProcessor {
 
                 for (Entry<TemplateAnalysis, Set<Expression>> exprEntry : expressions.entrySet()) {
 
-                    Map<Integer, Match> generatedIdsToMatches = new HashMap<>();
+                    Map<Integer, Match> generatedIdsToMatches = Collections.emptyMap();
+                    for (TemplateExpressionMatchesBuildItem templateExpressionMatchesBuildItem : expressionMatches) {
+                        if (templateExpressionMatchesBuildItem.templateGeneratedId.equals(exprEntry.getKey().generatedId)) {
+                            generatedIdsToMatches = templateExpressionMatchesBuildItem.getGeneratedIdsToMatches();
+                            break;
+                        }
+                    }
 
                     for (Expression expression : exprEntry.getValue()) {
                         // msg:hello_world(foo.name)
@@ -407,7 +414,7 @@ public class MessageBundleProcessor {
                                             incorrectExpressions, expression, index, implicitClassToMembersUsed,
                                             templateIdToPathFun, generatedIdsToMatches);
                                     Match match = results.get(param.toOriginalString());
-                                    if (match != null && !Types.isAssignableFrom(match.type(),
+                                    if (match != null && !match.isEmpty() && !Types.isAssignableFrom(match.type(),
                                             methodParams.get(idx), index)) {
                                         incorrectExpressions
                                                 .produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -484,6 +484,7 @@ public class QuteProcessor {
             List<TypeCheckExcludeBuildItem> excludes,
             BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
             BuildProducer<ImplicitValueResolverBuildItem> implicitClasses,
+            BuildProducer<TemplateExpressionMatchesBuildItem> expressionMatches,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             List<CheckedTemplateBuildItem> checkedTemplates,
             QuteConfig config) {
@@ -559,6 +560,9 @@ public class QuteProcessor {
                                     generatedIdsToMatches));
                 }
             }
+
+            expressionMatches
+                    .produce(new TemplateExpressionMatchesBuildItem(templateAnalysis.generatedId, generatedIdsToMatches));
         }
 
         for (Entry<DotName, Set<String>> entry : implicitClassToMembersUsed.entrySet()) {

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateExpressionMatchesBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateExpressionMatchesBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.qute.deployment;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.qute.deployment.QuteProcessor.Match;
+
+final class TemplateExpressionMatchesBuildItem extends MultiBuildItem {
+
+    final String templateGeneratedId;
+
+    private final Map<Integer, Match> generatedIdsToMatches;
+
+    public TemplateExpressionMatchesBuildItem(String templateGeneratedId, Map<Integer, Match> generatedIdsToMatches) {
+        this.templateGeneratedId = templateGeneratedId;
+        this.generatedIdsToMatches = generatedIdsToMatches;
+    }
+
+    Match getMatch(Integer generatedId) {
+        return generatedIdsToMatches.get(generatedId);
+    }
+
+    Map<Integer, Match> getGeneratedIdsToMatches() {
+        return generatedIdsToMatches;
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
@@ -20,7 +20,8 @@ public class MessageBundleTemplateExpressionValidationTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MyBundle.class, Item.class)
-                    .addAsResource(new StringAsset("{msg:hello('foo')} {msg:hello_and_bye} {msg:hello(1,2)}"),
+                    .addAsResource(new StringAsset(
+                            "{@java.util.List<java.lang.Integer> names} {msg:hello('foo')} {msg:hello_and_bye} {msg:hello(1,2)} {#each names}{msg:helloName(it)}{/each}"),
                             "templates/hello.html"))
             .assertException(t -> {
                 Throwable e = t;
@@ -35,10 +36,11 @@ public class MessageBundleTemplateExpressionValidationTest {
                 if (te == null) {
                     fail("No template exception thrown: " + t);
                 }
-                assertTrue(te.getMessage().contains("Found template problems (3)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found template problems (4)"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello('foo')"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello_and_bye"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello(1,2)"), te.getMessage());
+                assertTrue(te.getMessage().contains("msg:helloName(it)"), te.getMessage());
             });
 
     @Test
@@ -51,6 +53,9 @@ public class MessageBundleTemplateExpressionValidationTest {
 
         @Message("Hello {item.name}")
         String hello(Item item);
+
+        @Message("Hello {name}!")
+        String helloName(String name);
 
     }
 


### PR DESCRIPTION
- NPE is currently thrown if a type-safe message expression references a
parent expression via hint
- resolves #16590