### PR TITLE
CI incremental: don't even run most test jobs if not affected by changes

### DIFF
--- a/.github/filter-native-tests-json.sh
+++ b/.github/filter-native-tests-json.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Purpose: Prints a filtered version of native-tests.json, with "test-modules" reduced to the ones passed in as the first argument.
+#          This first argument is expected to the define one module per line.
+#          "include" elements that (after filtering) have no "test-modules" anymore are deleted entirely!
+# Note: This script is only for CI and does therefore not aim to be compatible with BSD/macOS.
+
+set -e -u -o pipefail
+shopt -s failglob
+
+# path of this shell script
+PRG_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+JSON=$(cat ${PRG_PATH}/native-tests.json)
+
+# Step 0: print unfiltered json and exit in case the parameter is empty (assumption: full build)
+if [ -z "$1" ]
+then
+  echo "${JSON}"
+  exit 0
+fi
+
+# Step 1: build an expression for grep that will only extract the given modules from each "test-modules" list,
+#         including a trailing comma (if exists). Note: mvn doesn't mind something like -pl 'foo,'.
+EXPR='('
+while read -r impacted
+do
+  EXPR+="((?<=^)|(?<=,)|(?<=, ))${impacted}(,|$)|"
+done < <(echo -n "$1" | grep -Po '(?<=integration-tests/).+')
+EXPR+=')'
+
+# Step 2: apply the filter expression via grep to each "test-modules" list and replace each original list with the filtered one
+while read -r modules
+do
+  # Note: switch off pipefail briefly to avoid failing when nothing matches
+  set +o pipefail
+  # Note: paste joins all matches to get a single line
+  FILTERED=$(echo -n "${modules}" | grep -Po "${EXPR}" | paste -sd " " -)
+  set -o pipefail
+  JSON=$(echo -n "${JSON}" | sed "s/${modules}/${FILTERED}/")
+done < <(echo -n "${JSON}" | jq -r '.include[] | ."test-modules"')
+
+# Step 3: print result, deleting entire elements from "include" array that now have an empty "test-modules" list
+echo "${JSON}" | jq 'del(.include[] | select(."test-modules" == ""))'

