### PR TITLE
Bootstrap: fix loading an overlapping workspace

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -118,6 +118,26 @@ public class LocalWorkspaceDiscoveryTest {
     }
 
     @Test
+    public void loadOverlappingWorkspaceLayout() throws Exception {
+        final URL moduleUrl = Thread.currentThread().getContextClassLoader()
+                .getResource("overlapping-workspace-layout/root/root/module1");
+        assertNotNull(moduleUrl);
+        final Path moduleDir = Paths.get(moduleUrl.toURI());
+
+        final LocalProject module1 = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setCurrentProject(moduleDir.toString()))
+                        .getCurrentProject();
+        final LocalWorkspace ws = module1.getWorkspace();
+
+        final LocalProject wsModule1 = ws.getProject("org.acme", "module1");
+        assertNotNull(wsModule1);
+        assertEquals(module1.getDir().toAbsolutePath(), wsModule1.getDir().toAbsolutePath());
+        assertTrue(module1 == wsModule1);
+        assertNotNull(ws.getProject("org.acme", "root"));
+        assertEquals(2, ws.getProjects().size());
+    }
+
+    @Test
     public void loadWorkspaceWithDirBreaks() throws Exception {
         final URL projectUrl = Thread.currentThread().getContextClassLoader().getResource("workspace-with-dir-breaks/root");
         assertNotNull(projectUrl);

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/README.txt
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/README.txt
@@ -1,0 +1,3 @@
+Apparently, this kind of layout could be created for some projects by the Pipeline Jenkins plugin:
+1) the Jenkins job clones the repository to /home/jenkins/workspace/<project-name> to find the Jenkinsfile, which contains a definition of the pipeline
+2) the pipeline file checks out the repository to build into a subdirectory /home/jenkins/workspace/<project-name>/<project-name>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/module1/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>root</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module1</artifactId>
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module1</module>
+    </modules>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/root/module1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/root/module1/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>root</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module1</artifactId>
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/root/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/overlapping-workspace-layout/root/root/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module1</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
This is a fix for loading an "overlapping" workspace filesystem layout. Apparently, this kind of layout could be created for some projects by the Pipeline Jenkins plugin:
1) the Jenkins job clones the repository to `/home/jenkins/workspace/<project-name>` to find the Jenkinsfile, which contains a definition of the pipeline;
2) the pipeline file checks out the repository to build into a subdirectory `/home/jenkins/workspace/<project-name>/<project-name>`.

This is currently confusing the workspace loader which picks up modules from both places and may fail to resolve local artifacts.