### PR TITLE
Use the watch service when possible

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -20,16 +20,16 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -52,6 +52,11 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.changeagent.ClassChangeAgent;
+import io.quarkus.deployment.dev.filewatch.FileChangeCallback;
+import io.quarkus.deployment.dev.filewatch.FileChangeEvent;
+import io.quarkus.deployment.dev.filewatch.FileSystemWatcher;
+import io.quarkus.deployment.dev.filewatch.PollingFileSystemWatcher;
+import io.quarkus.deployment.dev.filewatch.WatchServiceFileSystemWatcher;
 import io.quarkus.deployment.dev.testing.TestListener;
 import io.quarkus.deployment.dev.testing.TestRunner;
 import io.quarkus.deployment.dev.testing.TestSupport;
@@ -61,6 +66,7 @@ import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.dev.spi.HotReplacementSetup;
 
 public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable {
+    public static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux");
 
     private static final Logger log = Logger.getLogger(RuntimeUpdatesProcessor.class);
 
@@ -100,7 +106,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private final BiConsumer<Set<String>, ClassScanResult> restartCallback;
     private final BiConsumer<DevModeContext.ModuleInfo, String> copyResourceNotification;
     private final BiFunction<String, byte[], byte[]> classTransformers;
-    private Timer timer;
+
     private final ReentrantLock scanLock = new ReentrantLock();
 
     /**
@@ -112,6 +118,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private final TestSupport testSupport;
     private volatile boolean firstTestScanComplete;
     private volatile Boolean instrumentationEnabled;
+    private FileSystemWatcher testClassChangeWatcher;
 
     public RuntimeUpdatesProcessor(Path applicationRoot, DevModeContext context, QuarkusCompiler compiler,
             DevModeType devModeType, BiConsumer<Set<String>, ClassScanResult> restartCallback,
@@ -140,9 +147,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 @Override
                 public void testsDisabled() {
                     synchronized (RuntimeUpdatesProcessor.this) {
-                        if (timer != null) {
-                            timer.cancel();
-                            timer = null;
+                        if (testClassChangeWatcher != null) {
+                            try {
+                                testClassChangeWatcher.close();
+                            } catch (IOException e) {
+                                //ignore
+                            }
+                            testClassChangeWatcher = null;
                         }
                     }
                 }
@@ -169,19 +180,30 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 .collect(toList());
     }
 
-    private Timer startTestScanningTimer() {
+    private void startTestScanningTimer() {
         synchronized (this) {
-            if (timer == null) {
-                timer = new Timer("Test Compile Timer", true);
-                timer.schedule(new TimerTask() {
+            if (testClassChangeWatcher == null) {
+                if (IS_LINUX) {
+                    testClassChangeWatcher = new WatchServiceFileSystemWatcher("Quarkus Test Watcher", true);
+                } else {
+                    testClassChangeWatcher = new PollingFileSystemWatcher("Quarkus Test Watcher", 500, true);
+                }
+                FileChangeCallback callback = new FileChangeCallback() {
                     @Override
-                    public void run() {
+                    public void handleChanges(Collection<FileChangeEvent> changes) {
                         periodicTestCompile();
                     }
-                }, 1, 1000);
+                };
+                for (DevModeContext.ModuleInfo module : context.getAllModules()) {
+                    for (String path : module.getMain().getSourcePaths()) {
+                        testClassChangeWatcher.watchPath(new File(path), callback);
+                    }
+                }
+                for (String path : context.getApplicationRoot().getTest().get().getSourcePaths()) {
+                    testClassChangeWatcher.watchPath(new File(path), callback);
+                }
             }
         }
-        return timer;
     }
 
     private void periodicTestCompile() {
@@ -846,10 +868,10 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public void close() throws IOException {
-        if (timer != null) {
-            timer.cancel();
-        }
         compiler.close();
+        if (testClassChangeWatcher != null) {
+            testClassChangeWatcher.close();
+        }
     }
 
     private Map<Path, Long> expandGlobPattern(Path root, Path configFile) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeCallback.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeCallback.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.deployment.dev.filewatch;
+
+import java.util.Collection;
+
+/**
+ * Callback for file system change events
+ *
+ * @see FileSystemWatcher
+ * @author Stuart Douglas
+ */
+public interface FileChangeCallback {
+
+    /**
+     * Method that is invoked when file system changes are detected.
+     *
+     * @param changes the file system changes
+     */
+    void handleChanges(final Collection<FileChangeEvent> changes);
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeEvent.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeEvent.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.deployment.dev.filewatch;
+
+import java.io.File;
+
+/**
+ * The event object that is fired when a file system change is detected.
+ *
+ * @see FileSystemWatcher
+ *
+ * @author Stuart Douglas
+ */
+public class FileChangeEvent {
+
+    private final File file;
+    private final Type type;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param file the file which is being watched
+     * @param type the type of event that was encountered
+     */
+    public FileChangeEvent(File file, Type type) {
+        this.file = file;
+        this.type = type;
+    }
+
+    /**
+     * Get the file which was being watched.
+     *
+     * @return the file which was being watched
+     */
+    public File getFile() {
+        return file;
+    }
+
+    /**
+     * Get the type of event.
+     *
+     * @return the type of event
+     */
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * Watched file event types. More may be added in the future.
+     */
+    public static enum Type {
+        /**
+         * A file was added in a directory.
+         */
+        ADDED,
+        /**
+         * A file was removed from a directory.
+         */
+        REMOVED,
+        /**
+         * A file was modified in a directory.
+         */
+        MODIFIED,
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileSystemWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileSystemWatcher.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.deployment.dev.filewatch;
+
+import java.io.Closeable;
+import java.io.File;
+
+/**
+ * File system watcher service. This watcher can be used to receive notifications about a specific path.
+ *
+ * @author Stuart Douglas
+ */
+public interface FileSystemWatcher extends Closeable {
+
+    /**
+     * Watch the given path recursively, and invoke the callback when a change is made.
+     *
+     * @param file The path to watch
+     * @param callback The callback
+     */
+    void watchPath(final File file, final FileChangeCallback callback);
+
+    /**
+     * Stop watching a path.
+     *
+     * @param file the path
+     * @param callback the callback
+     */
+    void unwatchPath(final File file, final FileChangeCallback callback);
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/PollingFileSystemWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/PollingFileSystemWatcher.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.deployment.dev.filewatch;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Polling based file system watcher service, for use on operating systems that don't have
+ * a useful watch service.
+ *
+ * @author Stuart Douglas
+ */
+public class PollingFileSystemWatcher implements FileSystemWatcher, Runnable {
+
+    private static final Logger log = Logger.getLogger(PollingFileSystemWatcher.class);
+
+    private static final AtomicInteger threadIdCounter = new AtomicInteger(0);
+    public static final String THREAD_NAME = "xnio-polling-file-watcher";
+
+    private final Map<File, PollHolder> files = Collections.synchronizedMap(new HashMap<File, PollHolder>());
+
+    private final Thread watchThread;
+    private final long pollInterval;
+
+    private volatile boolean stopped = false;
+
+    public PollingFileSystemWatcher(final String name, long pollInterval, final boolean daemon) {
+        watchThread = new Thread(this, THREAD_NAME + "[" + name + "]-" + threadIdCounter);
+        watchThread.setDaemon(daemon);
+        watchThread.start();
+        this.pollInterval = pollInterval;
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            try {
+                doNotify();
+                Thread.sleep(pollInterval);
+            } catch (InterruptedException e) {
+                //ignore
+            }
+        }
+    }
+
+    private void doNotify() {
+        for (Map.Entry<File, PollHolder> entry : files.entrySet()) {
+            Map<File, Long> result = doScan(entry.getKey());
+            List<FileChangeEvent> currentDiff = doDiff(result, entry.getValue().currentFileState);
+            if (!currentDiff.isEmpty()) {
+                entry.getValue().currentFileState = result;
+                for (FileChangeCallback callback : entry.getValue().callbacks) {
+                    invokeCallback(callback, currentDiff);
+                }
+            }
+        }
+    }
+
+    private List<FileChangeEvent> doDiff(Map<File, Long> newFileState, Map<File, Long> currentFileState) {
+        final List<FileChangeEvent> results = new ArrayList<FileChangeEvent>();
+        final Map<File, Long> currentCopy = new HashMap<File, Long>(currentFileState);
+        for (Map.Entry<File, Long> newEntry : newFileState.entrySet()) {
+            Long old = currentCopy.remove(newEntry.getKey());
+            if (old == null) {
+                results.add(new FileChangeEvent(newEntry.getKey(), FileChangeEvent.Type.ADDED));
+            } else {
+                if (!old.equals(newEntry.getValue()) && !newEntry.getKey().isDirectory()) {
+                    //we don't add modified events for directories
+                    //as we will be generating modified events for the files in the dir anyway
+                    results.add(new FileChangeEvent(newEntry.getKey(), FileChangeEvent.Type.MODIFIED));
+                }
+            }
+        }
+        for (Map.Entry<File, Long> old : currentCopy.entrySet()) {
+            results.add(new FileChangeEvent(old.getKey(), FileChangeEvent.Type.REMOVED));
+        }
+        return results;
+    }
+
+    @Override
+    public synchronized void watchPath(File file, FileChangeCallback callback) {
+        PollHolder holder = files.get(file);
+        if (holder == null) {
+            files.put(file, holder = new PollHolder(doScan(file)));
+        }
+        holder.callbacks.add(callback);
+    }
+
+    @Override
+    public synchronized void unwatchPath(File file, final FileChangeCallback callback) {
+        PollHolder holder = files.get(file);
+        if (holder != null) {
+            holder.callbacks.remove(callback);
+            if (holder.callbacks.isEmpty()) {
+                files.remove(file);
+            }
+        }
+        files.remove(file);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stopped = true;
+        watchThread.interrupt();
+    }
+
+    private class PollHolder {
+        Map<File, Long> currentFileState;
+        final List<FileChangeCallback> callbacks = new ArrayList<FileChangeCallback>();
+
+        private PollHolder(Map<File, Long> currentFileState) {
+            this.currentFileState = currentFileState;
+        }
+    }
+
+    static Map<File, Long> doScan(File file) {
+        final Map<File, Long> results = new HashMap<File, Long>();
+
+        final Deque<File> toScan = new ArrayDeque<File>();
+        toScan.add(file);
+        while (!toScan.isEmpty()) {
+            File next = toScan.pop();
+            if (next.isDirectory()) {
+                results.put(next, next.lastModified());
+                File[] list = next.listFiles();
+                if (list != null) {
+                    for (File f : list) {
+                        toScan.push(new File(f.getAbsolutePath()));
+                    }
+                }
+            } else {
+                results.put(next, next.lastModified());
+            }
+        }
+        return results;
+    }
+
+    static void invokeCallback(FileChangeCallback callback, List<FileChangeEvent> results) {
+        try {
+            callback.handleChanges(results);
+        } catch (Exception e) {
+            log.error("Failed to invoke class change callback", e);
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/WatchServiceFileSystemWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/WatchServiceFileSystemWatcher.java
@@ -1,0 +1,266 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.deployment.dev.filewatch;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logging.Logger;
+
+/**
+ * File system watcher service based on JDK7 {@link WatchService}. Instantiating this class will create a new thread,
+ * that will run until {@link #close()} is called.
+ *
+ * @author Stuart Douglas
+ */
+public class WatchServiceFileSystemWatcher implements FileSystemWatcher, Runnable {
+
+    private static final Logger log = Logger.getLogger(WatchServiceFileSystemWatcher.class);
+
+    private static final AtomicInteger threadIdCounter = new AtomicInteger(0);
+    public static final String THREAD_NAME = "xnio-file-watcher";
+
+    private WatchService watchService;
+    private final Map<File, PathData> files = Collections.synchronizedMap(new HashMap<File, PathData>());
+    private final Map<WatchKey, PathData> pathDataByKey = Collections
+            .synchronizedMap(new IdentityHashMap<WatchKey, PathData>());
+
+    private volatile boolean stopped = false;
+    private final Thread watchThread;
+
+    public WatchServiceFileSystemWatcher(final String name, final boolean daemon) {
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        watchThread = new Thread(this, THREAD_NAME + "[" + name + "]-" + threadIdCounter);
+        watchThread.setDaemon(daemon);
+        watchThread.start();
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            try {
+                final WatchKey key = watchService.take();
+                if (key != null) {
+                    try {
+                        PathData pathData = pathDataByKey.get(key);
+                        if (pathData != null) {
+                            final List<FileChangeEvent> results = new ArrayList<FileChangeEvent>();
+                            List<WatchEvent<?>> events = key.pollEvents();
+                            final Set<File> addedFiles = new HashSet<File>();
+                            final Set<File> deletedFiles = new HashSet<File>();
+                            for (WatchEvent<?> event : events) {
+                                Path eventPath = (Path) event.context();
+                                File targetFile = ((Path) key.watchable()).resolve(eventPath).toFile();
+                                FileChangeEvent.Type type;
+
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                                    type = FileChangeEvent.Type.ADDED;
+                                    addedFiles.add(targetFile);
+                                    if (targetFile.isDirectory()) {
+                                        try {
+                                            addWatchedDirectory(pathData, targetFile);
+                                        } catch (IOException e) {
+                                            log.debugf(e, "Could not add watched directory %s", targetFile);
+                                        }
+                                    }
+                                } else if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+                                    type = FileChangeEvent.Type.MODIFIED;
+                                } else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
+                                    type = FileChangeEvent.Type.REMOVED;
+                                    deletedFiles.add(targetFile);
+                                } else {
+                                    continue;
+                                }
+                                results.add(new FileChangeEvent(targetFile, type));
+                            }
+                            key.pollEvents().clear();
+
+                            //now we need to prune the results, to remove duplicates
+                            //e.g. if the file is modified after creation we only want to
+                            //show the create event
+                            Iterator<FileChangeEvent> it = results.iterator();
+                            while (it.hasNext()) {
+                                FileChangeEvent event = it.next();
+                                if (event.getType() == FileChangeEvent.Type.MODIFIED) {
+                                    if (addedFiles.contains(event.getFile()) &&
+                                            deletedFiles.contains(event.getFile())) {
+                                        // XNIO-344
+                                        // All file change events (ADDED, REMOVED and MODIFIED) occurred here.
+                                        // This happens when an updated file is moved from the different
+                                        // filesystems or the directory having different project quota on Linux.
+                                        // ADDED and REMOVED events will be removed in the latter conditional branching.
+                                        // So, this MODIFIED event needs to be kept for the file change notification.
+                                        continue;
+                                    }
+                                    if (addedFiles.contains(event.getFile()) ||
+                                            deletedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                } else if (event.getType() == FileChangeEvent.Type.ADDED) {
+                                    if (deletedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                } else if (event.getType() == FileChangeEvent.Type.REMOVED) {
+                                    if (addedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                }
+                            }
+
+                            if (!results.isEmpty()) {
+                                for (FileChangeCallback callback : pathData.callbacks) {
+                                    invokeCallback(callback, results);
+                                }
+                            }
+                        }
+                    } finally {
+                        //if the key is no longer valid remove it from the files list
+                        if (!key.reset()) {
+                            files.remove(key.watchable());
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                //ignore
+            } catch (ClosedWatchServiceException cwse) {
+                // the watcher service is closed, so no more waiting on events
+                // @see https://developer.jboss.org/message/911519
+                break;
+            }
+        }
+    }
+
+    @Override
+    public synchronized void watchPath(File file, FileChangeCallback callback) {
+        try {
+            PathData data = files.get(file);
+            if (data == null) {
+                Set<File> allDirectories = doScan(file).keySet();
+                Path path = Paths.get(file.toURI());
+                data = new PathData(path);
+                for (File dir : allDirectories) {
+                    addWatchedDirectory(data, dir);
+                }
+                files.put(file, data);
+            }
+            data.callbacks.add(callback);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void addWatchedDirectory(PathData data, File dir) throws IOException {
+        Path path = Paths.get(dir.toURI());
+        WatchKey key = path.register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        pathDataByKey.put(key, data);
+        data.keys.add(key);
+    }
+
+    @Override
+    public synchronized void unwatchPath(File file, final FileChangeCallback callback) {
+        PathData data = files.get(file);
+        if (data != null) {
+            data.callbacks.remove(callback);
+            if (data.callbacks.isEmpty()) {
+                files.remove(file);
+                for (WatchKey key : data.keys) {
+                    key.cancel();
+                    pathDataByKey.remove(key);
+                }
+
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stopped = true;
+        watchThread.interrupt();
+        if (watchService != null) {
+            watchService.close();
+        }
+    }
+
+    private static Map<File, Long> doScan(File file) {
+        final Map<File, Long> results = new HashMap<File, Long>();
+
+        final Deque<File> toScan = new ArrayDeque<File>();
+        toScan.add(file);
+        while (!toScan.isEmpty()) {
+            File next = toScan.pop();
+            if (next.isDirectory()) {
+                results.put(next, next.lastModified());
+                File[] list = next.listFiles();
+                if (list != null) {
+                    for (File f : list) {
+                        toScan.push(new File(f.getAbsolutePath()));
+                    }
+                }
+            }
+        }
+        return results;
+    }
+
+    private static void invokeCallback(FileChangeCallback callback, List<FileChangeEvent> results) {
+        try {
+            callback.handleChanges(results);
+        } catch (Exception e) {
+            log.error("Failed to invoke watch callback", e);
+        }
+    }
+
+    private class PathData {
+        final Path path;
+        final List<FileChangeCallback> callbacks = new ArrayList<FileChangeCallback>();
+        final List<WatchKey> keys = new ArrayList<WatchKey>();
+
+        private PathData(Path path) {
+            this.path = path;
+        }
+    }
+
+}


### PR DESCRIPTION
Using the watch service on Linux allows for
tests to run instantly after the file is saved.

Other platforms don't have a useful watch service
implementation, so we still use polling for these
platforms.