### PR TITLE
Enable Oracle DB container images for testing, normalize build properties

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -15,7 +15,7 @@
         {
             "category": "Data2",
             "timeout": 65,
-            "test-modules": "jpa, jpa-mysql, jpa-db2",
+            "test-modules": "jpa, jpa-mysql, jpa-db2, jpa-oracle",
             "os-name": "ubuntu-latest"
         },
         {

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -2,61 +2,28 @@
 
 ## Running the tests
 
-By default, the tests of this module are disabled.
 
 To run the tests in a standard JVM with an Oracle database started as a Docker container, you can run the following command:
 
 ```
-mvn verify -Dtest-oracle -Dstart-oracle-containers
+mvn verify -Dtest-containers -Dstart-containers
 ```
 
 To also test as a native image, add `-Dnative`:
 
 ```
-mvn verify -Dtest-oracle -Dstart-oracle-containers -Dnative
+mvn verify -Dtest-containers -Dstart-containers -Dnative
 ```
 
 Alternatively you can connect to your own Oracle database.
 Reconfigure the connection URL with `-Doracledb.url=jdbc:Oracle://...`;
 Authentication parameters might need to be changed in the Quarkus configuration file `application.properties`.
 
-## How to get the Docker image
-
-### Authenticate and fetching the image
-
-There are multiple alternatives; describing the simplest way here.
-
-First, you will need an account on [hub.docker.com](hub.docker.com). Create one if you need, and login.
-
-Go to https://hub.docker.com/_/oracle-database-enterprise-edition ; review and accept the developer license terms;
-this will allow your account to access the reference image.
-
-Them from local shell, authorize your local docker instance to use the image you just linked to your account:
-
-```
-docker login
-```
-
-Now start pulling, as it's quite large:
-```
-docker pull store/oracle/database-enterprise:12.2.0.1-slim
-```
-
 ### Starting Oracle via docker
 
 ```
-docker run -it --rm=true --name ORCLCDB -p 1521:1521 store/oracle/database-enterprise:12.2.0.1-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:11-slim
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.
 
-Once the `docker` standalone command works, you can use `-Dstart-oracle-containers` as described earlier to let the build
-automatically start/stop the containers as necessary.
-
-## A note on build properties
-
-N.B. the property names to enable running tests of this module (`-Dtest-oracle`) and starting the container (`-Dstart-oracle-containers`)
-are different than the ones used by many other Quarkus modules because of the need to authenticate on dockerhub and
-approve the license terms; in particular at the time of writing this isn't supported by our CI infrastructure.
-
-This might evolve, hopefully conforming to the same parameter names as other modules.

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -14,8 +14,9 @@
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
     <properties>
-        <oracledb.url>jdbc:oracle:thin:@localhost:1521:ORCLCDB</oracledb.url>
-        <oracle.image>store/oracle/database-enterprise:12.2.0.1-slim</oracle.image>
+        <oracledb.url>jdbc:oracle:thin:@localhost:1521:XE</oracledb.url>
+        <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->
+        <oracle.image>gvenzl/oracle-xe:11-slim</oracle.image>
     </properties>
 
     <dependencies>
@@ -128,7 +129,7 @@
             <id>test-oracle</id>
             <activation>
                 <property>
-                    <name>test-oracle</name>
+                    <name>test-containers</name>
                 </property>
             </activation>
             <build>
@@ -153,11 +154,11 @@
             <id>docker-oracle</id>
             <activation>
                 <property>
-                    <name>start-oracle-containers</name>
+                    <name>start-containers</name>
                 </property>
             </activation>
             <properties>
-                <oracledb.url>jdbc:oracle:thin:@localhost:1521:ORCLCDB</oracledb.url>
+                <oracledb.url>jdbc:oracle:thin:@localhost:1521:XE</oracledb.url>
             </properties>
             <build>
                 <plugins>
@@ -168,12 +169,13 @@
                             <images>
                                 <image>
                                     <name>${oracle.image}</name>
-                                    <!-- Be warned: tricky to change! -->
-                                    <alias>ORCLCDB</alias>
                                     <run>
                                         <ports>
                                             <port>1521:1521</port>
                                         </ports>
+                                        <env>
+                                            <ORACLE_PASSWORD>hibernate_orm_test</ORACLE_PASSWORD>
+                                        </env>
                                         <log>
                                             <prefix>Oracle Database: </prefix>
                                             <date>default</date>
@@ -182,10 +184,8 @@
                                         <wait>
                                             <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
-                                            <time>600000</time>
-                                            <!-- Oracle documentation suggests to wait for "healthy status" but in practice this is often
-                                            too early. We're forced to wait for the first log related to interval partitioning: -->
-                                            <log>ADDED INTERVAL PARTITION SYS_P1427</log>
+                                            <time>100000</time>
+                                            <log>DATABASE IS READY TO USE!</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=oracle
-quarkus.datasource.username=sys as sysdba
-quarkus.datasource.password=Oradoc_db1
+quarkus.datasource.username=SYSTEM
+quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${oracledb.url}
 quarkus.datasource.jdbc.max-size=1
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -4,3 +4,4 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${oracledb.url}
 quarkus.datasource.jdbc.max-size=1
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false


### PR DESCRIPTION
Switched to a new freely available container image of the Oracle DB

Also this allows us to now enable these tests as part of regular CI builds: adapted the build properties to conform to the standard ones we use, and amended insntructions.