### PR TITLE
Stop TestResourceManager using System props

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -144,7 +144,7 @@ public final class ExtensionLoader {
         final BuildTimeConfigurationReader reader = new BuildTimeConfigurationReader(roots);
 
         // now prepare & load the build configuration
-        final SmallRyeConfigBuilder builder = ConfigUtils.configBuilder(false);
+        final SmallRyeConfigBuilder builder = ConfigUtils.configBuilder(false, launchMode);
 
         final DefaultValuesConfigurationSource ds1 = new DefaultValuesConfigurationSource(
                 reader.getBuildTimePatternMap());

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.configuration.RuntimeOverrideConfigSource;
 
 public class StartupActionImpl implements StartupAction {
 
@@ -139,6 +140,11 @@ public class StartupActionImpl implements StartupAction {
             Thread.currentThread().setContextClassLoader(old);
         }
 
+    }
+
+    @Override
+    public void overrideConfig(Map<String, String> config) {
+        RuntimeOverrideConfigSource.setConfig(runtimeClassLoader, config);
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeOverrideConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeOverrideConfigSource.java
@@ -1,0 +1,65 @@
+package io.quarkus.runtime.configuration;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Config source that is used to handle {@code io.quarkus.bootstrap.app.StartupAction#overrideConfig(java.util.Map)}
+ *
+ */
+public class RuntimeOverrideConfigSource implements ConfigSource {
+
+    public static final String FIELD_NAME = "CONFIG";
+    public static final String GENERATED_CLASS_NAME = RuntimeOverrideConfigSource.class.getName() + "$$GeneratedMapHolder";
+
+    final Map<String, String> values;
+
+    public RuntimeOverrideConfigSource(ClassLoader classLoader) {
+        try {
+            Class<?> cls = classLoader.loadClass(GENERATED_CLASS_NAME);
+            Map<String, String> values = (Map<String, String>) cls.getDeclaredField(FIELD_NAME).get(null);
+            this.values = values == null ? Collections.emptyMap() : values;
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static void setConfig(ClassLoader runtimeClassLoader, Map<String, String> config) {
+        try {
+            Class<?> cls = runtimeClassLoader.loadClass(GENERATED_CLASS_NAME);
+            cls.getDeclaredField(FIELD_NAME).set(null, new HashMap<>(config));
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return new HashMap<>(values);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return values.keySet();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return 399; //one less that system properties
+    }
+
+    @Override
+    public String getValue(String s) {
+        return values.get(s);
+    }
+
+    @Override
+    public String getName() {
+        return "Config Override Config Source";
+    }
+
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -334,8 +335,10 @@ public class ConfiguredBeanTest {
         assertNotNull(defaultValues);
         assertEquals(Integer.MIN_VALUE + 100, defaultValues.getOrdinal());
 
-        // Should be the first
-        ConfigSource applicationProperties = config.getConfigSources().iterator().next();
+        // Should be the second, after RuntimeOverrideConfigSource
+        Iterator<ConfigSource> iterator = config.getConfigSources().iterator();
+        iterator.next();
+        ConfigSource applicationProperties = iterator.next();
         assertNotNull(applicationProperties);
         assertEquals(1000, applicationProperties.getOrdinal());
 

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/beans/PublicKeyProducer.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/beans/PublicKeyProducer.java
@@ -24,7 +24,7 @@ public class PublicKeyProducer {
     }
 
     public void setPublicKey(DSAPublicKey publicKey) {
-        log.infof("setPublicKey, key=%s", publicKey);
+        log.debugf("setPublicKey, key=%s", publicKey);
         this.publicKey = publicKey;
     }
 }

--- a/extensions/container-image/deployment/src/test/java/io/quarkus/container/image/deployment/ContainerImageInfoTest.java
+++ b/extensions/container-image/deployment/src/test/java/io/quarkus/container/image/deployment/ContainerImageInfoTest.java
@@ -19,6 +19,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.DefaultValuesConfigurationSource;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
@@ -105,7 +106,7 @@ public class ContainerImageInfoTest {
     private void whenPublishImageInfo() {
         BuildTimeConfigurationReader reader = new BuildTimeConfigurationReader(
                 Collections.singletonList(ContainerImageConfig.class));
-        SmallRyeConfigBuilder builder = ConfigUtils.configBuilder(false);
+        SmallRyeConfigBuilder builder = ConfigUtils.configBuilder(false, LaunchMode.NORMAL);
 
         DefaultValuesConfigurationSource ds = new DefaultValuesConfigurationSource(
                 reader.getBuildTimePatternMap());

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,8 +1,14 @@
 package io.quarkus.bootstrap.app;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 public interface StartupAction {
+
+    /**
+     * Overrides runtime config.
+     */
+    void overrideConfig(Map<String, String> config);
 
     RunningQuarkusApplication run(String... args) throws Exception;
 

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,7 @@ public class MailerTest {
 
     @BeforeEach
     public void init() {
-        mailServer = "http://" + System.getProperty("fake.mailer") + "/api/emails";
+        mailServer = "http://" + ConfigProvider.getConfig().getValue("fake.mailer", String.class) + "/api/emails";
     }
 
     @AfterEach

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -186,7 +186,8 @@ public class VaultITCase {
     @Test
     public void httpclient() {
 
-        String anotherWrappingToken = System.getProperty("vault-test.another-password-kv-v2-wrapping-token");
+        String anotherWrappingToken = ConfigProviderResolver.instance().getConfig()
+                .getValue("vault-test.another-password-kv-v2-wrapping-token", String.class);
         VaultKvSecretV2 unwrap = vaultInternalSystemBackend.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
         assertEquals(VAULT_AUTH_USERPASS_PASSWORD, unwrap.data.data.get(USERPASS_WRAPPING_TOKEN_PASSWORD_KEY));
         try {
@@ -197,8 +198,10 @@ public class VaultITCase {
             assertEquals(400, e.getStatus());
         }
 
-        String appRoleRoleId = System.getProperty("vault-test.role-id");
-        String appRoleSecretId = System.getProperty("vault-test.secret-id");
+        String appRoleRoleId = ConfigProviderResolver.instance().getConfig()
+                .getValue("vault-test.role-id", String.class);
+        String appRoleSecretId = ConfigProviderResolver.instance().getConfig()
+                .getValue("vault-test.secret-id", String.class);
         VaultAppRoleAuth vaultAppRoleAuth = vaultInternalAppRoleAuthMethod.login(appRoleRoleId, appRoleSecretId);
         String appRoleClientToken = vaultAppRoleAuth.auth.clientToken;
         assertNotNull(appRoleClientToken);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
@@ -29,7 +30,7 @@ final class LauncherUtil {
     }
 
     static Config installAndGetSomeConfig() {
-        final SmallRyeConfig config = ConfigUtils.configBuilder(false).build();
+        final SmallRyeConfig config = ConfigUtils.configBuilder(false, LaunchMode.NORMAL).build();
         QuarkusConfigFactory.setConfig(config);
         final ConfigProviderResolver cpr = ConfigProviderResolver.instance();
         try {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -30,12 +30,14 @@ import org.jboss.jandex.IndexView;
 
 public class TestResourceManager implements Closeable {
 
+    public static final String CLOSEABLE_NAME = TestResourceManager.class.getName() + ".closeable";
+
     private static final int ANNOTATION = 0x00002000;
 
     private final List<TestResourceEntry> sequentialTestResourceEntries;
     private final List<TestResourceEntry> parallelTestResourceEntries;
     private final List<TestResourceEntry> allTestResourceEntries;
-    private Map<String, String> oldSystemProps;
+    private final Map<String, String> configProperties = new ConcurrentHashMap<>();
     private boolean started = false;
     private boolean hasPerTestResources = false;
 
@@ -117,19 +119,10 @@ public class TestResourceManager implements Closeable {
 
             waitForAllFutures(startFutures);
 
-            oldSystemProps = new HashMap<>();
-            for (Map.Entry<String, String> i : ret.entrySet()) {
-                oldSystemProps.put(i.getKey(), System.getProperty(i.getKey()));
-                if (i.getValue() == null) {
-                    System.clearProperty(i.getKey());
-                } else {
-                    System.setProperty(i.getKey(), i.getValue());
-                }
-            }
         } finally {
             executor.shutdown();
         }
-
+        configProperties.putAll(ret);
         return ret;
 
     }
@@ -159,17 +152,6 @@ public class TestResourceManager implements Closeable {
             return;
         }
         started = false;
-        if (oldSystemProps != null) {
-            for (Map.Entry<String, String> e : oldSystemProps.entrySet()) {
-                if (e.getValue() == null) {
-                    System.clearProperty(e.getKey());
-                } else {
-                    System.setProperty(e.getKey(), e.getValue());
-                }
-
-            }
-        }
-        oldSystemProps = null;
         for (TestResourceEntry entry : allTestResourceEntries) {
             try {
                 entry.getTestResource().stop();
@@ -182,6 +164,11 @@ public class TestResourceManager implements Closeable {
             cpr.releaseConfig(cpr.getConfig());
         } catch (Throwable ignored) {
         }
+        configProperties.clear();
+    }
+
+    public Map<String, String> getConfigProperties() {
+        return configProperties;
     }
 
     private Set<TestResourceClassEntry> initParallelTestResources(Set<TestResourceClassEntry> uniqueEntries) {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -106,7 +106,7 @@ public class QuarkusDevModeTest
     private Path projectSourceRoot;
     private Path testLocation;
     private String[] commandLineArgs = new String[0];
-
+    private final Map<String, String> oldSystemProps = new HashMap<>();
     private final Map<String, String> buildSystemProperties = new HashMap<>();
 
     private static final List<CompilationProvider> compilationProviders;
@@ -189,18 +189,31 @@ public class QuarkusDevModeTest
         }
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
-            TestResourceManager manager = new TestResourceManager(extensionContext.getRequiredTestClass());
-            manager.init();
-            manager.start();
-            store.put(TestResourceManager.class.getName(), new ExtensionContext.Store.CloseableResource() {
+            TestResourceManager testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());
+            testResourceManager.init();
+            Map<String, String> properties = testResourceManager.start();
+            TestResourceManager tm = testResourceManager;
 
+            store.put(TestResourceManager.class.getName(), testResourceManager);
+            store.put(TestResourceManager.CLOSEABLE_NAME, new ExtensionContext.Store.CloseableResource() {
                 @Override
                 public void close() throws Throwable {
-                    manager.close();
+                    tm.close();
                 }
             });
         }
-
+        TestResourceManager tm = (TestResourceManager) store.get(TestResourceManager.class.getName());
+        //dev mode tests just use system properties
+        //we set them here and clear them in afterAll
+        //so they don't interfere with other tests
+        for (Map.Entry<String, String> i : tm.getConfigProperties().entrySet()) {
+            oldSystemProps.put(i.getKey(), System.getProperty(i.getKey()));
+            if (i.getValue() == null) {
+                System.clearProperty(i.getKey());
+            } else {
+                System.setProperty(i.getKey(), i.getValue());
+            }
+        }
         Class<?> testClass = extensionContext.getRequiredTestClass();
         try {
             deploymentDir = Files.createTempDirectory("quarkus-dev-mode-test");
@@ -234,6 +247,13 @@ public class QuarkusDevModeTest
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
+        for (Map.Entry<String, String> e : oldSystemProps.entrySet()) {
+            if (e.getValue() == null) {
+                System.clearProperty(e.getKey());
+            } else {
+                System.setProperty(e.getKey(), e.getValue());
+            }
+        }
         rootLogger.setHandlers(originalRootLoggerHandlers);
         inMemoryLogHandler.clearRecords();
         ClearCache.clearAnnotationCache();

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -333,7 +333,8 @@ public class QuarkusProdModeTest
             TestResourceManager manager = new TestResourceManager(extensionContext.getRequiredTestClass());
             manager.init();
             testResourceProperties = manager.start();
-            store.put(TestResourceManager.class.getName(), new ExtensionContext.Store.CloseableResource() {
+            store.put(TestResourceManager.class.getName(), manager);
+            store.put(TestResourceManager.CLOSEABLE_NAME, new ExtensionContext.Store.CloseableResource() {
 
                 @Override
                 public void close() throws Throwable {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -120,7 +120,31 @@ public class QuarkusIntegrationTestExtension
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
             additionalProperties.putAll(devDbProps);
-            additionalProperties.putAll(testResourceManager.start());
+            Map<String, String> resourceManagerProps = testResourceManager.start();
+            Map<String, String> old = new HashMap<>();
+            for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
+                old.put(i.getKey(), System.getProperty(i.getKey()));
+                if (i.getValue() == null) {
+                    System.clearProperty(i.getKey());
+                } else {
+                    System.setProperty(i.getKey(), i.getValue());
+                }
+            }
+            context.getStore(ExtensionContext.Namespace.GLOBAL).put(NativeTestExtension.class.getName() + ".systemProps",
+                    new ExtensionContext.Store.CloseableResource() {
+                        @Override
+                        public void close() throws Throwable {
+                            for (Map.Entry<String, String> i : old.entrySet()) {
+                                old.put(i.getKey(), System.getProperty(i.getKey()));
+                                if (i.getValue() == null) {
+                                    System.clearProperty(i.getKey());
+                                } else {
+                                    System.setProperty(i.getKey(), i.getValue());
+                                }
+                            }
+                        }
+                    });
+            additionalProperties.putAll(resourceManagerProps);
 
             String artifactType = quarkusArtifactProperties.getProperty("type");
             if (artifactType == null) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -335,7 +335,9 @@ public class QuarkusTestExtension
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources());
             testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
-            testResourceManager.getClass().getMethod("start").invoke(testResourceManager);
+            Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
+                    .invoke(testResourceManager);
+            startupAction.overrideConfig(properties);
             hasPerTestResources = (boolean) testResourceManager.getClass().getMethod("hasPerTestResources")
                     .invoke(testResourceManager);
 

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
@@ -29,6 +29,11 @@ public abstract class AbstractKubernetesTestResource<T> implements QuarkusTestRe
         }
 
         configureServer();
+        //these actually need to be system properties
+        //as they are read directly as system props, and not from Quarkus config
+        for (Map.Entry<String, String> entry : systemProps.entrySet()) {
+            System.setProperty(entry.getKey(), entry.getValue());
+        }
 
         return systemProps;
     }


### PR DESCRIPTION
System props are global so can interfere with
the dev mode process when running continuous
testing. This is not done by directly providing
the config to the application.

Note that dev mode tests and native tests still
use system properties, as this is not an issue
for continuous testing.