### PR TITLE
Enable synthetic beans to be application classes

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
@@ -141,6 +141,5 @@ public final class SyntheticBeanBuildItem extends MultiBuildItem {
         RuntimeValue<?> getRuntimeValue() {
             return runtimeValue;
         }
-
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -62,6 +62,7 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
                     .params(params)
                     .defaultBean(defaultBean)
                     .removable(removable)
+                    .forceApplicationClass(forceApplicationClass)
                     .build());
         }
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -40,6 +40,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
     protected boolean removable;
     protected final Map<String, Object> params;
     protected Type providerType;
+    protected boolean forceApplicationClass;
 
     protected BeanConfiguratorBase(DotName implClazz) {
         this.implClazz = implClazz;
@@ -63,6 +64,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         types.addAll(base.types);
         qualifiers.clear();
         qualifiers.addAll(base.qualifiers);
+        forceApplicationClass = base.forceApplicationClass;
         scope(base.scope);
         if (base.alternativePriority != null) {
             alternativePriority(base.alternativePriority);
@@ -168,6 +170,17 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
 
     public B unremovable() {
         this.removable = false;
+        return self();
+    }
+
+    /**
+     * Forces the bean to be considered an 'application class', so it will be defined in the runtime
+     * ClassLoader and re-created on each redeployment.
+     *
+     * @return self
+     */
+    public B forceApplicationClass() {
+        this.forceApplicationClass = true;
         return self();
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -150,7 +150,8 @@ public class BeanGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(bean.getImplClazz().name());
+        boolean isApplicationClass = applicationClassPredicate.test(bean.getImplClazz().name())
+                || bean.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.BEAN : null, generateSources);
 
@@ -267,7 +268,7 @@ public class BeanGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(beanClass.name());
+        boolean isApplicationClass = applicationClassPredicate.test(beanClass.name()) || bean.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.BEAN : null, generateSources);
 
@@ -373,7 +374,7 @@ public class BeanGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
+        boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name()) || bean.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.BEAN : null, generateSources);
 
@@ -465,7 +466,7 @@ public class BeanGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
+        boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name()) || bean.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.BEAN : null, generateSources);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -83,6 +83,8 @@ public class BeanInfo implements InjectionTargetInfo {
 
     private final Map<String, Object> params;
 
+    private final boolean forceApplicationClass;
+
     BeanInfo(AnnotationTarget target, BeanDeployment beanDeployment, ScopeInfo scope, Set<Type> types,
             Set<AnnotationInstance> qualifiers,
             List<Injection> injections, BeanInfo declaringBean, DisposerInfo disposer, Integer alternativePriority,
@@ -91,7 +93,7 @@ public class BeanInfo implements InjectionTargetInfo {
         this(null, null, target, beanDeployment, scope, types, qualifiers, injections, declaringBean, disposer,
                 alternativePriority,
                 stereotypes, name, isDefaultBean, null, null,
-                Collections.emptyMap(), true);
+                Collections.emptyMap(), true, false);
     }
 
     BeanInfo(ClassInfo implClazz, Type providerType, AnnotationTarget target, BeanDeployment beanDeployment, ScopeInfo scope,
@@ -101,7 +103,7 @@ public class BeanInfo implements InjectionTargetInfo {
             List<StereotypeInfo> stereotypes,
             String name, boolean isDefaultBean, Consumer<MethodCreator> creatorConsumer,
             Consumer<MethodCreator> destroyerConsumer,
-            Map<String, Object> params, boolean isRemovable) {
+            Map<String, Object> params, boolean isRemovable, boolean forceApplicationClass) {
         this.target = Optional.ofNullable(target);
         if (implClazz == null && target != null) {
             implClazz = initImplClazz(target, beanDeployment);
@@ -140,6 +142,7 @@ public class BeanInfo implements InjectionTargetInfo {
         this.interceptedMethods = new ConcurrentHashMap<>();
         this.decoratedMethods = new ConcurrentHashMap<>();
         this.lifecycleInterceptors = new ConcurrentHashMap<>();
+        this.forceApplicationClass = forceApplicationClass;
     }
 
     @Override
@@ -335,6 +338,10 @@ public class BeanInfo implements InjectionTargetInfo {
         } else {
             return disposer == null && destroyerConsumer == null;
         }
+    }
+
+    public boolean isForceApplicationClass() {
+        return forceApplicationClass;
     }
 
     /**
@@ -792,6 +799,8 @@ public class BeanInfo implements InjectionTargetInfo {
 
         private boolean removable = true;
 
+        private boolean forceApplicationClass;
+
         Builder() {
             injections = Collections.emptyList();
             stereotypes = Collections.emptyList();
@@ -890,9 +899,13 @@ public class BeanInfo implements InjectionTargetInfo {
         BeanInfo build() {
             return new BeanInfo(implClazz, providerType, target, beanDeployment, scope, types, qualifiers, injections,
                     declaringBean, disposer, alternativePriority, stereotypes, name, isDefaultBean, creatorConsumer,
-                    destroyerConsumer, params, removable);
+                    destroyerConsumer, params, removable, forceApplicationClass);
         }
 
+        public Builder forceApplicationClass(boolean forceApplicationClass) {
+            this.forceApplicationClass = forceApplicationClass;
+            return this;
+        }
     }
 
 }


### PR DESCRIPTION
Even if the superclass is not ann application class if
the generated bytecode references application classes then
it may be nessesary for the synthetic bean to be an
application class.