### PR TITLE
Use newer versions of containers

### DIFF
--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -15,6 +15,11 @@ import io.quarkus.deployment.annotations.BuildStep;
 
 public class DB2DevServicesProcessor {
 
+    /**
+     * If you update this remember to update the container-license-acceptance.txt in the tests
+     */
+    public static final String TAG = "11.5.5.1";
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupDB2() {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.DB2, new DevServicesDatasourceProvider() {
@@ -22,7 +27,7 @@ public class DB2DevServicesProcessor {
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
                 Db2Container container = new Db2Container(
-                        DockerImageName.parse(imageName.orElse("ibmcom/db2:" + Db2Container.DEFAULT_TAG))
+                        DockerImageName.parse(imageName.orElse("ibmcom/db2:" + TAG))
                                 .asCompatibleSubstituteFor(DockerImageName.parse("ibmcom/db2")))
                                         .withPassword(password.orElse("quarkus"))
                                         .withUsername(username.orElse("quarkus"))

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/postgresql/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/postgresql/deployment/MariaDBDevServicesProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 
 public class MariaDBDevServicesProcessor {
 
+    public static final String TAG = "10.5.9";
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMariaDB() {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MARIADB, new DevServicesDatasourceProvider() {
@@ -22,7 +24,7 @@ public class MariaDBDevServicesProcessor {
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
                 MariaDBContainer container = new MariaDBContainer(
-                        DockerImageName.parse(imageName.orElse(MariaDBContainer.IMAGE + ":" + MariaDBContainer.DEFAULT_TAG))
+                        DockerImageName.parse(imageName.orElse(MariaDBContainer.IMAGE + ":" + TAG))
                                 .asCompatibleSubstituteFor(DockerImageName.parse(MariaDBContainer.IMAGE)))
                                         .withPassword(password.orElse("quarkus"))
                                         .withUsername(username.orElse("quarkus"))

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -16,6 +16,11 @@ import io.quarkus.deployment.annotations.BuildStep;
 
 public class MSSQLDevServicesProcessor {
 
+    /**
+     * If you update this remember to update the container-license-acceptance.txt in the tests
+     */
+    public static final String TAG = "2019-CU10-ubuntu-20.04";
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMSSQL() {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MSSQL, new DevServicesDatasourceProvider() {
@@ -24,7 +29,7 @@ public class MSSQLDevServicesProcessor {
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
                 JdbcDatabaseContainer container = new MSSQLServerContainer(
                         DockerImageName
-                                .parse(imageName.orElse(MSSQLServerContainer.IMAGE + ":" + MSSQLServerContainer.DEFAULT_TAG))
+                                .parse(imageName.orElse(MSSQLServerContainer.IMAGE + ":" + TAG))
                                 .asCompatibleSubstituteFor(MSSQLServerContainer.IMAGE))
                                         .withPassword(password.orElse("Quarkuspassword1"));
                 additionalProperties.forEach(container::withUrlParam);

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/postgresql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/postgresql/deployment/MySQLDevServicesProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 
 public class MySQLDevServicesProcessor {
 
+    public static final String TAG = "8.0.24";
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMysql() {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MYSQL, new DevServicesDatasourceProvider() {
@@ -22,7 +24,7 @@ public class MySQLDevServicesProcessor {
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
                 MySQLContainer container = new MySQLContainer(
-                        DockerImageName.parse(imageName.orElse(MySQLContainer.IMAGE + ":" + MySQLContainer.DEFAULT_TAG))
+                        DockerImageName.parse(imageName.orElse(MySQLContainer.IMAGE + ":" + TAG))
                                 .asCompatibleSubstituteFor(DockerImageName.parse(MySQLContainer.IMAGE)))
                                         .withPassword(password.orElse("quarkus"))
                                         .withUsername(username.orElse("quarkus"))

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -15,7 +15,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 
 public class PostgresqlDevServicesProcessor {
 
-    public static final String DEFAULT = PostgreSQLContainer.IMAGE + ":" + PostgreSQLContainer.DEFAULT_TAG;
+    public static final String TAG = "13.2";
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupPostgres() {
@@ -24,7 +24,7 @@ public class PostgresqlDevServicesProcessor {
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties) {
                 PostgreSQLContainer container = new PostgreSQLContainer(
-                        DockerImageName.parse(imageName.orElse(DEFAULT))
+                        DockerImageName.parse(imageName.orElse(PostgreSQLContainer.IMAGE + ":" + TAG))
                                 .asCompatibleSubstituteFor(DockerImageName.parse(PostgreSQLContainer.IMAGE)))
                                         .withPassword(password.orElse("quarkus"))
                                         .withUsername(username.orElse("quarkus"))

--- a/extensions/jdbc/jdbc-db2/deployment/src/test/resources/container-license-acceptance.txt
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-ibmcom/db2:11.5.0.0a
+ibmcom/db2:11.5.5.1

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/container-license-acceptance.txt
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04


### PR DESCRIPTION
The default testcontainers versions are quite old,
and newer JDK11 releases no longer have compatible
ciphers, which means connections will fail.