### PR TITLE
Upgrade SmallRye Health to 3.0.2 and Add security context propagation to the health check invocations

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <microprofile-jwt.version>1.2</microprofile-jwt.version>
         <smallrye-common.version>1.6.0</smallrye-common.version>
         <smallrye-config.version>2.2.0</smallrye-config.version>
-        <smallrye-health.version>3.0.1</smallrye-health.version>
+        <smallrye-health.version>3.0.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.4</smallrye-open-api.version>
         <smallrye-graphql.version>1.1.0</smallrye-graphql.version>

--- a/docs/src/main/asciidoc/smallrye-health.adoc
+++ b/docs/src/main/asciidoc/smallrye-health.adoc
@@ -320,6 +320,10 @@ error along with the health check response.
         }
 ----
 
+== Context propagation into the health check invocations
+
+For the perfomance reasons the context (e.g., CDI or security context) is not propagated into each health check invocation. However, if you need to enable this functionality you can set the config property `quarkus.smallrye-health.context-propagation=true` to allow the context propagation into every health check call.
+
 == Extension health checks
 
 Some extension may provide default health checks, including the extension will automatically register its health checks.

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
@@ -43,6 +43,12 @@ public class SmallRyeHealthConfig {
     String wellnessPath;
 
     /**
+     * Whether the context should be propagated to each health check invocation.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean contextPropagation;
+
+    /**
      * SmallRye Health UI configuration
      */
     @ConfigItem

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.ShutdownListenerBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -265,6 +266,14 @@ class SmallRyeHealthProcessor {
                 .blockingRoute()
                 .build());
 
+    }
+
+    @BuildStep
+    public void translateSmallRyeConfigValues(SmallRyeHealthConfig healthConfig,
+            BuildProducer<SystemPropertyBuildItem> systemProperties) {
+        if (healthConfig.contextPropagation) {
+            systemProperties.produce(new SystemPropertyBuildItem("io.smallrye.health.context.propagation", "true"));
+        }
     }
 
     @BuildStep(onlyIf = OpenAPIIncluded.class)

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckContextPropagationTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckContextPropagationTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.smallrye.health.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
+
+public class HealthCheckContextPropagationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.smallrye-health.context-propagation", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RequestScopedBean.class, ContextualHC.class));
+
+    @Test
+    public void testContextPropagatedToHealthChecks() {
+        try {
+            RestAssured.defaultParser = Parser.JSON;
+
+            String firstResponse = when().get("/q/health").then()
+                    .body("status", is("UP"),
+                            "checks.status", contains("UP"),
+                            "checks.name", contains(ContextualHC.class.getName()),
+                            "checks.data", is(notNullValue()))
+                    .extract().response().jsonPath().getString("checks.data.request-scoped-instance");
+
+            String secondResponse = when().get("/q/health").then()
+                    .extract().response().jsonPath().getString("checks.data.request-scoped-instance");
+
+            String thirdResponse = when().get("/q/health").then()
+                    .extract().response().jsonPath().getString("checks.data.request-scoped-instance");
+
+            Assertions.assertNotEquals(firstResponse, secondResponse, getMessage("first", "second"));
+            Assertions.assertNotEquals(firstResponse, thirdResponse, getMessage("first", "third"));
+            Assertions.assertNotEquals(secondResponse, thirdResponse, getMessage("second", "third"));
+        } finally {
+            RestAssured.reset();
+        }
+    }
+
+    private String getMessage(String response1, String response2) {
+        return String.format("The CDI context should have been propagated to the health check invocations. " +
+                "However, %s and %s responses are the same", response1, response2);
+    }
+
+    @RequestScoped
+    static class RequestScopedBean {
+
+        String uuid;
+
+        @PostConstruct
+        public void init() {
+            uuid = UUID.randomUUID().toString();
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+    }
+
+    @Liveness
+    @ApplicationScoped
+    static class ContextualHC implements HealthCheck {
+
+        @Inject
+        RequestScopedBean requestScopedBean;
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.named(ContextualHC.class.getName()).up()
+                    .withData("request-scoped-instance", requestScopedBean.getUuid())
+                    .build();
+        }
+    }
+
+}

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
@@ -6,6 +6,8 @@ import java.io.UncheckedIOException;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
 import io.vertx.core.Handler;
@@ -34,6 +36,10 @@ abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
     }
 
     private void doHandle(RoutingContext ctx) {
+        QuarkusHttpUser user = (QuarkusHttpUser) ctx.user();
+        if (user != null) {
+            Arc.container().instance(CurrentIdentityAssociation.class).get().setIdentity(user.getSecurityIdentity());
+        }
         SmallRyeHealthReporter reporter = Arc.container().instance(SmallRyeHealthReporter.class).get();
         SmallRyeHealth health = getHealth(reporter, ctx);
         HttpServerResponse resp = ctx.response();


### PR DESCRIPTION
The context propagation to the health checks requires a recreating of Unis on the SR Health side with every invocation. This needs to be enabled on the SR side with the config property `io.smallrye.health.context.propagation`. Can someone point me to how or even if I should document this in Quarkus? In the guide? Make a quarkus property that would translate to this SR property?

Fixes #16813 