### PR TITLE
Ability to pause live reload

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -112,6 +112,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private final TestSupport testSupport;
     private volatile boolean firstTestScanComplete;
     private volatile Boolean instrumentationEnabled;
+    private volatile boolean liveReloadEnabled = true;
 
     public RuntimeUpdatesProcessor(Path applicationRoot, DevModeContext context, QuarkusCompiler compiler,
             DevModeType devModeType, BiConsumer<Set<String>, ClassScanResult> restartCallback,
@@ -286,6 +287,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public boolean doScan(boolean userInitiated) throws IOException {
+        return doScan(userInitiated, false);
+    }
+
+    public boolean doScan(boolean userInitiated, boolean force) throws IOException {
+        if (!liveReloadEnabled && !force) {
+            return false;
+        }
         scanLock.lock();
         try {
             if (testSupport != null) {
@@ -886,6 +894,16 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             log.info("Instrumentation based restart disabled");
         }
         return instrumentationEnabled;
+    }
+
+    public boolean toggleLiveReloadEnabled() {
+        liveReloadEnabled = !liveReloadEnabled;
+        if (liveReloadEnabled) {
+            log.info("Live reload enabled");
+        } else {
+            log.info("Live reload disabled");
+        }
+        return liveReloadEnabled;
     }
 
     static class TimestampSet {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.dev.testing;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -8,6 +9,7 @@ import org.jboss.logging.Logger;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestIdentifier;
 
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
 import io.quarkus.dev.console.InputHandler;
 import io.quarkus.dev.console.QuarkusConsole;
 
@@ -60,6 +62,14 @@ public class TestConsoleHandler implements TestListener {
                         printUsage();
                     } else if (k == 'b') {
                         testController.toggleBrokenOnlyMode();
+                    } else if (k == 'l') {
+                        RuntimeUpdatesProcessor.INSTANCE.toggleLiveReloadEnabled();
+                    } else if (k == 's') {
+                        try {
+                            RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
+                        } catch (IOException e) {
+                            log.error("Live reload scan failed", e);
+                        }
                     }
                 }
             }
@@ -83,8 +93,10 @@ public class TestConsoleHandler implements TestListener {
         System.out.println("b - Toggle 'broken only' mode, where only failing tests are run");
         System.out.println("v - Print failures from the last test run");
         System.out.println("o - Toggle test output");
+        System.out.println("p - Pause tests");
         System.out.println("i - Toggle instrumentation based reload");
-        System.out.println("d - Disable tests");
+        System.out.println("l - Toggle live reload");
+        System.out.println("s - Force live reload scan");
         System.out.println("h - Display this help");
 
     }


### PR DESCRIPTION
This is super simple ATM, and only possible
to used when contiuous testing is enabled,
but can be expanded later.