### PR TITLE
CI JDK EA: open java.net to work around InaccessibleObjectException in reporting

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -105,6 +105,8 @@ jobs:
         run: rm -r ~/.m2/repository/io/quarkus
       - name: Report status
         if: "always() && github.repository == 'quarkusio/quarkus' && github.event_name != 'workflow_dispatch'"
+        env:
+          JDK_JAVA_OPTIONS: --add-opens=java.base/java.net=ALL-UNNAMED
         shell: bash
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup


### PR DESCRIPTION
This is a gift that keeps on giving...

Should fix:
```
[jbang] Resolving dependencies...
[jbang]     Resolving org.kohsuke:github-api:1.101...Done
[jbang]     Resolving info.picocli:picocli:4.2.0...Done
[jbang] Dependencies resolved
[jbang] Building jar...
The CI build had status failure.
Report issue found: [CI] - Early Access JDK build - https://github.com/quarkusio/quarkus/issues/15867
The issue is currently CLOSED
java.io.UncheckedIOException: java.io.IOException: Failed to set the custom verb
	at Report.run(NativeBuildReport.java:88)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at Report.main(NativeBuildReport.java:97)
Caused by: java.io.IOException: Failed to set the custom verb
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:759)
	at org.kohsuke.github.Requester.setupConnection(Requester.java:745)
	at org.kohsuke.github.Requester._to(Requester.java:388)
	at org.kohsuke.github.Requester.to(Requester.java:336)
	at org.kohsuke.github.GHIssue.edit(GHIssue.java:239)
	at org.kohsuke.github.GHIssue.reopen(GHIssue.java:263)
	at Report.run(NativeBuildReport.java:81)
	... 8 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field protected java.lang.String java.net.HttpURLConnection.method accessible: module java.base does not "opens java.net" to unnamed module @2a11e646
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:177)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:756)
	... 14 more
```
https://github.com/quarkusio/quarkus/runs/2395888493?check_suite_focus=true