### PR TITLE
Make client-id optional for OIDC service applications

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -786,6 +786,30 @@ Note that the OpenId Connect Provider externally accessible token and other endp
 In such cases, if you work with Keycloak then please start it with a `KEYCLOAK_FRONTEND_URL` system property set to the externally accessible base URL.
 If you work with other Openid Connect providers then please check your provider's documentation.
 
+== How to use 'client-id' property
+
+`quarkus.oidc.client-id` property identifies an OpenId Connect Client which requested the current bearer token. It can be an SPA application running in a browser or a Quarkus `web-app` confidential client application propagating the access token to the Quarkus `service` application.
+
+This property is required if the `service` application is expected to introspect the tokens remotely - which is always the case for the opaque tokens.
+This property is optional if the local Json Web Key token verification only is used.
+
+Nonetheless, setting this propery is encouraged even if the endpoint does not require an access to the remote introspection endpoint. The reasons behind it that `client-id`, if set, can be used to verify the token audience and will also be included in the logs when the token verification fails for the better traceability of the tokens issued to specific clients to be analyzed over a longer period of time.
+
+For example, if your OpenId Connect provider sets a token audience then the following configuration pattern is recommended:
+
+[source, properties]
+----
+# Set client-id
+quarkus.oidc.client-id=quarkus-app
+# Token audience claim must contain 'quarkus-app'
+quarkus.oidc.token.audience=${quarkus.oidc.client-id}
+----
+
+If you set `quarkus.oidc.client-id` but your endpoint does not require a remote access to one of OpenId Connect Provider endpoints (introspection, token acquisition, etc) then do not set a client secret with the `quarkus.oidc.credentials` or similar properties as it will not be used.
+
+Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` property.
+
+
 == References
 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -107,7 +107,7 @@ public class OidcClientRecorder {
         }
 
         try {
-            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false);
+            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false, false);
         } catch (Throwable t) {
             LOG.debug(t.getMessage());
             String message = String.format("'%s' client configuration is not initialized", oidcClientId);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -36,12 +36,18 @@ public class OidcCommonUtils {
 
     }
 
-    public static void verifyCommonConfiguration(OidcCommonConfig oidcConfig, boolean isServerConfig) {
+    public static void verifyCommonConfiguration(OidcCommonConfig oidcConfig, boolean clientIdOptional,
+            boolean isServerConfig) {
         final String configPrefix = isServerConfig ? "quarkus.oidc." : "quarkus.oidc-client.";
-        if (!oidcConfig.getAuthServerUrl().isPresent() || !oidcConfig.getClientId().isPresent()) {
+        if (!oidcConfig.getAuthServerUrl().isPresent()) {
             throw new ConfigurationException(
-                    String.format("Both '%1$sauth-server-url' and '%1$sclient-id' properties must be configured",
+                    String.format("'%sauth-server-url' property must be configured",
                             configPrefix));
+        }
+
+        if (!clientIdOptional && !oidcConfig.getClientId().isPresent()) {
+            throw new ConfigurationException(
+                    String.format("'%sclient-id' property must be configured", configPrefix));
         }
 
         try {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -117,7 +117,11 @@ public class OidcProvider {
             if (!details.isEmpty()) {
                 detail = details.get(0).getErrorMessage();
             }
-            LOG.debugf("Token verification has failed: %s", detail);
+            if (oidcConfig.clientId.isPresent()) {
+                LOG.debugf("Verification of the token issued to client %s has failed: %s", oidcConfig.clientId.get(), detail);
+            } else {
+                LOG.debugf("Token verification has failed: %s", detail);
+            }
             throw ex;
         }
         return new TokenVerificationResult(OidcUtils.decodeJwtContent(token), null);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -147,13 +147,13 @@ public class OidcRecorder {
         }
 
         try {
-            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, true);
+            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, isServiceApp(oidcConfig), true);
         } catch (ConfigurationException t) {
             return Uni.createFrom().failure(t);
         }
 
         if (!oidcConfig.discoveryEnabled) {
-            if (oidcConfig.applicationType != ApplicationType.SERVICE) {
+            if (!isServiceApp(oidcConfig)) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
                     throw new OIDCException("'web-app' applications must have 'authorization-path' and 'token-path' properties "
                             + "set when the discovery is disabled.");
@@ -166,7 +166,7 @@ public class OidcRecorder {
             }
         }
 
-        if (ApplicationType.SERVICE.equals(oidcConfig.applicationType)) {
+        if (isServiceApp(oidcConfig)) {
             if (oidcConfig.token.refreshExpired) {
                 throw new ConfigurationException(
                         "The 'token.refresh-expired' property can only be enabled for " + ApplicationType.WEB_APP
@@ -201,7 +201,7 @@ public class OidcRecorder {
     }
 
     private static TenantConfigContext createTenantContextFromPublicKey(OidcTenantConfig oidcConfig) {
-        if (oidcConfig.applicationType != ApplicationType.SERVICE) {
+        if (!isServiceApp(oidcConfig)) {
             throw new ConfigurationException("'public-key' property can only be used with the 'service' applications");
         }
         LOG.debug("'public-key' property for the local token verification is set,"
@@ -315,6 +315,10 @@ public class OidcRecorder {
                 return null;
             }
         });
+    }
+
+    private static boolean isServiceApp(OidcTenantConfig oidcConfig) {
+        return ApplicationType.SERVICE.equals(oidcConfig.applicationType);
     }
 
 }

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -13,6 +13,10 @@ quarkus.oidc.tenant-b.credentials.secret=secret
 quarkus.oidc.tenant-b.token.issuer=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-b.application-type=service
 
+# Tenant B - 2 clients
+quarkus.oidc.tenant-b2.auth-server-url=${keycloak.url}/realms/quarkus-b
+# issuer is discovered
+
 # Tenant B Service No Discovery (Introspection + User Info)
 quarkus.oidc.tenant-b-no-discovery.auth-server-url=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-b-no-discovery.discovery-enabled=false

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -157,6 +157,27 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testTenantBAllClients() {
+        RestAssured.given().auth().oauth2(getAccessToken("alice", "b"))
+                .when().get("/tenant/tenant-b2/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-b2:alice"));
+
+        RestAssured.given().auth().oauth2(getAccessToken("alice", "b", "b2"))
+                .when().get("/tenant/tenant-b2/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-b2:alice"));
+
+        // should give a 401 given that access token from issuer c can not access tenant b
+        RestAssured.given().auth().oauth2(getAccessToken("alice", "c"))
+                .when().get("/tenant/tenant-b2/api/user")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testResolveTenantIdentifier() {
         RestAssured.given().auth().oauth2(getAccessToken("alice", "b"))
                 .when().get("/tenant/tenant-b/api/user")
@@ -353,6 +374,10 @@ public class BearerTokenAuthorizationTest {
     }
 
     private String getAccessToken(String userName, String clientId) {
+        return getAccessToken(userName, clientId, clientId);
+    }
+
+    private String getAccessToken(String userName, String realmId, String clientId) {
         return RestAssured
                 .given()
                 .param("grant_type", "password")
@@ -361,7 +386,7 @@ public class BearerTokenAuthorizationTest {
                 .param("client_id", "quarkus-app-" + clientId)
                 .param("client_secret", "secret")
                 .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + clientId + "/protocol/openid-connect/token")
+                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + realmId + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
     }
 

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -30,6 +30,9 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
             RealmRepresentation realm = createRealm(KEYCLOAK_REALM + realmId);
 
             realm.getClients().add(createClient("quarkus-app-" + realmId));
+            if ("b".equals(realmId)) {
+                realm.getClients().add(createClient("quarkus-app-b2"));
+            }
             realm.getUsers().add(createUser("alice", "user"));
             realm.getUsers().add(createUser("admin", "user", "admin"));
             realm.getUsers().add(createUser("jdoe", "user", "confidential"));


### PR DESCRIPTION
Fixes #17021

(the earlier issue is #15707).

This PR makes `client-id` optional for OIDC `service` applications.

Initially, it feels wrong :-), may be we relax some security, but as mentioned at #17021, IMHO it is better not to require users to have something like:
```
quarkus.oidc.tenant-b.auth-server-url=${keycloak.url}/realms/quarkus-b
quarkus.oidc.tenant-b.client-id=whatever
quarkus.oidc.tenant-b.credentials.secret=likewise
```

in their configuration and still have it working :-).
Of course, in most real cases, users do know the `client-id`, so they would have
```
quarkus.oidc.tenant-b.auth-server-url=${keycloak.url}/realms/quarkus-b
quarkus.oidc.tenant-b.client-id=quarkus-app-b
quarkus.oidc.tenant-b.credentials.secret=secret
```
thinking it may be important, but then again, neither `client-id` nor `secret` are actually used for verifying the bearer tokens - unless the remote introspection is needed - so then why would users set the secret for example ?

So yes, after thinking more about it after a 2nd user mentioning it, IMHO the compromise offered with this PR is not too bad:

* Make `client-id` optional for `service` applications (decided not to require disabling the introspection for it - as it is not known at the start up what types of tokens will flow)
* Encourage users to set it to have a better correlation between the failed access tokens and client (doc it, update the way the error is logged)
* Now a single `service` endpoint can get tokens from a multi-client realm if needed (ex - one from SPA and one from the upstream code flow endpoint which propagates AT) 

So now, for the local JWT verification one can just have:
```
quarkus.oidc.tenant-b.auth-server-url=${keycloak.url}/realms/quarkus-b
# May be needed to avoid the introspection call (=> client-id and secret) when JWKs are refreshed
#quarkus.oidc,token.disable-jwt-introspection=true
```
