### PR TITLE
JDK16 fixes and workarounds that should make the EA job pass

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -28,7 +28,8 @@ jobs:
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     timeout-minutes: 360
     env:
-      MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m
+      # "--add-opens ..." to work around https://youtrack.jetbrains.com/issue/KT-43704
+      MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m --add-opens java.base/java.util=ALL-UNNAMED
     steps:
 
       - name: Set up JDK

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -72,8 +72,9 @@ jobs:
         # -fae to try to gather as many failures as possible
         # (but not maven.test.failure.ignore because test report generation is buggy)
         # Gradle bits are excluded due to https://github.com/gradle/gradle/issues/13481
+        # descriptor-tests (integration-tests/maven) are disabled due to https://github.com/quarkusio/quarkus/issues/16862 (and/or 16806)
         run: |
-          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae -pl '!devtools/gradle' -pl '!integration-tests/gradle'
+          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae -pl '!devtools/gradle' -pl '!integration-tests/gradle' -Dno-descriptor-tests
       # Test reports disabled due to: https://github.com/ScaCap/action-surefire-report/issues/39
       #- name: Publish Test Report
       #  if: always()

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -71,8 +71,9 @@ jobs:
       - name: Build with Maven
         # -fae to try to gather as many failures as possible
         # (but not maven.test.failure.ignore because test report generation is buggy)
+        # Gradle bits are excluded due to https://github.com/gradle/gradle/issues/13481
         run: |
-          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae
+          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae -pl '!devtools/gradle' -pl '!integration-tests/gradle'
       # Test reports disabled due to: https://github.com/ScaCap/action-surefire-report/issues/39
       #- name: Publish Test Report
       #  if: always()

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -306,14 +306,17 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <systemPropertyVariables>
+                        <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                        <systemPropertyVariables combine.self="override">
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>${maven.home}</maven.home>
                             <maven.repo.local>${settings.localRepository}</maven.repo.local>
                             <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
                             <project.version>${project.version}</project.version> <!-- some dev tools tests need this -->
                         </systemPropertyVariables>
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m</argLine> <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
+                        <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
+                        <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
                         <trimStackTrace>false</trimStackTrace>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
@@ -330,6 +333,8 @@
                             <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
                             <project.version>${project.version}</project.version> <!-- some dev tools tests need this -->
                         </systemPropertyVariables>
+                        <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                        <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
                         <trimStackTrace>false</trimStackTrace>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1048,5 +1048,16 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>jdk16-workarounds</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <properties>
+                <!-- auto-exclude tests that are known to fail on JDK 16 (tagged via @Tag("failsOnJDK16")) -->
+                <excludedGroups>failsOnJDK16</excludedGroups>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -627,6 +627,10 @@
                         <jvmTarget>${maven.compiler.release}</jvmTarget>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.2.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -136,6 +136,8 @@
         <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>
 
         <enforce-test-deps-scope.skip>${enforcer.skip}</enforce-test-deps-scope.skip>
+
+        <surefire.argLine.additional></surefire.argLine.additional>
     </properties>
 
     <dependencyManagement>
@@ -316,7 +318,7 @@
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}"</argLine>
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional}</argLine>
                         <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
                         <trimStackTrace>false</trimStackTrace>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -316,6 +316,7 @@
                         <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m</argLine> <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
                         <trimStackTrace>false</trimStackTrace>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -331,6 +332,7 @@
                         </systemPropertyVariables>
                         <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
                         <trimStackTrace>false</trimStackTrace>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.cli.core.ExecuteUtil;
