### PR TITLE
Bump dokka-maven-plugin to remove jcenter repository

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -71,14 +71,6 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </pluginRepository>
-        </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -166,7 +158,7 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>1.4.30</version>
+                <version>1.4.32</version>
                 <executions>
                     <execution>
                         <id>javadoc</id>

--- a/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
@@ -81,14 +81,6 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -191,7 +183,7 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>1.4.30</version>
+                <version>1.4.32</version>
                 <executions>
                     <execution>
                         <id>javadoc</id>


### PR DESCRIPTION
The dokka-maven-plugin and all dependencies are now available on maven central. 

This branch update the plugin version and removes the jcenter reference. 