### PR TITLE
Use the watch service when possible

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -20,10 +20,12 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,6 +54,9 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.changeagent.ClassChangeAgent;
+import io.quarkus.deployment.dev.filewatch.FileChangeCallback;
+import io.quarkus.deployment.dev.filewatch.FileChangeEvent;
+import io.quarkus.deployment.dev.filewatch.WatchServiceFileSystemWatcher;
 import io.quarkus.deployment.dev.testing.TestListener;
 import io.quarkus.deployment.dev.testing.TestRunner;
 import io.quarkus.deployment.dev.testing.TestSupport;
@@ -59,8 +64,10 @@ import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.dev.spi.HotReplacementSetup;
+import io.quarkus.dev.testing.TestScanningLock;
 
 public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable {
+    public static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux");
 
     private static final Logger log = Logger.getLogger(RuntimeUpdatesProcessor.class);
 
@@ -100,7 +107,6 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private final BiConsumer<Set<String>, ClassScanResult> restartCallback;
     private final BiConsumer<DevModeContext.ModuleInfo, String> copyResourceNotification;
     private final BiFunction<String, byte[], byte[]> classTransformers;
-    private Timer timer;
     private final ReentrantLock scanLock = new ReentrantLock();
 
     /**
@@ -113,6 +119,9 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private volatile boolean firstTestScanComplete;
     private volatile Boolean instrumentationEnabled;
     private volatile boolean liveReloadEnabled = true;
+
+    private WatchServiceFileSystemWatcher testClassChangeWatcher;
+    private Timer testClassChangeTimer;
 
     public RuntimeUpdatesProcessor(Path applicationRoot, DevModeContext context, QuarkusCompiler compiler,
             DevModeType devModeType, BiConsumer<Set<String>, ClassScanResult> restartCallback,
@@ -141,9 +150,17 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 @Override
                 public void testsDisabled() {
                     synchronized (RuntimeUpdatesProcessor.this) {
-                        if (timer != null) {
-                            timer.cancel();
-                            timer = null;
+                        if (testClassChangeWatcher != null) {
+                            try {
+                                testClassChangeWatcher.close();
+                            } catch (IOException e) {
+                                //ignore
+                            }
+                            testClassChangeWatcher = null;
+                        }
+                        if (testClassChangeTimer != null) {
+                            testClassChangeTimer.cancel();
+                            testClassChangeTimer = null;
                         }
                     }
                 }
@@ -170,47 +187,87 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 .collect(toList());
     }
 
-    private Timer startTestScanningTimer() {
+    private void startTestScanningTimer() {
         synchronized (this) {
-            if (timer == null) {
-                timer = new Timer("Test Compile Timer", true);
-                timer.schedule(new TimerTask() {
-                    @Override
-                    public void run() {
-                        periodicTestCompile();
+            if (testClassChangeWatcher == null && testClassChangeTimer == null) {
+                if (IS_LINUX) {
+                    //note that this is only used for notifications that something has changed,
+                    //this triggers the same file scan as the polling approach
+                    //this is not as efficient as it could be, but saves having two separate code paths
+                    testClassChangeWatcher = new WatchServiceFileSystemWatcher("Quarkus Test Watcher", true);
+                    FileChangeCallback callback = new FileChangeCallback() {
+                        @Override
+                        public void handleChanges(Collection<FileChangeEvent> changes) {
+                            //sometimes changes come through as two events
+                            //which can cause problems for our CI tests
+                            //and cause unessesary runs.
+                            //we add a half second delay for CI tests, to make sure this does not cause
+                            //problems
+                            try {
+                                if (context.isTest()) {
+                                    Thread.sleep(500);
+                                }
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                            periodicTestCompile();
+                        }
+                    };
+                    for (DevModeContext.ModuleInfo module : context.getAllModules()) {
+                        for (String path : module.getMain().getSourcePaths()) {
+                            testClassChangeWatcher.watchPath(new File(path), callback);
+                        }
+                        if (module.getMain().getResourcePath() != null) {
+                            testClassChangeWatcher.watchPath(new File(module.getMain().getResourcePath()), callback);
+                        }
                     }
-                }, 1, 1000);
+                    for (String path : context.getApplicationRoot().getTest().get().getSourcePaths()) {
+                        testClassChangeWatcher.watchPath(new File(path), callback);
+                    }
+                    if (context.getApplicationRoot().getTest().get().getResourcePath() != null) {
+                        testClassChangeWatcher
+                                .watchPath(new File(context.getApplicationRoot().getTest().get().getResourcePath()), callback);
+                    }
+                    periodicTestCompile();
+                } else {
+                    testClassChangeTimer = new Timer("Test Compile Timer", true);
+                    testClassChangeTimer.schedule(new TimerTask() {
+                        @Override
+                        public void run() {
+                            periodicTestCompile();
+                        }
+                    }, 1, 1000);
+                }
             }
         }
-        return timer;
     }
 
     private void periodicTestCompile() {
-        //noop if already scanning
-        if (scanLock.tryLock()) {
-            try {
-                ClassScanResult changedTestClassResult = compileTestClasses();
-                ClassScanResult changedApp = checkForChangedClasses(compiler, DevModeContext.ModuleInfo::getMain, false, test);
-                Set<String> filesChanged = checkForFileChange(DevModeContext.ModuleInfo::getMain, test);
-                boolean configFileRestartNeeded = filesChanged.stream().map(watchedFilePaths::get)
-                        .anyMatch(Boolean.TRUE::equals);
-                ClassScanResult merged = ClassScanResult.merge(changedTestClassResult, changedApp);
-                if (configFileRestartNeeded) {
-                    if (compileProblem != null) {
-                        testSupport.getTestRunner().testCompileFailed(compileProblem);
-                    } else {
-                        testSupport.getTestRunner().runTests(null);
-                    }
-                } else if (merged.isChanged()) {
-                    if (compileProblem != null) {
-                        testSupport.getTestRunner().testCompileFailed(compileProblem);
-                    } else {
-                        testSupport.getTestRunner().runTests(merged);
-                    }
+        scanLock.lock();
+        TestScanningLock.lockForTests();
+        try {
+            ClassScanResult changedTestClassResult = compileTestClasses();
+            ClassScanResult changedApp = checkForChangedClasses(compiler, DevModeContext.ModuleInfo::getMain, false, test);
+            Set<String> filesChanged = checkForFileChange(DevModeContext.ModuleInfo::getMain, test);
+            boolean configFileRestartNeeded = filesChanged.stream().map(watchedFilePaths::get)
+                    .anyMatch(Boolean.TRUE::equals);
+            ClassScanResult merged = ClassScanResult.merge(changedTestClassResult, changedApp);
+            if (configFileRestartNeeded) {
+                if (compileProblem != null) {
+                    testSupport.getTestRunner().testCompileFailed(compileProblem);
+                } else {
+                    testSupport.getTestRunner().runTests(null);
                 }
-            } finally {
-                scanLock.unlock();
+            } else if (merged.isChanged()) {
+                if (compileProblem != null) {
+                    testSupport.getTestRunner().testCompileFailed(compileProblem);
+                } else {
+                    testSupport.getTestRunner().runTests(merged);
+                }
             }
+        } finally {
+            TestScanningLock.unlockForTests();
+            scanLock.unlock();
         }
     }
 
@@ -856,10 +913,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public void close() throws IOException {
-        if (timer != null) {
-            timer.cancel();
-        }
         compiler.close();
+        if (testClassChangeWatcher != null) {
+            testClassChangeWatcher.close();
+        }
+        if (testClassChangeTimer != null) {
+            testClassChangeTimer.cancel();
+        }
     }
 
     private Map<Path, Long> expandGlobPattern(Path root, Path configFile) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeCallback.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeCallback.java
@@ -1,0 +1,18 @@
+package io.quarkus.deployment.dev.filewatch;
+
+import java.util.Collection;
+
+/**
+ * Callback for file system change events
+ *
+ */
+public interface FileChangeCallback {
+
+    /**
+     * Method that is invoked when file system changes are detected.
+     *
+     * @param changes the file system changes
+     */
+    void handleChanges(final Collection<FileChangeEvent> changes);
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeEvent.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/FileChangeEvent.java
@@ -1,0 +1,63 @@
+package io.quarkus.deployment.dev.filewatch;
+
+import java.io.File;
+
+/**
+ * The event object that is fired when a file system change is detected.
+ *
+ * @see WatchServiceFileSystemWatcher
+ *
+ */
+public class FileChangeEvent {
+
+    private final File file;
+    private final Type type;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param file the file which is being watched
+     * @param type the type of event that was encountered
+     */
+    public FileChangeEvent(File file, Type type) {
+        this.file = file;
+        this.type = type;
+    }
+
+    /**
+     * Get the file which was being watched.
+     *
+     * @return the file which was being watched
+     */
+    public File getFile() {
+        return file;
+    }
+
+    /**
+     * Get the type of event.
+     *
+     * @return the type of event
+     */
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * Watched file event types. More may be added in the future.
+     */
+    public static enum Type {
+        /**
+         * A file was added in a directory.
+         */
+        ADDED,
+        /**
+         * A file was removed from a directory.
+         */
+        REMOVED,
+        /**
+         * A file was modified in a directory.
+         */
+        MODIFIED,
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/WatchServiceFileSystemWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filewatch/WatchServiceFileSystemWatcher.java
@@ -1,0 +1,246 @@
+package io.quarkus.deployment.dev.filewatch;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logging.Logger;
+
+/**
+ * File system watcher service based on JDK7 {@link WatchService}. Instantiating this class will create a new thread,
+ * that will run until {@link #close()} is called.
+ *
+ * NOTE: this was copied from Xnio, it provides more functionality than we currently need.
+ *
+ */
+public class WatchServiceFileSystemWatcher implements Runnable {
+
+    private static final Logger log = Logger.getLogger(WatchServiceFileSystemWatcher.class);
+
+    private static final AtomicInteger threadIdCounter = new AtomicInteger(0);
+
+    private WatchService watchService;
+    private final Map<File, PathData> files = Collections.synchronizedMap(new HashMap<File, PathData>());
+    private final Map<WatchKey, PathData> pathDataByKey = Collections
+            .synchronizedMap(new IdentityHashMap<WatchKey, PathData>());
+
+    private volatile boolean stopped = false;
+    private final Thread watchThread;
+
+    public WatchServiceFileSystemWatcher(final String name, final boolean daemon) {
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        watchThread = new Thread(this, name + " - " + threadIdCounter);
+        watchThread.setDaemon(daemon);
+        watchThread.start();
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            try {
+                final WatchKey key = watchService.take();
+                if (key != null) {
+                    try {
+                        PathData pathData = pathDataByKey.get(key);
+                        if (pathData != null) {
+                            final List<FileChangeEvent> results = new ArrayList<FileChangeEvent>();
+                            List<WatchEvent<?>> events = key.pollEvents();
+                            final Set<File> addedFiles = new HashSet<File>();
+                            final Set<File> deletedFiles = new HashSet<File>();
+                            for (WatchEvent<?> event : events) {
+                                Path eventPath = (Path) event.context();
+                                File targetFile = ((Path) key.watchable()).resolve(eventPath).toFile();
+                                FileChangeEvent.Type type;
+
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                                    type = FileChangeEvent.Type.ADDED;
+                                    addedFiles.add(targetFile);
+                                    if (targetFile.isDirectory()) {
+                                        try {
+                                            addWatchedDirectory(pathData, targetFile);
+                                        } catch (IOException e) {
+                                            log.debugf(e, "Could not add watched directory %s", targetFile);
+                                        }
+                                    }
+                                } else if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+                                    type = FileChangeEvent.Type.MODIFIED;
+                                } else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
+                                    type = FileChangeEvent.Type.REMOVED;
+                                    deletedFiles.add(targetFile);
+                                } else {
+                                    continue;
+                                }
+                                results.add(new FileChangeEvent(targetFile, type));
+                            }
+                            key.pollEvents().clear();
+
+                            //now we need to prune the results, to remove duplicates
+                            //e.g. if the file is modified after creation we only want to
+                            //show the create event
+                            Iterator<FileChangeEvent> it = results.iterator();
+                            while (it.hasNext()) {
+                                FileChangeEvent event = it.next();
+                                if (event.getType() == FileChangeEvent.Type.MODIFIED) {
+                                    if (addedFiles.contains(event.getFile()) &&
+                                            deletedFiles.contains(event.getFile())) {
+                                        // XNIO-344
+                                        // All file change events (ADDED, REMOVED and MODIFIED) occurred here.
+                                        // This happens when an updated file is moved from the different
+                                        // filesystems or the directory having different project quota on Linux.
+                                        // ADDED and REMOVED events will be removed in the latter conditional branching.
+                                        // So, this MODIFIED event needs to be kept for the file change notification.
+                                        continue;
+                                    }
+                                    if (addedFiles.contains(event.getFile()) ||
+                                            deletedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                } else if (event.getType() == FileChangeEvent.Type.ADDED) {
+                                    if (deletedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                } else if (event.getType() == FileChangeEvent.Type.REMOVED) {
+                                    if (addedFiles.contains(event.getFile())) {
+                                        it.remove();
+                                    }
+                                }
+                            }
+
+                            if (!results.isEmpty()) {
+                                for (FileChangeCallback callback : pathData.callbacks) {
+                                    invokeCallback(callback, results);
+                                }
+                            }
+                        }
+                    } finally {
+                        //if the key is no longer valid remove it from the files list
+                        if (!key.reset()) {
+                            files.remove(key.watchable());
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                //ignore
+            } catch (ClosedWatchServiceException cwse) {
+                // the watcher service is closed, so no more waiting on events
+                // @see https://developer.jboss.org/message/911519
+                break;
+            }
+        }
+    }
+
+    public synchronized void watchPath(File file, FileChangeCallback callback) {
+        try {
+            PathData data = files.get(file);
+            if (data == null) {
+                Set<File> allDirectories = doScan(file).keySet();
+                Path path = Paths.get(file.toURI());
+                data = new PathData(path);
+                for (File dir : allDirectories) {
+                    addWatchedDirectory(data, dir);
+                }
+                files.put(file, data);
+            }
+            data.callbacks.add(callback);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void addWatchedDirectory(PathData data, File dir) throws IOException {
+        Path path = Paths.get(dir.toURI());
+        WatchKey key = path.register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        pathDataByKey.put(key, data);
+        data.keys.add(key);
+    }
+
+    public synchronized void unwatchPath(File file, final FileChangeCallback callback) {
+        PathData data = files.get(file);
+        if (data != null) {
+            data.callbacks.remove(callback);
+            if (data.callbacks.isEmpty()) {
+                files.remove(file);
+                for (WatchKey key : data.keys) {
+                    key.cancel();
+                    pathDataByKey.remove(key);
+                }
+
+            }
+        }
+    }
+
+    public void close() throws IOException {
+        this.stopped = true;
+        watchThread.interrupt();
+        if (watchService != null) {
+            watchService.close();
+        }
+    }
+
+    private static Map<File, Long> doScan(File file) {
+        final Map<File, Long> results = new HashMap<File, Long>();
+
+        final Deque<File> toScan = new ArrayDeque<File>();
+        toScan.add(file);
+        while (!toScan.isEmpty()) {
+            File next = toScan.pop();
+            if (next.isDirectory()) {
+                results.put(next, next.lastModified());
+                File[] list = next.listFiles();
+                if (list != null) {
+                    for (File f : list) {
+                        toScan.push(new File(f.getAbsolutePath()));
+                    }
+                }
+            }
+        }
+        return results;
+    }
+
+    private static void invokeCallback(FileChangeCallback callback, List<FileChangeEvent> results) {
+        try {
+            callback.handleChanges(results);
+        } catch (Exception e) {
+            log.error("Failed to invoke watch callback", e);
+        }
+    }
+
+    private class PathData {
+        final Path path;
+        final List<FileChangeCallback> callbacks = new ArrayList<FileChangeCallback>();
+        final List<WatchKey> keys = new ArrayList<WatchKey>();
+
+        private PathData(Path path) {
+            this.path = path;
+        }
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/FileSystemWatcherTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/FileSystemWatcherTestCase.java
@@ -1,0 +1,192 @@
+package io.quarkus.deployment.dev;
+
+import static io.quarkus.deployment.dev.filewatch.FileChangeEvent.Type.ADDED;
+import static io.quarkus.deployment.dev.filewatch.FileChangeEvent.Type.MODIFIED;
+import static io.quarkus.deployment.dev.filewatch.FileChangeEvent.Type.REMOVED;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.dev.filewatch.FileChangeCallback;
+import io.quarkus.deployment.dev.filewatch.FileChangeEvent;
+import io.quarkus.deployment.dev.filewatch.WatchServiceFileSystemWatcher;
+
+/**
+ * Test file system watcher, non poll based
+ */
+public class FileSystemWatcherTestCase {
+    public static final String DIR_NAME = "/fileSystemWatcherTest";
+    public static final String EXISTING_FILE_NAME = "a.txt";
+    public static final String EXISTING_DIR = "existingDir";
+
+    private final BlockingDeque<Collection<FileChangeEvent>> results = new LinkedBlockingDeque<>();
+    private final BlockingDeque<Collection<FileChangeEvent>> secondResults = new LinkedBlockingDeque<>();
+
+    File rootDir;
+    File existingSubDir;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        //this can be slow on other OS's
+        //as it just relies on polling
+        Assumptions.assumeTrue(RuntimeUpdatesProcessor.IS_LINUX);
+
+        rootDir = new File(System.getProperty("java.io.tmpdir") + DIR_NAME);
+        deleteRecursive(rootDir);
+
+        rootDir.mkdirs();
+        File existing = new File(rootDir, EXISTING_FILE_NAME);
+        touchFile(existing);
+        existingSubDir = new File(rootDir, EXISTING_DIR);
+        existingSubDir.mkdir();
+        existing = new File(existingSubDir, EXISTING_FILE_NAME);
+        touchFile(existing);
+    }
+
+    private static void touchFile(File existing) throws IOException {
+        FileOutputStream out = new FileOutputStream(existing);
+        try {
+            out.write(("data" + System.currentTimeMillis()).getBytes());
+            out.flush();
+        } finally {
+            out.close();
+        }
+    }
+
+    @AfterEach
+    public void after() {
+        if (rootDir != null) {
+            deleteRecursive(rootDir);
+        }
+    }
+
+    @Test
+    public void testFileSystemWatcher() throws Exception {
+        WatchServiceFileSystemWatcher watcher = new WatchServiceFileSystemWatcher("test", true);
+        try {
+            watcher.watchPath(rootDir, new FileChangeCallback() {
+                @Override
+                public void handleChanges(Collection<FileChangeEvent> changes) {
+                    results.add(changes);
+                }
+            });
+            watcher.watchPath(rootDir, new FileChangeCallback() {
+                @Override
+                public void handleChanges(Collection<FileChangeEvent> changes) {
+                    secondResults.add(changes);
+                }
+            });
+            //first add a file
+            File added = new File(rootDir, "newlyAddedFile.txt").getAbsoluteFile();
+            touchFile(added);
+            checkResult(added, ADDED);
+            added.setLastModified(500);
+            checkResult(added, MODIFIED);
+            added.delete();
+            Thread.sleep(1);
+            checkResult(added, REMOVED);
+            added = new File(existingSubDir, "newSubDirFile.txt");
+            touchFile(added);
+            checkResult(added, ADDED);
+            added.setLastModified(500);
+            checkResult(added, MODIFIED);
+            added.delete();
+            Thread.sleep(1);
+            checkResult(added, REMOVED);
+            File existing = new File(rootDir, EXISTING_FILE_NAME);
+            existing.delete();
+            Thread.sleep(1);
+            checkResult(existing, REMOVED);
+            File newDir = new File(rootDir, "newlyCreatedDirectory");
+            newDir.mkdir();
+            checkResult(newDir, ADDED);
+            added = new File(newDir, "newlyAddedFileInNewlyAddedDirectory.txt").getAbsoluteFile();
+            touchFile(added);
+            checkResult(added, ADDED);
+            added.setLastModified(500);
+            checkResult(added, MODIFIED);
+            added.delete();
+            Thread.sleep(1);
+            checkResult(added, REMOVED);
+
+        } finally {
+            watcher.close();
+        }
+
+    }
+
+    private void checkResult(File file, FileChangeEvent.Type type) throws InterruptedException {
+        Collection<FileChangeEvent> results = this.results.poll(20, TimeUnit.SECONDS);
+        Collection<FileChangeEvent> secondResults = this.secondResults.poll(20, TimeUnit.SECONDS);
+        Assertions.assertNotNull(results);
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals(1, secondResults.size());
+        FileChangeEvent res = results.iterator().next();
+        FileChangeEvent res2 = secondResults.iterator().next();
+
+        //sometime OS's will give a MODIFIED event before the REMOVED one
+        //We consume these events here
+        long endTime = System.currentTimeMillis() + 10000;
+        while (type == REMOVED
+                && (res.getType() == MODIFIED || res2.getType() == MODIFIED)
+                && System.currentTimeMillis() < endTime) {
+            FileChangeEvent[] nextEvents = consumeEvents();
+            res = nextEvents[0];
+            res2 = nextEvents[1];
+        }
+
+        //sometime OS's will give a MODIFIED event on its parent folder before the ADDED one
+        //We consume these events here
+        endTime = System.currentTimeMillis() + 10000;
+        while (type == ADDED
+                && (res.getType() == MODIFIED || res2.getType() == MODIFIED)
+                && (res.getFile().equals(file.getParentFile()) || res2.getFile().equals(file.getParentFile()))
+                && !file.isDirectory()
+                && System.currentTimeMillis() < endTime) {
+            FileChangeEvent[] nextEvents = consumeEvents();
+            res = nextEvents[0];
+            res2 = nextEvents[1];
+        }
+
+        Assertions.assertEquals(file, res.getFile());
+        Assertions.assertEquals(type, res.getType());
+        Assertions.assertEquals(file, res2.getFile());
+        Assertions.assertEquals(type, res2.getType());
+    }
+
+    private FileChangeEvent[] consumeEvents() throws InterruptedException {
+        FileChangeEvent[] nextEvents = new FileChangeEvent[2];
+        Collection<FileChangeEvent> results = this.results.poll(1, TimeUnit.SECONDS);
+        Collection<FileChangeEvent> secondResults = this.secondResults.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(results);
+        Assertions.assertNotNull(secondResults);
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals(1, secondResults.size());
+        nextEvents[0] = results.iterator().next();
+        nextEvents[1] = secondResults.iterator().next();
+
+        return nextEvents;
+    }
+
+    public static void deleteRecursive(final File file) {
+        File[] files = file.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                deleteRecursive(f);
+            }
+        }
+        file.delete();
+    }
+
+}

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/TestScanningLock.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/TestScanningLock.java
@@ -1,0 +1,27 @@
+package io.quarkus.dev.testing;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * lock that is used to prevent scanning while the dev mode test is updating classes
+ *
+ * This prevents races in the continuous testing tests. It's not an ideal solution
+ * but its the only one I can think of at the moment.
+ */
+public class TestScanningLock {
+
+    private static final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * There is a race when testing this, where you can see the intermediate empty state of the
+     * file, or where the file time changes twice. Dev mode tests hold this lock during modification
+     * to avoid the race.
+     */
+    public static void lockForTests() {
+        lock.lock();
+    }
+
+    public static void unlockForTests() {
+        lock.unlock();
+    }
+}


### PR DESCRIPTION
Using the watch service on Linux allows for
tests to run instantly after the file is saved.

Other platforms don't have a useful watch service
implementation, so we still use polling for these
platforms.