### PR TITLE
Renamed NativeImageBuildStepTest to GraalVMTest

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.deployment.pkg.steps.GraalVM.Distribution;
 import io.quarkus.deployment.pkg.steps.GraalVM.Version;
 
-public class NativeImageBuildStepTest {
+public class GraalVMTest {
 
     @Test
     public void testGraalVMVersionDetected() {


### PR DESCRIPTION
Because this class tests the `io.quarkus.deployment.pkg.steps.GraalVM` class only