### PR TITLE
Make QuarkusJacksonJsonCodec mapper configurable

### DIFF
--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/vertx/QuarkusJacksonJsonCodec.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/vertx/QuarkusJacksonJsonCodec.java
@@ -72,7 +72,11 @@ class QuarkusJacksonJsonCodec implements JsonCodec {
         mapper.registerModule(module);
     }
 
-    private ObjectMapper prettyMapper() {
+    public static ObjectMapper mapper() {
+        return mapper;
+    }
+
+    public static ObjectMapper prettyMapper() {
         if (prettyMapper == null) {
             prettyMapper = mapper.copy();
             prettyMapper.configure(SerializationFeature.INDENT_OUTPUT, true);


### PR DESCRIPTION
With Quarkus 2.0, when:
- a new `ObjectMapper` instance is created by `QuarkusJacksonJsonCodec` because `ArcContainer` is unavailable
- an `UnrecognizedPropertyException` is thrown from a test that uses `io.vertx.core.json.Json`

there is no way to configure the `ObjectMapper` instance created by `QuarkusJacksonJsonCodec` to accept unknown properties.

This PR makes the `QuarkusJacksonJsonCodec` underlying `ObjectMapper` instances public and therefore configurable. The same thing exists in [DatabindCodec from Vert.x](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java#L68-L80).