### PR TITLE
CI: remove categories from matrix

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -1,28 +1,4 @@
 {
-    "category": [
-        "Main",
-        "Data1",
-        "Data2",
-        "Data3",
-        "Data4",
-        "Data5",
-        "Data6",
-        "Data7",
-        "Security1",
-        "Security2",
-        "Security3",
-        "Amazon",
-        "Messaging1",
-        "Messaging2",
-        "Cache",
-        "HTTP",
-        "Misc1",
-        "Misc2",
-        "Misc3",
-        "Misc4",
-        "Spring",
-        "gRPC"
-    ],
     "include": [
         {
             "category": "Main",


### PR DESCRIPTION
The `category` array is redundant, as it can be inferred by the corresponding `category` objects of the `include' array.

Its removal allows workflows combining json files, like in [mandrel.yml](https://github.com/graalvm/mandrel/blob/d0a18c92e650213da06d59181f5e5d6559e67290/.github/workflows/mandrel.yml#L98) , to avoid the need of merging the `category` array.