--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -8,107 +8,107 @@
         {
             "category": "Data1",
             "timeout": 65,
-            "test-modules": "jpa-h2 jpa-mariadb jpa-mssql jpa-derby jpa-without-entity hibernate-tenancy"
+            "test-modules": "jpa-h2, jpa-mariadb, jpa-mssql, jpa-derby, jpa-without-entity, hibernate-tenancy"
         },
         {
             "category": "Data2",
             "timeout": 65,
-            "test-modules": "jpa jpa-mysql jpa-db2"
+            "test-modules": "jpa, jpa-mysql, jpa-db2"
         },
         {
             "category": "Data3",
             "timeout": 70,
-            "test-modules": "flyway hibernate-orm-panache hibernate-orm-panache-kotlin hibernate-orm-envers liquibase"
+            "test-modules": "flyway, hibernate-orm-panache, hibernate-orm-panache-kotlin, hibernate-orm-envers, liquibase"
         },
         {
             "category": "Data4",
             "timeout": 55,
-            "test-modules": "mongodb-client mongodb-panache mongodb-rest-data-panache mongodb-panache-kotlin redis-client neo4j hibernate-orm-rest-data-panache"
+            "test-modules": "mongodb-client, mongodb-panache, mongodb-rest-data-panache, mongodb-panache-kotlin, redis-client, neo4j, hibernate-orm-rest-data-panache"
         },
         {
             "category": "Data5",
             "timeout": 65,
-            "test-modules": "jpa-postgresql narayana-stm narayana-jta reactive-pg-client hibernate-reactive-postgresql"
+            "test-modules": "jpa-postgresql, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql"
         },
         {
             "category": "Data6",
             "timeout": 50,
-            "test-modules": "elasticsearch-rest-client elasticsearch-rest-high-level-client hibernate-search-orm-elasticsearch hibernate-reactive-panache"
+            "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, hibernate-search-orm-elasticsearch, hibernate-reactive-panache"
         },
         {
             "category": "Data7",
             "timeout": 65,
-            "test-modules": "reactive-mysql-client reactive-db2-client hibernate-reactive-db2 hibernate-reactive-mysql"
+            "test-modules": "reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql"
         },
         {
             "category": "Amazon",
             "timeout": 45,
-            "test-modules": "amazon-services amazon-lambda amazon-lambda-http"
+            "test-modules": "amazon-services, amazon-lambda, amazon-lambda-http"
         },
         {
             "category": "Messaging1",
             "timeout": 100,
-            "test-modules": "kafka kafka-ssl kafka-sasl kafka-avro kafka-avro-apicurio2 kafka-snappy kafka-streams reactive-messaging-kafka"
+            "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro, kafka-avro-apicurio2, kafka-snappy, kafka-streams, reactive-messaging-kafka"
         },
         {
             "category": "Messaging2",
             "timeout": 70,
-            "test-modules": "artemis-core artemis-jms reactive-messaging-amqp reactive-messaging-http"
+            "test-modules": "artemis-core, artemis-jms, reactive-messaging-amqp, reactive-messaging-http"
         },
         {
             "category": "Security1",
             "timeout": 50,
-            "test-modules": "elytron-security-oauth2 elytron-security elytron-security-jdbc elytron-undertow elytron-security-ldap bouncycastle bouncycastle-jsse bouncycastle-fips"
+            "test-modules": "elytron-security-oauth2, elytron-security, elytron-security-jdbc, elytron-undertow, elytron-security-ldap, bouncycastle, bouncycastle-jsse, bouncycastle-fips"
         },
         {
             "category": "Security2",
             "timeout": 70,
-            "test-modules": "oidc oidc-code-flow oidc-tenancy oidc-client oidc-client-reactive oidc-token-propagation oidc-wiremock oidc-client-wiremock"
+            "test-modules": "oidc, oidc-code-flow, oidc-tenancy, oidc-client, oidc-client-reactive, oidc-token-propagation, oidc-wiremock, oidc-client-wiremock"
         },
         {
             "category": "Security3",
             "timeout": 50,
-            "test-modules": "vault vault-app vault-agroal keycloak-authorization smallrye-jwt-token-propagation"
+            "test-modules": "vault, vault-app, vault-agroal, keycloak-authorization, smallrye-jwt-token-propagation"
         },
         {
             "category": "Cache",
             "timeout": 55,
-            "test-modules": "infinispan-cache-jpa infinispan-client cache"
+            "test-modules": "infinispan-cache-jpa, infinispan-client, cache"
         },
         {
             "category": "HTTP",
             "timeout": 70,
-            "test-modules": "elytron-resteasy resteasy-jackson resteasy-mutiny resteasy-reactive-kotlin vertx vertx-http vertx-web vertx-web-jackson vertx-graphql virtual-http rest-client"
+            "test-modules": "elytron-resteasy, resteasy-jackson, resteasy-mutiny, resteasy-reactive-kotlin, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client"
         },
         {
             "category": "Misc1",
             "timeout": 65,
-            "test-modules": "maven jackson jsonb jsch jgit quartz qute consul-config logging-min-level-unset logging-min-level-set"
+            "test-modules": "maven, jackson, jsonb, jsch, jgit, quartz, qute, consul-config, logging-min-level-unset, logging-min-level-set, simple with space"
         },
         {
             "category": "Misc2",
             "timeout": 65,
-            "test-modules": "tika hibernate-validator test-extension logging-gelf bootstrap-config mailer native-config-profile"
+            "test-modules": "tika, hibernate-validator, test-extension, logging-gelf, bootstrap-config, mailer, native-config-profile"
         },
         {
             "category": "Misc3",
             "timeout": 65,
-            "test-modules": "kubernetes-client openshift-client smallrye-config smallrye-graphql smallrye-metrics "
+            "test-modules": "kubernetes-client, openshift-client, smallrye-config, smallrye-graphql, smallrye-metrics"
         },
         {
             "category": "Misc4",
             "timeout": 65,
-            "test-modules": "picocli-native gradle micrometer-mp-metrics micrometer-prometheus logging-json jaxp opentelemetry"
+            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, opentelemetry"
         },
         {
             "category": "Spring",
             "timeout": 55,
-            "test-modules": "spring-di spring-web spring-data-jpa spring-boot-properties spring-cloud-config-client spring-data-rest"
+            "test-modules": "spring-di, spring-web, spring-data-jpa, spring-boot-properties, spring-cloud-config-client, spring-data-rest"
         },
         {
             "category": "gRPC",
             "timeout": 65,
-            "test-modules": "grpc-health grpc-interceptors grpc-mutual-auth grpc-plain-text-gzip grpc-plain-text-mutiny grpc-proto-v2 grpc-streaming grpc-tls"
+            "test-modules": "grpc-health, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-tls"
         }
     ]
 }

