### PR TITLE
OIDC: Fix IllegalStateException when processing opaque tokens

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -19,6 +19,7 @@ public final class OidcConstants {
     public static final String INTROSPECTION_TOKEN_ACTIVE = "active";
     public static final String INTROSPECTION_TOKEN_EXP = "exp";
     public static final String INTROSPECTION_TOKEN_USERNAME = "username";
+    public static final String INTROSPECTION_TOKEN_SUB = "sub";
 
     public static final String PASSWORD_GRANT_USERNAME = "username";
     public static final String PASSWORD_GRANT_PASSWORD = "password";

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -169,16 +169,21 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             builder.addCredential(tokenCred);
                             OidcUtils.setSecurityIdentityUserInfo(builder, userInfo);
                             OidcUtils.setSecurityIdentityConfigMetadata(builder, resolvedContext);
+                            String principalMember = "";
                             if (result.introspectionResult.containsKey(OidcConstants.INTROSPECTION_TOKEN_USERNAME)) {
-                                final String userName = result.introspectionResult
-                                        .getString(OidcConstants.INTROSPECTION_TOKEN_USERNAME);
-                                builder.setPrincipal(new Principal() {
-                                    @Override
-                                    public String getName() {
-                                        return userName;
-                                    }
-                                });
+                                principalMember = OidcConstants.INTROSPECTION_TOKEN_USERNAME;
+                            } else if (result.introspectionResult.containsKey(OidcConstants.INTROSPECTION_TOKEN_SUB)) {
+                                // fallback to "sub", if "username" is not present
+                                principalMember = OidcConstants.INTROSPECTION_TOKEN_SUB;
                             }
+                            final String userName = principalMember.isEmpty() ? ""
+                                    : result.introspectionResult.getString(principalMember);
+                            builder.setPrincipal(new Principal() {
+                                @Override
+                                public String getName() {
+                                    return userName;
+                                }
+                            });
                             if (result.introspectionResult.containsKey(OidcConstants.TOKEN_SCOPE)) {
                                 for (String role : result.introspectionResult.getString(OidcConstants.TOKEN_SCOPE).split(" ")) {
                                     builder.addRole(role.trim());


### PR DESCRIPTION
OIDC: Fix IllegalStateException when processing opaque tokens from OIDC providers which do not fill the "username" field in the response from "introspect" call, falls back to "sub" field instead (fixes #12755)