### PR TITLE
Fix reflection registration issue with Jackson's @JsonSerialize & @JsonDeserialize

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -135,6 +135,17 @@ public class JacksonProcessor {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
                 reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, usingValue.asClass().name().toString()));
             }
+            AnnotationValue keyUsingValue = deserializeInstance.value("keyUsing");
+            if (keyUsingValue != null) {
+                // the Deserializers are constructed internally by Jackson using a no-args constructor
+                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, keyUsingValue.asClass().name().toString()));
+            }
+            AnnotationValue contentUsingValue = deserializeInstance.value("contentUsing");
+            if (contentUsingValue != null) {
+                // the Deserializers are constructed internally by Jackson using a no-args constructor
+                reflectiveClass
+                        .produce(new ReflectiveClassBuildItem(false, false, contentUsingValue.asClass().name().toString()));
+            }
         }
 
         // handle the various @JsonSerialize cases
@@ -143,6 +154,23 @@ public class JacksonProcessor {
             if (usingValue != null) {
                 // the Serializers are constructed internally by Jackson using a no-args constructor
                 reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, usingValue.asClass().name().toString()));
+            }
+            AnnotationValue keyUsingValue = serializeInstance.value("keyUsing");
+            if (keyUsingValue != null) {
+                // the Deserializers are constructed internally by Jackson using a no-args constructor
+                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, keyUsingValue.asClass().name().toString()));
+            }
+            AnnotationValue contentUsingValue = serializeInstance.value("contentUsing");
+            if (contentUsingValue != null) {
+                // the Deserializers are constructed internally by Jackson using a no-args constructor
+                reflectiveClass
+                        .produce(new ReflectiveClassBuildItem(false, false, contentUsingValue.asClass().name().toString()));
+            }
+            AnnotationValue nullsUsingValue = serializeInstance.value("nullsUsing");
+            if (nullsUsingValue != null) {
+                // the Deserializers are constructed internally by Jackson using a no-args constructor
+                reflectiveClass
+                        .produce(new ReflectiveClassBuildItem(false, false, nullsUsingValue.asClass().name().toString()));
             }
         }
 


### PR DESCRIPTION
This is a follow up to PR #12387.

It registers the rest of the “using” options (`keyUsing`, `contentUsing`, `nullsUsing`) for both `@JsonSerialize` and `@JsonDeserialize`
