### PR TITLE
Ensure that a non-indexed entry doesn't break generic type resolution

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -152,6 +153,20 @@ public class JandexUtilTest {
                 A.class);
         checkRepoArg(index, ErasedRepo1.class, Repo.class, A.class);
         checkRepoArg(index, ErasedRepo2.class, Repo.class, A.class);
+    }
+
+    @Test
+    public void testNonProblematicUnindexed() {
+        final Index index = index(Single.class, SingleFromInterfaceAndSuperClass.class);
+        checkRepoArg(index, SingleFromInterfaceAndSuperClass.class, Single.class, String.class);
+    }
+
+    @Test
+    public void testProblematicUnindexed() {
+        final Index index = index(Single.class, AbstractSingleImpl.class, ExtendsAbstractSingleImpl.class);
+        assertThatThrownBy(() -> {
+            JandexUtil.resolveTypeParameters(name(ExtendsAbstractSingleImpl.class), name(Single.class), index);
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     public interface Single<T> {

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -158,7 +158,7 @@ public class KubernetesClientProcessor {
                         if (watcherGenericTypes.size() == 1) {
                             watchedClasses.add(watcherGenericTypes.get(0).name());
                         }
-                    } catch (IllegalStateException ignored) {
+                    } catch (IllegalArgumentException ignored) {
                         // when the class has no subclasses and we were not able to determine the generic types, it's likely that
                         // the watcher will fail due to not being able to deserialize the class
                         if (applicationIndex.getIndex().getAllKnownSubclasses(c.name()).isEmpty()) {


### PR DESCRIPTION
This can happen if say some interface extends a JDK interface and there
is no reason the type resolution should fail because of it