--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -3,112 +3,140 @@
         {
             "category": "Main",
             "timeout": 40,
-            "test-modules": "main"
+            "test-modules": "main",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data1",
             "timeout": 65,
-            "test-modules": "jpa-h2, jpa-mariadb, jpa-mssql, jpa-derby, jpa-without-entity, hibernate-tenancy"
+            "test-modules": "jpa-h2, jpa-mariadb, jpa-mssql, jpa-derby, jpa-without-entity, hibernate-tenancy",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data2",
             "timeout": 65,
-            "test-modules": "jpa, jpa-mysql, jpa-db2"
+            "test-modules": "jpa, jpa-mysql, jpa-db2",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data3",
             "timeout": 70,
-            "test-modules": "flyway, hibernate-orm-panache, hibernate-orm-panache-kotlin, hibernate-orm-envers, liquibase"
+            "test-modules": "flyway, hibernate-orm-panache, hibernate-orm-panache-kotlin, hibernate-orm-envers, liquibase",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data4",
             "timeout": 55,
-            "test-modules": "mongodb-client, mongodb-panache, mongodb-rest-data-panache, mongodb-panache-kotlin, redis-client, neo4j, hibernate-orm-rest-data-panache"
+            "test-modules": "mongodb-client, mongodb-panache, mongodb-rest-data-panache, mongodb-panache-kotlin, redis-client, neo4j, hibernate-orm-rest-data-panache",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data5",
             "timeout": 65,
-            "test-modules": "jpa-postgresql, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql"
+            "test-modules": "jpa-postgresql, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data6",
             "timeout": 50,
-            "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, hibernate-search-orm-elasticsearch, hibernate-reactive-panache"
+            "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, hibernate-search-orm-elasticsearch, hibernate-reactive-panache",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Data7",
             "timeout": 65,
-            "test-modules": "reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql"
+            "test-modules": "reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Amazon",
             "timeout": 45,
-            "test-modules": "amazon-services, amazon-lambda, amazon-lambda-http"
+            "test-modules": "amazon-services, amazon-lambda, amazon-lambda-http",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Messaging1",
             "timeout": 100,
-            "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro, kafka-avro-apicurio2, kafka-snappy, kafka-streams, reactive-messaging-kafka"
+            "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro, kafka-avro-apicurio2, kafka-snappy, kafka-streams, reactive-messaging-kafka",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Messaging2",
             "timeout": 70,
-            "test-modules": "artemis-core, artemis-jms, reactive-messaging-amqp, reactive-messaging-http"
+            "test-modules": "artemis-core, artemis-jms, reactive-messaging-amqp, reactive-messaging-http",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Security1",
             "timeout": 50,
-            "test-modules": "elytron-security-oauth2, elytron-security, elytron-security-jdbc, elytron-undertow, elytron-security-ldap, bouncycastle, bouncycastle-jsse, bouncycastle-fips"
+            "test-modules": "elytron-security-oauth2, elytron-security, elytron-security-jdbc, elytron-undertow, elytron-security-ldap, bouncycastle, bouncycastle-jsse, bouncycastle-fips",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Security2",
             "timeout": 70,
-            "test-modules": "oidc, oidc-code-flow, oidc-tenancy, oidc-client, oidc-client-reactive, oidc-token-propagation, oidc-wiremock, oidc-client-wiremock"
+            "test-modules": "oidc, oidc-code-flow, oidc-tenancy, oidc-client, oidc-client-reactive, oidc-token-propagation, oidc-wiremock, oidc-client-wiremock",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Security3",
             "timeout": 50,
-            "test-modules": "vault, vault-app, vault-agroal, keycloak-authorization, smallrye-jwt-token-propagation"
+            "test-modules": "vault, vault-app, vault-agroal, keycloak-authorization, smallrye-jwt-token-propagation",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Cache",
             "timeout": 55,
-            "test-modules": "infinispan-cache-jpa, infinispan-client, cache"
+            "test-modules": "infinispan-cache-jpa, infinispan-client, cache",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "HTTP",
             "timeout": 70,
-            "test-modules": "elytron-resteasy, resteasy-jackson, resteasy-mutiny, resteasy-reactive-kotlin, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client"
+            "test-modules": "elytron-resteasy, resteasy-jackson, resteasy-mutiny, resteasy-reactive-kotlin, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc1",
             "timeout": 65,
-            "test-modules": "maven, jackson, jsonb, jsch, jgit, quartz, qute, consul-config, logging-min-level-unset, logging-min-level-set, simple with space"
+            "test-modules": "maven, jackson, jsonb, jsch, jgit, quartz, qute, consul-config, logging-min-level-unset, logging-min-level-set, simple with space",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc2",
             "timeout": 65,
-            "test-modules": "tika, hibernate-validator, test-extension, logging-gelf, bootstrap-config, mailer, native-config-profile"
+            "test-modules": "tika, hibernate-validator, test-extension, logging-gelf, bootstrap-config, mailer, native-config-profile",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc3",
             "timeout": 65,
-            "test-modules": "kubernetes-client, openshift-client, smallrye-config, smallrye-graphql, smallrye-metrics"
+            "test-modules": "kubernetes-client, openshift-client, smallrye-config, smallrye-graphql, smallrye-metrics",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc4",
             "timeout": 65,
-            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, opentelemetry"
+            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, opentelemetry",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "Spring",
             "timeout": 55,
-            "test-modules": "spring-di, spring-web, spring-data-jpa, spring-boot-properties, spring-cloud-config-client, spring-data-rest"
+            "test-modules": "spring-di, spring-web, spring-data-jpa, spring-boot-properties, spring-cloud-config-client, spring-data-rest",
+            "os-name": "ubuntu-latest"
         },
         {
             "category": "gRPC",
             "timeout": 65,
-            "test-modules": "grpc-health, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-tls"
+            "test-modules": "grpc-health, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-tls",
+            "os-name": "ubuntu-latest"
+        },
+        {
+            "category": "Windows - hibernate-validator",
+            "timeout": 20,
+            "test-modules": "hibernate-validator",
+            "os-name": "windows-latest"
         }
     ]
 }

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -34,8 +34,7 @@ env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
   COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
