### PR TITLE
Add support for SNI (Server Name Indication) for the HTTP server

### DIFF
--- a/extensions/vertx-http/deployment/src/test/resources/conf/ssl-pem.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/ssl-pem.conf
@@ -1,6 +1,6 @@
 # Enable SSL, configure the key store
-quarkus.http.ssl.certificate.file=server-cert.pem
-quarkus.http.ssl.certificate.key-file=server-key.pem
+quarkus.http.ssl.certificate.files=server-cert.pem
+quarkus.http.ssl.certificate.key-files=server-key.pem
 # Test that server starts with this option
 # See https://github.com/quarkusio/quarkus/issues/8336
 quarkus.http.insecure-requests=disabled

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -10,18 +11,42 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * A certificate configuration. Either the certificate and key files must be given, or a key store must be given.
  */
 @ConfigGroup
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class CertificateConfig {
+
     /**
      * The file path to a server certificate or certificate chain in PEM format.
+     *
+     * @deprecated Use {@link #files} instead.
      */
     @ConfigItem
+    @Deprecated
     public Optional<Path> file;
 
     /**
-     * The file path to the corresponding certificate private key file in PEM format.
+     * The list of path to server certificates using the PEM format.
+     * Specifying multiple files require SNI to be enabled.
      */
     @ConfigItem
+    public Optional<List<Path>> files;
+
+    /**
+     * The file path to the corresponding certificate private key file in PEM format.
+     *
+     * @deprecated Use {@link #keyFiles} instead.
+     */
+    @ConfigItem
+    @Deprecated
     public Optional<Path> keyFile;
+
+    /**
+     * The list of path to server certificates private key file using the PEM format.
+     * Specifying multiple files require SNI to be enabled.
+     *
+     * The order of the key files must match the order of the certificates.
+     */
+    @ConfigItem
+    public Optional<List<Path>> keyFiles;
 
     /**
      * An optional key store which holds the certificate information instead of specifying separate files.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
@@ -30,4 +30,11 @@ public class ServerSslConfig {
     @ConfigItem(defaultValue = "TLSv1.3,TLSv1.2")
     public List<String> protocols;
 
+    /**
+     * Enables Server Name Indication (SNI), an TLS extension allowing the server to use multiple certificates.
+     * The client indicate the server name during the TLS handshake, allowing the server to select the right certificate.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean sni;
+
 }


### PR DESCRIPTION
With SNI enabled, the server can handle multiple certificates. During the TLS handshake, the client indicates the service name allowing the service to looks for the correct certificate and completes the handshake.

The JKS and PKCS12 format allow the key stores to contain multiple certificates. However, the PEM format does not allow that. For this reason, the configuration of the PEM certificate and key are now accepting lists of paths. The previous (singular) form are deprecated but still supported.

SNI must be enabled explicitly as the server cannot verify if the key stores contain multiple certificates (JKS / PKCS12).

This commit does not enable SNI on gRPC, as the gRPC server does not handle it. See https://github.com/vert-x3/vertx-grpc/issues/70 for details.

Fix #16851