### PR TITLE
Reduce 20 mins grace period in DevModeTestUtils to 3 mins

### DIFF
--- a/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeTestUtils.java
+++ b/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeTestUtils.java
@@ -63,11 +63,11 @@ public class DevModeTestUtils {
                 .pollDelay(1, TimeUnit.SECONDS)
                 //Allow for a long maximum time as the first hit to a build might require to download dependencies from Maven repositories;
                 //some, such as org.jetbrains.kotlin:kotlin-compiler, are huge and will take more than a minute.
-                .atMost(20, TimeUnit.MINUTES).until(() -> {
+                .atMost(3, TimeUnit.MINUTES).until(() -> {
                     try {
                         String broken = brokenReason.get();
                         if (broken != null) {
-                            //try and avoid waiting 20m
+                            //try and avoid waiting 3m
                             resp.set("BROKEN: " + broken);
                             return true;
                         }


### PR DESCRIPTION
This was introduced 2 years ago by @Sanne and whatever was the reason for such a generous grace period back then, today it shouldn't be necessary anymore and it even conflicts with surefire timeout of 10 mins we have in some places now. 
(and it can be annoying locally when you scan for failures in multiple tests of a module, e.g. on JDK 16)