### PR TITLE
Manage docker-java version in the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -213,6 +213,7 @@
         <avro.version>1.10.2</avro.version>
         <jacoco.version>0.8.6</jacoco.version>
         <testcontainers.version>1.15.3</testcontainers.version>
+        <docker-java.version>3.2.8</docker-java.version> <!-- must be the version Testcontainers use -->
         <aesh-readline.version>2.1</aesh-readline.version>
     </properties>
 
@@ -2660,6 +2661,51 @@
                         <artifactId>checker-qual</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-core</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-httpclient5</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-jersey</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-netty</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-okhttp</artifactId>
+                <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-zerodep</artifactId>
+                <version>${docker-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.cloud.functions</groupId>


### PR DESCRIPTION
Testcontainers has a dependency on docker-java, and the two versions
must be in sync. If they are not, class loading errors occur.

Quarkus BOM manages Testcontainers, but does not manage docker-java.
(Note that Testcontainers BOM doesn't manage docker-java either.)

Which means that if user has a dependency that transitively brings in
both, such as `strimzi-test-container`, it may happen that incompatible
versions of Testcontainers (as managed by Quarkus BOM) and docker-java
(as managed by `strimzi-test-container`) are present, leading to
hard-to-diagnose problems.

Proper fix, in my opinion, is for Quarkus BOM to manage docker-java.
Unfortunately, docker-java doesn't provide a BOM, so we have to
spell out all its artifacts.