### PR TITLE
Update OidcClient to recognize non-standard grant response properties

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -81,12 +82,54 @@ public class OidcClientConfig extends OidcCommonConfig {
         @ConfigItem(defaultValue = "client")
         public Type type = Type.CLIENT;
 
+        /**
+         * Access token property name in a token grant response
+         */
+        @ConfigItem(defaultValue = OidcConstants.ACCESS_TOKEN_VALUE)
+        public String accessTokenProperty = OidcConstants.ACCESS_TOKEN_VALUE;
+
+        /**
+         * Refresh token property name in a token grant response
+         */
+        @ConfigItem(defaultValue = OidcConstants.REFRESH_TOKEN_VALUE)
+        public String refreshTokenProperty = OidcConstants.REFRESH_TOKEN_VALUE;
+
+        /**
+         * Refresh token property name in a token grant response
+         */
+        @ConfigItem(defaultValue = OidcConstants.EXPIRES_IN)
+        public String expiresInProperty = OidcConstants.EXPIRES_IN;
+
         public Type getType() {
             return type;
         }
 
         public void setType(Type type) {
             this.type = type;
+        }
+
+        public String getAccessTokenProperty() {
+            return accessTokenProperty;
+        }
+
+        public void setAccessTokenProperty(String accessTokenProperty) {
+            this.accessTokenProperty = accessTokenProperty;
+        }
+
+        public String getRefreshTokenProperty() {
+            return refreshTokenProperty;
+        }
+
+        public void setRefreshTokenProperty(String refreshTokenProperty) {
+            this.refreshTokenProperty = refreshTokenProperty;
+        }
+
+        public String getExpiresInProperty() {
+            return expiresInProperty;
+        }
+
+        public void setExpiresInProperty(String expiresInProperty) {
+            this.expiresInProperty = expiresInProperty;
         }
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -111,10 +111,10 @@ public class OidcClientImpl implements OidcClient {
         if (resp.statusCode() == 200) {
             LOG.debugf("%s OidcClient has %s the tokens", oidcConfig.getId().get(), (refresh ? "refreshed" : "acquired"));
             JsonObject json = resp.bodyAsJsonObject();
-            final String accessToken = json.getString(OidcConstants.ACCESS_TOKEN_VALUE);
-            final String refreshToken = json.getString(OidcConstants.REFRESH_TOKEN_VALUE);
+            final String accessToken = json.getString(oidcConfig.grant.accessTokenProperty);
+            final String refreshToken = json.getString(oidcConfig.grant.refreshTokenProperty);
             Long accessTokenExpiresAt;
-            Long accessTokenExpiresIn = json.getLong(OidcConstants.EXPIRES_IN);
+            Long accessTokenExpiresIn = json.getLong(oidcConfig.grant.expiresInProperty);
             if (accessTokenExpiresIn != null) {
                 accessTokenExpiresAt = Instant.now().getEpochSecond() + accessTokenExpiresIn;
             } else {

--- a/integration-tests/oidc-client-wiremock/pom.xml
+++ b/integration-tests/oidc-client-wiremock/pom.xml
@@ -14,10 +14,6 @@
     <name>Quarkus - Integration Tests - OpenID Connect Client Wiremock</name>
     <description>Module that contains OpenID Connect Client tests using Wiremock</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-    </properties>
-
     <dependencies>
         <!-- test dependencies -->
         <dependency>
@@ -91,19 +87,9 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <keycloak.url>${keycloak.url}</keycloak.url>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <keycloak.url>${keycloak.url}</keycloak.url>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -6,15 +6,28 @@ import javax.ws.rs.Path;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.Tokens;
+
 @Path("/frontend")
 public class FrontendResource {
     @Inject
     @RestClient
     ProtectedResourceServiceOidcClient protectedResourceServiceOidcClient;
 
+    @Inject
+    @NamedOidcClient("non-standard-response")
+    Tokens tokens;
+
     @GET
     @Path("echoToken")
     public String echoToken() {
         return protectedResourceServiceOidcClient.echoToken();
+    }
+
+    @GET
+    @Path("echoTokenNonStandardResponse")
+    public String echoTokenNonStandardResponse() {
+        return tokens.getAccessToken() + " " + tokens.getRefreshToken();
     }
 }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -7,6 +7,18 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
+quarkus.oidc-client.non-standard-response.auth-server-url=${keycloak.url}
+quarkus.oidc-client.non-standard-response.discovery-enabled=false
+quarkus.oidc-client.non-standard-response.token-path=/non-standard-tokens
+quarkus.oidc-client.non-standard-response.client-id=quarkus-app
+quarkus.oidc-client.non-standard-response.credentials.secret=secret
+quarkus.oidc-client.non-standard-response.grant.type=password
+quarkus.oidc-client.non-standard-response.grant.access-token-property=accessToken
+quarkus.oidc-client.non-standard-response.grant.refresh-token-property=refreshToken
+quarkus.oidc-client.non-standard-response.grant.expires-in-property=expiresIn
+quarkus.oidc-client.non-standard-response.grant-options.password.username=alice
+quarkus.oidc-client.non-standard-response.grant-options.password.password=alice
+
 io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -35,6 +35,14 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
                                 "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+        server.stubFor(WireMock.post("/non-standard-tokens")
+                .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"accessToken\":\"access_token_n\", \"expiresIn\":4, \"refreshToken\":\"refresh_token_n\"}")));
+
         server.stubFor(WireMock.post("/tokens")
                 .withRequestBody(matching("grant_type=refresh_token&refresh_token=refresh_token_1"))
                 .willReturn(WireMock
@@ -46,8 +54,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
 
         Map<String, String> conf = new HashMap<>();
-        conf.put("quarkus.oidc-client.auth-server-url", server.baseUrl());
-        conf.put("keycloak-url", server.baseUrl());
+        conf.put("keycloak.url", server.baseUrl());
         return conf;
     }
 

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -53,6 +53,14 @@ public class OidcClientTest {
         checkLog();
     }
 
+    @Test
+    public void testEchoTokensNonStandardResponse() {
+        RestAssured.when().get("/frontend/echoTokenNonStandardResponse")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_n refresh_token_n"));
+    }
+
     private void checkLog() {
         final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Fixes #16957.

Some 3rd party providers may return `accessToken` instead of a standard `access_token`, etc - so this PR makes a simple enhancement, for OidcClient to recognize 3 standard properties it works with, to get the access token, refresh token and access token expires in values