### PR TITLE
Prevent a failed cancellation of a file upload from hanging a request

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/MultipartFormHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/MultipartFormHandler.java
@@ -171,13 +171,17 @@ public class MultipartFormHandler implements RuntimeConfigurableServerRestHandle
         private void cancelUploads() {
             for (FileUpload fileUpload : context.fileUploads()) {
                 FileSystem fileSystem = context.vertx().fileSystem();
-                if (!fileUpload.cancel()) {
-                    String uploadedFileName = fileUpload.uploadedFileName();
-                    fileSystem.delete(uploadedFileName, deleteResult -> {
-                        if (deleteResult.failed()) {
-                            LOG.warn("Delete of uploaded file failed: " + uploadedFileName, deleteResult.cause());
-                        }
-                    });
+                try {
+                    if (!fileUpload.cancel()) {
+                        String uploadedFileName = fileUpload.uploadedFileName();
+                        fileSystem.delete(uploadedFileName, deleteResult -> {
+                            if (deleteResult.failed()) {
+                                LOG.warn("Delete of uploaded file failed: " + uploadedFileName, deleteResult.cause());
+                            }
+                        });
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Unable to cancel file upload:", e);
                 }
             }
         }


### PR DESCRIPTION
Sporadically, CI would report:

```
2021-05-08T00:15:24.1064400Z 2021-05-08 00:14:54,208 ERROR [io.qua.ver.cor.run.VertxCoreRecorder] (vert.x-eventloop-thread-0) Uncaught exception received by Vert.x: java.lang.IllegalStateException: File handle is closed
2021-05-08T00:15:24.1077034Z 	at io.vertx.core.file.impl.AsyncFileImpl.checkClosed(AsyncFileImpl.java:544)
2021-05-08T00:15:24.1078922Z 	at io.vertx.core.file.impl.AsyncFileImpl.check(AsyncFileImpl.java:539)
2021-05-08T00:15:24.1080404Z 	at io.vertx.core.file.impl.AsyncFileImpl.drainHandler(AsyncFileImpl.java:271)
2021-05-08T00:15:24.1081993Z 	at io.vertx.core.file.impl.AsyncFileImpl.drainHandler(AsyncFileImpl.java:54)
2021-05-08T00:15:24.1083423Z 	at io.vertx.core.streams.impl.PipeImpl.close(PipeImpl.java:138)
2021-05-08T00:15:24.1085718Z 	at io.vertx.core.http.impl.HttpServerFileUploadImpl.cancelStreamToFileSystem(HttpServerFileUploadImpl.java:223)
2021-05-08T00:15:24.1088067Z 	at io.vertx.ext.web.impl.FileUploadImpl.cancel(FileUploadImpl.java:72)
2021-05-08T00:15:24.1090548Z 	at io.quarkus.resteasy.reactive.server.runtime.MultipartFormHandler$MultipartFormVertxHandler.cancelUploads(MultipartFormHandler.java:174)
2021-05-08T00:15:24.1093542Z 	at io.quarkus.resteasy.reactive.server.runtime.MultipartFormHandler$MultipartFormVertxHandler$1.handle(MultipartFormHandler.java:128)
2021-05-08T00:15:24.1096689Z 	at io.quarkus.resteasy.reactive.server.runtime.MultipartFormHandler$MultipartFormVertxHandler$1.handle(MultipartFormHandler.java:125)
2021-05-08T00:15:24.1103341Z 	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:96)
2021-05-08T00:15:24.1105030Z 	at io.vertx.core.http.impl.HttpEventHandler.handleException(HttpEventHandler.java:89)
2021-05-08T00:15:24.1107325Z 	at io.vertx.core.http.impl.Http1xServerRequest.handleException(Http1xServerRequest.java:612)
2021-05-08T00:15:24.1109474Z 	at io.vertx.core.http.impl.Http1xServerRequest.onData(Http1xServerRequest.java:524)
2021-05-08T00:15:24.1111266Z 	at io.vertx.core.http.impl.Http1xServerRequest.lambda$pendingQueue$1(Http1xServerRequest.java:127)
2021-05-08T00:15:24.1113021Z 	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:240)
2021-05-08T00:15:24.1114600Z 	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:130)
2021-05-08T00:15:24.1116519Z 	at io.vertx.core.http.impl.Http1xServerRequest.handleContent(Http1xServerRequest.java:141)
2021-05-08T00:15:24.1118381Z 	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:73)
2021-05-08T00:15:24.1119918Z 	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:189)
2021-05-08T00:15:24.1121796Z 	at io.vertx.core.http.impl.Http1xServerConnection.onContent(Http1xServerConnection.java:183)
2021-05-08T00:15:24.1124045Z 	at io.vertx.core.http.impl.Http1xServerConnection.handleOther(Http1xServerConnection.java:156)
2021-05-08T00:15:24.1126402Z 	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:144)
2021-05-08T00:15:24.1128302Z 	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:153)
2021-05-08T00:15:24.1129838Z 	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:154)
2021-05-08T00:15:24.1131927Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
2021-05-08T00:15:24.1134611Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
2021-05-08T00:15:24.1137927Z 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
2021-05-08T00:15:24.1142116Z 	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
2021-05-08T00:15:24.1146128Z 	at io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler.channelRead(WebSocketServerExtensionHandler.java:102)
2021-05-08T00:15:24.1150059Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
2021-05-08T00:15:24.1152744Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
2021-05-08T00:15:24.1155615Z 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
2021-05-08T00:15:24.1158179Z 	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
2021-05-08T00:15:24.1160750Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
2021-05-08T00:15:24.1163762Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
2021-05-08T00:15:24.1167193Z 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
2021-05-08T00:15:24.1197452Z 	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
2021-05-08T00:15:24.1203707Z 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
2021-05-08T00:15:24.1206581Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
2021-05-08T00:15:24.1209488Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
2021-05-08T00:15:24.1213087Z 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
2021-05-08T00:15:24.1215358Z 	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
2021-05-08T00:15:24.1217905Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
2021-05-08T00:15:24.1221498Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
2021-05-08T00:15:24.1223922Z 	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
2021-05-08T00:15:24.1226014Z 	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
2021-05-08T00:15:24.1227885Z 	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
2021-05-08T00:15:24.1230018Z 	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
2021-05-08T00:15:24.1231948Z 	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
2021-05-08T00:15:24.1233394Z 	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
2021-05-08T00:15:24.1261489Z 	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
2021-05-08T00:15:24.1275338Z 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2021-05-08T00:15:24.1277339Z 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2021-05-08T00:15:24.1278777Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2021-05-08T00:15:24.1279228Z 
2021-05-08T00:15:24.1581940Z 2021-05-08 00:15:24,136 INFO  [io.quarkus] (main) Quarkus stopped in 0.033s
2021-05-08T00:15:24.1584852Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 32.308 s <<< FAILURE! - in io.quarkus.resteasy.reactive.server.test.multipart.TooLargeFormAttributeMultipartFormInputTest
2021-05-08T00:15:24.1589697Z [ERROR] io.quarkus.resteasy.reactive.server.test.multipart.TooLargeFormAttributeMultipartFormInputTest.test  Time elapsed: 30.502 s  <<< ERROR!
2021-05-08T00:15:24.1592621Z java.net.SocketTimeoutException: Read timed out
2021-05-08T00:15:24.1593623Z 	at java.base/java.net.SocketInputStream.socketRead0(Native Method)
2021-05-08T00:15:24.1594890Z 	at java.base/java.net.SocketInputStream.socketRead(SocketInputStream.java:115)
2021-05-08T00:15:24.1596436Z 	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:168)
2021-05-08T00:15:24.1597705Z 	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:140)
```

So this PR makes sure that even if a cancellation request fails, the request doesn't hang 