### PR TITLE
Add support for hibernate.metadata_builder_contributor

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -113,6 +113,22 @@ public class HibernateOrmConfigPersistenceUnit {
     public Optional<String> implicitNamingStrategy;
 
     /**
+     * Class name of a custom {@link org.hibernate.boot.spi.MetadataBuilderContributor} implementation.
+     *
+     * [NOTE]
+     * ====
+     * Not all customization options exposed by {@link org.hibernate.boot.MetadataBuilder}
+     * will work correctly. Stay clear of options related to classpath scanning in particular.
+     *
+     * This setting is exposed mainly to allow registration of types, converters and SQL functions.
+     * ====
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    public Optional<String> metadataBuilderContributor;
+
+    /**
      * Query related configuration.
      */
     @ConfigItem
@@ -183,6 +199,7 @@ public class HibernateOrmConfigPersistenceUnit {
                 maxFetchDepth.isPresent() ||
                 physicalNamingStrategy.isPresent() ||
                 implicitNamingStrategy.isPresent() ||
+                metadataBuilderContributor.isPresent() ||
                 query.isAnyPropertySet() ||
                 database.isAnyPropertySet() ||
                 jdbc.isAnyPropertySet() ||

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -43,6 +43,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.beanvalidation.BeanValidationIntegrator;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
 import org.jboss.jandex.AnnotationInstance;
@@ -790,6 +791,11 @@ public final class HibernateOrmProcessor {
         persistenceUnitConfig.implicitNamingStrategy.ifPresent(
                 namingStrategy -> descriptor.getProperties()
                         .setProperty(AvailableSettings.IMPLICIT_NAMING_STRATEGY, namingStrategy));
+
+        // Metadata builder contributor
+        persistenceUnitConfig.metadataBuilderContributor.ifPresent(
+                className -> descriptor.getProperties()
+                        .setProperty(EntityManagerFactoryBuilderImpl.METADATA_BUILDER_CONTRIBUTOR, className));
 
         //charset
         descriptor.getProperties().setProperty(AvailableSettings.HBM2DDL_CHARSET_NAME,

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/CustomMetadataBuilderContributor.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/CustomMetadataBuilderContributor.java
@@ -1,0 +1,49 @@
+package io.quarkus.hibernate.orm.metadatabuildercontributor;
+
+import java.util.List;
+
+import org.hibernate.QueryException;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
+
+public class CustomMetadataBuilderContributor implements MetadataBuilderContributor {
+    @Override
+    public void contribute(MetadataBuilder metadataBuilder) {
+        metadataBuilder.applySqlFunction(
+                "addHardcodedSuffix",
+                new HardcodedSuffixFunction("_some_suffix"));
+    }
+
+    private static final class HardcodedSuffixFunction implements SQLFunction {
+        private final String suffix;
+
+        private HardcodedSuffixFunction(String suffix) {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public boolean hasArguments() {
+            return true;
+        }
+
+        @Override
+        public boolean hasParenthesesIfNoArguments() {
+            return false;
+        }
+
+        @Override
+        public Type getReturnType(Type firstArgumentType, Mapping mapping) throws QueryException {
+            return StringType.INSTANCE;
+        }
+
+        @Override
+        public String render(Type firstArgumentType, List arguments, SessionFactoryImplementor factory) throws QueryException {
+            return "(" + arguments.get(0) + " || '" + suffix + "')";
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/MetadataBuilderContributorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/MetadataBuilderContributorTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.hibernate.orm.metadatabuildercontributor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MetadataBuilderContributorTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class)
+                    .addClass(CustomMetadataBuilderContributor.class)
+                    .addAsResource("application-metadata-builder-contributor.properties", "application.properties"));
+
+    @Inject
+    EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void test() {
+        MyEntity entity = new MyEntity();
+        entity.setName("some_name");
+        entityManager.persist(entity);
+
+        assertThat(entityManager.createQuery("select addHardcodedSuffix(e.name) from MyEntity e", String.class)
+                .getSingleResult())
+                        .isEqualTo("some_name_some_suffix");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/MyEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/metadatabuildercontributor/MyEntity.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm.metadatabuildercontributor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class MyEntity {
+    @Id
+    private long id;
+
+    private String name;
+
+    public MyEntity() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-metadata-builder-contributor.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-metadata-builder-contributor.properties
@@ -1,0 +1,7 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.metadata-builder-contributor=io.quarkus.hibernate.orm.metadatabuildercontributor.CustomMetadataBuilderContributor

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -574,9 +574,7 @@ public class FastBootMetadataBuilder {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void applyMetadataBuilderContributor() {
-
         Object metadataBuilderContributorSetting = buildTimeSettings
                 .get(EntityManagerFactoryBuilderImpl.METADATA_BUILDER_CONTRIBUTOR);
 
@@ -584,36 +582,54 @@ public class FastBootMetadataBuilder {
             return;
         }
 
-        MetadataBuilderContributor metadataBuilderContributor = null;
-        Class<? extends MetadataBuilderContributor> metadataBuilderContributorImplClass = null;
-
-        if (metadataBuilderContributorSetting instanceof MetadataBuilderContributor) {
-            metadataBuilderContributor = (MetadataBuilderContributor) metadataBuilderContributorSetting;
-        } else if (metadataBuilderContributorSetting instanceof Class) {
-            metadataBuilderContributorImplClass = (Class<? extends MetadataBuilderContributor>) metadataBuilderContributorSetting;
-        } else if (metadataBuilderContributorSetting instanceof String) {
-            final ClassLoaderService classLoaderService = standardServiceRegistry.getService(ClassLoaderService.class);
-
-            metadataBuilderContributorImplClass = classLoaderService
-                    .classForName((String) metadataBuilderContributorSetting);
-        } else {
-            throw new IllegalArgumentException(
-                    "The provided " + EntityManagerFactoryBuilderImpl.METADATA_BUILDER_CONTRIBUTOR + " setting value ["
-                            + metadataBuilderContributorSetting + "] is not supported!");
-        }
-
-        if (metadataBuilderContributorImplClass != null) {
-            try {
-                metadataBuilderContributor = metadataBuilderContributorImplClass.getDeclaredConstructor().newInstance();
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw new IllegalArgumentException("The MetadataBuilderContributor class ["
-                        + metadataBuilderContributorImplClass + "] could not be instantiated!", e);
-            }
-        }
+        MetadataBuilderContributor metadataBuilderContributor = loadSettingInstance(
+                EntityManagerFactoryBuilderImpl.METADATA_BUILDER_CONTRIBUTOR,
+                metadataBuilderContributorSetting,
+                MetadataBuilderContributor.class);
 
         if (metadataBuilderContributor != null) {
             metadataBuilderContributor.contribute(metamodelBuilder);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T loadSettingInstance(String settingName, Object settingValue, Class<T> clazz) {
+        T instance = null;
+        Class<? extends T> instanceClass = null;
+
+        if (clazz.isAssignableFrom(settingValue.getClass())) {
+            instance = (T) settingValue;
+        } else if (settingValue instanceof Class) {
+            instanceClass = (Class<? extends T>) settingValue;
+        } else if (settingValue instanceof String) {
+            String settingStringValue = (String) settingValue;
+            if (standardServiceRegistry != null) {
+                final ClassLoaderService classLoaderService = standardServiceRegistry.getService(ClassLoaderService.class);
+
+                instanceClass = classLoaderService.classForName(settingStringValue);
+            } else {
+                try {
+                    instanceClass = (Class<? extends T>) Class.forName(settingStringValue);
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException("Can't load class: " + settingStringValue, e);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "The provided " + settingName + " setting value [" + settingValue + "] is not supported!");
+        }
+
+        if (instanceClass != null) {
+            try {
+                instance = instanceClass.getConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                throw new IllegalArgumentException(
+                        "The " + clazz.getSimpleName() + " class [" + instanceClass + "] could not be instantiated!",
+                        e);
+            }
+        }
+
+        return instance;
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -64,9 +64,18 @@ public final class PrevalidatedQuarkusMetadata implements MetadataImplementor {
     // New helpers on this Quarkus specific metadata; these are useful to boot and manage the recorded state:
 
     public SessionFactoryOptionsBuilder buildSessionFactoryOptionsBuilder() {
-        return new SessionFactoryOptionsBuilder(
+        SessionFactoryOptionsBuilder builder = new SessionFactoryOptionsBuilder(
                 metadata.getMetadataBuildingOptions().getServiceRegistry(),
                 metadata.getBootstrapContext());
+        // This would normally be done by the constructor of SessionFactoryBuilderImpl,
+        // but we don't use a builder to create the session factory, for some reason.
+        Map<String, SQLFunction> sqlFunctions = metadata.getSqlFunctionMap();
+        if (sqlFunctions != null) {
+            for (Map.Entry<String, SQLFunction> entry : sqlFunctions.entrySet()) {
+                builder.applySqlFunction(entry.getKey(), entry.getValue());
+            }
+        }
+        return builder;
     }
 
     //Relevant overrides:


### PR DESCRIPTION
Fixes #13807

To be honest I'm not a fan of the `org.hibernate.boot.MetadataBuilder` API, because it exposes many different things.

Some of these things can be of great value for Quarkus users:

* Defining user types
* Defining custom SQL functions
* Defining attribute converters (without annotations)
* etc.

Others are duplicate of configuration properties:

* Defining naming strategies
* Defining the default schema name
* Configuring cache regions
* `etc.`

And finally, some really are implementation details for Quarkus users and shouldn't be exposed:

* Defining scan options, environment, scanner, archive descriptor factory.
* Defining a class loader to use while building the metadata
* Calling build() and getting a `Metadata` object

On the other hand, we could expose our own wrapper that only exposes the methods that make sense, but it would duplicate efforts, and I don't think it would be very user-friendly to diverge from "official" ORM APIs here.

So... I'm submitting this PR anyway, knowing full well it's not perfect, but it's something.