### PR TITLE
Bump github-api (and picoli) in jbang report

### DIFF
--- a/.github/NativeBuildReport.java
+++ b/.github/NativeBuildReport.java
@@ -1,7 +1,7 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.101
-//DEPS info.picocli:picocli:4.2.0
+//DEPS org.kohsuke:github-api:1.128
+//DEPS info.picocli:picocli:4.6.1
 
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;


### PR DESCRIPTION
Supersedes #16684. Tested successfully in my fork (with JDK 16 this time).