### PR TITLE
Fix PathTestHelper.isTestClass(...) to use the actual test dir instead of pre-defined fragments

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -231,9 +231,8 @@ public final class PathTestHelper {
         if (resource == null) {
             return false;
         }
-        String classFileName = className.replace('.', File.separatorChar) + ".class";
         if (Files.isDirectory(testLocation)) {
-            return resource.getProtocol().startsWith("file") && isInTestDir(resource);
+            return resource.getProtocol().startsWith("file") && toPath(resource).startsWith(testLocation);
         }
         if (!resource.getProtocol().equals("jar")) {
             return false;


### PR DESCRIPTION
The issue is that if the application project path already contains a path fragment, e.g., `test-classes`, the `PathTestHelper.isTestClass(...)` will return true even for a non-test class.