### PR TITLE
Remove duplicate junit-jupiter dependency from core-deployment

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -74,11 +74,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
It's not a test scoped dep anymore.