### PR TITLE
Support providing explicit options to VaultTransitSecretEngine sign & verifySignature

### DIFF
--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/transit/VaultTransitSignBody.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/transit/VaultTransitSignBody.java
@@ -15,5 +15,7 @@ public class VaultTransitSignBody implements VaultModel {
     public Boolean prehashed;
     @JsonProperty("signature_algorithm")
     public String signatureAlgorithm;
+    @JsonProperty("marshaling_algorithm")
+    public String marshalingAlgorithm;
 
 }

--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/transit/VaultTransitVerifyBody.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/transit/VaultTransitVerifyBody.java
@@ -13,5 +13,7 @@ public class VaultTransitVerifyBody implements VaultModel {
     public Boolean prehashed;
     @JsonProperty("signature_algorithm")
     public String signatureAlgorithm;
+    @JsonProperty("marshaling_algorithm")
+    public String marshalingAlgorithm;
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultTransitSecretEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultTransitSecretEngine.java
@@ -9,6 +9,7 @@ import io.quarkus.vault.transit.EncryptionRequest;
 import io.quarkus.vault.transit.KeyConfigRequestDetail;
 import io.quarkus.vault.transit.KeyCreationRequestDetail;
 import io.quarkus.vault.transit.RewrappingRequest;
+import io.quarkus.vault.transit.SignVerifyOptions;
 import io.quarkus.vault.transit.SigningInput;
 import io.quarkus.vault.transit.SigningRequest;
 import io.quarkus.vault.transit.TransitContext;
@@ -166,8 +167,21 @@ public interface VaultTransitSecretEngine {
     String sign(String keyName, SigningInput input, TransitContext transitContext);
 
     /**
+     * Sign the input with the specified key and an optional explicit sign/verify options and an optional transit
+     * context used for key derivation, if applicable.
+     *
+     * @param keyName the signing key to use
+     * @param input data to sign
+     * @param options optional explicit sign/verify options
+     * @param transitContext optional transit context used for key derivation
+     * @return the signature
+     * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#sign-data">sign data</a>
+     */
+    String sign(String keyName, SigningInput input, SignVerifyOptions options, TransitContext transitContext);
+
+    /**
      * Sign a list of inputs items. Each item shall specify the input to sign, an optional key version, and
-     * an optional transit context used for ky derivation, if applicable.
+     * an optional transit context used for key derivation, if applicable.
      * If any error occurs, the service will throw a {@link VaultSigningBatchException}
      *
      * @param keyName the signing key to use
@@ -176,6 +190,19 @@ public interface VaultTransitSecretEngine {
      * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#sign-data">sign data</a>
      */
     Map<SigningRequest, String> sign(String keyName, List<SigningRequest> requests);
+
+    /**
+     * Sign a list of inputs items and an optional explicit sign/verify options. Each item shall specify the input to
+     * sign, an optional key version, and an optional transit context used for key derivation, if applicable.
+     * If any error occurs, the service will throw a {@link VaultSigningBatchException}
+     *
+     * @param keyName the signing key to use
+     * @param requests the list of inputs to sign
+     * @param options optional explicit sign/verify options
+     * @return a map of each request with its corresponding signature item
+     * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#sign-data">sign data</a>
+     */
+    Map<SigningRequest, String> sign(String keyName, List<SigningRequest> requests, SignVerifyOptions options);
 
     /**
      * Checks that the signature was obtained from signing the input with the specified key.
@@ -201,16 +228,43 @@ public interface VaultTransitSecretEngine {
     void verifySignature(String keyName, String signature, SigningInput input, TransitContext transitContext);
 
     /**
+     * Checks that the signature was obtained from signing the input with the specified key an an optional explicit
+     * sign/verify options.
+     * The service will throw a {@link VaultException} if this is not the case.
+     *
+     * @param keyName the key that was used to sign the input
+     * @param signature the signature obtained from one of the sign methods
+     * @param input the original input data
+     * @param options optional explicit sign/verify options
+     * @param transitContext optional transit context used for key derivation
+     * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#verify-signed-data">verify signed data</a>
+     */
+    void verifySignature(String keyName, String signature, SigningInput input, SignVerifyOptions options,
+            TransitContext transitContext);
+
+    /**
      * Checks a list of verification requests. Each request shall specify an input and the signature we want to match
-     * against, and an optional transit context used for key derivation, if applicable.
-     * If the signature does not match, or if any other error occurs,
-     * the service will throw a {@link VaultVerificationBatchException}
+     * against, and an optional transit context used for key derivation, if applicable. If the signature does not
+     * match, or if any other error occurs, the service will throw a {@link VaultVerificationBatchException}
      *
      * @param keyName the key that was used to sign the input
      * @param requests a list of items specifying an input and a signature to match against
      * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#verify-signed-data">verify signed data</a>
      */
     void verifySignature(String keyName, List<VerificationRequest> requests);
+
+    /**
+     * Checks a list of verification requests. Each request shall specify an input and the signature we want to match
+     * against, and an optional explicit sign/verify options and an optionals transit context used for key derivation,
+     * if applicable. If the signature does not match, or if any other error occurs, the service will throw a
+     * {@link VaultVerificationBatchException}
+     *
+     * @param keyName the key that was used to sign the input
+     * @param requests a list of items specifying an input and a signature to match against
+     * @param options optional explicit sign/verify options
+     * @see <a href="https://www.vaultproject.io/api/secret/transit/index.html#verify-signed-data">verify signed data</a>
+     */
+    void verifySignature(String keyName, List<VerificationRequest> requests, SignVerifyOptions options);
 
     // --- admin operations
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/transit/SignVerifyOptions.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/transit/SignVerifyOptions.java
@@ -1,0 +1,45 @@
+package io.quarkus.vault.transit;
+
+public class SignVerifyOptions {
+
+    private String signatureAlgorithm;
+    private String hashAlgorithm;
+    private Boolean prehashed;
+    private String marshalingAlgorithm;
+
+    public String getSignatureAlgorithm() {
+        return signatureAlgorithm;
+    }
+
+    public SignVerifyOptions setSignatureAlgorithm(String signatureAlgorithm) {
+        this.signatureAlgorithm = signatureAlgorithm;
+        return this;
+    }
+
+    public String getHashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    public SignVerifyOptions setHashAlgorithm(String hashAlgorithm) {
+        this.hashAlgorithm = hashAlgorithm;
+        return this;
+    }
+
+    public Boolean getPrehashed() {
+        return prehashed;
+    }
+
+    public SignVerifyOptions setPrehashed(Boolean prehashed) {
+        this.prehashed = prehashed;
+        return this;
+    }
+
+    public String getMarshalingAlgorithm() {
+        return marshalingAlgorithm;
+    }
+
+    public SignVerifyOptions setMarshalingAlgorithm(String marshalingAlgorithm) {
+        this.marshalingAlgorithm = marshalingAlgorithm;
+        return this;
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
@@ -13,6 +13,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -38,6 +39,7 @@ import io.quarkus.vault.transit.EncryptionRequest;
 import io.quarkus.vault.transit.KeyConfigRequestDetail;
 import io.quarkus.vault.transit.KeyCreationRequestDetail;
 import io.quarkus.vault.transit.RewrappingRequest;
+import io.quarkus.vault.transit.SignVerifyOptions;
 import io.quarkus.vault.transit.SigningInput;
 import io.quarkus.vault.transit.SigningRequest;
 import io.quarkus.vault.transit.TransitContext;
@@ -126,6 +128,66 @@ public class VaultTransitITCase {
     public void signString() {
         String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, null);
         transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input, null);
+    }
+
+    @Test
+    public void signStringExplicitHashAlgorithmSha256() {
+        SignVerifyOptions options = new SignVerifyOptions().setHashAlgorithm("sha2-256");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input, options, null);
+    }
+
+    @Test
+    public void signStringExplicitHashAlgorithmSha512() {
+        SignVerifyOptions options = new SignVerifyOptions().setHashAlgorithm("sha2-512");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input, options, null);
+    }
+
+    @Test
+    public void signStringExplicitHashAlgorithmMismatched() {
+        SignVerifyOptions options = new SignVerifyOptions().setHashAlgorithm("sha2-256");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        assertThrows(VaultException.class,
+                () -> transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input,
+                        options.setHashAlgorithm("sha1"), null));
+    }
+
+    @Test
+    public void signStringExplicitMarshalingAlgorithmASN1() {
+        SignVerifyOptions options = new SignVerifyOptions().setMarshalingAlgorithm("asn1");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input, options, null);
+    }
+
+    @Test
+    public void signStringExplicitMarshalingAlgorithmJWS() {
+        SignVerifyOptions options = new SignVerifyOptions().setMarshalingAlgorithm("jws");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input, options, null);
+    }
+
+    @Test
+    public void signStringExplicitMarshalingAlgorithmMismatched() {
+        SignVerifyOptions options = new SignVerifyOptions().setMarshalingAlgorithm("jws");
+        String signature = transitSecretEngine.sign(SIGN_KEY_NAME, input, options, null);
+        assertThrows(VaultException.class,
+                () -> transitSecretEngine.verifySignature(SIGN_KEY_NAME, signature, input,
+                        options.setMarshalingAlgorithm("asn1"), null));
+    }
+
+    @Test
+    public void signStringExplicitSignatureAlgorithmPKCS1() {
+        SignVerifyOptions options = new SignVerifyOptions().setSignatureAlgorithm("pkcs1v15");
+        String signature = transitSecretEngine.sign(SIGN_KEY2_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY2_NAME, signature, input, options, null);
+    }
+
+    @Test
+    public void signStringExplicitSignatureAlgorithmPSS() {
+        SignVerifyOptions options = new SignVerifyOptions().setSignatureAlgorithm("pss");
+        String signature = transitSecretEngine.sign(SIGN_KEY2_NAME, input, options, null);
+        transitSecretEngine.verifySignature(SIGN_KEY2_NAME, signature, input, options, null);
     }
 
     @Test

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -371,7 +371,7 @@ public class VaultTestExtension {
         execVault(format("vault write -f transit/keys/%s", ENCRYPTION_KEY2_NAME));
         execVault(format("vault write transit/keys/%s derived=true", ENCRYPTION_DERIVED_KEY_NAME));
         execVault(format("vault write transit/keys/%s type=ecdsa-p256", SIGN_KEY_NAME));
-        execVault(format("vault write transit/keys/%s type=ecdsa-p256", SIGN_KEY2_NAME));
+        execVault(format("vault write transit/keys/%s type=rsa-2048", SIGN_KEY2_NAME));
         execVault(format("vault write transit/keys/%s type=ed25519 derived=true", SIGN_DERIVATION_KEY_NAME));
 
         execVault("vault write transit/keys/jws type=ecdsa-p256");


### PR DESCRIPTION
Fixes #17033 

The `VaultTransitSecretEngine.sign` and `VaultTransitSecretEngine.verifySignature` now have variants that take a `SignVerifyOptions` value.

`SignVerifyOptions` allows specifying the following options from the Vault API:
* `hashAlgorithm` (aka `hash_algorithm`)
* `signatureAlgorithm` - (aka `signature_algorithm`)
* `prehashed`
* `marshalingAlgorithm` - (aka `marshaling_algorithm`)

Some of these options (e.g. `hashAlgorithm`, `signatureAlgorithm` and `prehashed`) can be configured for specific transit keys via Quarkus config. The explicit options provided via `SignVerifyOptions` take precedence over any conifgured values.