### PR TITLE
Removing deprecated BuildStep.applicationArchiveMarkers()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -64,7 +64,6 @@ import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.ProduceWeak;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.annotations.Weak;
-import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.BootstrapConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.BytecodeRecorderObjectLoaderBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
@@ -487,7 +486,6 @@ public final class ExtensionLoader {
                 method.setAccessible(true);
             }
             final BuildStep buildStep = method.getAnnotation(BuildStep.class);
-            final String[] archiveMarkers = buildStep.applicationArchiveMarkers();
             final Class<? extends BooleanSupplier>[] onlyIf = buildStep.onlyIf();
             final Class<? extends BooleanSupplier>[] onlyIfNot = buildStep.onlyIfNot();
             final Parameter[] methodParameters = method.getParameters();
@@ -520,14 +518,6 @@ public final class ExtensionLoader {
                 }
             }
             final BooleanSupplier finalAddStep = addStep;
-
-            if (archiveMarkers.length > 0) {
-                chainConfig = chainConfig.andThen(bcb -> bcb.addBuildStep(bc -> {
-                    for (String marker : archiveMarkers) {
-                        bc.produce(new AdditionalApplicationArchiveMarkerBuildItem(marker));
-                    }
-                }).produces(AdditionalApplicationArchiveMarkerBuildItem.class).buildIf(finalAddStep));
-            }
 
             if (isRecorder) {
                 assert recordAnnotation != null;

--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
@@ -64,20 +64,6 @@ import io.quarkus.runtime.annotations.Recorder;
 public @interface BuildStep {
 
     /**
-     * Indicates that the provided file names should be considered to be application index markers.
-     *
-     * If these are present in library on the class path then the library will be indexed, and this index will be
-     * used when evaluating application components.
-     *
-     * This should not be used, {@link io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem}
-     * should just be produced directly instead.
-     *
-     * This method will be removed at some point post Quarkus 1.1.
-     */
-    @Deprecated
-    String[] applicationArchiveMarkers() default {};
-
-    /**
      * Only include this build step if the given supplier class(es) return {@code true}.
      *
      * @return the supplier class array


### PR DESCRIPTION
Quoting the javadoc `This method will be removed at some point post Quarkus 1.1.`