### PR TITLE
Add note on testcontainers properties in devservice

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -74,6 +74,11 @@ ibmcom/db2:11.5.0.0a
 mcr.microsoft.com/mssql/server:2017-CU12
 ----
 
+[NOTE]
+====
+All services based on containers are ran using `testcontainers`. Even though extra URL properties can be set in your `application.properties` file, specific `testcontainers` properties such as `TC_INITSCRIPT`, `TC_INITFUNCTION`, `TC_DAEMON`, `TC_TMPFS` are not supported.
+====
+
 === JDBC datasource
 
 Add the `agroal` extension plus one of `jdbc-db2`, `jdbc-derby`, `jdbc-h2`, `jdbc-mariadb`, `jdbc-mssql`, `jdbc-mysql`, `jdbc-oracle` or `jdbc-postgresql`.


### PR DESCRIPTION
This adds a note in documentation to specify that `testcontainers` specific jdbc url properties are not supported.  

close #16738 
close #16125