### PR TITLE
Dispatches coroutines in the correct thread on suspending endpoints

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -1,11 +1,14 @@
 package io.quarkus.resteasy.reactive.server.deployment;
 
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -19,18 +22,15 @@ import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
 import org.jboss.resteasy.reactive.server.runtime.kotlin.ApplicationCoroutineScope;
 import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineEndpointInvoker;
+import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineInvocationHandlerFactory;
 import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineMethodProcessor;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
 
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
-import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class KotlinCoroutineIntegrationProcessor {
 
@@ -40,6 +40,11 @@ public class KotlinCoroutineIntegrationProcessor {
     @BuildStep
     AdditionalBeanBuildItem produceCoroutineScope() {
         return AdditionalBeanBuildItem.builder().addBeanClass(ApplicationCoroutineScope.class).setUnremovable().build();
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem produceCoroutineInvocationHandlerFactory() {
+        return AdditionalBeanBuildItem.builder().addBeanClass(CoroutineInvocationHandlerFactory.class).setUnremovable().build();
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -85,7 +85,7 @@ public class KotlinCoroutineIntegrationProcessor {
 
             private void ensureNotBlocking(MethodInfo method) {
                 if (method.annotation(BLOCKING_ANNOTATION) != null) {
-                    String format = String.format("Suspendable @Blocking methods aren't supported yet: %s.%s",
+                    String format = String.format("Suspendable @Blocking methods are not supported yet: %s.%s",
                             method.declaringClass().name(), method.name());
                     throw new IllegalStateException(format);
                 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -1,14 +1,11 @@
 package io.quarkus.resteasy.reactive.server.deployment;
 
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
-import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -26,11 +23,15 @@ import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineInvocationHand
 import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineMethodProcessor;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
 
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
 
 public class KotlinCoroutineIntegrationProcessor {
 
@@ -39,12 +40,9 @@ public class KotlinCoroutineIntegrationProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem produceCoroutineScope() {
-        return AdditionalBeanBuildItem.builder().addBeanClass(ApplicationCoroutineScope.class).setUnremovable().build();
-    }
-
-    @BuildStep
-    AdditionalBeanBuildItem produceCoroutineInvocationHandlerFactory() {
-        return AdditionalBeanBuildItem.builder().addBeanClass(CoroutineInvocationHandlerFactory.class).setUnremovable().build();
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClasses(CoroutineInvocationHandlerFactory.class, ApplicationCoroutineScope.class)
+                .setUnremovable().build();
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -17,10 +17,12 @@ import org.jboss.resteasy.reactive.server.core.parameters.NullParamExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+import org.jboss.resteasy.reactive.server.runtime.kotlin.ApplicationCoroutineScope;
 import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineEndpointInvoker;
 import org.jboss.resteasy.reactive.server.runtime.kotlin.CoroutineMethodProcessor;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
 
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -34,6 +36,11 @@ public class KotlinCoroutineIntegrationProcessor {
 
     static final DotName CONTINUATION = DotName.createSimple("kotlin.coroutines.Continuation");
     public static final String NAME = KotlinCoroutineIntegrationProcessor.class.getName();
+
+    @BuildStep
+    AdditionalBeanBuildItem produceCoroutineScope() {
+        return AdditionalBeanBuildItem.builder().addBeanClass(ApplicationCoroutineScope.class).setUnremovable().build();
+    }
 
     @BuildStep
     MethodScannerBuildItem scanner() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core-jvm</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 
@@ -56,6 +55,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
@@ -2,7 +2,6 @@ package org.jboss.resteasy.reactive.server.runtime.kotlin
 
 import io.vertx.core.Context
 import kotlinx.coroutines.*
-import org.eclipse.microprofile.context.ManagedExecutor
 import javax.annotation.PreDestroy
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
@@ -33,15 +32,5 @@ class VertxDispatcher(private val vertxContext: Context) : CoroutineDispatcher()
         vertxContext.runOnContext {
             block.run()
         }
-    }
-}
-
-/**
- * Dispatches coroutine into the managed thread pool
- */
-class ExecutorDispatcher(private val managedExecutor: ManagedExecutor): CoroutineDispatcher() {
-    override fun dispatch(context: CoroutineContext, block: Runnable) {
-        // todo may need to handle failed job submissions
-        managedExecutor.execute(block)
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.reactive.server.runtime.kotlin
+
+import io.vertx.core.Context
+import kotlinx.coroutines.*
+import javax.enterprise.context.ApplicationScoped
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Application wide coroutine scope. Should start and die with the rest of the application, along with child coroutines
+ * (structured concurrency).
+ *
+ * This should be the main interception point to place user specific [CoroutineContext.Element] objects. Things
+ * like activity ids, logger context propagation, tracing, exception handlers, etc.
+ */
+@ApplicationScoped
+class ApplicationCoroutineScope : CoroutineScope, AutoCloseable {
+    override val coroutineContext: CoroutineContext = SupervisorJob()
+
+    override fun close() {
+        coroutineContext.cancel()
+    }
+}
+
+/**
+ * Dispatches the coroutine in a worker thread from Vertx.
+ */
+class VertxDispatcher(val vertxContext: Context) : CoroutineDispatcher() {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        // todo sync context variables
+        vertxContext.runOnContext {
+            block.run()
+        }
+    }
+
+    override val key: CoroutineContext.Key<*> = ContinuationInterceptor
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
@@ -2,8 +2,8 @@ package org.jboss.resteasy.reactive.server.runtime.kotlin
 
 import io.vertx.core.Context
 import kotlinx.coroutines.*
+import org.eclipse.microprofile.context.ManagedExecutor
 import javax.enterprise.context.ApplicationScoped
-import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -25,13 +25,18 @@ class ApplicationCoroutineScope : CoroutineScope, AutoCloseable {
 /**
  * Dispatches the coroutine in a worker thread from Vertx.
  */
-class VertxDispatcher(val vertxContext: Context) : CoroutineDispatcher() {
+class VertxDispatcher(private val vertxContext: Context) : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         // todo sync context variables
         vertxContext.runOnContext {
             block.run()
         }
     }
+}
 
-    override val key: CoroutineContext.Key<*> = ContinuationInterceptor
+class ExecutorDispatcher(private val managedExecutor: ManagedExecutor): CoroutineDispatcher() {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        managedExecutor.runAsync(block)
+    }
+
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/ApplicationCoroutineScope.kt
@@ -4,7 +4,7 @@ import io.vertx.core.Context
 import kotlinx.coroutines.*
 import org.eclipse.microprofile.context.ManagedExecutor
 import javax.annotation.PreDestroy
-import javax.enterprise.context.ApplicationScoped
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -14,7 +14,7 @@ import kotlin.coroutines.CoroutineContext
  * This should be the main interception point to place user specific [CoroutineContext.Element] objects. Things
  * like activity ids, logger context propagation, tracing, exception handlers, etc.
  */
-@ApplicationScoped
+@Singleton
 class ApplicationCoroutineScope : CoroutineScope, AutoCloseable {
     override val coroutineContext: CoroutineContext = SupervisorJob()
 
@@ -29,6 +29,7 @@ class ApplicationCoroutineScope : CoroutineScope, AutoCloseable {
  */
 class VertxDispatcher(private val vertxContext: Context) : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
+        // context propagation for suspending functions is not enabled yet, will be handled later
         vertxContext.runOnContext {
             block.run()
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineEndpointInvoker.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineEndpointInvoker.kt
@@ -2,6 +2,20 @@ package org.jboss.resteasy.reactive.server.runtime.kotlin
 
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
 
+/**
+ * Base interface implemented by the synthetic beans that represent suspending rest endpoints.
+ *
+ * @see [KotlinCoroutineIntegrationProcessor]
+ * @see [EndpointInvoker]
+ */
 interface CoroutineEndpointInvoker: EndpointInvoker {
+    /**
+     * Delegates control over the bean that defines the endpoint
+     *
+     * **API note:** Actual Java synthetic bytecode has a 3rd parameter that is the actual coroutine state machine.
+     * @param instance the rest endpoint instance bean
+     * @param parameters the call parameters
+     * @return the coroutine result which may be the computation result, or a suspension point.
+     */
     suspend fun invokeCoroutine(instance: Any, parameters: Array<out Any>): Any?
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
@@ -13,10 +13,7 @@ import org.slf4j.LoggerFactory
 private val logger = LoggerFactory.getLogger(CoroutineInvocationHandler::class.java)
 
 class CoroutineInvocationHandler(private val invoker: EndpointInvoker,
-                                 private val coroutineScope: CoroutineScope,
-                                 managedExecutor: ManagedExecutor) : ServerRestHandler {
-
-    private val executorDispatcher = ExecutorDispatcher(managedExecutor)
+                                 private val coroutineScope: CoroutineScope) : ServerRestHandler {
 
     override fun handle(requestContext: ResteasyReactiveRequestContext) {
         if (requestContext.result != null) {
@@ -28,8 +25,7 @@ class CoroutineInvocationHandler(private val invoker: EndpointInvoker,
         }
 
         val dispatcher: CoroutineDispatcher = Vertx.currentContext()?.let(::VertxDispatcher)
-                // The @Blocking annotation will not run in a Vertx context
-                ?: executorDispatcher
+                ?: throw IllegalStateException("No Vertx context found")
 
         logger.debug("Handling request with dispatcher {}", dispatcher)
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
@@ -1,25 +1,37 @@
 package org.jboss.resteasy.reactive.server.runtime.kotlin
 
-import kotlinx.coroutines.GlobalScope
+import io.vertx.core.Vertx
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
+import org.slf4j.LoggerFactory
 
-class CoroutineInvocationHandler(private val invoker: EndpointInvoker) : ServerRestHandler {
+private val logger = LoggerFactory.getLogger(CoroutineInvocationHandler::class.java)
+
+class CoroutineInvocationHandler(private val invoker: EndpointInvoker, private val coroutineScope: ApplicationCoroutineScope) : ServerRestHandler {
     override fun handle(requestContext: ResteasyReactiveRequestContext) {
         if (requestContext.result != null) {
             return
         }
+        if (invoker !is CoroutineEndpointInvoker) {
+            requestContext.handleException(IllegalStateException("Not a coroutine invoker"), true)
+            return
+        }
+
+        val dispatcher: CoroutineDispatcher = Vertx.currentContext()?.let(::VertxDispatcher)
+                // The @Blocking annotation will not run in a Vertx context
+                ?: Dispatchers.IO
+
+        logger.debug("Handling request with dispatcher {}", dispatcher)
+
         requestContext.requireCDIRequestScope()
         requestContext.suspend()
-        GlobalScope.launch {
+        coroutineScope.launch(context = dispatcher) {
             try {
-                if (invoker is CoroutineEndpointInvoker) {
-                    requestContext.result = invoker.invokeCoroutine(requestContext.endpointInstance, requestContext.parameters)
-                } else {
-                    throw Exception("Not a CoroutineEndpointInvoker")
-                }
+                requestContext.result = invoker.invokeCoroutine(requestContext.endpointInstance, requestContext.parameters)
             } catch (t: Throwable) {
                 // passing true since the target doesn't change and we want response filters to be able to know what the resource method was
                 requestContext.handleException(t, true)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandlerFactory.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandlerFactory.kt
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.reactive.server.runtime.kotlin
+
+import org.eclipse.microprofile.context.ManagedExecutor
+import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
+import javax.enterprise.context.ApplicationScoped
+import javax.inject.Inject
+
+/**
+ * Factory for the [CoroutineInvocationHandler] that is already part of the CDI container
+ */
+@ApplicationScoped
+class CoroutineInvocationHandlerFactory @Inject constructor(
+        private val applicationCoroutineScope: ApplicationCoroutineScope,
+        private val managedExecutor: ManagedExecutor
+) {
+    fun createHandler(invoker: EndpointInvoker): ServerRestHandler {
+        return CoroutineInvocationHandler(invoker, applicationCoroutineScope, managedExecutor)
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandlerFactory.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandlerFactory.kt
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.server.runtime.kotlin
 
-import org.eclipse.microprofile.context.ManagedExecutor
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
 import javax.enterprise.context.ApplicationScoped
@@ -11,10 +10,9 @@ import javax.inject.Inject
  */
 @ApplicationScoped
 class CoroutineInvocationHandlerFactory @Inject constructor(
-        private val applicationCoroutineScope: ApplicationCoroutineScope,
-        private val managedExecutor: ManagedExecutor
+        private val applicationCoroutineScope: ApplicationCoroutineScope
 ) {
     fun createHandler(invoker: EndpointInvoker): ServerRestHandler {
-        return CoroutineInvocationHandler(invoker, applicationCoroutineScope, managedExecutor)
+        return CoroutineInvocationHandler(invoker, applicationCoroutineScope)
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineMethodProcessor.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineMethodProcessor.kt
@@ -1,28 +1,30 @@
 package org.jboss.resteasy.reactive.server.runtime.kotlin
 
-import io.quarkus.arc.Arc
 import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer
 import org.jboss.resteasy.reactive.server.model.ServerResourceMethod
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
 import java.util.function.Supplier
+import javax.enterprise.inject.spi.CDI
 
 /**
  * Intercepts method invocations to force an EndpointInvoker.
  */
-//this class is serialized, hence the default value
 open class CoroutineMethodProcessor @Deprecated("Used only in synthetic code") constructor() : HandlerChainCustomizer {
 
     constructor(alternativeInvoker: Supplier<EndpointInvoker>): this() {
         this.alternativeInvoker = alternativeInvoker
     }
 
-    private lateinit var alternativeInvoker: Supplier<EndpointInvoker>
+    lateinit var alternativeInvoker: Supplier<EndpointInvoker>
 
-    private val scope by lazy { Arc.container().instance(ApplicationCoroutineScope::class.java).get() }
+    // not pretty, but this seems to be a limitation of the current method scanning process
+    // the HandlerChainCustomizer is called in a build step, but also at runtime to actually create the invocation handler
+    // classes like SecurityContextOverrideHandler also use this approach
+    private val handlerFactory by lazy { CDI.current().select(CoroutineInvocationHandlerFactory::class.java).get() }
 
     override fun alternateInvocationHandler(invoker: EndpointInvoker): ServerRestHandler {
-        return CoroutineInvocationHandler(invoker, scope)
+        return handlerFactory.createHandler(invoker)
     }
 
     override fun alternateInvoker(method: ServerResourceMethod): Supplier<EndpointInvoker>? {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineMethodProcessor.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineMethodProcessor.kt
@@ -1,17 +1,31 @@
 package org.jboss.resteasy.reactive.server.runtime.kotlin
 
+import io.quarkus.arc.Arc
 import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer
 import org.jboss.resteasy.reactive.server.model.ServerResourceMethod
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
 import java.util.function.Supplier
 
-open class CoroutineMethodProcessor (var supplier: Supplier<EndpointInvoker>? = null) : HandlerChainCustomizer {
+/**
+ * Intercepts method invocations to force an EndpointInvoker.
+ */
+//this class is serialized, hence the default value
+open class CoroutineMethodProcessor @Deprecated("Used only in synthetic code") constructor() : HandlerChainCustomizer {
+
+    constructor(alternativeInvoker: Supplier<EndpointInvoker>): this() {
+        this.alternativeInvoker = alternativeInvoker
+    }
+
+    private lateinit var alternativeInvoker: Supplier<EndpointInvoker>
+
+    private val scope by lazy { Arc.container().instance(ApplicationCoroutineScope::class.java).get() }
+
     override fun alternateInvocationHandler(invoker: EndpointInvoker): ServerRestHandler {
-        return CoroutineInvocationHandler(invoker)
+        return CoroutineInvocationHandler(invoker, scope)
     }
 
     override fun alternateInvoker(method: ServerResourceMethod): Supplier<EndpointInvoker>? {
-        return supplier
+        return alternativeInvoker
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/EndpointInvoker.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/EndpointInvoker.java
@@ -1,6 +1,19 @@
 package org.jboss.resteasy.reactive.server.spi;
 
+/**
+ * Base interface implemented by the synthetic beans that represent rest endpoints.
+ *
+ * @see CoroutineEndpointInvoker
+ */
 public interface EndpointInvoker {
 
+    /**
+     * Delegates control over the bean that defines the endpoint
+     * 
+     * @param instance the bean instance
+     * @param parameters the method arguments
+     * @return the result of the method call
+     * @throws Exception the exception thrown in the bean call
+     */
     Object invoke(Object instance, Object[] parameters) throws Exception;
 }


### PR DESCRIPTION
fixes #16739

When reasteasy reactive endpoints are delegated to the correct bean, it ensures the coroutine is dispatched in the same context that was processing the endpoint.
If the endpoint has not a Vertx context, it launches the coroutine in the IO dispatcher. This was observed when we add the @Blocking annotation a suspending the endpoint.