-  NATIVE_TEST_MAVEN_OPTS: "-Dquarkus.native.container-build=true -Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
-  WINDOWS_NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
   JVM_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -Dformat.skip -DskipDocs"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
@@ -470,13 +469,11 @@ jobs:
         os:
           - {
             name: "ubuntu-latest",
-            family: "Linux",
-            path: "linux"
+            family: "Linux"
           }
           - {
             name: "windows-latest",
-            family: "Windows",
-            path: "windows"
+            family: "Windows"
           }
     steps:
       - uses: actions/checkout@v2
@@ -685,7 +682,7 @@ jobs:
   native-tests:
     name: Native Tests - ${{matrix.category}}
     needs: calculate-test-jobs
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os-name}}
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
@@ -699,13 +696,28 @@ jobs:
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
     steps:
       - uses: actions/checkout@v2
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: 11
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
+      - name: Install cl.exe
+        if: startsWith(matrix.os-name, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1
+      - uses: microsoft/setup-msbuild@v1
+        if: startsWith(matrix.os-name, 'windows')
+      - name: Setup GraalVM
+        id: setup-graalvm
+        uses: DeLaGuardo/setup-graalvm@master
+        if: startsWith(matrix.os-name, 'windows')
+        with:
+          graalvm-version: '21.0.0.java11'
+      - name: Install native-image component
+        if: startsWith(matrix.os-name, 'windows')
+        run: |
+          gu.cmd install native-image
       # We do this so we can get better analytics for the downloaded version of the build images
       - name: Update Docker Client User Agent
         shell: bash
@@ -720,9 +732,11 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
+        shell: bash
         env:
           TEST_MODULES: ${{matrix.test-modules}}
-        run: ./mvnw $COMMON_MAVEN_ARGS -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_OPTS
+          CONTAINER_BUILD: ${{startsWith(matrix.os-name, 'windows') && 'false' || 'true'}}
+        run: ./mvnw $COMMON_MAVEN_ARGS -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_OPTS -Dquarkus.native.container-build=$CONTAINER_BUILD
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -738,93 +752,5 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: "surefire-reports-Native Tests - ${{matrix.category}}"
-          path: "**/target/*-reports/TEST-*.xml"
-          retention-days: 2
-
-  native-tests-windows:
-    name: Native Tests - Windows - ${{matrix.category}}
-    needs: build-jdk11
-    #needs: needs.calculate-test-jobs.outputs.native_matrix
-    runs-on: windows-latest
-    env:
-      # leave more space for the actual native compilation and execution
-      MAVEN_OPTS: -Xmx1g
-    # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    # Ignore the following YAML Schema error
-    timeout-minutes: ${{matrix.timeout}}
-    strategy:
-      max-parallel: 8
-      fail-fast: false
-      # we only run a native build on Windows for Hibernate Validator just to be sure
-      # that we can build native executables on Windows
-      # matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
-      matrix:
-        include:
-          - category: hibernate-validator
-            timeout: 20
-            test-modules: hibernate-validator
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
-      - name: Set up JDK 11
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: 11
-      - name: Install cl.exe
-        uses: ilammy/msvc-dev-cmd@v1
-      - uses: microsoft/setup-msbuild@v1
-      - name: Setup GraalVM
-        id: setup-graalvm
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: '21.0.0.java11'
-      - name: Install native-image component
-        run: |
-          gu.cmd install native-image
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      # We do this so we can get better analytics for the downloaded version of the build images
-      - name: Update Docker Client User Agent
-        shell: bash
-        run: |
-          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v1
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
-      - name: Build
-        shell: bash
-        env:
-          TEST_MODULES: ${{matrix.test-modules}}
-          CATEGORY: ${{matrix.category}}
-        run: |
-          for i in $TEST_MODULES
-          do modules+="integration-tests/$i,"; done
-          ./mvnw $COMMON_MAVEN_ARGS -pl "${modules}" $WINDOWS_NATIVE_TEST_MAVEN_OPTS ${{ needs.build-jdk11.outputs.gib_args }}
-      - name: Prepare failure archive (if maven failed)
-        if: failure()
-        shell: bash
-        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name '*.log' | tar -czf test-reports.tgz -T -
-      - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: test-reports-native-windows-${{matrix.category}}
-          path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
-        uses: actions/upload-artifact@v2
-        if: ${{ failure() || cancelled() }}
-        with:
-          name: "surefire-reports-Native Tests - Windows - ${{matrix.category}}"
           path: "**/target/*-reports/TEST-*.xml"
           retention-days: 2

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -86,8 +86,16 @@ jobs:
              ) \
            ) \
          )"
