### PR TITLE
Adding support for regular expressions in CORS origins configuration

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -189,7 +189,7 @@ following properties will be applied before passing the request on to its actual
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.http.cors.origins|*|The comma-separated list of origins allowed for CORS. The filter allows any origin if this is not set or set to '*'.
+|quarkus.http.cors.origins|*|The comma-separated list of origins allowed for CORS. Values starting and ending with '/'' will be treated as regular expressions. The filter allows any origin if this is not set or set to '*'.
 |quarkus.http.cors.methods|*|The comma-separated list of HTTP methods allowed for CORS. The filter allows any method if this is
 not set or set to '*'.
 |quarkus.http.cors.headers|*|The comma-separated list of HTTP headers allowed for CORS. The filter allows any header if this is
@@ -205,12 +205,12 @@ when the request’s credentials mode Request.credentials is “include”
 
 include::duration-format-note.adoc[]
 
-Here's what a full CORS filter configuration could look like:
+Here's what a full CORS filter configuration could look like, including a regular expression defining an allowed origin:
 
 [source, properties]
 ----
 quarkus.http.cors=true
-quarkus.http.cors.origins=http://foo.com,http://www.bar.io
+quarkus.http.cors.origins=http://foo.com,http://www.bar.io,/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/
 quarkus.http.cors.methods=GET,PUT,POST
 quarkus.http.cors.headers=X-Custom
 quarkus.http.cors.exposed-headers=Content-Disposition

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -1,10 +1,14 @@
 package io.quarkus.vertx.http.runtime.cors;
 
 import static io.quarkus.vertx.http.runtime.cors.CORSFilter.isConfiguredWithWildcard;
+import static io.quarkus.vertx.http.runtime.cors.CORSFilter.isOriginAllowedByRegex;
+import static io.quarkus.vertx.http.runtime.cors.CORSFilter.parseAllowedOriginsRegex;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -22,4 +26,15 @@ public class CORSFilterTest {
         Assertions.assertFalse(isConfiguredWithWildcard(Optional.of(Collections.singletonList("http://localhost:8080/"))));
     }
 
+    @Test
+    public void isOriginAllowedByRegexTest() {
+        Assertions.assertFalse(isOriginAllowedByRegex(Collections.emptyList(), "http://locahost:8080"));
+        Assertions.assertEquals(
+                parseAllowedOriginsRegex(Optional.of(Collections.singletonList("http://localhost:8080"))).size(),
+                0);
+        List<Pattern> regexList = parseAllowedOriginsRegex(
+                Optional.of(Collections.singletonList("/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/")));
+        Assertions.assertEquals(regexList.size(), 1);
+        Assertions.assertTrue(isOriginAllowedByRegex(regexList, "https://abc-123.app.mydomain.com"));
+    }
 }


### PR DESCRIPTION
## Description

This PR adds the ability to specify allowed CORS origins with regular expressions.

If using a regex, the expression must begin and end with **/**
e.g `/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/`

Fixes #16814.