### PR TITLE
Rest Client Reactive - fixed @RegisterProvider support

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/AnnotationRegisteredProviders.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/AnnotationRegisteredProviders.java
@@ -1,0 +1,19 @@
+package io.quarkus.rest.client.reactive.runtime;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AnnotationRegisteredProviders {
+    private final Map<String, Map<Class<?>, Integer>> providers = new HashMap<>();
+
+    public Map<Class<?>, Integer> getProviders(Class<?> clientClass) {
+        Map<Class<?>, Integer> providersForClass = providers.get(clientClass.getName());
+        return providersForClass == null ? Collections.emptyMap() : providersForClass;
+    }
+
+    // used by generated code
+    public void addProviders(String className, Map<Class<?>, Integer> providersForClass) {
+        this.providers.put(className, providersForClass);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -238,6 +238,12 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
         RestClientListeners.get().forEach(listener -> listener.onNewClient(aClass, this));
 
+        AnnotationRegisteredProviders annotationRegisteredProviders = Arc.container()
+                .instance(AnnotationRegisteredProviders.class).get();
+        for (Map.Entry<Class<?>, Integer> mapper : annotationRegisteredProviders.getProviders(aClass).entrySet()) {
+            register(mapper.getKey(), mapper.getValue());
+        }
+
         Object defaultMapperDisabled = getConfiguration().getProperty(DEFAULT_MAPPER_DISABLED);
         Boolean globallyDisabledMapper = ConfigProvider.getConfig()
                 .getOptionalValue(DEFAULT_MAPPER_DISABLED, Boolean.class).orElse(false);

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/Apple.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/Apple.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.rest.client;
+package io.quarkus.it.rest.client.main;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/AppleClient.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/AppleClient.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.rest.client;
+package io.quarkus.it.rest.client.main;
 
 import java.util.concurrent.CompletionStage;
 
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
 @Path("")
 @RegisterProvider(DefaultCtorTestFilter.class)
 @RegisterProvider(NonDefaultCtorTestFilter.class)
-public interface SimpleClient {
+public interface AppleClient {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/ClientWithExceptionMapper.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/ClientWithExceptionMapper.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.rest.client.main;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.it.rest.client.main.MyResponseExceptionMapper.MyException;
+
+@Path("/unprocessable")
+@RegisterProvider(MyResponseExceptionMapper.class)
+@RegisterRestClient(configKey = "w-exception-mapper")
+public interface ClientWithExceptionMapper {
+    @GET
+    String get() throws MyException;
+}

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/DefaultCtorTestFilter.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/DefaultCtorTestFilter.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.rest.client;
+package io.quarkus.it.rest.client.main;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/MyResponseExceptionMapper.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/MyResponseExceptionMapper.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.rest.client.main;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+public class MyResponseExceptionMapper implements ResponseExceptionMapper<Exception> {
+    @Override
+    public Exception toThrowable(Response response) {
+        if (response.getStatus() == 422) {
+            return new MyException("expected");
+        } else {
+            return new IllegalStateException("");
+        }
+    }
+
+    public static class MyException extends Exception {
+        public MyException(String message) {
+            super(message);
+        }
+    }
+}

--- a/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/NonDefaultCtorTestFilter.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/java/io/quarkus/it/rest/client/main/NonDefaultCtorTestFilter.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.rest.client;
+package io.quarkus.it.rest.client.main;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;

--- a/integration-tests/resteasy-reactive-rest-client/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive-rest-client/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+w-exception-mapper/mp-rest/url=${test.url}

--- a/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/resteasy-reactive-rest-client/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -19,10 +19,12 @@ public class BasicTest {
 
     @TestHTTPResource("/apples")
     String appleUrl;
+    @TestHTTPResource()
+    String baseUrl;
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void shouldWork() {
+    void shouldWork() {
         List<Map> results = RestAssured.with().body(appleUrl).post("/call-client")
                 .then()
                 .statusCode(200)
@@ -32,6 +34,20 @@ public class BasicTest {
             assertThat(m).containsOnlyKeys("cultivar");
         });
         Map<Object, Long> valueByCount = results.stream().collect(Collectors.groupingBy(m -> m.get("cultivar"), counting()));
-        assertThat(valueByCount).containsOnly(entry("cortland", 3L), entry("cortland2", 3L), entry("cortland3", 3L));
+        assertThat(valueByCount).containsOnly(entry("cortland", 3L), entry("lobo", 3L), entry("golden delicious", 3L));
+    }
+
+    @Test
+    void shouldMapException() {
+        RestAssured.with().body(baseUrl).post("/call-client-with-exception-mapper")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void shouldMapExceptionCdi() {
+        RestAssured.with().body(baseUrl).post("/call-cdi-client-with-exception-mapper")
+                .then()
+                .statusCode(200);
     }
 }


### PR DESCRIPTION
related to #16702 

Before the change, providers registered with the `@RegisterProvider` annotation were registered in the generated stub, on the WebTarget. While this is enough for most non-MP-specific cases, it is not for microprofile ones, like ResponseExceptionMapper.

This change introduces a new bean `AnnotationRegisteredProviders` that stores information about the provider classes coming from annotations. This bean is used when a rest client stub is built with `RestClientBuilderImpl`.
The info about the annotations is gathered at build-time. The bean has an abstract superclass to minimize the amount of generated bytecode.