### PR TITLE
Support for path-specific authentication mechanisms

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -207,6 +207,25 @@ You can also use link:security-testing#configuring-user-information[User Propert
 One can combine multiple authentication mechanisms if they get the authentication credentials from the different sources.
 For example, combining built-in `Basic` and `quarkus-oidc` `Bearer` authentication mechanisms is allowed, but combining `quarkus-oidc` `Bearer` and `smallrye-jwt` authentication mechanisms is not allowed because both will attempt to verify the token extracted from the HTTP `Authorization Bearer` scheme.
 
+=== Path Specific Authentication Mechanism
+
+You can enforce that only a single authentication mechanism is selected for a given request path, for example:
+[source,properties]
+----
+quarkus.http.auth.permission.basic-or-bearer.paths=/service
+quarkus.http.auth.permission.basic-or-bearer.policy=authenticated
+
+quarkus.http.auth.permission.basic.paths=/basic-only
+quarkus.http.auth.permission.basic.policy=authenticated
+quarkus.http.auth.permission.basic.auth-mechanism=basic
+
+quarkus.http.auth.permission.bearer.paths=/bearer-only
+quarkus.http.auth.permission.bearer.policy=authenticated
+quarkus.http.auth.permission.bearer.auth-mechanism=bearer
+----
+
+The value of the `auth-mechanism` property must match the authentication scheme supported by HttpAuthenticationMechanism such as `basic` or `bearer` or `form`, etc.
+
 == Proactive Authentication
 
 By default, Quarkus does what we call proactive authentication. This means that if an incoming request has a

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathHandler.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathHandler.java
@@ -21,7 +21,7 @@ public class PathHandler {
                     ret.append(user.getSecurityIdentity().getPrincipal().getName());
                 }
                 ret.append(":");
-                ret.append(event.normalisedPath());
+                ret.append(event.normalizedPath());
                 event.response().end(ret.toString());
             }
         });

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
@@ -53,4 +53,11 @@ public class PolicyMappingConfig {
      */
     @ConfigItem
     public Optional<List<String>> paths;
+
+    /**
+     * Path specific authentication mechanism which must be used to authenticate a user.
+     * It needs to match {@link HttpCredentialTransport} authentication scheme such as 'basic', 'bearer', 'form', etc.
+     */
+    @ConfigItem
+    public Optional<String> authMechanism;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
 public class FormAuthenticationMechanism implements HttpAuthenticationMechanism {
+    private static final String FORM = "form";
 
     private static final Logger log = Logger.getLogger(FormAuthenticationMechanism.class);
 
@@ -194,6 +195,6 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     @Override
     public HttpCredentialTransport getCredentialTransport() {
-        return new HttpCredentialTransport(HttpCredentialTransport.Type.POST, postLocation);
+        return new HttpCredentialTransport(HttpCredentialTransport.Type.POST, postLocation, FORM);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpCredentialTransport.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpCredentialTransport.java
@@ -17,10 +17,16 @@ public class HttpCredentialTransport {
 
     private final Type transportType;
     private final String typeTarget;
+    private final String authenticationScheme;
 
     public HttpCredentialTransport(Type transportType, String typeTarget) {
+        this(transportType, typeTarget, typeTarget);
+    }
+
+    public HttpCredentialTransport(Type transportType, String typeTarget, String authenticationScheme) {
         this.transportType = Objects.requireNonNull(transportType);
         this.typeTarget = Objects.requireNonNull(typeTarget).toLowerCase();
+        this.authenticationScheme = Objects.requireNonNull(authenticationScheme);
     }
 
     public enum Type {
@@ -57,13 +63,14 @@ public class HttpCredentialTransport {
 
         if (transportType != that.transportType)
             return false;
-        return typeTarget.equals(that.typeTarget);
+        return typeTarget.equals(that.typeTarget) && this.authenticationScheme.equals(that.authenticationScheme);
     }
 
     @Override
     public int hashCode() {
         int result = transportType.hashCode();
         result = 31 * result + typeTarget.hashCode();
+        result = 31 * result + authenticationScheme.hashCode();
         return result;
     }
 
@@ -72,6 +79,7 @@ public class HttpCredentialTransport {
         return "HttpCredentialTransport{" +
                 "transportType=" + transportType +
                 ", typeTarget='" + typeTarget + '\'' +
+                ", authenticationScheme='" + authenticationScheme + '\'' +
                 '}';
     }
 
@@ -81,5 +89,9 @@ public class HttpCredentialTransport {
 
     public String getTypeTarget() {
         return typeTarget;
+    }
+
+    public String getAuthenticationScheme() {
+        return authenticationScheme;
     }
 }

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/VertxResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/VertxResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.Router;
@@ -21,6 +22,32 @@ public class VertxResource {
                         event.response().end(data);
                     }
                 });
+            }
+        });
+        router.route("/basic-only").handler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+                StringBuilder ret = new StringBuilder();
+                if (user != null) {
+                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
+                }
+                ret.append(":");
+                ret.append(event.normalizedPath());
+                event.response().end(ret.toString());
+            }
+        });
+        router.route("/bearer-only").handler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+                StringBuilder ret = new StringBuilder();
+                if (user != null) {
+                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
+                }
+                ret.append(":");
+                ret.append(event.normalizedPath());
+                event.response().end(ret.toString());
             }
         });
     }

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -11,3 +11,11 @@ quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.users.alice=password
 quarkus.security.users.embedded.roles.alice=user
+
+quarkus.http.auth.permission.basic.paths=/basic-only
+quarkus.http.auth.permission.basic.policy=authenticated
+quarkus.http.auth.permission.basic.auth-mechanism=basic
+
+quarkus.http.auth.permission.bearer.paths=/bearer-only
+quarkus.http.auth.permission.bearer.policy=authenticated
+quarkus.http.auth.permission.bearer.auth-mechanism=bearer

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -5,9 +5,7 @@ import static io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManag
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
@@ -63,9 +61,8 @@ public class BearerTokenAuthorizationTest {
 
     @Test
     public void testBasicAuth() {
-        byte[] basicAuthBytes = "alice:password".getBytes(StandardCharsets.UTF_8);
-        RestAssured.given()
-                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(basicAuthBytes))
+        RestAssured.given().auth()
+                .preemptive().basic("alice", "password")
                 .when().get("/api/users/me")
                 .then()
                 .statusCode(200)
@@ -157,6 +154,41 @@ public class BearerTokenAuthorizationTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello World"));
+    }
+
+    @Test
+    public void testBearerAuthFailureWhereBasicIsRequired() {
+        RestAssured.given().auth().oauth2(getAccessToken("alice"))
+                .when().get("/basic-only")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testBasicAuthWhereBasicIsRequired() {
+        RestAssured.given().auth()
+                .preemptive().basic("alice", "password")
+                .when().get("/basic-only")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice:/basic-only"));
+    }
+
+    @Test
+    public void testBasicAuthFailureWhereBearerIsRequired() {
+        RestAssured.given().auth().preemptive().basic("alice", "password")
+                .when().get("/bearer-only")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testBearerAuthWhereBasicIsRequired() {
+        RestAssured.given().auth().oauth2(getAccessToken("alice"))
+                .when().get("/bearer-only")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice@gmail.com:/bearer-only"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #11886

This PR allows to select a specific authentication mechanism for a specifc path. It does not try to support the overlapping paths which is not practical, (ex, `/a=basic`, `/a/b=bearer`, etc). The first matching path wins