### PR TITLE
Introduction of the extension (catalog) compatibility info based on capabilities

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/compatibility/ExtensionCatalogCompatibility.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/compatibility/ExtensionCatalogCompatibility.java
@@ -1,0 +1,186 @@
+package io.quarkus.platform.catalog.compatibility;
+
+import io.quarkus.maven.ArtifactKey;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Extension catalog compatibility info.
+ */
+public class ExtensionCatalogCompatibility {
+
+    /**
+     * Collects extension compatibility info for a given catalog. This method simply calls
+     * {@code forExtensions(catalog.getExtensions(), catalog)}.
+     *
+     * @param catalog extension catalog
+     * @return extension compatibility info for all the extensions in the catalog
+     */
+    public static ExtensionCatalogCompatibility forCatalog(ExtensionCatalog catalog) {
+        return forExtensions(catalog.getExtensions(), catalog);
+    }
+
+    /**
+     * Collects extension compatibility info for specific extensions from the extension catalog.
+     *
+     * @param extensions extensions to collect the compatibility info for
+     * @param catalog extension catalog
+     * @return extension compatibility info for the provided extensions
+     */
+    public static ExtensionCatalogCompatibility forExtensions(Iterable<Extension> extensions, ExtensionCatalog catalog) {
+
+        final Map<ArtifactKey, Extension> catalogExtMap = new HashMap<>(catalog.getExtensions().size());
+        for (Extension e : catalog.getExtensions()) {
+            catalogExtMap.put(e.getArtifact().getKey(), e);
+        }
+
+        final Map<ArtifactKey, Map<String, CapabilityInfo>> capInfoMap = new HashMap<>();
+        final List<ExtensionCapabilityInfo> branches = new ArrayList<>();
+        for (Extension e : extensions) {
+            final List<ArtifactKey> depKeys = extensionDependencies(e.getMetadata());
+            Map<String, CapabilityInfo> allCaps = Collections.emptyMap();
+            Map<String, CapabilityInfo> extCaps = providedCapabilities(e, capInfoMap);
+            if (!extCaps.isEmpty()) {
+                allCaps = new HashMap<>(extCaps);
+            }
+            for (ArtifactKey key : depKeys) {
+                final Extension dep = catalogExtMap.get(key);
+                // normally, the catalog should contain all of them
+                if (dep == null) {
+                    continue;
+                }
+                extCaps = providedCapabilities(dep, capInfoMap);
+                if (!extCaps.isEmpty()) {
+                    if (allCaps.isEmpty()) {
+                        allCaps = new HashMap<>(extCaps);
+                    } else {
+                        allCaps.putAll(extCaps);
+                    }
+                }
+            }
+            if (!allCaps.isEmpty()) {
+                branches.add(new ExtensionCapabilityInfo(e, allCaps));
+            }
+        }
+
+        List<ExtensionCompatibility> conflictingExtensions = Collections.emptyList();
+        for (ExtensionCapabilityInfo extCapInfo : branches) {
+            Map<ArtifactKey, Extension> conflicts = null;
+            for (ExtensionCapabilityInfo otherExtCapInfo : branches) {
+                if (otherExtCapInfo == extCapInfo) {
+                    continue;
+                }
+                if (extCapInfo.isInConflictWith(otherExtCapInfo)) {
+                    if (conflicts == null) {
+                        conflicts = new HashMap<>();
+                    }
+                    conflicts.put(otherExtCapInfo.e.getArtifact().getKey(), otherExtCapInfo.e);
+                }
+            }
+            if (conflicts != null) {
+                if (conflictingExtensions.isEmpty()) {
+                    conflictingExtensions = new ArrayList<>();
+                }
+                conflictingExtensions.add(new ExtensionCompatibility(extCapInfo.e, conflicts));
+            }
+        }
+        return new ExtensionCatalogCompatibility(conflictingExtensions);
+    }
+
+    private final List<ExtensionCompatibility> compatibilityInfo;
+
+    private ExtensionCatalogCompatibility(List<ExtensionCompatibility> conflictingExtensions) {
+        this.compatibilityInfo = Objects.requireNonNull(conflictingExtensions);
+    }
+
+    public Collection<ExtensionCompatibility> getExtensionCompatibility() {
+        return compatibilityInfo;
+    }
+
+    public boolean isEmpty() {
+        return compatibilityInfo.isEmpty();
+    }
+
+    private static Map<String, CapabilityInfo> providedCapabilities(Extension e,
+            Map<ArtifactKey, Map<String, CapabilityInfo>> capInfoMap) {
+        Map<String, CapabilityInfo> map = capInfoMap.get(e.getArtifact().getKey());
+        if (map == null) {
+            final List<String> providedNames = providedCapabilities(e);
+            if (providedNames.isEmpty()) {
+                map = Collections.emptyMap();
+            } else {
+                map = new HashMap<>(providedNames.size());
+                for (String name : providedNames) {
+                    map.put(name, new CapabilityInfo(name, e));
+                }
+            }
+            capInfoMap.put(e.getArtifact().getKey(), map);
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> providedCapabilities(Extension e) {
+        Map<?, ?> map = (Map<?, ?>) e.getMetadata().getOrDefault("capabilities", Collections.emptyMap());
+        if (map.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<String> caps = (List<String>) map.get("provides");
+        return caps == null ? Collections.emptyList() : caps;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<ArtifactKey> extensionDependencies(Map<String, Object> metadata) {
+        final List<String> extDeps = (List<String>) metadata.getOrDefault("extension-dependencies", Collections.emptyList());
+        if (extDeps.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return extDeps.stream().map(ArtifactKey::fromString).collect(Collectors.toList());
+    }
+
+    private static class ExtensionCapabilityInfo {
+        final Extension e;
+        final Map<String, CapabilityInfo> caps;
+
+        ExtensionCapabilityInfo(Extension e, Map<String, CapabilityInfo> caps) {
+            this.e = e;
+            this.caps = caps;
+        }
+
+        boolean isInConflictWith(ExtensionCapabilityInfo other) {
+            if (other.caps.isEmpty() || caps.isEmpty()) {
+                return false;
+            }
+            for (CapabilityInfo otherCap : other.caps.values()) {
+                final CapabilityInfo provided = caps.get(otherCap.name);
+                if (provided != null && !provided.providerKey().equals(otherCap.providerKey())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static class CapabilityInfo {
+
+        final String name;
+        final Extension provider;
+
+        CapabilityInfo(String name, Extension provider) {
+            this.name = Objects.requireNonNull(name);
+            this.provider = Objects.requireNonNull(provider);
+        }
+
+        ArtifactKey providerKey() {
+            return provider.getArtifact().getKey();
+        }
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/compatibility/ExtensionCompatibility.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/compatibility/ExtensionCompatibility.java
@@ -1,0 +1,50 @@
+package io.quarkus.platform.catalog.compatibility;
+
+import io.quarkus.maven.ArtifactKey;
+import io.quarkus.registry.catalog.Extension;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Extension compatibility info.
+ */
+public class ExtensionCompatibility {
+
+    private final Extension e;
+    private final Map<ArtifactKey, Extension> conflictingExtensions;
+
+    public ExtensionCompatibility(Extension e, Map<ArtifactKey, Extension> conflictingExtensions) {
+        this.e = Objects.requireNonNull(e);
+        this.conflictingExtensions = Objects.requireNonNull(conflictingExtensions);
+    }
+
+    /**
+     * Extension this compatibility info belongs to.
+     *
+     * @return extension this compatibility info belongs to
+     */
+    public Extension getExtension() {
+        return e;
+    }
+
+    /**
+     * All the extensions that are known to be incompatible with the extension returned by {@link #getExtension()}.
+     *
+     * @return all the extensions known to be incompatible with the extension returned by {@link #getExtension()}
+     */
+    public Collection<Extension> getIncompatibleExtensions() {
+        return conflictingExtensions.values();
+    }
+
+    /**
+     * Checks whether an extension with the given key is incompatible with the one return by {@link #getExtension()}.
+     *
+     * @param extensionKey extension key to check for incompatibility
+     * @return true, if the extension with the given key is incompatible with one return by {@link #getExtension()}, otherwise -
+     *         false
+     */
+    public boolean isIncompatibleWith(ArtifactKey extensionKey) {
+        return conflictingExtensions.containsKey(extensionKey);
+    }
+}

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/compatibility/ExtensionCatalogCompatibilityTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/compatibility/ExtensionCatalogCompatibilityTest.java
@@ -1,0 +1,171 @@
+package io.quarkus.platform.catalog.compatibility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.json.JsonExtension;
+import io.quarkus.registry.catalog.json.JsonExtensionCatalog;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionCatalogCompatibilityTest {
+
+    @Test
+    public void testEmpty() throws Exception {
+
+        final JsonExtensionCatalog catalog = new JsonExtensionCatalog();
+
+        catalog.addExtension(new ExtensionBuilder(ArtifactCoords.fromString("org.acme:a-classic:1.0"))
+                .addCapability("classic")
+                .build());
+
+        catalog.addExtension(new ExtensionBuilder(ArtifactCoords.fromString("org.acme:a-reactive:1.0"))
+                .addCapability("reactive")
+                .build());
+
+        final ExtensionCatalogCompatibility catalogCompat = ExtensionCatalogCompatibility.forCatalog(catalog);
+        assertTrue(catalogCompat.isEmpty());
+    }
+
+    @Test
+    public void testDirectCapabilityConflict() throws Exception {
+
+        final JsonExtensionCatalog catalog = new JsonExtensionCatalog();
+
+        final ArtifactCoords aClassic = ArtifactCoords.fromString("org.acme:a-classic:1.0");
+        catalog.addExtension(extensionBuilder(aClassic)
+                .addCapability("a")
+                .build());
+
+        final ArtifactCoords aReactive = ArtifactCoords.fromString("org.acme:a-reactive:1.0");
+        catalog.addExtension(extensionBuilder(aReactive)
+                .addCapability("a")
+                .build());
+
+        catalog.addExtension(new ExtensionBuilder(ArtifactCoords.fromString("org.acme:b-classic:1.0"))
+                .addCapability("classic")
+                .build());
+
+        catalog.addExtension(new ExtensionBuilder(ArtifactCoords.fromString("org.acme:b-reactive:1.0"))
+                .addCapability("reactive")
+                .build());
+
+        final Map<ArtifactCoords, ExtensionCompatibility> compatMap = compatMap(catalog);
+        assertFalse(compatMap.isEmpty());
+        assertIncompatibleWith(compatMap.get(aClassic), aReactive);
+        assertIncompatibleWith(compatMap.get(aReactive), aClassic);
+        assertEquals(2, compatMap.size());
+    }
+
+    @Test
+    public void testTransitiveCapabilityConflict() throws Exception {
+
+        final JsonExtensionCatalog catalog = new JsonExtensionCatalog();
+
+        final ArtifactCoords aClassic = ArtifactCoords.fromString("org.acme:a-classic:1.0");
+        catalog.addExtension(extensionBuilder(aClassic)
+                .addCapability("a")
+                .build());
+
+        final ArtifactCoords aReactive = ArtifactCoords.fromString("org.acme:a-reactive:1.0");
+        catalog.addExtension(extensionBuilder(aReactive)
+                .addCapability("a")
+                .build());
+
+        final ArtifactCoords bClassic = ArtifactCoords.fromString("org.acme:b-classic:1.0");
+        catalog.addExtension(new ExtensionBuilder(bClassic)
+                .addDependency(aClassic)
+                .build());
+
+        final ArtifactCoords bReactive = ArtifactCoords.fromString("org.acme:b-reactive:1.0");
+        catalog.addExtension(new ExtensionBuilder(bReactive)
+                .addDependency(aReactive)
+                .build());
+
+        final ArtifactCoords cClassic = ArtifactCoords.fromString("org.acme:c-classic:1.0");
+        catalog.addExtension(new ExtensionBuilder(cClassic)
+                .addDependency(bClassic)
+                .addDependency(aClassic)
+                .build());
+
+        final ArtifactCoords cReactive = ArtifactCoords.fromString("org.acme:c-reactive:1.0");
+        catalog.addExtension(new ExtensionBuilder(cReactive)
+                .addDependency(bReactive)
+                .addDependency(aReactive)
+                .build());
+
+        final Map<ArtifactCoords, ExtensionCompatibility> compatMap = compatMap(catalog);
+        assertFalse(compatMap.isEmpty());
+        assertIncompatibleWith(compatMap.get(aClassic), aReactive, bReactive, cReactive);
+        assertIncompatibleWith(compatMap.get(aReactive), aClassic, bClassic, cClassic);
+        assertIncompatibleWith(compatMap.get(bClassic), aReactive, bReactive, cReactive);
+        assertIncompatibleWith(compatMap.get(bReactive), aClassic, bClassic, cClassic);
+        assertIncompatibleWith(compatMap.get(cClassic), aReactive, bReactive, cReactive);
+        assertIncompatibleWith(compatMap.get(cReactive), aClassic, bClassic, cClassic);
+        assertEquals(6, compatMap.size());
+    }
+
+    private static void assertIncompatibleWith(ExtensionCompatibility ec, ArtifactCoords... keys) {
+        assertNotNull(ec);
+        assertEquals(new HashSet<>(Arrays.asList(keys)), coordsSet(ec.getIncompatibleExtensions()));
+    }
+
+    private static Set<ArtifactCoords> coordsSet(Collection<Extension> extensions) {
+        return extensions.stream().map(e -> e.getArtifact()).collect(Collectors.toSet());
+    }
+
+    private static Map<ArtifactCoords, ExtensionCompatibility> compatMap(ExtensionCatalog catalog) {
+        return toMap(ExtensionCatalogCompatibility.forCatalog(catalog).getExtensionCompatibility());
+    }
+
+    private static Map<ArtifactCoords, ExtensionCompatibility> toMap(Collection<ExtensionCompatibility> c) {
+        final Map<ArtifactCoords, ExtensionCompatibility> m = new HashMap<>(c.size());
+        c.forEach(e -> m.put(e.getExtension().getArtifact(), e));
+        return m;
+    }
+
+    private static ExtensionBuilder extensionBuilder(ArtifactCoords coords) {
+        return new ExtensionBuilder(coords);
+    }
+
+    private static class ExtensionBuilder {
+
+        private final JsonExtension e = new JsonExtension();
+
+        ExtensionBuilder(ArtifactCoords coords) {
+            e.setArtifact(coords);
+        }
+
+        @SuppressWarnings("unchecked")
+        ExtensionBuilder addCapability(String cap) {
+            ((Map<String, List<String>>) e.getMetadata().computeIfAbsent("capabilities",
+                    s -> Collections.singletonMap("provides", new ArrayList<>()))).get("provides").add(cap);
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        ExtensionBuilder addDependency(ArtifactCoords coords) {
+            ((List<String>) e.getMetadata().computeIfAbsent("extension-dependencies",
+                    s -> new ArrayList<>())).add(coords.getKey().toString());
+            return this;
+        }
+
+        Extension build() {
+            return e;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces means to collect extension compatibility info and check whether any combination of extensions is compatible based on provided capabilities.

It also adds `extension-dependencies` element to the extension metadata which contains a list of extensions that are dependencies of the current extension.