+    outputs:
+      gib_args: ${{ steps.get-gib-args.outputs.gib_args }}
+      gib_impacted: ${{ steps.get-gib-impacted.outputs.impacted_modules }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Add quarkusio remote
+        shell: bash
+        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - uses: n1hility/cancel-previous-runs@v2
         # quarkus-bot will handle this much more efficiently, but it's not active in/for forks
         if: github.repository != 'quarkusio/quarkus'
@@ -113,10 +121,8 @@ jobs:
           # refresh cache every month to avoid unlimited growth
           key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build
-        # note: '-Pincremental -Dgib.disable' shall only trigger the download of gitflow-incremental-builder, not activate it
-        #       since -Dincremental deactivates dependencies in bom-descriptor-json (which we do need here), -P is used instead
         run: |
-          ./mvnw -T1C $COMMON_MAVEN_ARGS -DskipTests -DskipITs -Dinvoker.skip -Dno-format -Dtcks -Pincremental -Dgib.disable clean install
+          ./mvnw -T1C $COMMON_MAVEN_ARGS -DskipTests -DskipITs -Dinvoker.skip -Dno-format -Dtcks clean install
       - name: Verify extension dependencies
         shell: bash
         run: |
@@ -129,17 +135,6 @@ jobs:
             git --no-pager diff '*pom.xml' 1>&2
             exit 1
           fi
-      - name: Tar Maven Repo
-        shell: bash
-        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-      - name: Persist Maven Repo
-        uses: actions/upload-artifact@v1
-        with:
-          name: maven-repo
-          path: maven-repo.tgz
-      - name: Delete Local Artifacts From Cache
-        shell: bash
-        run: rm -r ~/.m2/repository/io/quarkus
       - name: Get GIB arguments
         id: get-gib-args
         env:
@@ -152,19 +147,77 @@ jobs:
           GIB_ARGS="-Dincremental -Dgib.disableSelectedProjectsHandling -Dgib.untracked=false -Dgib.uncommitted=false"
           if [ -n "$PULL_REQUEST_BASE" ]
           then
-              # The PR defines a clear merge target so just use that branch for reference, *unless*:
-              # - the current branch is a backport branch
-              GIB_ARGS+=" -Dgib.referenceBranch=origin/$PULL_REQUEST_BASE -Dgib.disableIfBranchMatches='.*backport.*'"
+            # The PR defines a clear merge target so just use that branch for reference, *unless*:
+            # - the current branch is a backport branch
+            GIB_ARGS+=" -Dgib.referenceBranch=origin/$PULL_REQUEST_BASE -Dgib.disableIfBranchMatches='.*backport.*'"
           else
-              # No PR means the merge target is uncertain so fetch & use main of quarkusio/quarkus, *unless*:
-              # - the current branch is main or some released branch like 1.10
-              # - the current branch is a backport branch targeting some released branch like 1.10 (merge target is not main)
-              GIB_ARGS+=" -Dgib.referenceBranch=refs/remotes/quarkusio/main -Dgib.fetchReferenceBranch -Dgib.disableIfBranchMatches='main|\d+\.\d+|.*backport.*'"
+            # No PR means the merge target is uncertain so fetch & use main of quarkusio/quarkus, *unless*:
+            # - the current branch is main or some released branch like 1.10
+            # - the current branch is a backport branch targeting some released branch like 1.10 (merge target is not main)
+            GIB_ARGS+=" -Dgib.referenceBranch=refs/remotes/quarkusio/main -Dgib.fetchReferenceBranch -Dgib.disableIfBranchMatches='main|\d+\.\d+|.*backport.*'"
           fi
           echo "GIB_ARGS: $GIB_ARGS"
           echo "::set-output name=gib_args::${GIB_ARGS}"
+      - name: Get GIB impacted modules
+        id: get-gib-impacted
+        # mvnw just for creating gib-impacted.log ("validate" should not waste much time if not incremental at all, e.g. on main)
+        run: |
+          ./mvnw -q -T1C $COMMON_MAVEN_ARGS -Dtcks -Dquickly-ci ${{ steps.get-gib-args.outputs.gib_args }} -Dgib.logImpactedTo=gib-impacted.log validate
+          [ -f gib-impacted.log ] && GIB_IMPACTED=$(sed "s|$(pwd)/||" gib-impacted.log) || GIB_IMPACTED=''
+          echo "GIB_IMPACTED: ${GIB_IMPACTED}"
+          echo "::set-output name=impacted_modules::${GIB_IMPACTED//$'\n'/'%0A'}"
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/io/quarkus
+
+  calculate-test-jobs:
+    name: Calculate Test Jobs
+    runs-on: ubuntu-latest
+    # Skip main in forks
+    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
+    needs: build-jdk11
+    env:
+      GIB_IMPACTED_MODULES: ${{ needs.build-jdk11.outputs.gib_impacted }}
     outputs:
-      gib_args: ${{ steps.get-gib-args.outputs.gib_args }}
+      native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
+      run_devtools: ${{ steps.calc-run-flags.outputs.run_devtools }}
+      run_gradle: ${{ steps.calc-run-flags.outputs.run_gradle }}
+      run_maven: ${{ steps.calc-run-flags.outputs.run_maven }}
+      run_tcks: ${{ steps.calc-run-flags.outputs.run_tcks }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Calculate matrix from native-tests.json
+        id: calc-native-matrix
+        run: |
+          echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
+          json=$(.github/filter-native-tests-json.sh "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "::set-output name=matrix::${json}"
+      - name: Calculate run flags
+        id: calc-run-flags
+        run: |
+          run_devtools=true; run_gradle=true; run_maven=true; run_tcks=true
+          if [ -n "${GIB_IMPACTED_MODULES}" ]
+          then
+            # Important: keep -pl ... in actual jobs in sync with the following grep commands!
+            if ! echo -n "${GIB_IMPACTED_MODULES}" | grep -q 'integration-tests/devtools'; then run_devtools=false; fi
+            if ! echo -n "${GIB_IMPACTED_MODULES}" | grep -q 'integration-tests/gradle'; then run_gradle=false; fi
+            if ! echo -n "${GIB_IMPACTED_MODULES}" | grep -q 'integration-tests/maven'; then run_maven=false; fi
+            if ! echo -n "${GIB_IMPACTED_MODULES}" | grep -q 'tcks/.*'; then run_tcks=false; fi
+          fi
+          echo "run_devtools=${run_devtools}, run_gradle=${run_gradle}, run_maven=${run_maven}, run_tcks=${run_tcks}"
+          echo "::set-output name=run_devtools::${run_devtools}"
+          echo "::set-output name=run_gradle::${run_gradle}"
+          echo "::set-output name=run_maven::${run_maven}"
+          echo "::set-output name=run_tcks::${run_tcks}"
 
   linux-jvm-tests:
     name: JVM Tests - JDK ${{matrix.java.name}}
@@ -303,11 +356,11 @@ jobs:
   linux-jvm-maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
+    needs: calculate-test-jobs
     env:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    needs: build-jdk11
+    if: "needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -319,11 +372,6 @@ jobs:
           }
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -338,7 +386,8 @@ jobs:
         with:
           java-version: ${{ matrix.java.java-version }}
       - name: Build
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven' ${{ needs.build-jdk11.outputs.gib_args }}
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -360,21 +409,16 @@ jobs:
   windows-jdk11-jvm-maven-tests:
     name: Maven Tests - JDK 11 Windows
     runs-on: windows-latest
+    needs: calculate-test-jobs
     env:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    needs: build-jdk11
+    if: "needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 60
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -390,7 +434,8 @@ jobs:
           java-version: 11
       - name: Build
         shell: bash
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven' ${{ needs.build-jdk11.outputs.gib_args }}
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -412,12 +457,12 @@ jobs:
   gradle-tests-jdk11-jvm:
     name: Gradle Tests - JDK 11 ${{matrix.os.family}}
     runs-on: ${{matrix.os.name}}
+    needs: calculate-test-jobs
     env:
       # leave more space for the actual gradle execution (which is just wrapped by maven)
       MAVEN_OPTS: -Xmx1g
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    needs: build-jdk11
+    if: "needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 80
     strategy:
       fail-fast: false
@@ -435,11 +480,6 @@ jobs:
           }
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -469,7 +509,8 @@ jobs:
           fi
       - name: Build
         shell: bash
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl integration-tests/gradle ${{ needs.build-jdk11.outputs.gib_args }}
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl integration-tests/gradle
       - name: Upload Surefire reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
@@ -481,9 +522,9 @@ jobs:
   linux-jvm-devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
+    needs: calculate-test-jobs
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    needs: build-jdk11
+    if: "needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -495,11 +536,6 @@ jobs:
           }
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -514,7 +550,8 @@ jobs:
         with:
           java-version: ${{ matrix.java.java-version }}
       - name: Build
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools' ${{ needs.build-jdk11.outputs.gib_args }}
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -536,19 +573,14 @@ jobs:
   windows-jdk11-jvm-devtools-tests:
     name: Devtools Tests - JDK 11 Windows
     runs-on: windows-latest
