### PR TITLE
Fix path of java.security in Dockerfile

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -36,7 +36,7 @@ RUN microdnf install curl ca-certificates $\{JAVA_PACKAGE} \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/$\{RUN_JAVA_VERSION}/run-java-sh-$\{RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
     && chown 1001 /deployments/run-java.sh \
     && chmod 540 /deployments/run-java.sh \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/conf/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"


### PR DESCRIPTION
Fixes #16471
The path has changed with Java 11.