### PR TITLE
Removed extra char in docs

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -415,7 +415,7 @@ or jars, you can make sure that your jar is treated like a Quarkus application l
 
 This will allow Quarkus to index and enhance your entities as if they were inside the current project.
 
-[[dev-mode]]]
+[[dev-mode]]
 == Hibernate ORM in development mode
 
 Quarkus development mode is really useful for applications that mix front end or services and database access.


### PR DESCRIPTION
This fixes the doc rendering as in https://quarkus.io/guides/hibernate-orm#defining-entities-in-external-projects-or-jars