### PR TITLE
Remove duplicate dependency to quarkus-mongodb-client-deployment-spi

### DIFF
--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -98,10 +98,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mongodb-client-deployment-spi</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The dependency is already declared at line 37.