### PR TITLE
Add JDK8 extensions for coroutines to the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4777,6 +4777,11 @@
                 <artifactId>kotlinx-coroutines-core-jvm</artifactId>
                 <version>${kotlin.coroutine.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-jdk8</artifactId>
+                <version>${kotlin.coroutine.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
There is no JDK11 specific module