### PR TITLE
Removed deprecated BuildStep.loadsApplicationClasses()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
@@ -104,10 +104,4 @@ public @interface BuildStep {
      * @return the supplier class array
      */
     Class<? extends BooleanSupplier>[] onlyIfNot() default {};
-
-    /**
-     * This no longer has any effect, and will be removed in future.
-     */
-    @Deprecated
-    boolean loadsApplicationClasses() default false;
 }


### PR DESCRIPTION
The method was deprecated more than a year ago in
https://github.com/quarkusio/quarkus/commit/0010cd79ea249348bf5d69ad995198724febd5d9#diff-5176423fbfab42c5d6ff42848f470c1e666698023e86f16c71ecc014f82f5ab2