### PR TITLE
Don't index invisible muti-release classes

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -34,7 +34,7 @@ import org.jboss.logging.Logger;
  */
 public class JarClassPathElement implements ClassPathElement {
 
-    private static final int JAVA_VERSION;
+    public static final int JAVA_VERSION;
 
     static {
         int version = 8;


### PR DESCRIPTION
Don't index classes that are not able to be
loaded as the current Java version is too low.

Note that if a newer JDK is used to run the
resulting application these classes will become
visible, however this is less likely to cause
problems than the current situation.

This is because adding invisible classes to the
index can result in bytecode being generated which
references these classes, which will cause startup
to fail. The alternative of not adding them to the
index only means that some annotation based funcationaly
(such as CDI) won't work for those classes, but
this seems a corner case (and the solution is to
build with the same version you are running).