### PR TITLE
Update OIDC to use GET for UserInfo

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -53,7 +53,7 @@ public class OidcProviderClient {
     }
 
     public Uni<JsonObject> getUserInfo(String token) {
-        return client.postAbs(metadata.getUserInfoUri())
+        return client.getAbs(metadata.getUserInfoUri())
                 .putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + token)
                 .send().onItem().transform(resp -> getUserInfo(resp));
     }


### PR DESCRIPTION
Fixes #17020

@pedroigor It will likely be the smallest PR ever :-) as we have a few tests checking `UserInfo`. Interesting KC also accepts POST - probably most providers do