### PR TITLE
Add basic jbang devmode test

### DIFF
--- a/integration-tests/jbang/pom.xml
+++ b/integration-tests/jbang/pom.xml
@@ -15,6 +15,11 @@
     <name>Quarkus - Integration Tests - JBang enablement</name>
 
     <dependencies>
+  		<dependency>
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-compress</artifactId>
+           <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>

--- a/integration-tests/jbang/pom.xml
+++ b/integration-tests/jbang/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-jbang</artifactId>
+
+    <name>Quarkus - Integration Tests - JBang enablement</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bom-quarkus-platform-descriptor</artifactId>
+            <version>${project.version}</version>
+            <type>json</type>
+            <classifier>${project.version}</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-exec</artifactId>
+            <version>1.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <escapeString>\</escapeString>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <!-- Since there is no quarkus-maven-plugin build goal in this pom,
+                 this profile will not directly yield a native image like in the other modules.
+                 Instead, there are IT classes in this module that trigger the native image compilation. -->
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <!-- add some custom config, the rest comes from parent -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- add a system property that can be used by JUnit to determine whether a native image can be built -->
+                                <quarkus.test.native>true</quarkus.test.native>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>platform-descriptor-tests</id>
+            <activation>
+                <property>
+                    <name>!no-descriptor-tests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-platform-descriptor-json-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>validate-extensions-json</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <jsonGroupId>io.quarkus</jsonGroupId>
+                                    <jsonArtifactId>quarkus-bom-quarkus-platform-descriptor</jsonArtifactId>
+                                    <jsonVersion>${project.version}</jsonVersion>
+                                    <ignoredGroupIds>
+                                        <ignoredGroupId>software.amazon.awssdk</ignoredGroupId>
+                                    </ignoredGroupIds>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/jbang/src/test/java/io/quarkus/jbang/RunJBangTest.java
+++ b/integration-tests/jbang/src/test/java/io/quarkus/jbang/RunJBangTest.java
@@ -1,0 +1,142 @@
+package io.quarkus.jbang;
+
+import static io.quarkus.bootstrap.util.PropertyUtils.isWindows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.zeroturnaround.exec.ProcessExecutor;
+import org.zeroturnaround.exec.ProcessResult;
+import org.zeroturnaround.exec.StartedProcess;
+import org.zeroturnaround.exec.stream.LogOutputStream;
+
+class RunJBangTest {
+
+    private static final String LATEST_DOWNLOAD_JBANG_ZIP = "https://www.jbang.dev/releases/latest/download/jbang.zip";
+    private static Path DEVMODE_SCRIPT;
+    private static Path JBANG_DIR = null;
+
+    int port;
+
+    /**
+     * Downloads latest jbang in static dir and setup JBANG_DIR to be 100% isolated
+     * from whatever jbang could otherwise be installed on the system.
+     */
+    @BeforeAll
+    static void downloadLatestJBang(@TempDir Path tempdir) throws IOException {
+        InputStream in = new URL(LATEST_DOWNLOAD_JBANG_ZIP).openStream();
+        JBANG_DIR = tempdir.resolve(".jbang");
+        Path zipfile = tempdir.resolve("jbang.zip");
+        Files.copy(in, zipfile, StandardCopyOption.REPLACE_EXISTING);
+        TestHelper.unzip(zipfile, JBANG_DIR, true, null);
+
+        //copy over files to allow edit
+        DEVMODE_SCRIPT = tempdir.resolve("devmode.java");
+        Files.copy(new File("target/test-classes/devmode.java").toPath(), DEVMODE_SCRIPT, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @BeforeEach
+    void init() {
+        port = TestHelper.getRandomNumber(8000, 9999);
+    }
+
+    private ProcessExecutor getJBangExecutor(String... args) {
+        String cmd;
+        if (isWindows()) {
+            cmd = "bin/jbang.cmd";
+        } else {
+            cmd = "bin/jbang";
+        }
+
+        List<String> realargs = new ArrayList<>();
+        realargs.add(JBANG_DIR.resolve(cmd).toString());
+        realargs.addAll(Arrays.asList(args));
+
+        return new ProcessExecutor().command(realargs)
+                .environment("JBANG_DIR", JBANG_DIR.toAbsolutePath().toString())
+                .redirectErrorStream(true).readOutput(true);
+    }
+
+    /**
+     * just a sanity check that jbang is behaving as we expect with respect to config
+     **/
+    @Test
+    void testRunJBangWithProperDir() throws IOException, InterruptedException, TimeoutException {
+
+        String result = getJBangExecutor("version", "--verbose")
+                .exitValue(0)
+                .execute().outputUTF8();
+        assertThat(result).contains(JBANG_DIR.toAbsolutePath().toString());
+    }
+
+    @Test
+    void testRunJBangInDevMode() throws IOException, InterruptedException, TimeoutException, ExecutionException {
+
+        final CountDownLatch listening = new CountDownLatch(1);
+        final CountDownLatch devmode = new CountDownLatch(1);
+        String base = "http://localhost:" + port;
+
+        StartedProcess exec = getJBangExecutor("-Dquarkus.dev", "-Dq.v=999-SNAPSHOT",
+                "-Dquarkus.http.port=" + port,
+                DEVMODE_SCRIPT.toAbsolutePath().toString())
+                        .exitValue(77) // 77 - means we explicitly killed it. Anything else something went wrong
+                        .redirectOutput(new LogOutputStream() {
+                            @Override
+                            protected void processLine(String line) {
+                                System.out.println(line);
+                                if (line.contains("Listening on:")) {
+                                    listening.countDown();
+                                } else if(line.contains("Profile dev activated")) {
+                                    devmode.countDown();
+                                }
+                            }
+                        })
+                        .start();
+
+        try {
+            Future<ProcessResult> future = exec.getFuture();
+
+            //wait for listening to show up
+            listening.await(10, TimeUnit.SECONDS);
+
+            //check quarkus is running and responding
+            String result = TestHelper.performRequest(base + "/hello", 200);
+            assertThat(result).isEqualTo("Hello from Quarkus with jbang.dev");
+
+            //if listening then devmode should also already be there
+            assertThatNoException().as("dev mode not activated while running jbang").isThrownBy(() -> devmode.await(5, TimeUnit.MILLISECONDS));
+
+            
+            String output = future.get(5, TimeUnit.SECONDS).outputUTF8();
+
+        } finally {
+            //kill quarkus process
+            String result = TestHelper.performRequest(base + "/hello/kill", 200);
+            assertThat(result).isEqualTo("KILLED");
+
+            exec.getProcess().destroyForcibly();
+
+
+        }
+    }
+
+}

--- a/integration-tests/jbang/src/test/java/io/quarkus/jbang/TestHelper.java
+++ b/integration-tests/jbang/src/test/java/io/quarkus/jbang/TestHelper.java
@@ -1,0 +1,151 @@
+package io.quarkus.jbang;
+
+import static io.quarkus.bootstrap.util.PropertyUtils.isWindows;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.deployment.util.IoUtil;
+
+public class TestHelper {
+
+    static public int getRandomNumber(int min, int max) {
+        return (int) ((Math.random() * (max - min)) + min);
+    }
+
+    // Taken from jbang - generic method that handles unzipping a jar, strip root folder and deals with
+    // setting proper permissions on the resulting folders.
+    public static void unzip(Path zip, Path outputDir, boolean stripRootFolder, Path selectFolder) throws IOException {
+        try (ZipFile zipFile = new ZipFile(zip.toFile())) {
+            Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry zipEntry = entries.nextElement();
+                Path entry = Paths.get(zipEntry.getName());
+                if (stripRootFolder) {
+                    if (entry.getNameCount() == 1) {
+                        continue;
+                    }
+                    entry = entry.subpath(1, entry.getNameCount());
+                }
+                if (selectFolder != null) {
+                    if (!entry.startsWith(selectFolder) || entry.equals(selectFolder)) {
+                        continue;
+                    }
+                    entry = entry.subpath(selectFolder.getNameCount(), entry.getNameCount());
+                }
+                entry = outputDir.resolve(entry).normalize();
+                if (!entry.startsWith(outputDir)) {
+                    throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+                }
+                if (zipEntry.isDirectory()) {
+                    Files.createDirectories(entry);
+                } else if (zipEntry.isUnixSymlink()) {
+                    Scanner s = new Scanner(zipFile.getInputStream(zipEntry)).useDelimiter("\\A");
+                    String result = s.hasNext() ? s.next() : "";
+                    Files.createSymbolicLink(entry, Paths.get(result));
+                } else {
+                    if (!Files.isDirectory(entry.getParent())) {
+                        Files.createDirectories(entry.getParent());
+                    }
+                    try (InputStream zis = zipFile.getInputStream(zipEntry)) {
+                        Files.copy(zis, entry);
+                    }
+                    int mode = zipEntry.getUnixMode();
+                    if (mode != 0 && !isWindows()) {
+                        Set<PosixFilePermission> permissions = PosixFilePermissionSupport.toPosixFilePermissions(mode);
+                        Files.setPosixFilePermissions(entry, permissions);
+                    }
+                }
+            }
+        }
+    }
+
+    static String performRequest(String path, int expectedCode) {
+        try {
+            URL url = new URL(path);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            // the default Accept header used by HttpURLConnection is not compatible with RESTEasy negotiation as it uses q=.2
+            connection.setRequestProperty("Accept", "text/html, *; q=0.2, */*; q=0.2");
+            if (connection.getResponseCode() != expectedCode) {
+                Assertions.fail("Invalid response code " + connection.getResponseCode());
+            }
+            return new String(IoUtil.readBytes(connection.getInputStream()), StandardCharsets.UTF_8);
+        } catch (FileNotFoundException e) {
+            if (expectedCode == 404) {
+                return "";
+            }
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static class PosixFilePermissionSupport {
+
+        private static final int OWNER_READ_FILEMODE = 0b100_000_000;
+        private static final int OWNER_WRITE_FILEMODE = 0b010_000_000;
+        private static final int OWNER_EXEC_FILEMODE = 0b001_000_000;
+
+        private static final int GROUP_READ_FILEMODE = 0b000_100_000;
+        private static final int GROUP_WRITE_FILEMODE = 0b000_010_000;
+        private static final int GROUP_EXEC_FILEMODE = 0b000_001_000;
+
+        private static final int OTHERS_READ_FILEMODE = 0b000_000_100;
+        private static final int OTHERS_WRITE_FILEMODE = 0b000_000_010;
+        private static final int OTHERS_EXEC_FILEMODE = 0b000_000_001;
+
+        private PosixFilePermissionSupport() {
+        }
+
+        static Set<PosixFilePermission> toPosixFilePermissions(int octalFileMode) {
+            Set<PosixFilePermission> permissions = new LinkedHashSet<>();
+            // Owner
+            if ((octalFileMode & OWNER_READ_FILEMODE) == OWNER_READ_FILEMODE) {
+                permissions.add(PosixFilePermission.OWNER_READ);
+            }
+            if ((octalFileMode & OWNER_WRITE_FILEMODE) == OWNER_WRITE_FILEMODE) {
+                permissions.add(PosixFilePermission.OWNER_WRITE);
+            }
+            if ((octalFileMode & OWNER_EXEC_FILEMODE) == OWNER_EXEC_FILEMODE) {
+                permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            }
+            // Group
+            if ((octalFileMode & GROUP_READ_FILEMODE) == GROUP_READ_FILEMODE) {
+                permissions.add(PosixFilePermission.GROUP_READ);
+            }
+            if ((octalFileMode & GROUP_WRITE_FILEMODE) == GROUP_WRITE_FILEMODE) {
+                permissions.add(PosixFilePermission.GROUP_WRITE);
+            }
+            if ((octalFileMode & GROUP_EXEC_FILEMODE) == GROUP_EXEC_FILEMODE) {
+                permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            }
+            // Others
+            if ((octalFileMode & OTHERS_READ_FILEMODE) == OTHERS_READ_FILEMODE) {
+                permissions.add(PosixFilePermission.OTHERS_READ);
+            }
+            if ((octalFileMode & OTHERS_WRITE_FILEMODE) == OTHERS_WRITE_FILEMODE) {
+                permissions.add(PosixFilePermission.OTHERS_WRITE);
+            }
+            if ((octalFileMode & OTHERS_EXEC_FILEMODE) == OTHERS_EXEC_FILEMODE) {
+                permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            }
+            return permissions;
+        }
+    }
+}

--- a/integration-tests/jbang/src/test/resources/devmode.java
+++ b/integration-tests/jbang/src/test/resources/devmode.java
@@ -1,0 +1,43 @@
+//DEPS io.quarkus:quarkus-bom:${q.v}@pom
+//DEPS io.quarkus:quarkus-resteasy
+//JAVAC_OPTIONS -parameters
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.Quarkus;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import io.quarkus.runtime.ShutdownEvent;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import static io.quarkus.runtime.LaunchMode.current;
+
+@Path("/hello")
+@ApplicationScoped
+public class devmode {
+
+    @GET
+    public String sayHello() {
+        return "Hello from Quarkus with jbang.dev";
+    }
+
+    boolean killed = false;
+
+    @Path("/kill")
+    @GET
+    public String hello() {
+        killed = true;
+        Quarkus.asyncExit(77);
+        return "KILLED";
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        if(killed && current().equals(LaunchMode.DEVELOPMENT)) {
+            //force system exit in case of devmode
+            System.out.println("Forced exit!");
+            System.exit(77);
+        }
+    }
+}

--- a/integration-tests/jbang/src/test/resources/devmode.java
+++ b/integration-tests/jbang/src/test/resources/devmode.java
@@ -2,15 +2,19 @@
 //DEPS io.quarkus:quarkus-resteasy
 //JAVAC_OPTIONS -parameters
 
+import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.Quarkus;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+
+import java.util.function.Consumer;
 
 import static io.quarkus.runtime.LaunchMode.current;
 
@@ -29,15 +33,14 @@ public class devmode {
     @GET
     public String hello() {
         killed = true;
+        ApplicationLifecycleManager.setDefaultExitCodeHandler(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer integer) {
+                System.out.println("Forced exit!");
+                System.exit(integer);
+            }
+        });
         Quarkus.asyncExit(77);
         return "KILLED";
-    }
-
-    void onStop(@Observes ShutdownEvent ev) {
-        if(killed && current().equals(LaunchMode.DEVELOPMENT)) {
-            //force system exit in case of devmode
-            System.out.println("Forced exit!");
-            System.exit(77);
-        }
     }
 }

--- a/integration-tests/jbang/src/test/resources/devmode.java
+++ b/integration-tests/jbang/src/test/resources/devmode.java
@@ -27,12 +27,9 @@ public class devmode {
         return "Hello from Quarkus with jbang.dev";
     }
 
-    boolean killed = false;
-
     @Path("/kill")
     @GET
     public String hello() {
-        killed = true;
         ApplicationLifecycleManager.setDefaultExitCodeHandler(new Consumer<Integer>() {
             @Override
             public void accept(Integer integer) {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -36,6 +36,7 @@
         <module>common-jpa-entities</module>
         <module>infinispan-client</module>
         <module>devtools</module>
+        <module>jbang</module>
         <module>gradle</module>
         <module>main</module>
         <module>kafka</module>
@@ -320,4 +321,3 @@
         </profile>
     </profiles>
 </project>
-


### PR DESCRIPTION
Downloads latest jbang, launch jbang with quarkus app to assert devmode
is enabled and uses zt-exec for ease of use to process output.

Currently it fails as with devmode when you call `Quarkus.asyncExit(77)`
it does not actually exit. That should be fixed before we push this.

One question is how the junit test can best get the actual built version as
right now we use 999-SNAPSHOT version; would need the specific one otherwise
this will fail during release build. 

