### PR TITLE
Ensure that a JAX-RS client exception does not depend on the server parts

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/WebClientApplicationException.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/WebClientApplicationException.java
@@ -1,6 +1,18 @@
 package org.jboss.resteasy.reactive.client.api;
 
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
 /**
@@ -17,19 +29,150 @@ public class WebClientApplicationException extends WebApplicationException {
     }
 
     public WebClientApplicationException(String reason) {
-        super(reason);
-    }
-
-    public WebClientApplicationException(Throwable t) {
-        super(t);
-    }
-
-    public WebClientApplicationException(String reason, Throwable t) {
-        super(reason, t);
+        super(reason, null, DummyResponse.INSTANCE);
     }
 
     @Override
     public final Response getResponse() {
         return null;
+    }
+
+    // used in order to avoid depending on the server parts just for generating the exception
+    private static class DummyResponse extends Response {
+
+        private static final DummyResponse INSTANCE = new DummyResponse();
+
+        private DummyResponse() {
+        }
+
+        @Override
+        public int getStatus() {
+            return 0;
+        }
+
+        @Override
+        public StatusType getStatusInfo() {
+            return null;
+        }
+
+        @Override
+        public Object getEntity() {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(Class<T> entityType) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(GenericType<T> entityType) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(Class<T> entityType, Annotation[] annotations) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(GenericType<T> entityType, Annotation[] annotations) {
+            return null;
+        }
+
+        @Override
+        public boolean hasEntity() {
+            return false;
+        }
+
+        @Override
+        public boolean bufferEntity() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            return null;
+        }
+
+        @Override
+        public Locale getLanguage() {
+            return null;
+        }
+
+        @Override
+        public int getLength() {
+            return 0;
+        }
+
+        @Override
+        public Set<String> getAllowedMethods() {
+            return null;
+        }
+
+        @Override
+        public Map<String, NewCookie> getCookies() {
+            return null;
+        }
+
+        @Override
+        public EntityTag getEntityTag() {
+            return null;
+        }
+
+        @Override
+        public Date getDate() {
+            return null;
+        }
+
+        @Override
+        public Date getLastModified() {
+            return null;
+        }
+
+        @Override
+        public URI getLocation() {
+            return null;
+        }
+
+        @Override
+        public Set<Link> getLinks() {
+            return null;
+        }
+
+        @Override
+        public boolean hasLink(String relation) {
+            return false;
+        }
+
+        @Override
+        public Link getLink(String relation) {
+            return null;
+        }
+
+        @Override
+        public Link.Builder getLinkBuilder(String relation) {
+            return null;
+        }
+
+        @Override
+        public MultivaluedMap<String, Object> getMetadata() {
+            return null;
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getStringHeaders() {
+            return null;
+        }
+
+        @Override
+        public String getHeaderString(String name) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This is done because if this exception is thrown from the client when
the server parts have not been installed, then we end up with

`java.lang.RuntimeException: Resteasy Reactive server side components are not installed`

in the logs