### PR TITLE
CI: Bump 'JVM Tests - JDK 15' to JDK 16 and EA job to 17-ea

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -34,8 +34,8 @@ env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
   COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
-  NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
-  JVM_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -Dformat.skip -DskipDocs"
+  NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  JVM_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dformat.skip -DskipDocs"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
@@ -226,7 +226,7 @@ jobs:
     needs: build-jdk11
     timeout-minutes: 240
     env:
-      MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
+      MAVEN_OPTS: ${{ matrix.java.maven_opts }}
     strategy:
       fail-fast: false
       matrix:
@@ -234,12 +234,14 @@ jobs:
           - {
             name: "11",
             java-version: 11,
-            maven_args: ""
+            maven_args: "",
+            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           }
           - {
-            name: "15",
-            java-version: 15,
-            maven_args: "-pl !integration-tests/kubernetes/quarkus-standard-way"
+            name: "16",
+            java-version: 16,
+            maven_args: "-pl '!devtools/gradle' -Dno-descriptor-tests",
+            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g --add-opens java.base/java.util=ALL-UNNAMED"
           }
 
     steps:
@@ -280,7 +282,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
         shell: bash
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -Dsurefire.timeout=600 -pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/devtools ${{ matrix.java.maven_args }} ${{ needs.build-jdk11.outputs.gib_args }}
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -Dsurefire.timeout=600 -pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/devtools ${{ matrix.java.maven_args }} ${{ needs.build-jdk11.outputs.gib_args }}
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -386,7 +388,7 @@ jobs:
           java-version: ${{ matrix.java.java-version }}
       - name: Build
         # Important: keep -pl ... in sync with "Calculate run flags"!
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl 'integration-tests/maven'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -434,7 +436,7 @@ jobs:
       - name: Build
         shell: bash
         # Important: keep -pl ... in sync with "Calculate run flags"!
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/maven'
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl 'integration-tests/maven'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -507,7 +509,7 @@ jobs:
       - name: Build
         shell: bash
         # Important: keep -pl ... in sync with "Calculate run flags"!
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl integration-tests/gradle
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl integration-tests/gradle
       - name: Upload Surefire reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
@@ -548,7 +550,7 @@ jobs:
           java-version: ${{ matrix.java.java-version }}
       - name: Build
         # Important: keep -pl ... in sync with "Calculate run flags"!
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools'
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl 'integration-tests/devtools'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -594,7 +596,7 @@ jobs:
       - name: Build
         shell: bash
         # Important: keep -pl ... in sync with "Calculate run flags"!
-        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_OPTS install -pl 'integration-tests/devtools'
+        run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl 'integration-tests/devtools'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -736,7 +738,7 @@ jobs:
         env:
           TEST_MODULES: ${{matrix.test-modules}}
           CONTAINER_BUILD: ${{startsWith(matrix.os-name, 'windows') && 'false' || 'true'}}
-        run: ./mvnw $COMMON_MAVEN_ARGS -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_OPTS -Dquarkus.native.container-build=$CONTAINER_BUILD
+        run: ./mvnw $COMMON_MAVEN_ARGS -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=$CONTAINER_BUILD
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -9,12 +9,11 @@ on:
       jdkVersion:
         description: 'JDK version'
         required: true
-        # switch to 17-ea once 16 has been fixed and is running in regular CI
         # make sure to keep the default of JDK_VERSION in sync!
-        default: '16'
+        default: '17-ea'
 
 env:
-  JDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdkVersion || '16' }}
+  JDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdkVersion || '17-ea' }}
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
   JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Dformat.skip"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ nb-configuration.xml
 .cache
 /lsp/
 .jbang
+.sdkmanrc

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions Status](<https://img.shields.io/github/workflow/status/QuarkusIO/quarkus/Quarkus CI?logo=GitHub&style=for-the-badge>)](https://github.com/quarkusio/quarkus/actions?query=workflow%3A%22Quarkus+CI%22)
 [![License](https://img.shields.io/github/license/quarkusio/quarkus?style=for-the-badge&logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
-[![Supported JVM Versions](https://img.shields.io/badge/JVM-8--11--15-brightgreen.svg?style=for-the-badge&logo=Java)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
+[![Supported JVM Versions](https://img.shields.io/badge/JVM-8--11--16-brightgreen.svg?style=for-the-badge&logo=Java)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
 
 # Quarkus - Supersonic Subatomic Java
 


### PR DESCRIPTION
and bump 'Early Access JDK Build' to JDK 17-ea

Resolves #16195

The EA job will fail with many probelms. I had a quick look and e.g. mockito is not yet compatible with Java 17 (ASM that is).
But that's not a pressing problem ATM.