### PR TITLE
Skip caching Multi and log WARN message at build time

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
@@ -14,6 +14,7 @@ import io.quarkus.cache.runtime.CacheInvalidateAllInterceptor;
 import io.quarkus.cache.runtime.CacheInvalidateInterceptor;
 import io.quarkus.cache.runtime.CacheKeyParameterPositions;
 import io.quarkus.cache.runtime.CacheResultInterceptor;
+import io.smallrye.mutiny.Multi;
 
 public class CacheDeploymentConstants {
 
@@ -36,6 +37,9 @@ public class CacheDeploymentConstants {
     // MicroProfile REST Client.
     public static final DotName REGISTER_REST_CLIENT = DotName
             .createSimple("org.eclipse.microprofile.rest.client.inject.RegisterRestClient");
+
+    // Mutiny.
+    public static final DotName MULTI = dotName(Multi.class);
 
     // Annotations parameters.
     public static final String CACHE_NAME_PARAM = "cacheName";

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/MultiValueTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/MultiValueTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Tests the {@link CacheResult} annotation on methods returning {@link Multi}.
+ */
+public class MultiValueTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void test() {
+
+        /*
+         * io.smallrye.mutiny.Multi values returned by methods annotated with @CacheResult should never be cached.
+         * Let's check that the cached method from this test is executed on each call.
+         */
+        Multi<String> multi1 = cachedService.cachedMethod();
+        assertEquals(1, cachedService.getInvocations());
+        Multi<String> multi2 = cachedService.cachedMethod();
+        assertEquals(2, cachedService.getInvocations());
+
+        /*
+         * io.smallrye.mutiny.Uni emitted items are cached by a callback when the Unis are resolved.
+         * We need to make sure this isn't the case for Multi values.
+         */
+        multi1.collect().asList().await().indefinitely();
+        cachedService.cachedMethod();
+        assertEquals(3, cachedService.getInvocations());
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        private int invocations;
+
+        @CacheResult(cacheName = "test-cache")
+        public Multi<String> cachedMethod() {
+            invocations++;
+            return Multi.createFrom().items("We", "are", "not", "cached!");
+        }
+
+        public int getInvocations() {
+            return invocations;
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -12,6 +12,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.cache.CacheException;
 import io.quarkus.cache.CacheResult;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 
@@ -25,6 +26,14 @@ public class CacheResultInterceptor extends CacheInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext invocationContext) throws Throwable {
+        /*
+         * io.smallrye.mutiny.Multi values are never cached.
+         * There's already a WARN log entry at build time so we don't need to log anything at run time.
+         */
+        if (Multi.class.isAssignableFrom(invocationContext.getMethod().getReturnType())) {
+            return invocationContext.proceed();
+        }
+
         CacheInterceptionContext<CacheResult> interceptionContext = getInterceptionContext(invocationContext,
                 CacheResult.class, true);
 


### PR DESCRIPTION
As discussed on [Zulip](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Quarkus.20Cache.20on.20method.20which.20returns.20Uni/near/234881282), this PR prints a `WARN` message in the log at build time when `@CacheResult` is used on a method returning `Multi`.

I also updated `CacheResultInterceptor` to stop caching the `Multi`.