### PR TITLE
Add Amazon SSM extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1889,6 +1889,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-ssm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-ssm-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-iam</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
@@ -18,6 +18,7 @@ public enum Feature {
     AMAZON_SQS,
     AMAZON_SES,
     AMAZON_KMS,
+    AMAZON_SSM,
     ARTEMIS_CORE,
     ARTEMIS_JMS,
     CACHE,

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -294,6 +294,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-amazon-ssm</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-apache-httpclient</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -255,6 +255,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-ssm-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apache-httpclient-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/amazon-ssm.adoc
+++ b/docs/src/main/asciidoc/amazon-ssm.adoc
@@ -1,0 +1,363 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Quarkus - Amazon SSM Client
+:extension-status: preview
+
+include::./attributes.adoc[]
+
+AWS Systems Manager (formerly Amazon Simple Systems Manager, or SSM) is a service that you can use to view and control your infrastructure on AWS.
+One of the most useful features of SSM for microservices is the https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html[Parameter Store], which provides secure, hierarchical storage for configuration data management and secrets management..
+
+You can find more information about SSM at https://docs.aws.amazon.com/systems-manager/[the AWS Systems Manager website].
+
+NOTE: The SSM extension is based on https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/welcome.html[AWS Java SDK 2.x].
+It's a major rewrite of the 1.x code base that offers two programming models (Blocking & Async).
+
+include::./status-include.adoc[]
+
+The Quarkus extension supports two programming models:
+
+* Blocking access using URL Connection HTTP client (by default) or the Apache HTTP Client
+* https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/basics-async.html[Asynchronous programming] based on JDK's `CompletableFuture` objects and the Netty HTTP client.
+
+In this guide, we see how you can get your REST services to use SSM locally and on AWS.
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* JDK 11+ installed with `JAVA_HOME` configured appropriately
+* an IDE
+* Apache Maven {maven-version}
+* An AWS Account to access the SSM service
+* Docker for your system to run SSM locally for testing purposes
+
+=== Set up SSM locally
+
+The easiest way to start working with SSM is to run a local instance as a container.
+
+[source,bash,subs="verbatim,attributes"]
+----
+docker run --rm --name local-ssm --publish 8014:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:0.11.1
+----
+This starts a SSM instance that is accessible on port `8014`.
+
+Create an AWS profile for your local instance using AWS CLI:
+[source,shell,subs="verbatim,attributes"]
+----
+$ aws configure --profile localstack
+AWS Access Key ID [None]: test-key
+AWS Secret Access Key [None]: test-secret
+Default region name [None]: us-east-1
+Default output format [None]:
+----
+
+== Solution
+The application built here allows to store and retrieve parameters using the SSM parameter store.
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `amazon-ssm-quickstart` {quickstarts-tree-url}/amazon-ssm-quickstart[directory].
+
+== Creating the Maven project
+
+First, we need a new project. Create a new project with the following command:
+
+[source,bash,subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=amazon-ssm-quickstart \
+    -DclassName="org.acme.ssm.QuarkusSsmSyncResource" \
+    -Dpath="/sync" \
+    -Dextensions="resteasy,resteasy-jackson,amazon-ssm,resteasy-mutiny"
+cd amazon-ssm-quickstart
+----
+
+This command generates a Maven structure importing the RESTEasy/JAX-RS, Mutiny and Amazon SSM Client extensions.
+After this, the `amazon-ssm` extension has been added to your `pom.xml` as well as the Mutiny support for RESTEasy.
+
+== Creating JSON REST service
+
+In this example, we will create an application that allows us to store and retrieve parameters to and from SSM parameter store using a RESTful API.
+The example application will demonstrate the two programming models supported by the extension.
+
+Let's start with an abstract `org.acme.ssm.QuarkusSsmResource` class to provide the common functionality we will need for both the synchronous and asynchrounous exposures.
+
+[source,java]
+----
+package org.acme.ssm;
+
+import static java.lang.Boolean.TRUE;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+import java.util.stream.Collector;
+
+import javax.annotation.PostConstruct;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+import software.amazon.awssdk.services.ssm.model.ParameterType;
+import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
+
+public abstract class QuarkusSsmResource {
+
+    @ConfigProperty(name = "parameters.path") <1>
+    String parametersPath;
+
+    @PostConstruct <2>
+    void normalizePath() {
+        if (!parametersPath.startsWith("/")) {
+            parametersPath = "/" + parametersPath;
+        }
+        if (!parametersPath.endsWith("/")) {
+            parametersPath = parametersPath + "/";
+        }
+    }
+
+    protected Collector<Parameter, ?, Map<String, String>> parametersToMap() { <3>
+        return toMap(p -> p.name().substring(parametersPath.length()), Parameter::value);
+    }
+
+    protected GetParametersByPathRequest generateGetParametersByPathRequest() {
+        return GetParametersByPathRequest.builder() <4>
+                .path(parametersPath)
+                .withDecryption(TRUE)
+                .build();
+    }
+
+    protected PutParameterRequest generatePutParameterRequest(String name, String value, boolean secure) {
+        return PutParameterRequest.builder() <5>
+                .name(parametersPath + name)
+                .value(value)
+                .type(secure ? ParameterType.SECURE_STRING : ParameterType.STRING)
+                .overwrite(TRUE)
+                .build();
+    }
+
+    protected GetParameterRequest generateGetParameterRequest(String name) {
+        return GetParameterRequest.builder() <6>
+                .name(parametersPath + name)
+                .withDecryption(TRUE)
+                .build();
+    }
+}
+----
+
+<1> Inject a configured path under which to store parameters
+<2> Ensure the path starts and ends with `/`
+<3> Collect parameters into a map of simple names and values
+<4> Generate a request for all parameters under the configured path
+<5> Generate a request to set a specific parameter
+<6> Generate a request to get a specific parameter value
+
+Now, we can extend the class and create the synchronous implementation in the `org.acme.ssm.QuarkusSsmSyncResource` class.
+
+[source,java]
+----
+package org.acme.ssm;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+@Path("/sync")
+public class QuarkusSsmSyncResource extends QuarkusSsmResource {
+
+    @Inject <1>
+    SsmClient ssm;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, String> getParameters() {
+        return ssm.getParametersByPath(generateGetParametersByPathRequest())
+                .parameters().stream().collect(parametersToMap());
+    }
+
+    @PUT
+    @Path("/{name}")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void setParameter(@PathParam("name") String name,
+            @QueryParam("secure") @DefaultValue("false") boolean secure,
+            String value) {
+
+        ssm.putParameter(generatePutParameterRequest(name, value, secure));
+    }
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getParameter(@PathParam("name") String name) {
+        return ssm.getParameter(generateGetParameterRequest(name))
+                .parameter().value();
+    }
+}
+----
+
+<1> Inject the client provided by the amazon-ssm extension
+
+Using the Amazon SSM SDK, we can easily store and retrieve arbitrary name/value pairs, and we can optionally store the values in a secure manner.
+
+== Configuring SSM clients
+
+Both SSM clients (sync and async) are configurable via the `application.properties` file that can be provided in the `src/main/resources` directory.
+Additionally, you need to add to the classpath a proper implementation of the sync client. By default the extension uses the URL connection HTTP client, so
+you need to add a URL connection client dependency to the `pom.xml` file:
+
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>url-connection-client</artifactId>
+</dependency>
+----
+
+If you want to use Apache HTTP client instead, configure it as follows:
+
+[source,properties]
+----
+quarkus.ssm.sync-client.type=apache
+----
+
+And add the following dependency to the application `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>apache-client</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-apache-httpclient</artifactId>
+</dependency>
+----
+
+If you're going to use a local SSM instance, configure it as follows:
+
+[source,properties]
+----
+quarkus.ssm.endpoint-override=http://localhost:8014 <1>
+
+quarkus.ssm.aws.region=us-east-1 <2>
+quarkus.ssm.aws.credentials.type=static <3>
+quarkus.ssm.aws.credentials.static-provider.access-key-id=test-key
+quarkus.ssm.aws.credentials.static-provider.secret-access-key=test-secret
+----
+
+<1> Override the SSM client to use localstack instead of the actual AWS service
+<2> Localstack defaults to `us-east-1`
+<3> The `static` credentials provider lets you set the `access-key-id` and `secret-access-key` directly
+
+If you want to work with an AWS account, you can simply remove or comment out all Amazon SSM related properties. By default, the SSM client extension will use the `default` credentials provider chain that looks for credentials in this order:
+
+include::./amazon-credentials.adoc[]
+
+And the region from your AWS CLI profile will be used.
+
+== Next steps
+
+=== Packaging
+
+Packaging your application is as simple as `./mvnw clean package`.
+It can then be run with `java -Dparameters.path=/quarkus/is/awesome/ -jar target/quarkus-app/quarkus-run.jar`.
+
+With GraalVM installed, you can also create a native executable binary: `./mvnw clean package -Dnative`.
+Depending on your system, that will take some time.
+
+=== Going asynchronous
+
+Thanks to the AWS SDK v2.x used by the Quarkus extension, you can use the asynchronous programming model out of the box.
+
+Create a `org.acme.ssm.QuarkusSsmAsyncResource` REST resource that will be similar to our `QuarkusSsmSyncResource` but using an asynchronous programming model.
+
+[source,java]
+----
+package org.acme.ssm;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+
+@Path("/async")
+public class QuarkusSsmAsyncResource extends QuarkusSsmResource {
+
+    @Inject
+    SsmAsyncClient ssm;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Map<String, String>> getParameters() {
+        return Uni.createFrom().completionStage(ssm.getParametersByPath(generateGetParametersByPathRequest()))
+                .onItem().transform(r -> r.parameters().stream().collect(parametersToMap()));
+    }
+
+    @PUT
+    @Path("/{name}")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> setParameter(@PathParam("name") String name,
+            @QueryParam("secure") @DefaultValue("false") boolean secure,
+            String value) {
+
+        return Uni.createFrom().completionStage(ssm.putParameter(generatePutParameterRequest(name, value, secure)))
+                .onItem().transform(r -> null);
+    }
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> getParameter(@PathParam("name") String name) {
+        return Uni.createFrom().completionStage(ssm.getParameter(generateGetParameterRequest(name)))
+                .onItem().transform(r -> r.parameter().value());
+    }
+}
+----
+
+Note that the `SsmAsyncClient` behaves just like the `SsmClient`, but returns `CompletionStage` objects which we use to create `Uni` instances, and then transform the emitted item.
+
+To enable the asynchronous client, we also need to add the Netty HTTP client dependency to the `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>netty-nio-client</artifactId>
+</dependency>
+----
+
+== Configuration Reference
+
+include::{generated-dir}/config/quarkus-amazon-ssm.adoc[opts=optional, leveloffset=+1]

--- a/extensions/amazon-services/pom.xml
+++ b/extensions/amazon-services/pom.xml
@@ -23,5 +23,6 @@
         <module>sqs</module>
         <module>ses</module>
         <module>kms</module>
+        <module>ssm</module>
     </modules>
 </project>

--- a/extensions/amazon-services/ssm/deployment/pom.xml
+++ b/extensions/amazon-services/ssm/deployment/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-ssm-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-ssm-deployment</artifactId>
+    <name>Quarkus - Amazon Services - SSM - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-ssm</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-services/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
+++ b/extensions/amazon-services/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
@@ -1,0 +1,152 @@
+package io.quarkus.amazon.ssm.deployment;
+
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.amazon.common.deployment.AbstractAmazonServiceProcessor;
+import io.quarkus.amazon.common.deployment.AmazonClientAsyncTransportBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuilderBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuilderConfiguredBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientInterceptorsPathBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientSyncTransportBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonHttpClients;
+import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
+import io.quarkus.amazon.ssm.runtime.SsmBuildTimeConfig;
+import io.quarkus.amazon.ssm.runtime.SsmClientProducer;
+import io.quarkus.amazon.ssm.runtime.SsmConfig;
+import io.quarkus.amazon.ssm.runtime.SsmRecorder;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+public class SsmProcessor extends AbstractAmazonServiceProcessor {
+
+    SsmBuildTimeConfig buildTimeConfig;
+
+    @Override
+    protected Feature amazonServiceClientName() {
+        return Feature.AMAZON_SSM;
+    }
+
+    @Override
+    protected String configName() {
+        return "ssm";
+    }
+
+    @Override
+    protected DotName syncClientName() {
+        return DotName.createSimple(SsmClient.class.getName());
+    }
+
+    @Override
+    protected DotName asyncClientName() {
+        return DotName.createSimple(SsmAsyncClient.class.getName());
+    }
+
+    @Override
+    protected String builtinInterceptorsPath() {
+        return "software/amazon/awssdk/services/ssm/execution.interceptors";
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem producer() {
+        return AdditionalBeanBuildItem.unremovableOf(SsmClientProducer.class);
+    }
+
+    @BuildStep
+    void setup(BeanRegistrationPhaseBuildItem beanRegistrationPhase,
+            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
+            BuildProducer<FeatureBuildItem> feature,
+            BuildProducer<AmazonClientInterceptorsPathBuildItem> interceptors,
+            BuildProducer<AmazonClientBuildItem> clientProducer) {
+
+        setupExtension(beanRegistrationPhase, extensionSslNativeSupport, feature, interceptors, clientProducer,
+                buildTimeConfig.sdk, buildTimeConfig.syncClient);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonApacheHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupApacheSyncTransport(List<AmazonClientBuildItem> amazonClients, SsmRecorder recorder,
+            AmazonClientApacheTransportRecorder transportRecorder,
+            SsmConfig runtimeConfig, BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createApacheSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient,
+                recorder.getSyncConfig(runtimeConfig),
+                syncTransports);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SsmRecorder recorder,
+            AmazonClientUrlConnectionTransportRecorder transportRecorder,
+            SsmConfig runtimeConfig, BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createUrlConnectionSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient,
+                recorder.getSyncConfig(runtimeConfig),
+                syncTransports);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonNettyHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupNettyAsyncTransport(List<AmazonClientBuildItem> amazonClients, SsmRecorder recorder,
+            AmazonClientNettyTransportRecorder transportRecorder,
+            SsmConfig runtimeConfig, BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports) {
+
+        createNettyAsyncTransportBuilder(amazonClients,
+                transportRecorder,
+                recorder.getAsyncConfig(runtimeConfig),
+                asyncTransports);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void createClientBuilders(List<AmazonClientSyncTransportBuildItem> syncTransports,
+            List<AmazonClientAsyncTransportBuildItem> asyncTransports, SsmRecorder recorder,
+            SsmConfig runtimeConfig, BuildProducer<AmazonClientBuilderBuildItem> builderProducer) {
+
+        createClientBuilders(syncTransports, asyncTransports, builderProducer,
+                (syncTransport) -> recorder.createSyncBuilder(runtimeConfig, syncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(runtimeConfig, asyncTransport));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void configureClient(List<AmazonClientBuilderBuildItem> clients, SsmRecorder recorder,
+            AmazonClientRecorder commonRecorder,
+            SsmConfig runtimeConfig,
+            BuildProducer<AmazonClientBuilderConfiguredBuildItem> producer) {
+
+        initClientBuilders(clients, commonRecorder, recorder.getAwsConfig(runtimeConfig), recorder.getSdkConfig(runtimeConfig),
+                buildTimeConfig.sdk, producer);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void buildClients(List<AmazonClientBuilderConfiguredBuildItem> configuredClients, SsmRecorder recorder,
+            BeanContainerBuildItem beanContainer,
+            ShutdownContextBuildItem shutdown) {
+
+        buildClients(configuredClients,
+                (syncBuilder) -> recorder.buildClient(syncBuilder, beanContainer.getValue(), shutdown),
+                (asyncBuilder) -> recorder.buildAsyncClient(asyncBuilder, beanContainer.getValue(), shutdown));
+    }
+}

--- a/extensions/amazon-services/ssm/deployment/src/test/java/io/quarkus/amazon/ssm/deployment/SsmSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/ssm/deployment/src/test/java/io/quarkus/amazon/ssm/deployment/SsmSyncClientFullConfigTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.amazon.ssm.deployment;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+public class SsmSyncClientFullConfigTest {
+
+    @Inject
+    SsmClient client;
+
+    @Inject
+    SsmAsyncClient async;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("sync-urlconn-full-config.properties", "application.properties"));
+
+    @Test
+    public void test() {
+        // should finish with success
+    }
+}

--- a/extensions/amazon-services/ssm/deployment/src/test/resources/sync-urlconn-full-config.properties
+++ b/extensions/amazon-services/ssm/deployment/src/test/resources/sync-urlconn-full-config.properties
@@ -1,0 +1,10 @@
+quarkus.ssm.endpoint-override=http://localhost:9090
+
+quarkus.ssm.aws.region=us-east-1
+quarkus.ssm.aws.credentials.type=static
+quarkus.ssm.aws.credentials.static-provider.access-key-id=test-key
+quarkus.ssm.aws.credentials.static-provider.secret-access-key=test-secret
+
+quarkus.ssm.sync-client.type = url
+quarkus.ssm.sync-client.connection-timeout = 0.100S
+quarkus.ssm.sync-client.socket-timeout = 0.100S

--- a/extensions/amazon-services/ssm/pom.xml
+++ b/extensions/amazon-services/ssm/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-services-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-ssm-parent</artifactId>
+    <name>Quarkus - Amazon Services - SSM</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/amazon-services/ssm/runtime/pom.xml
+++ b/extensions/amazon-services/ssm/runtime/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-ssm-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-ssm</artifactId>
+    <name>Quarkus - Amazon Services - SSM - Runtime</name>
+    <description>Connect to Amazon SSM</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+            <exclusions>
+                <!-- we exclude them here because we want to make them optional -->
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>url-connection-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmBuildTimeConfig.java
+++ b/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmBuildTimeConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.amazon.ssm.runtime;
+
+import io.quarkus.amazon.common.runtime.SdkBuildTimeConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientBuildTimeConfig;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Amazon SSM build time configuration
+ */
+@ConfigRoot(name = "ssm", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class SsmBuildTimeConfig {
+
+    /**
+     * SDK client configurations for AWS SSM client
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public SdkBuildTimeConfig sdk;
+
+    /**
+     * Sync HTTP transport configuration for Amazon SSM client
+     */
+    @ConfigItem
+    public SyncHttpClientBuildTimeConfig syncClient;
+}

--- a/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmClientProducer.java
+++ b/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmClientProducer.java
@@ -1,0 +1,52 @@
+package io.quarkus.amazon.ssm.runtime;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmAsyncClientBuilder;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+
+@ApplicationScoped
+public class SsmClientProducer {
+
+    private volatile SsmClientBuilder syncConfiguredBuilder;
+    private volatile SsmAsyncClientBuilder asyncConfiguredBuilder;
+
+    private SsmClient client;
+    private SsmAsyncClient asyncClient;
+
+    @Produces
+    @ApplicationScoped
+    public SsmClient client() {
+        client = syncConfiguredBuilder.build();
+        return client;
+    }
+
+    @Produces
+    @ApplicationScoped
+    public SsmAsyncClient asyncClient() {
+        asyncClient = asyncConfiguredBuilder.build();
+        return asyncClient;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (client != null) {
+            client.close();
+        }
+        if (asyncClient != null) {
+            asyncClient.close();
+        }
+    }
+
+    public void setSyncConfiguredBuilder(SsmClientBuilder syncConfiguredBuilder) {
+        this.syncConfiguredBuilder = syncConfiguredBuilder;
+    }
+
+    public void setAsyncConfiguredBuilder(SsmAsyncClientBuilder asyncConfiguredBuilder) {
+        this.asyncConfiguredBuilder = asyncConfiguredBuilder;
+    }
+}

--- a/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmConfig.java
+++ b/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmConfig.java
@@ -1,0 +1,42 @@
+package io.quarkus.amazon.ssm.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "ssm", phase = ConfigPhase.RUN_TIME)
+public class SsmConfig {
+
+    /**
+     * AWS SDK client configurations
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocSection
+    public SdkConfig sdk;
+
+    /**
+     * AWS services configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public AwsConfig aws;
+
+    /**
+     * Sync HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public SyncHttpClientConfig syncClient;
+
+    /**
+     * Netty HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public NettyHttpClientConfig asyncClient;
+}

--- a/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmRecorder.java
+++ b/extensions/amazon-services/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmRecorder.java
@@ -1,0 +1,73 @@
+package io.quarkus.amazon.ssm.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmAsyncClientBuilder;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+
+@Recorder
+public class SsmRecorder {
+
+    public RuntimeValue<SyncHttpClientConfig> getSyncConfig(SsmConfig config) {
+        return new RuntimeValue<>(config.syncClient);
+    }
+
+    public RuntimeValue<NettyHttpClientConfig> getAsyncConfig(SsmConfig config) {
+        return new RuntimeValue<>(config.asyncClient);
+    }
+
+    public RuntimeValue<AwsConfig> getAwsConfig(SsmConfig config) {
+        return new RuntimeValue<>(config.aws);
+    }
+
+    public RuntimeValue<SdkConfig> getSdkConfig(SsmConfig config) {
+        return new RuntimeValue<>(config.sdk);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createSyncBuilder(SsmConfig config, RuntimeValue<SdkHttpClient.Builder> transport) {
+        SsmClientBuilder builder = SsmClient.builder();
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(SsmConfig config,
+            RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+
+        SsmAsyncClientBuilder builder = SsmAsyncClient.builder();
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+
+    public RuntimeValue<SsmClient> buildClient(RuntimeValue<? extends AwsClientBuilder> builder,
+            BeanContainer beanContainer,
+            ShutdownContext shutdown) {
+        SsmClientProducer producer = beanContainer.instance(SsmClientProducer.class);
+        producer.setSyncConfiguredBuilder((SsmClientBuilder) builder.getValue());
+        shutdown.addShutdownTask(producer::destroy);
+        return new RuntimeValue<>(producer.client());
+    }
+
+    public RuntimeValue<SsmAsyncClient> buildAsyncClient(RuntimeValue<? extends AwsClientBuilder> builder,
+            BeanContainer beanContainer,
+            ShutdownContext shutdown) {
+        SsmClientProducer producer = beanContainer.instance(SsmClientProducer.class);
+        producer.setAsyncConfiguredBuilder((SsmAsyncClientBuilder) builder.getValue());
+        shutdown.addShutdownTask(producer::destroy);
+        return new RuntimeValue<>(producer.asyncClient());
+    }
+}

--- a/extensions/amazon-services/ssm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amazon-services/ssm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "Amazon SSM"
+metadata:
+  keywords:
+    - "ssm"
+    - "aws"
+    - "amazon"
+  guide: "https://quarkus.io/guides/amazon-ssm"
+  categories:
+    - "data"
+  status: "preview"

--- a/integration-tests/amazon-services/pom.xml
+++ b/integration-tests/amazon-services/pom.xml
@@ -21,6 +21,7 @@
         <kms.url>http://localhost:8011</kms.url>
         <ses.url>http://localhost:8012</ses.url>
         <iam.url>http://localhost:8013</iam.url>
+        <ssm.url>http://localhost:8014</ssm.url>
     </properties>
 
     <dependencies>
@@ -63,6 +64,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-kms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-ssm</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -108,6 +113,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-kms-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-ssm-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -303,7 +321,7 @@
                                     <alias>aws-local-stack</alias>
                                     <run>
                                         <env>
-                                            <SERVICES>s3,dynamodb,sns,sqs,kms,ses</SERVICES>
+                                            <SERVICES>s3,dynamodb,sns,sqs,kms,ssm,ses</SERVICES>
                                             <START_WEB>0</START_WEB>
                                         </env>
                                         <ports>
@@ -314,6 +332,7 @@
                                             <port>8011:4599</port> <!-- KMS -->
                                             <port>8012:4566</port> <!-- SES -->
                                             <port>8013:4593</port> <!-- IAM -->
+                                            <port>8014:4583</port> <!-- SSM -->
                                         </ports>
                                         <log/>
                                         <wait>

--- a/integration-tests/amazon-services/src/main/java/io/quarkus/it/amazon/ssm/SsmResource.java
+++ b/integration-tests/amazon-services/src/main/java/io/quarkus/it/amazon/ssm/SsmResource.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.amazon.ssm;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.jboss.logging.Logger;
+
+import software.amazon.awssdk.services.ssm.SsmAsyncClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+import software.amazon.awssdk.services.ssm.model.ParameterType;
+
+@Path("/ssm")
+public class SsmResource {
+
+    private static final Logger LOG = Logger.getLogger(SsmResource.class);
+    public final static String TEXT = "Quarkus is awsome";
+    private static final String SYNC_PARAM = "quarkus/sync-" + UUID.randomUUID().toString();
+    private static final String ASYNC_PARAM = "quarkus/async-" + UUID.randomUUID().toString();
+
+    @Inject
+    SsmClient ssmClient;
+
+    @Inject
+    SsmAsyncClient ssmAsyncClient;
+
+    @GET
+    @Path("sync")
+    @Produces(TEXT_PLAIN)
+    public String testSync() {
+        LOG.info("Testing Sync SSM client with parameter: " + SYNC_PARAM);
+        //Put parameter
+        ssmClient.putParameter(r -> r.name(SYNC_PARAM).type(ParameterType.SECURE_STRING).value(TEXT));
+        //Get parameter
+        return ssmClient.getParameter(r -> r.name(SYNC_PARAM).withDecryption(Boolean.TRUE)).parameter().value();
+    }
+
+    @GET
+    @Path("async")
+    @Produces(TEXT_PLAIN)
+    public CompletionStage<String> testAsync() {
+        LOG.info("Testing Async SSM client with parameter: " + ASYNC_PARAM);
+        //Put and get parameter
+        return ssmAsyncClient.putParameter(r -> r.name(ASYNC_PARAM).type(ParameterType.SECURE_STRING).value(TEXT))
+                .thenCompose(result -> ssmAsyncClient.getParameter(r -> r.name(ASYNC_PARAM).withDecryption(Boolean.TRUE)))
+                .thenApply(GetParameterResponse::parameter)
+                .thenApply(Parameter::value);
+    }
+}

--- a/integration-tests/amazon-services/src/main/resources/application.properties
+++ b/integration-tests/amazon-services/src/main/resources/application.properties
@@ -32,6 +32,12 @@ quarkus.kms.aws.credentials.type=static
 quarkus.kms.aws.credentials.static-provider.access-key-id=test-key
 quarkus.kms.aws.credentials.static-provider.secret-access-key=test-secret
 
+quarkus.ssm.endpoint-override=${ssm.url}
+quarkus.ssm.aws.region=us-east-1
+quarkus.ssm.aws.credentials.type=static
+quarkus.ssm.aws.credentials.static-provider.access-key-id=test-key
+quarkus.ssm.aws.credentials.static-provider.secret-access-key=test-secret
+
 quarkus.ses.endpoint-override=${ses.url}
 quarkus.ses.aws.region=us-east-1
 quarkus.ses.aws.credentials.type=static

--- a/integration-tests/amazon-services/src/test/java/io/quarkus/it/amazon/AmazonSsmITCase.java
+++ b/integration-tests/amazon-services/src/test/java/io/quarkus/it/amazon/AmazonSsmITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.amazon;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class AmazonSsmITCase extends AmazonSsmTest {
+
+}

--- a/integration-tests/amazon-services/src/test/java/io/quarkus/it/amazon/AmazonSsmTest.java
+++ b/integration-tests/amazon-services/src/test/java/io/quarkus/it/amazon/AmazonSsmTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.amazon;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class AmazonSsmTest {
+
+    @Test
+    public void testSsmAsync() {
+        RestAssured.when().get("/test/ssm/async").then().body(is("Quarkus is awsome"));
+    }
+
+    @Test
+    public void testSsmSync() {
+        RestAssured.when().get("/test/ssm/sync").then().body(is("Quarkus is awsome"));
+    }
+}


### PR DESCRIPTION
Just like the title says, I created an extension for exposing the Amazon SSM SDK following the existing Amazon KMS extensions as a blueprint. I added a minimal test case and have done some integration in my own products to verify functionality, but there is no new functionality to speak of - it follows the same pattern as all the uniform Amazon clients.

This API is especially useful for those of us looking to store/retrieve dynamic parameters (including encrypted secrets) using the parameter store, and  my testing has focused exclusively on that aspect of the SSM client.