### PR TITLE
Reactive routes - handle constraint violations consistently

### DIFF
--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -180,7 +180,7 @@ class Methods {
     static final MethodDescriptor VALIDATION_HANDLE_VIOLATION_EXCEPTION = MethodDescriptor
             .ofMethod(ValidationSupport.class.getName(), "handleViolationException",
                     Void.TYPE.getName(), Methods.VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION,
-                    RoutingContext.class.getName());
+                    RoutingContext.class.getName(), Boolean.TYPE.getName());
 
     static final MethodDescriptor VALIDATOR_VALIDATE = MethodDescriptor
             .ofMethod("javax.validation.Validator", "validate", "java.util.Set",

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -744,9 +744,11 @@ class VertxWebProcessor {
                 block.assign(res, value);
             }
             CatchBlockCreator caught = block.addCatch(Methods.VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION);
+            boolean forceJsonEncoding = !descriptor.isContentTypeString() && !descriptor.isContentTypeBuffer()
+                    && !descriptor.isContentTypeMutinyBuffer();
             caught.invokeStaticMethod(
                     Methods.VALIDATION_HANDLE_VIOLATION_EXCEPTION,
-                    caught.getCaughtException(), invoke.getMethodParam(0));
+                    caught.getCaughtException(), invoke.getMethodParam(0), invoke.load(forceJsonEncoding));
             caught.returnValue(caught.loadNull());
         }
 
@@ -1028,7 +1030,7 @@ class VertxWebProcessor {
         // Encode to Json
         Methods.setContentTypeToJson(response, writer);
         // Validate res if needed
-        if (descriptor.isProducedResponseValidated()) {
+        if (descriptor.isProducedResponseValidated() && (descriptor.isReturningUni() || descriptor.isReturningMulti())) {
             return Methods.validateProducedItem(response, writer, res, validatorField, owner);
         } else {
             return writer.invokeStaticMethod(Methods.JSON_ENCODE, res);

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
@@ -49,15 +49,6 @@ public class MultiValidationTest {
                 .body("details", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
-
-        // Input parameter violation - HTML
-        given()
-                .queryParam("name", "doesNotMatch")
-                .when()
-                .get("/query")
-                .then().statusCode(400)
-                .body(containsString("ConstraintViolation"))
-                .body(is(not(emptyString())));
     }
 
     @ApplicationScoped

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
@@ -45,6 +45,25 @@ public class SyncValidationTest {
                 .get("/query")
                 .then().statusCode(200);
 
+        // Invalid parameter
+        given()
+                .when()
+                .get("/invalid-param")
+                .then()
+                .statusCode(400)
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(400))
+                .body("details", containsString("validation constraint violations"))
+                .body("violations[0].field", containsString("name"))
+                .body("violations[0].message", is(not(emptyString())));
+
+        // Invalid parameter - HTML output
+        get("/invalid-param-html")
+                .then()
+                // the return value is ok but the param is invalid
+                .statusCode(400)
+                .body(containsString("ConstraintViolation"), is(not(emptyString())));
+
         // JSON output
         given()
                 .header("Accept", "application/json")
@@ -57,12 +76,6 @@ public class SyncValidationTest {
                 .body("details", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
-
-        // HTML output
-        get("/invalid")
-                .then()
-                .statusCode(500)
-                .body(containsString("ConstraintViolation"), is(not(emptyString())));
 
         given()
                 .header("Accept", "application/json")
@@ -89,19 +102,21 @@ public class SyncValidationTest {
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
-        // Input parameter violation - HTML
+        // Input parameter violation - JSON
         given()
                 .queryParam("name", "doesNotMatch")
                 .when()
                 .get("/query")
                 .then().statusCode(400)
-                .body(containsString("ConstraintViolation"))
-                .body(is(not(emptyString())));
+                .body("title", containsString("Constraint Violation"))
+                .body("status", is(400))
+                .body("details", containsString("validation constraint violations"));
     }
 
     @ApplicationScoped
     public static class MyRoutes {
 
+        @Valid
         @Route(methods = HttpMethod.GET, path = "/valid")
         public Greeting getValidGreeting() {
             return new Greeting("luke", "hello");
@@ -118,9 +133,19 @@ public class SyncValidationTest {
             return new Greeting("neo", "hi");
         }
 
+        @Route
+        public Greeting invalidParam(@NotNull @Param String name) {
+            return new Greeting("neo", "hi");
+        }
+
         @Route(methods = HttpMethod.GET, path = "/query")
         public Greeting getGreetingWithName(@Pattern(regexp = "ne.*") @NotNull @Param("name") String name) {
             return new Greeting(name, "hi");
+        }
+
+        @Route
+        public String invalidParamHtml(@NotNull @Param String name) {
+            return "hi";
         }
 
     }

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
@@ -64,9 +64,9 @@ public class ValidationSupport {
         return json;
     }
 
-    public static void handleViolationException(ConstraintViolationException ex, RoutingContext rc) {
+    public static void handleViolationException(ConstraintViolationException ex, RoutingContext rc, boolean forceJsonEncoding) {
         String accept = rc.request().getHeader(ACCEPT_HEADER);
-        if (accept != null && accept.contains(APPLICATION_JSON)) {
+        if (forceJsonEncoding || accept != null && accept.contains(APPLICATION_JSON)) {
             rc.response().putHeader(RouteHandlers.CONTENT_TYPE, APPLICATION_JSON);
             JsonObject json = generateJsonResponse(ex.getConstraintViolations(), false);
             rc.response().setStatusCode(json.getInteger(PROBLEM_STATUS));


### PR DESCRIPTION
- a non-String non-Buffer return value is automatically encoded as JSON,
we should do the same if a constraint violation occurs
- resolves #15159