### PR TITLE
Allow Netty maxOrder configuration from the user and update default value

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyBuildTimeConfig.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyBuildTimeConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.netty.deployment;
+
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "netty", phase = ConfigPhase.BUILD_TIME)
+public class NettyBuildTimeConfig {
+
+    /**
+     * The value configuring the {@code io.netty.allocator.maxOrder} system property of Netty.
+     * The default value is {@code 3}.
+     *
+     * Configuring this property overrides the minimum {@code maxOrder} requested by the extensions.
+     *
+     * This property affects the memory consumption of the application.
+     * It must be used carefully.
+     * More details on https://programmer.group/pool-area-of-netty-memory-pool.html.
+     */
+    @ConfigItem
+    public OptionalInt allocatorMaxOrder;
+}


### PR DESCRIPTION
Update the default configuration of the `io.netty.allocator.maxOrder` property.

This property has a direct impact on the memory consumption of the application.
The current default is 1, while Netty itself uses 11.
While `1` worked well, recently, we started seeing issues, as Netty has assert statements failing with `1`.
Of course, you only see the issue if you run the application with assert enabled (in the IDE and some hot reload tests).

The extensions can request a higher value. The gRPC and RESTEasy Reactive extensions request `3`.

This commit updates the default value to `3` and provides a way for users to override the value.
If the user-configured value is lower than the extension request, it prints a warning during the build.
No matter what, the user-configured value is used.


Just, as a matter of comparison, the switch between 1 and 3 produces the following results (in term of memory consumption, after the first request):

_Getting Started_
|    maxOrder value    | JVM           |  Native | Native in Container |
| -------------|:-------------|:--------:|:--------:|
| 1  |  108M | 17M | 27M |
| 3 | 108M | 17M | 29M

_gRPC plain text_
|  maxOrder value | JVM           |  Native | Native in Container |
| -------------|:-------------|:--------:|:--------:|
| 1  |  111M | 20M | 36M |
| 3 | 112M | 20M | 36M |

So the switch does not have a huge impact on the initial memory usage. 
