### PR TITLE
Make sure we can mock Hibernate ORM's `Session` for ORM with Panache

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -754,6 +754,10 @@ public class MockTestCase {
 Note that there is no dependency on Mockito, you can use any mocking library you like, or even manually override the
 objects to provide the behaviour you require.
 
+NOTE: Using `@Inject` will get you a CDI proxy to the mock instance you install, which is not suitable for passing to methods such as `Mockito.verify`
+which want the mock instance itself. So if you need to call methods such as `verify` you need to hang on to the mock instance in your test, or use `@InjectMock`
+as shown below.
+
 ==== Further simplification with `@InjectMock`
 
 Building on the features provided by `QuarkusMock`, Quarkus also allows users to effortlessly take advantage of link:https://site.mockito.org/[Mockito] for mocking the beans supported by `QuarkusMock`.

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -876,12 +876,44 @@ public class PanacheFunctionalityTest {
 <1> Be sure to call your `verify` and `do*` methods on `PanacheMock` rather than `Mockito`, otherwise you won't know
 what mock object to pass.
 
+==== Mocking `EntityManager`, `Session` and entity instance methods
+
+If you need to mock entity instance methods, such as `persist()` you can do it by mocking the Hibernate ORM `Session` object:
+
+[source,java]
+----
+@QuarkusTest
+public class PanacheMockingTest {
+
+    @InjectMock
+    Session session;
+
+    @BeforeEach
+    public void setup() {
+        Query mockQuery = Mockito.mock(Query.class);
+        Mockito.doNothing().when(session).persist(Mockito.any());
+        Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
+        Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
+    }
+
+    @Test
+    public void testPanacheMocking() {
+        Person p = new Person();
+        // mocked via EntityManager mocking
+        p.persist();
+        Assertions.assertNull(p.id);
+
+        Mockito.verify(session, Mockito.times(1)).persist(Mockito.any());
+    }
+}
+----
+
 === Using the repository pattern
 
 If you are using the repository pattern you can use Mockito directly, using the `quarkus-junit5-mockito` module,
 which makes mocking beans much easier:
 
-[source,java]
+[source,xml]
 ----
 <dependency>
     <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -4,8 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
-import javax.inject.Singleton;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -153,7 +153,9 @@ public class HibernateOrmCdiProcessor {
             Class<T> type, List<DotName> allExposedTypes, Supplier<T> supplier, boolean defaultBean) {
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                 .configure(type)
-                .scope(Singleton.class)
+                // NOTE: this is using ApplicationScope and not Singleton, by design, in order to be mockable
+                // See https://github.com/quarkusio/quarkus/issues/16437
+                .scope(ApplicationScoped.class)
                 .unremovable()
                 .supplier(supplier);
 


### PR DESCRIPTION
Fixes #16437

The changing of scope of ORM's `Session` from `Singleton` to `ApplicationScoped` needs to be reviewed by @Sanne or whoever he delegates. Other question for the ORM people: should I document the `EntityManager/Session` mocking in the ORM guide? ATM it's documented in the ORM/Panache guide.

This contains commits by @geoand and @mkouba.