### PR TITLE
CI: Fix failure on empty native jobs matrix

### DIFF
--- a/.github/filter-native-tests-json.sh
+++ b/.github/filter-native-tests-json.sh
@@ -40,5 +40,13 @@ do
   JSON=$(echo -n "${JSON}" | sed "s/${modules}/${FILTERED}/")
 done < <(echo -n "${JSON}" | jq -r '.include[] | ."test-modules"')
 
-# Step 3: print result, deleting entire elements from "include" array that now have an empty "test-modules" list
-echo "${JSON}" | jq 'del(.include[] | select(."test-modules" == ""))'
+# Step 3: delete entire elements from "include" array that now have an empty "test-modules" list
+JSON=$(echo "${JSON}" | jq 'del(.include[] | select(."test-modules" == ""))')
+
+# Step 4: echo final result, printing only {} in case _all_ elements were removed from "include" array
+if [ -z "$(echo "${JSON}" | jq '.include[]')" ]
+then
+  echo -n '{}'
+else
+  echo -n "${JSON}"
+fi

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -687,7 +687,7 @@ jobs:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
+    if: "needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:


### PR DESCRIPTION
Fixes the workflow failure observed in https://github.com/quarkusio/quarkus/pull/17003#issuecomment-832661939

Before this new "normalization" to `{}`, the empty matrix was looking like this, which made it unnecessarily complicated to check:
```json
{  "include": []}
```