### PR TITLE
Make test failures more prominent in terminal output in continuous testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -166,12 +166,8 @@ public class TestConsoleHandler implements TestListener {
                             + " were skipped. Tests took " + (results.getTotalTime())
                             + "ms." + "\u001b[0m";
                 } else {
-                    StringBuilder sb = new StringBuilder(
-                            "\u001B[91mTest run failed, " + methodCount.get() + " tests were run, "
-                                    + results.getCurrentFailing().size()
-                                    + " failed, "
-                                    + skipped.get()
-                                    + " were skipped. Tests took " + results.getTotalTime() + "ms");
+                    int failedTestsNum = results.getCurrentFailing().size();
+                    boolean hasFailingTests = failedTestsNum > 0;
                     for (Map.Entry<String, TestClassResult> classEntry : results.getCurrentFailing().entrySet()) {
                         for (TestResult test : classEntry.getValue().getFailing()) {
                             log.error(
@@ -179,7 +175,12 @@ public class TestConsoleHandler implements TestListener {
                                     test.getTestExecutionResult().getThrowable().get());
                         }
                     }
-                    lastStatus = sb.toString() + "\u001b[0m";
+                    String output = String.format("Test run failed, %d tests were run, ", methodCount.get())
+                            + String.format("%s%d failed%s, ",
+                                    hasFailingTests ? "\u001B[1m" : "", failedTestsNum,
+                                    hasFailingTests ? "\u001B[2m" : "")
+                            + String.format("%d were skipped. Tests took %dms", skipped.get(), results.getTotalTime());
+                    lastStatus = "\u001B[91m" + output + "\u001b[0m";
                 }
                 //this will re-print when using the basic console
                 promptHandler.setPrompt(RUNNING_PROMPT);


### PR DESCRIPTION
Test failures now look something like this:

![failing](https://user-images.githubusercontent.com/4374975/116190573-90d54a00-a733-11eb-8d09-957a748b9f90.png)

The output for passing tests does not change:

![passing](https://user-images.githubusercontent.com/4374975/116190600-9d59a280-a733-11eb-9e9f-b70cbd0dceb6.png)
 
