### PR TITLE
Fix code.quarkus.io compatibility

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,6 @@ metadata:
   status: "preview"
   codestart:
     name: "amazon-lambda"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/azure-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,6 @@ metadata:
   status: "preview"
   codestart:
     name: "azure-functions-http"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,6 +12,6 @@ metadata:
   status: "experimental"
   codestart:
     name: "funqy-amazon-lambda"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -13,6 +13,6 @@ metadata:
   status: "experimental"
   codestart:
     name: "funqy-google-cloud-functions-example"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,6 @@ metadata:
   status: "experimental"
   codestart:
     name: "funqy-knative-events"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,6 +12,6 @@ metadata:
   status: "preview"
   codestart:
     name: "google-cloud-functions-http"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,6 @@ metadata:
   status: "preview"
   codestart:
     name: "google-cloud-functions"
-    kind: "singleton-example"
+    kind: "example"
     languages: "java"
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -35,6 +35,7 @@ public class CreateProject {
     public static final String NO_BUILDTOOL_WRAPPER = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-buildtool-wrapper");
     public static final String NO_CODE = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-code");
     public static final String EXAMPLE = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "example");
+    public static final String EXTRA_CODESTARTS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extra-codestarts");
 
     private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("(?:1\\.)?(\\d+)(?:\\..*)?");
 
@@ -86,6 +87,11 @@ public class CreateProject {
 
     public CreateProject sourceType(SourceType sourceType) {
         setValue(SOURCE_TYPE, sourceType);
+        return this;
+    }
+
+    public CreateProject extraCodestarts(Set<String> extraCodestarts) {
+        setValue(EXTRA_CODESTARTS, extraCodestarts);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.commands.handlers;
 
 import static io.quarkus.devtools.commands.CreateProject.EXAMPLE;
+import static io.quarkus.devtools.commands.CreateProject.EXTRA_CODESTARTS;
 import static io.quarkus.devtools.commands.CreateProject.NO_BUILDTOOL_WRAPPER;
 import static io.quarkus.devtools.commands.CreateProject.NO_CODE;
 import static io.quarkus.devtools.commands.CreateProject.NO_DOCKERFILES;
@@ -93,6 +94,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                     .buildTool(invocation.getQuarkusProject().getBuildTool())
                     .example(invocation.getValue(EXAMPLE))
                     .noCode(invocation.getValue(NO_CODE, false))
+                    .addCodestarts(invocation.getValue(EXTRA_CODESTARTS, Collections.emptySet()))
                     .noBuildToolWrapper(invocation.getValue(NO_BUILDTOOL_WRAPPER, false))
                     .noDockerfiles(invocation.getValue(NO_DOCKERFILES, false))
                     .addData(platformData)

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
@@ -59,6 +59,9 @@ public final class ExtensionProcessor {
     }
 
     public static CodestartKind getCodestartKind(Extension extension) {
+        if (getCodestartName(extension) == null) {
+            return null;
+        }
         return getMetadataValue(extension, MD_NESTED_CODESTART_KIND).toEnum(CodestartKind.class,
                 CodestartKind.EXTENSION_CODESTART);
     }


### PR DESCRIPTION
This is needed for code.quarkus.io and have been wrongly removed (by me) in a previous PR.
This also fix a bug in `ExtensionProcessor.getCodestartKind()` 

Following https://github.com/quarkusio/quarkus/pull/16692