### PR TITLE
Add DevServices support for Vault extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2337,6 +2337,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-vault-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-credentials</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -45,6 +45,11 @@ To complete this guide, you need:
 
 == Starting Vault
 
+[TIP]
+====
+Using <<dev-services,DevServices>>, Quarkus will take care of starting Vault in dev and test mode.
+====
+
 Let's start Vault in development mode:
 
 [source,bash, subs=attributes+]
@@ -278,6 +283,11 @@ quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=myapps/vault-quickstart/config
 ----
 
+[TIP]
+====
+Using <<dev-services,DevServices>>, Quarkus will take care of configuring the Vault connection in dev and test mode.
+====
+
 This should mount whatever keys are stored in `secret/myapps/vault-quickstart` as Config properties.
 
 Let's verify that by adding a new endpoint in GreetingResource:
@@ -507,6 +517,42 @@ path "auth/kubernetes/role/*" {
 ----
 
 You should adjust to the minimal set of access rights depending on your specific use case.
+
+[[dev-services]]
+== DevServices (Configuration Free Vault)
+
+Quarkus supports a feature called DevServices that allows you to create various containers without any config.
+What that means in practice is that if you have Docker running and have not configured `quarkus.vault.url`,
+Quarkus will automatically start a Vault container when running tests or in dev mode, and automatically
+configure the connection.
+
+When running the production version of the application, the Vault connection needs to be configured as normal,
+so if you want to include a production Vault config in your `application.properties` and continue to use DevServices
+we recommend that you use the `%prod.` profile to define your Vault connection settings.
+
+=== Automatic Secret Engine Provisioning
+
+To help with provisioning the automatically managed Vault instance, you can enable certain secret engines.
+
+[NOTE]
+====
+As mentioned above Vault containers started in dev mode automatically mount the  _kv secret engine v2_
+at `secret/`.
+====
+
+Enable the **Transit Secret Engine** at `transit/` using:
+
+[source,properties]
+----
+quarkus.vault.devservices.transit-enabled=true
+----
+
+Enable the **PKI Secret Engine** at `pki/` using:
+
+[source,properties]
+----
+quarkus.vault.devservices.pki-enabled=true
+----
 
 == Conclusion
 

--- a/extensions/vault/deployment-spi/pom.xml
+++ b/extensions/vault/deployment-spi/pom.xml
@@ -3,21 +3,20 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-extensions-parent</artifactId>
+        <artifactId>quarkus-vault-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-vault-parent</artifactId>
-    <name>Quarkus - Vault</name>
-    <packaging>pom</packaging>
-    <modules>
-        <module>deployment</module>
-        <module>deployment-spi</module>
-        <module>runtime</module>
-        <module>model</module>
-    </modules>
+    <artifactId>quarkus-vault-deployment-spi</artifactId>
+    <name>Quarkus - Vault - Deployment - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/extensions/vault/deployment-spi/src/main/java/io/quarkus/vault/deployment/devservices/DevServicesVaultResultBuildItem.java
+++ b/extensions/vault/deployment-spi/src/main/java/io/quarkus/vault/deployment/devservices/DevServicesVaultResultBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.vault.deployment.devservices;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class DevServicesVaultResultBuildItem extends SimpleBuildItem {
+    private final Map<String, String> properties;
+
+    public DevServicesVaultResultBuildItem(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/extensions/vault/deployment/pom.xml
+++ b/extensions/vault/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vault-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
@@ -44,6 +48,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>vault</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
@@ -1,0 +1,203 @@
+package io.quarkus.vault.deployment;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jboss.logging.Logger;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.IsDockerWorking;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.vault.deployment.devservices.DevServicesVaultResultBuildItem;
+import io.quarkus.vault.runtime.VaultVersions;
+import io.quarkus.vault.runtime.config.DevServicesConfig;
+import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
+
+public class DevServicesVaultProcessor {
+    private static final Logger log = Logger.getLogger(DevServicesVaultProcessor.class);
+    private static final String VAULT_IMAGE = "vault:" + VaultVersions.VAULT_TEST_VERSION;
+    private static final int VAULT_EXPOSED_PORT = 8200;
+    private static final String CONFIG_PREFIX = "quarkus.vault.";
+    private static final String URL_CONFIG_KEY = CONFIG_PREFIX + "url";
+    private static final String AUTH_CONFIG_PREFIX = CONFIG_PREFIX + "authentication.";
+    private static final String CLIENT_TOKEN_CONFIG_KEY = AUTH_CONFIG_PREFIX + "client-token";
+    private static volatile List<Closeable> closeables;
+    private static volatile DevServicesConfig capturedDevServicesConfiguration;
+    private static volatile boolean first = true;
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
+
+    @BuildStep(onlyIfNot = IsNormal.class)
+    public DevServicesVaultResultBuildItem startVaultContainers(LaunchModeBuildItem launchMode,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfiguration,
+            BuildProducer<ServiceStartBuildItem> serviceStartBuildItemBuildProducer, VaultBuildTimeConfig config) {
+
+        DevServicesConfig currentDevServicesConfiguration = config.devservices;
+
+        // figure out if we need to shut down and restart any existing Vault container
+        // if not and the Vault container have already started we just return
+        if (closeables != null) {
+            boolean restartRequired = launchMode.getLaunchMode() == LaunchMode.TEST;
+            if (!restartRequired) {
+                restartRequired = !currentDevServicesConfiguration.equals(capturedDevServicesConfiguration);
+            }
+            if (!restartRequired) {
+                return null;
+            }
+            for (Closeable closeable : closeables) {
+                try {
+                    closeable.close();
+                } catch (Throwable e) {
+                    log.error("Failed to stop Vault container", e);
+                }
+            }
+            closeables = null;
+            capturedDevServicesConfiguration = null;
+        }
+
+        capturedDevServicesConfiguration = currentDevServicesConfiguration;
+
+        StartResult startResult = startContainer(currentDevServicesConfiguration);
+        if (startResult == null) {
+            return null;
+        }
+
+        runTimeConfiguration.produce(new RunTimeConfigurationDefaultBuildItem(URL_CONFIG_KEY, startResult.url));
+        runTimeConfiguration
+                .produce(new RunTimeConfigurationDefaultBuildItem(CLIENT_TOKEN_CONFIG_KEY, startResult.clientToken));
+
+        Map<String, String> connectionProperties = new HashMap<>();
+        connectionProperties.put(URL_CONFIG_KEY, startResult.url);
+        connectionProperties.put(CLIENT_TOKEN_CONFIG_KEY, startResult.clientToken);
+
+        closeables = Collections.singletonList(startResult.closeable);
+
+        if (first) {
+            first = false;
+            Runnable closeTask = new Runnable() {
+                @Override
+                public void run() {
+                    if (closeables != null) {
+                        for (Closeable closeable : closeables) {
+                            try {
+                                closeable.close();
+                            } catch (Throwable t) {
+                                log.error("Failed to stop Vault container", t);
+                            }
+                        }
+                    }
+                    first = true;
+                    closeables = null;
+                    capturedDevServicesConfiguration = null;
+                }
+            };
+            QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
+            ((QuarkusClassLoader) cl.parent()).addCloseTask(closeTask);
+            Thread closeHookThread = new Thread(closeTask, "Vault container shutdown thread");
+            Runtime.getRuntime().addShutdownHook(closeHookThread);
+            ((QuarkusClassLoader) cl.parent()).addCloseTask(new Runnable() {
+                @Override
+                public void run() {
+                    Runtime.getRuntime().removeShutdownHook(closeHookThread);
+                }
+            });
+        }
+        return new DevServicesVaultResultBuildItem(connectionProperties);
+    }
+
+    private StartResult startContainer(DevServicesConfig devServicesConfig) {
+        if (!devServicesConfig.enabled) {
+            // explicitly disabled
+            log.debug("Not starting devservices for Vault as it has been disabled in the config");
+            return null;
+        }
+
+        if (!isDockerWorking.getAsBoolean()) {
+            log.warn("Please configure Vault URL or get a working docker instance");
+            return null;
+        }
+
+        boolean needToStart = !ConfigUtils.isPropertyPresent(URL_CONFIG_KEY);
+        if (!needToStart) {
+            log.debug("Not starting devservices for default Vault client as url have been provided");
+            return null;
+        }
+
+        String token = RandomStringUtils.randomAlphanumeric(10);
+
+        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(VAULT_IMAGE))
+                .asCompatibleSubstituteFor(VAULT_IMAGE);
+        FixedPortVaultContainer vaultContainer = new FixedPortVaultContainer(dockerImageName, devServicesConfig.port)
+                .withVaultToken(token);
+
+        if (devServicesConfig.transitEnabled) {
+            vaultContainer.withInitCommand("secrets enable transit");
+        }
+
+        if (devServicesConfig.pkiEnabled) {
+            vaultContainer.withInitCommand("secrets enable pki");
+        }
+
+        vaultContainer.start();
+
+        String url = "http://" + vaultContainer.getHost() + ":" + vaultContainer.getPort();
+        return new StartResult(url, token,
+                new Closeable() {
+                    @Override
+                    public void close() {
+                        vaultContainer.close();
+                    }
+                });
+    }
+
+    private static class StartResult {
+        private final String url;
+        private final String clientToken;
+        private final Closeable closeable;
+
+        public StartResult(String url, String clientToken, Closeable closeable) {
+            this.url = url;
+            this.clientToken = clientToken;
+            this.closeable = closeable;
+        }
+    }
+
+    private static class FixedPortVaultContainer extends VaultContainer<FixedPortVaultContainer> {
+        OptionalInt fixedExposedPort;
+
+        public FixedPortVaultContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort) {
+            super(dockerImageName);
+            this.fixedExposedPort = fixedExposedPort;
+        }
+
+        @Override
+        protected void configure() {
+            super.configure();
+            if (fixedExposedPort.isPresent()) {
+                addFixedExposedPort(fixedExposedPort.getAsInt(), VAULT_EXPOSED_PORT);
+            } else {
+                addExposedPort(VAULT_EXPOSED_PORT);
+            }
+        }
+
+        public int getPort() {
+            if (fixedExposedPort.isPresent()) {
+                return fixedExposedPort.getAsInt();
+            }
+            return super.getMappedPort(VAULT_EXPOSED_PORT);
+        }
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
@@ -1,0 +1,7 @@
+package io.quarkus.vault.runtime;
+
+public class VaultVersions {
+
+    public static final String VAULT_TEST_VERSION = "1.7.1";
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/DevServicesConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/DevServicesConfig.java
@@ -1,0 +1,76 @@
+package io.quarkus.vault.runtime.config;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class DevServicesConfig {
+
+    /**
+     * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled
+     * by default, unless there is an existing configuration present.
+     * <p>
+     * When DevServices is enabled Quarkus will attempt to automatically configure and start
+     * a vault instance when running in Dev or Test mode and when Docker is running.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
+     * The container image name to use, for container based DevServices providers.
+     */
+    @ConfigItem
+    public Optional<String> imageName;
+
+    /**
+     * Optional fixed port the dev service will listen to.
+     * <p>
+     * If not defined, the port will be chosen randomly.
+     */
+    @ConfigItem
+    public OptionalInt port;
+
+    /**
+     * Should the Transit secret engine be enabled
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean transitEnabled;
+
+    /**
+     * Should the PKI secret engine be enabled
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean pkiEnabled;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevServicesConfig that = (DevServicesConfig) o;
+        return enabled == that.enabled && Objects.equals(imageName,
+                that.imageName) && Objects.equals(port,
+                        that.port);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, imageName, port);
+    }
+
+    @Override
+    public String toString() {
+        return "DevServicesConfig{" +
+                "enabled=" + enabled +
+                ", imageName=" + imageName +
+                ", port=" + port +
+                '}';
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBuildTimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBuildTimeConfig.java
@@ -15,10 +15,17 @@ public class VaultBuildTimeConfig {
     @ConfigDocSection
     public HealthConfig health;
 
+    /**
+     * Dev services configuration.
+     */
+    @ConfigItem
+    public DevServicesConfig devservices;
+
     @Override
     public String toString() {
         return "VaultBuildTimeConfig{" +
                 "health=" + health +
+                ", devservices=" + devservices +
                 '}';
     }
 }

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>quarkus-redis-client-deployment-spi</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vault-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <!-- Avoid adding this to the BOM -->

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.BuildResult;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem;
 import io.quarkus.mongodb.deployment.devservices.DevServicesMongoResultBuildItem;
 import io.quarkus.redis.client.deployment.devservices.DevServicesRedisResultBuildItem;
+import io.quarkus.vault.deployment.devservices.DevServicesVaultResultBuildItem;
 
 public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
     @Override
@@ -54,6 +55,14 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
                 for (Map.Entry<String, String> entry : redisNamedConfiguration.getValue().getProperties().entrySet()) {
                     propertyConsumer.accept(entry.getKey(), entry.getValue());
                 }
+            }
+        }
+
+        DevServicesVaultResultBuildItem vaultDevServices = buildResult.consumeOptional(DevServicesVaultResultBuildItem.class);
+        if (vaultDevServices != null) {
+            Map<String, String> properties = vaultDevServices.getProperties();
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                propertyConsumer.accept(entry.getKey(), entry.getValue());
             }
         }
     }

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -48,6 +48,7 @@ import org.testcontainers.containers.output.OutputFrame;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.quarkus.vault.runtime.VaultVersions;
 import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
 import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
@@ -244,7 +245,7 @@ public class VaultTestExtension {
     }
 
     private String getVaultImage() {
-        return "vault:1.6.3";
+        return "vault:" + VaultVersions.VAULT_TEST_VERSION;
     }
 
     private void initVault() throws InterruptedException, IOException {


### PR DESCRIPTION
Enables DevServices for Vault.

* A single Vault container is supported (equivalent to the extension)
* The configuration allows for enabling engines:
* * Transit
* * PKI

Note that due to my unfamiliarity with how DevServices worked (although it seems mostly clear now) this is implemented essentially a copy of the recent PR #17070 for Redis. If there is complexity that can be removed or the feature can be better organized I'm all ears.
