### PR TITLE
Allow injection of RoutingContext in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/HelloService.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/HelloService.java
@@ -1,11 +1,20 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
+import java.util.Objects;
+
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import io.vertx.ext.web.RoutingContext;
 
 @RequestScoped
 public class HelloService {
 
+    @Inject
+    RoutingContext context;
+
     public String sayHello() {
+        Objects.requireNonNull(context);
         return "Hello";
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusCurrentRequest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusCurrentRequest.java
@@ -4,6 +4,7 @@ import org.jboss.resteasy.reactive.server.core.CurrentRequest;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.vertx.ext.web.RoutingContext;
 
 public class QuarkusCurrentRequest implements CurrentRequest {
 
@@ -20,6 +21,12 @@ public class QuarkusCurrentRequest implements CurrentRequest {
 
     @Override
     public void set(ResteasyReactiveRequestContext set) {
-        currentVertxRequest.setOtherHttpContextObject(set);
+        if (set == null) {
+            currentVertxRequest.setOtherHttpContextObject(null);
+            currentVertxRequest.setCurrent(null);
+        } else {
+            currentVertxRequest.setOtherHttpContextObject(set);
+            currentVertxRequest.setCurrent(set.unwrap(RoutingContext.class));
+        }
     }
 }


### PR DESCRIPTION
This is done in order to stay in line with what Quarkus allows
when using RESTEasy Classic

Fixes: #16934