@@ -157,6 +158,7 @@ public class CliTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     public void testGradleAddListRemove() throws Exception {
         // Gradle list command cannot be screen captured with the current implementation
         // so I will just test good return values
@@ -283,6 +285,7 @@ public class CliTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     public void testCreateGradleDefaults() throws Exception {
         Path project = workspace.resolve("code-with-quarkus");
 
@@ -302,6 +305,7 @@ public class CliTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     public void testGradleBuild() throws Exception {
 
         execute("create", "--gradle", "resteasy");

--- a/extensions/elytron-security-ldap/deployment/pom.xml
+++ b/extensions/elytron-security-ldap/deployment/pom.xml
@@ -76,5 +76,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
@@ -2,6 +2,7 @@ package io.quarkus.elytron.security.ldap;
 
 import static org.hamcrest.Matchers.equalTo;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.elytron.security.ldap.rest.ParametrizedPathsResource;
@@ -33,6 +34,7 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
+    @Tag("failsOnJDK16")
     public void testNotSearchingRecursiveFailure() {
         RestAssured.given().auth().preemptive().basic("subUser", "subUserPassword")
                 .when().get("/servlet-secured").then()
@@ -40,6 +42,7 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
+    @Tag("failsOnJDK16")
     public void testSecureRoleFailure() {
         RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUserPassword")
                 .when().get("/servlet-secured").then()
@@ -47,6 +50,7 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
+    @Tag("failsOnJDK16")
     public void testSecureAccessSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/servlet-secured").then()
@@ -66,6 +70,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, but no authorization. should see 403 error code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsGetRoleFailure() {
         RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUserPassword")
                 .when().get("/jaxrs-secured/roles-class").then()
@@ -76,6 +81,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsGetRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/roles-class").then()
@@ -86,6 +92,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsPathAdminRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("adminUser", "adminUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
@@ -93,6 +100,7 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsPathAdminRoleFailure() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
@@ -103,6 +111,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsPathUserRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/view").then()
@@ -113,6 +122,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsUserRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/secured").then()
@@ -121,6 +131,7 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsInjectedPrincipalSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/principal-secured").then()
@@ -151,6 +162,7 @@ public abstract class LdapSecurityRealmTest {
      * Test access a @DenyAll secured jaxrs resource with authentication. should see a 403 success code.
      */
     @Test
+    @Tag("failsOnJDK16")
     public void testJaxrsGetDenyAllWithAuth() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/denied").then()

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
@@ -2,6 +2,7 @@ package io.quarkus.elytron.security.ldap;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,6 +26,7 @@ public class SearchRecursiveTest {
                     .addAsResource("search-recursive/application.properties", "application.properties"));
 
     @Test()
+    @Tag("failsOnJDK16")
     public void testNotSearchingRecursiveFailure() {
         RestAssured.given().auth().preemptive().basic("subUser", "subUserPassword")
                 .when().get("/servlet-secured").then()

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -260,6 +260,7 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>${jacoco.agent.argLine}</argLine>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -259,7 +259,10 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>${jacoco.agent.argLine}</argLine>
+                        <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                        <systemPropertyVariables combine.self="override"/>
+                        <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                        <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -485,6 +485,7 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>${jacoco.agent.argLine}</argLine>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -484,7 +484,10 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>${jacoco.agent.argLine}</argLine>
+                        <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                        <systemPropertyVariables combine.self="override"/>
+                        <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                        <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
-        <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
+        <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
         <maven-core.version>3.8.1</maven-core.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -187,7 +187,10 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>${jacoco.agent.argLine}</argLine>
+                        <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                        <systemPropertyVariables combine.self="override"/>
+                        <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                        <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -188,6 +188,7 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>${jacoco.agent.argLine}</argLine>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -364,7 +364,10 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>${jacoco.agent.argLine}</argLine>
+                        <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                        <systemPropertyVariables combine.self="override"/>
+                        <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                        <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -365,6 +365,7 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>${jacoco.agent.argLine}</argLine>
+                        <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -323,7 +323,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.surefire.plugin}</version>
                 <configuration>
-                    <argLine>${jacoco.agent.argLine}</argLine>
+                    <!-- combine.self suppresses warnings about java.io.tmpdir being defined twice -->
+                    <systemPropertyVariables combine.self="override"/>
+                    <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
+                    <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                     <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                 </configuration>
             </plugin>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -324,6 +324,7 @@
                 <version>${version.surefire.plugin}</version>
                 <configuration>
                     <argLine>${jacoco.agent.argLine}</argLine>
+                    <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/container-image/maven-invoker-way/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/pom.xml
@@ -100,7 +100,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>integration-tests</id>
@@ -125,7 +124,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>3.0.2</version>
+                        <version>3.0.8</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
@@ -57,6 +57,7 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
     }
 
     @Test
+    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testRunTogetherCodestartsKotlin() throws Exception {
         generateProjectRunTests("maven", "kotlin", getExtensionCodestarts(), Collections.emptyMap());
     }
@@ -90,6 +91,7 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
 
     @ParameterizedTest
     @MethodSource("provideRunAloneCodestarts")
+    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testRunAloneCodestartsKotlin(String codestart) throws Exception {
         generateProjectRunTests("maven", "kotlin", singletonList(codestart), Collections.emptyMap());
     }

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
@@ -68,6 +68,7 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
 
     @ParameterizedTest
     @MethodSource("provideLanguages")
+    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testGradle(String language) throws Exception {
         final List<String> codestarts = getExtensionCodestarts();
         generateProjectRunTests("gradle", language, codestarts, Collections.emptyMap());
@@ -75,6 +76,7 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
 
     @ParameterizedTest
     @MethodSource("provideLanguages")
+    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testGradleKotlinDSL(String language) throws Exception {
         final List<String> codestarts = getExtensionCodestarts();
         generateProjectRunTests("gradle-kotlin-dsl", language, codestarts, Collections.emptyMap());

--- a/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
+++ b/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
@@ -2,6 +2,7 @@ package io.quarkus.elytron.security.ldap.it;
 
 import static org.hamcrest.Matchers.containsString;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -31,6 +32,7 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     void standard_role_authenticated() {
         RestAssured.given()
                 .redirects().follow(false)
@@ -42,6 +44,7 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     void standard_role_not_authorized() {
         RestAssured.given()
                 .redirects().follow(false)
@@ -53,6 +56,7 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     void admin_role_authorized() {
         RestAssured.given()
                 .when()
@@ -73,6 +77,7 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
+    @Tag("failsOnJDK16")
     void admin_role_not_authorized() {
         RestAssured.given()
                 .redirects().follow(false)

--- a/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
+++ b/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -18,6 +19,7 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
 public class KotlinDevModeIT extends RunAndCheckMojoTestBase {
 
     @Test
+    @Tag("failsOnJDK16")
     public void testThatTheApplicationIsReloadedOnKotlinChange() throws MavenInvocationException, IOException {
         testDir = initProject("projects/classic-kotlin", "projects/project-classic-run-kotlin-change");
         runAndCheck(false);

--- a/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinRemoteDevModeIT.java
+++ b/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinRemoteDevModeIT.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -18,6 +19,7 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
 public class KotlinRemoteDevModeIT extends RunAndCheckWithAgentMojoTestBase {
 
     @Test
+    @Tag("failsOnJDK16")
     public void testThatTheApplicationIsReloadedOnKotlinChange()
             throws MavenInvocationException, IOException, InterruptedException {
         testDir = initProject("projects/classic-kotlin", "projects/project-classic-run-kotlin-change-remote");

--- a/integration-tests/kubernetes/maven-invoker-way/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/pom.xml
@@ -104,7 +104,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>integration-tests</id>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,6 +26,7 @@ public class MethodSourceTest {
 
     @ParameterizedTest
     @MethodSource("provideDummyInput")
+    @Tag("failsOnJDK16")
     public void testParameterResolver(UnusedBean.DummyInput dummyInput, Matcher<String> matcher) {
         UnusedBean.DummyResult dummyResult = unusedBean.dummy(dummyInput);
         assertThat(dummyResult.getResult(), matcher);

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -29,6 +30,7 @@ public class ParameterResolverTest {
     @Test
     @ExtendWith(ParameterResolverTest.UnusedBeanDummyInputResolver.class)
     @ExtendWith(ParameterResolverTest.SupplierParameterResolver.class)
+    @Tag("failsOnJDK16")
     public void testParameterResolver(UnusedBean.DummyInput dummyInput, Supplier<UnusedBean.DummyInput> supplier) {
         UnusedBean.DummyResult dummyResult = unusedBean.dummy(dummyInput);
         assertEquals("whatever/6", dummyResult.getResult());
@@ -46,6 +48,7 @@ public class ParameterResolverTest {
 
     @Test
     @ExtendWith(ParameterResolverTest.ListWithNonSerializableParameterResolver.class)
+    @Tag("failsOnJDK16")
     public void testSerializableParameterResolverFallbackToXStream(List<NonSerializable> list) {
         assertEquals("foo", list.get(0).value);
         assertEquals("bar", list.get(1).value);

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -178,6 +179,7 @@ public class RestClientTestCase {
 
     @Test
     @DisableIfBuiltWithGraalVMOlderThan(GRAALVM_21_0)
+    @Tag("failsOnJDK16")
     public void testFaultTolerance() {
         RestAssured.when().get("/client/fault-tolerance").then()
                 .body(is("Hello fallback!"));

--- a/tcks/microprofile-fault-tolerance/pom.xml
+++ b/tcks/microprofile-fault-tolerance/pom.xml
@@ -29,7 +29,7 @@
                         <dependency>org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck</dependency>
                     </dependenciesToScan>
                     <reuseForks>false</reuseForks>
-                    <excludes>
+                    <excludes combine.children="append">
                         <!-- We do not support enablement via beans.xml -->
                         <exclude>org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest</exclude>
                     </excludes>
@@ -85,4 +85,26 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>jdk16-workarounds</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!-- fails with " module java.base does not "opens java.lang.invoke" to unnamed module" -->
+                                <exclude>org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodDefaultMethodTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -33,7 +33,7 @@
                         <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
                     </dependenciesToScan>
                     <reuseForks>false</reuseForks>
-                    <excludes>
+                    <excludes combine.children="append">
                         <!-- ConversationScope not supported in Quarkus -->
                         <exclude>org.eclipse.microprofile.rest.client.tck.cditests.HasConversationScopeTest</exclude>
                     </excludes>
@@ -173,4 +173,33 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk16-workarounds</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!-- fails with " module java.base does not "opens java.lang.invoke" to unnamed module" -->
+                                <exclude>org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest</exclude>
+                                <!-- the following tests fail for yet unknown reasons (assertion failures) -->
+                                <exclude>org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest</exclude>
+                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest</exclude>
+                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest</exclude>
+                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest</exclude>
+                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tcks/resteasy-reactive/pom.xml
+++ b/tcks/resteasy-reactive/pom.xml
@@ -72,7 +72,7 @@
                         </goals>
                         <configuration>
                             <executable>mvn</executable>
-                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args}</commandlineArgs>
+                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args} -Dsurefire.excludedEnvironmentVariables=MAVEN_OPTS</commandlineArgs>
                             <skip>${resteasy-reactive-testsuite.test.skip}</skip>
                         </configuration>
                     </execution>


### PR DESCRIPTION
First step for #16195.
See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Quarkus.20tested.20on.20Java.2016/near/237676424

I tried to divide everything in commits than can be addressed individually later, e.g. when fault-tolerance is fixed that one commit could be reverted.

I think the most controversial commit is the first one with `--add-opens`.
After a chat with @aloubyansky I decided to at least make sure it isn't propagated to tests via `MAVEN_OPTS` (which might spawn their own `mvn` subprocesses).
I suggest to keep `excludedEnvironmentVariables` _permanently_ because I think we generally don't want that propagation (until further notice).
I'm currently testing a `--illegal-access=warn` alternative to that `--add-opens` but I'm not convinced it's that much better.

For that `tmpdir` commit see https://github.com/quarkusio/quarkus/issues/16195#issuecomment-830860621 and https://github.com/quarkusio/quarkus/issues/16195#issuecomment-831523787. It's a bit of a mess currently but I didn't see a better solution until something in `jboss-parent` and/or Surefire changes.