### PR TITLE
Allow to disable ConfigProperties

### DIFF
--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -364,6 +364,37 @@ complex:
 
 WARNING: A limitation of such configuration is that the types used as the generic types of the lists need to be classes and not interfaces.
 
+=== Combining ConfigProperties with build time conditions
+
+Quarkus allows you to define conditions evaluated at build time (`@IfBuildProfile`, `@UnlessBuildProfile`, `@IfBuildProperty` and `@UnlessBuildProperty`) to enable or not the annotations `@ConfigProperties` and `@ConfigPrefix` which gives you a very flexible way to map your configuration.
+
+Let's assume that the configuration of a service is mapped thanks to a `@ConfigProperties` and you don't need this part of the configuration for your tests as it will be mocked, in that case you can define a build time condition like in the next example:
+
+`ServiceConfiguration.java`
+[source,java]
+----
+@UnlessBuildProfile("test") <1>
+@ConfigProperties
+public class ServiceConfiguration {
+    public String user;
+    public String password;
+}
+----
+<1> The annotation `@ConfigProperties` is considered if and only if the active profile is not `test`.
+
+`SomeBean.java`
+[source,java]
+----
+@ApplicationScoped
+public class SomeBean {
+
+    @Inject
+    Instance<ServiceConfiguration> serviceConfiguration; <1>
+
+}
+----
+<1> As the configuration of the service could be missing, we need to use `Instance<ServiceConfiguration>` as type at the injection point.
+
 [[configuration_profiles]]
 == Configuration Profiles
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildExclusionsBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildExclusionsBuildItem.java
@@ -1,0 +1,99 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A type of build item that contains only declaring classes, methods and fields that have been annotated with
+ * unsuccessful build time conditions. It aims to be used to manage the exclusion of the annotations thanks to the
+ * build time conditions also known as {@code IfBuildProfile}, {@code UnlessBuildProfile}, {@code IfBuildProperty} and
+ * {@code UnlessBuildProperty}
+ *
+ * @see io.quarkus.arc.deployment.PreAdditionalBeanBuildTimeConditionBuildItem
+ * @see io.quarkus.arc.profile.IfBuildProfile
+ * @see io.quarkus.arc.profile.UnlessBuildProfile
+ * @see io.quarkus.arc.properties.IfBuildProperty
+ * @see io.quarkus.arc.properties.UnlessBuildProperty
+ */
+public final class BuildExclusionsBuildItem extends SimpleBuildItem {
+
+    private final Set<String> excludedDeclaringClasses;
+    private final Set<String> excludedMethods;
+    private final Set<String> excludedFields;
+
+    public BuildExclusionsBuildItem(Set<String> excludedDeclaringClasses,
+            Set<String> excludedMethods,
+            Set<String> excludedFields) {
+        this.excludedDeclaringClasses = excludedDeclaringClasses;
+        this.excludedMethods = excludedMethods;
+        this.excludedFields = excludedFields;
+    }
+
+    public Set<String> getExcludedDeclaringClasses() {
+        return excludedDeclaringClasses;
+    }
+
+    public Set<String> getExcludedMethods() {
+        return excludedMethods;
+    }
+
+    public Set<String> getExcludedFields() {
+        return excludedFields;
+    }
+
+    /**
+     * Indicates whether the given target is excluded following the next rules:
+     * <p>
+     * <ul>
+     * <li>In case of a class it will check if it is part of the excluded classes</li>
+     * <li>In case of a method it will check if it is part of the excluded methods and if its declaring class
+     * is excluded</li>
+     * <li>In case of a method parameter it will check if its corresponding method is part of the excluded methods
+     * and if its declaring class is excluded</li>
+     * <li>In case of a field it will check if it is part of the excluded field and if its declaring class is excluded</li>
+     * <li>In all other cases, it is not excluded</li>
+     * </ul>
+     * 
+     * @param target the target to check.
+     * @return {@code true} if the target is excluded, {@code false} otherwise.
+     */
+    public boolean isExcluded(AnnotationTarget target) {
+        switch (target.kind()) {
+            case CLASS:
+                return excludedDeclaringClasses.contains(targetMapper(target));
+            case METHOD:
+                return excludedMethods.contains(targetMapper(target)) ||
+                        excludedDeclaringClasses.contains(targetMapper(target.asMethod().declaringClass()));
+            case METHOD_PARAMETER:
+                final MethodInfo method = target.asMethodParameter().method();
+                return excludedMethods.contains(targetMapper(method)) ||
+                        excludedDeclaringClasses.contains(targetMapper(method.declaringClass()));
+            case FIELD:
+                return excludedFields.contains(targetMapper(target)) ||
+                        excludedDeclaringClasses.contains(targetMapper(target.asField().declaringClass()));
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Converts the given target into a String unique representation.
+     * 
+     * @param target the target to convert.
+     * @return a unique representation as a {@code String} of the target
+     */
+    public static String targetMapper(AnnotationTarget target) {
+        final AnnotationTarget.Kind kind = target.kind();
+        if (kind == AnnotationTarget.Kind.CLASS) {
+            return target.asClass().toString();
+        } else if (kind == AnnotationTarget.Kind.METHOD) {
+            final MethodInfo method = target.asMethod();
+            return String.format("%s#%s", method.declaringClass(), method);
+        }
+        return target.asField().toString();
+    }
+}


### PR DESCRIPTION
fixes #17061

## Motivation

The annotation `@ConfigProperties` and `@ConfigPrefix` cannot be disabled once used which can be a problem when it maps an optional part of the configuration.

## Modifications

* Adds a new `BuildItem` called `BuildExclusionsBuildItem` to encapsulate all the classes, methods and fields that have been excluded thanks to build time conditions.
* Relies on `BuildExclusionsBuildItem#isExcluded` to potentially exclude what has been annotated with `@ConfigProperties` and `@ConfigPrefix` 
* Adds tests to validate that we can exclude a `@ConfigProperties` if applied on a class and a `@ConfigPrefix` if applied on a field or parameter.
* Adds some documentation about the feature