### PR TITLE
Fix the shutdown hook of the main executor for blocking tasks

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -91,7 +91,11 @@ public class ExecutorRecorder {
                 long interruptRemaining = threadPoolConfig.shutdownInterrupt.toNanos();
 
                 long start = System.nanoTime();
-                for (;;)
+                int loop = 1;
+                for (;;) {
+                    // This log can be very useful when debugging problems
+                    log.debugf("loop: %s, remaining: %s, intervalRemaining: %s, interruptRemaining: %s", loop++, remaining,
+                            intervalRemaining, interruptRemaining);
                     try {
                         if (!executor.awaitTermination(Math.min(remaining, intervalRemaining), TimeUnit.NANOSECONDS)) {
                             long elapsed = System.nanoTime() - start;
@@ -145,10 +149,12 @@ public class ExecutorRecorder {
                                     break;
                                 }
                             }
+                        } else {
+                            return;
                         }
-                        return;
                     } catch (InterruptedException ignored) {
                     }
+                }
             }
         };
     }


### PR DESCRIPTION
- resolves #16875

Previously, the `executor.awaitTermination()` was always invoked only once because the method returned no matter whether `executor.awaitTermination()` returned `true` or `false`.