+    needs: calculate-test-jobs
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    needs: build-jdk11
+    if: "needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 60
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -564,7 +596,8 @@ jobs:
           java-version: 11
       - name: Build
         shell: bash
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools' ${{ needs.build-jdk11.outputs.gib_args }}
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -585,9 +618,9 @@ jobs:
 
   tcks-test:
     name: MicroProfile TCKs Tests
-    needs: build-jdk11
+    needs: calculate-test-jobs
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
+    if: "needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     runs-on: ubuntu-latest
     timeout-minutes: 150
 
@@ -614,6 +647,8 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Verify
+        # Important: keep -pl ... in sync with "Calculate run flags"!
+        # Despite the pre-calculated run_tcks flag, GIB has to be re-run here to figure out the exact tcks submodules to build.
         run: ./mvnw $COMMON_MAVEN_ARGS -Dtcks -pl tcks -amd install ${{ needs.build-jdk11.outputs.gib_args }}
       - name: Verify resteasy-reative dependencies
         # note: ideally, this would be run _before_ mvnw but that would required building tcks/resteasy-reactive in two steps
@@ -647,24 +682,9 @@ jobs:
           path: "**/target/*-reports/TEST-*.xml"
           retention-days: 2
 
-  native-tests-read-json-matrix:
-    name: Native Tests - Read JSON matrix
-    runs-on: ubuntu-latest
-    # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
-    outputs:
-      matrix: ${{ steps.read.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v2
-      - id: read
-        run: |
-          json=$(tr -d '\n' < .github/native-tests.json )
-          echo $json
-          echo "::set-output name=matrix::${json}"
-
   native-tests:
     name: Native Tests - ${{matrix.category}}
-    needs: [build-jdk11, native-tests-read-json-matrix]
+    needs: calculate-test-jobs
     runs-on: ubuntu-latest
     env:
       # leave more space for the actual native compilation and execution
@@ -676,14 +696,9 @@ jobs:
     strategy:
       max-parallel: 8
       fail-fast: false
-      matrix: ${{ fromJson(needs.native-tests-read-json-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Add quarkusio remote
-        shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
@@ -707,17 +722,7 @@ jobs:
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}
-          CATEGORY: ${{matrix.category}}
-        run: |
-          for i in $TEST_MODULES
-          do modules+="integration-tests/$i,"; done
-          ./mvnw $COMMON_MAVEN_ARGS -pl "${modules}" $NATIVE_TEST_MAVEN_OPTS ${{ needs.build-jdk11.outputs.gib_args }}
-          # add the 'simple with spaces' project to the run of 'Misc1' by executing it explicitly
-          # done because there is no good way to pass strings with empty values to the previous command
-          # so this hack is as good as any
-          if [ "$CATEGORY" == "Misc1" ]; then
-            ./mvnw $COMMON_MAVEN_ARGS -Dnative -Dquarkus.native.container-build=true -pl 'integration-tests/simple with space/' verify ${{ needs.build-jdk11.outputs.gib_args }}
-          fi
+        run: ./mvnw $COMMON_MAVEN_ARGS -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_OPTS
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -735,9 +740,11 @@ jobs:
           name: "surefire-reports-Native Tests - ${{matrix.category}}"
           path: "**/target/*-reports/TEST-*.xml"
           retention-days: 2
+
   native-tests-windows:
     name: Native Tests - Windows - ${{matrix.category}}
-    needs: [build-jdk11, native-tests-read-json-matrix]
+    needs: build-jdk11
+    #needs: needs.calculate-test-jobs.outputs.native_matrix
     runs-on: windows-latest
     env:
       # leave more space for the actual native compilation and execution
@@ -751,9 +758,8 @@ jobs:
       fail-fast: false
       # we only run a native build on Windows for Hibernate Validator just to be sure
       # that we can build native executables on Windows
-      # matrix: ${{ fromJson(needs.native-tests-read-json-matrix.outputs.matrix) }}
+      # matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
       matrix:
-        category: [hibernate-validator]
         include:
           - category: hibernate-validator
             timeout: 20


### PR DESCRIPTION
Addresses points 4 and 5 of #15686:
> - CI: Don't execute native jobs at all in case the respective modules are not "impacted" (GIB-speak).
  This could work by executing `mvn validate -Dquickly-ci ... -Dgib.logImpactedTo=...` in some (new) upstream job (probably after the initial build job) which is then evaluating the logfile to prune the native jobs json file.
> - CI: in case the previous works, leverage that general approach for other jobs that execute only a fraction of modules (or even only one, e.g. `integration-tests/maven`).
  Instead of introducing matrices for all jobs, a simple `if` at job level might be more appropriate.
  Note: In theory, jobs without any `-pl ...` or with `-pl !...` could benefit from this as well, but the projects list to pass to `mvn` could be _huge_ (> 800 for a full build).

So with this change, many PRs will not even start most of the test jobs anymore (depending on what changed, of course).
This is done by:
- leveraging GIB's [`logImpactedTo`](https://github.com/famod/gitflow-incremental-builder#giblogimpactedto) in a separate, very optimized `mvn` execution in the initial build job
- consuming this logfile in the new intermediate job `calculate-test-jobs` which:
  - feeds it to a new script to aggressively prune/filter the `native-test.json` file for a smallest possible matrix (/cc @zakkak)
  - sets some run_* flags for devtools, gradle, maven and tcks (jobs that explicitely select specific modules)
- evaluating the new matrix and run_* flags accordingly, dropping full clones and GIB re-executions where possible

This is currently in **draft mode** because:
- [x] I need the blessing for the general approach. After that I would do some polishing and final tests.
- [x] I'd need a yay or nay for how I solved that "project with spaces" problem (masking via _, then unmasking before using), /cc @geoand 
- [x] We need to decide whether it's "bearable" to have a bit of module path duplication between `calculate-test-jobs` and the concrete test jobs (e.g. `integration-tests/gradle` is defined in two places).
  This could be solved by passing the module from the calculation job to the actual jobs (instead of run_*-flags?), which would also make it possible to drop the re-execution of GIB for the TCKs job (which selects not just a single module but an entire "sub-tree").
  Or we could simply add a big note to each actual test job to keep the calc job in sync. 🤷 
- [x] If that's fine with you guys, I'd like to try to include the Windows native job in `native-tests.json`, introducing a key like `os` or so to define the operating system.
  ~~This depends on docker working properly on Windows.~~

Btw, as already noted in the begining: I would like to keep the re-execution of GIB for the JVM test jobs because otherwise we would need to pass a potentially huge module list to `mvn`!

PS: I guess a `jq` guru would have done everything in that script with `jq`, but I'm not such a guru. 😉 
PPS: And yes, I though about jbang for a moment, but CI would need to download it for every push, the script isn't that terribly long/complex and BSD compatibility is not really a concern (unlike for the other scripts I added previously).