### PR TITLE
Disable DevService if docker is not running

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -1,5 +1,5 @@
 
-package io.quarkus.container.image.docker.deployment;
+package io.quarkus.deployment;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -13,9 +13,19 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.util.ExecUtil;
 
-public class DockerWorking implements BooleanSupplier {
+public class IsDockerWorking implements BooleanSupplier {
 
-    private static final Logger LOGGER = Logger.getLogger(DockerWorking.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(IsDockerWorking.class.getName());
+
+    private final boolean silent;
+
+    public IsDockerWorking() {
+        this(false);
+    }
+
+    public IsDockerWorking(boolean silent) {
+        this.silent = silent;
+    }
 
     @Override
     public boolean getAsBoolean() {
@@ -35,7 +45,9 @@ public class DockerWorking implements BooleanSupplier {
                 LOGGER.info("Docker daemon found. Version:" + filter.getOutput());
                 return true;
             } else {
-                LOGGER.warn("Could not determine version of Docker daemon");
+                if (!silent) {
+                    LOGGER.warn("Could not determine version of Docker daemon");
+                }
                 return false;
             }
         } catch (Exception e) {

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
+import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormalNotRemoteDev;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -50,7 +51,7 @@ public class DockerProcessor {
     private static final String DOCKER_DIRECTORY_NAME = "docker";
     static final String DOCKER_CONTAINER_IMAGE_NAME = "docker";
 
-    private final DockerWorking dockerWorking = new DockerWorking();
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking();
 
     @BuildStep
     public AvailableContainerImageExtensionBuildItem availability() {
@@ -75,7 +76,7 @@ public class DockerProcessor {
             return;
         }
 
-        if (!dockerWorking.getAsBoolean()) {
+        if (!isDockerWorking.getAsBoolean()) {
             throw new RuntimeException("Unable to build docker image. Please check your docker installation");
         }
 
@@ -107,7 +108,7 @@ public class DockerProcessor {
             return;
         }
 
-        if (!dockerWorking.getAsBoolean()) {
+        if (!isDockerWorking.getAsBoolean()) {
             throw new RuntimeException("Unable to build docker image. Please check your docker installation");
         }
 

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildIt
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
+import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -40,6 +41,8 @@ public class DevServicesDatasourceProcessor {
     static volatile List<RunTimeConfigurationDefaultBuildItem> databaseConfig;
 
     static volatile boolean first = true;
+
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
 
     @BuildStep(onlyIfNot = IsNormal.class)
     DevServicesDatasourceResultBuildItem launchDatabases(CurateOutcomeBuildItem curateOutcomeBuildItem,
@@ -180,6 +183,11 @@ public class DevServicesDatasourceProcessor {
             //explicitly disabled
             log.debug("Not starting devservices for " + (dbName == null ? "default datasource" : dbName)
                     + " as it has been disabled in the config");
+            return null;
+        }
+        if (!isDockerWorking.getAsBoolean()) {
+            log.warn("Please configure datasource URL for "
+                    + (dbName == null ? "default datasource" : dbName) + " or get a working docker instance");
             return null;
         }
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -17,6 +17,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -35,6 +36,8 @@ public class DevServicesMongoProcessor {
     static volatile List<Closeable> closeables;
     static volatile Map<String, CapturedProperties> capturedProperties;
     static volatile boolean first = true;
+
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
 
     @BuildStep(onlyIfNot = IsNormal.class)
     public DevServicesMongoResultBuildItem startMongo(List<MongoConnectionNameBuildItem> mongoConnections,
@@ -143,6 +146,13 @@ public class DevServicesMongoProcessor {
             // explicitly disabled
             log.debug("Not starting devservices for " + (isDefault(connectionName) ? "default datasource" : connectionName)
                     + " as it has been disabled in the config");
+            return null;
+        }
+
+        if (!isDockerWorking.getAsBoolean()) {
+            log.warn("Please configure datasource URL for "
+                    + (isDefault(connectionName) ? "default datasource" : connectionName)
+                    + " or get a working docker instance");
             return null;
         }
 


### PR DESCRIPTION
This branch adds a check that looks for a running docker daemon. If it's not present, the `DevServicesDatasourceProcessor` build step is not triggered. 

close #16904  