### PR TITLE
Upgrade to Gradle 7.2 and enable Gradle modules on JDK EA build

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -250,7 +250,7 @@ jobs:
           - {
             name: "16",
             java-version: 16,
-            maven_args: "$JVM_TEST_MAVEN_ARGS -pl '!devtools/gradle'",
+            maven_args: "$JVM_TEST_MAVEN_ARGS",
             maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
             os-name: "ubuntu-latest"
           }

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -70,9 +70,8 @@ jobs:
       - name: Build with Maven
         # -fae to try to gather as many failures as possible
         # (but not maven.test.failure.ignore because test report generation is buggy)
-        # Gradle bits are excluded due to https://github.com/gradle/gradle/issues/13481
         run: |
-          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae -pl '!devtools/gradle' -pl '!integration-tests/gradle'
+          ./mvnw $JVM_TEST_MAVEN_OPTS -Dtcks install -fae
       # Test reports disabled due to: https://github.com/ScaCap/action-surefire-report/issues/39
       #- name: Publish Test Report
       #  if: always()

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -59,7 +59,7 @@
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.1</proposed-maven-version>
         <maven-wrapper.version>0.7.7</maven-wrapper.version>
-        <gradle-wrapper.version>6.9</gradle-wrapper.version>
+        <gradle-wrapper.version>7.2</gradle-wrapper.version>
 
         <!-- MicroProfile TCK versions -->
         <microprofile-health-api.version>3.1</microprofile-health-api.version>

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -137,7 +137,7 @@ public class CliDriver {
         Files.walk(path)
                 .sorted(Comparator.reverseOrder())
                 .map(Path::toFile)
-                .forEach(File::delete);
+                .forEach(f -> retryDelete(f));
 
         Assertions.assertFalse(path.toFile().exists());
     }
@@ -350,5 +350,22 @@ public class CliDriver {
             return "-D" + name + "=" + value;
         }
         return null;
+    }
+
+    private static void retryDelete(File file) {
+        if (file.delete()) {
+            return;
+        }
+        int i = 0;
+        while (i++ < 10) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignored) {
+
+            }
+            if (file.delete()) {
+                break;
+            }
+        }
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.cli.build.ExecuteUtil;
@@ -23,7 +22,6 @@ import picocli.CommandLine;
 /**
  * Similar to CliProjectMavenTest ..
  */
-@Tag("failsOnJDK16")
 public class CliProjectGradleTest {
     static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
             .resolve("target/test-project/");

--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/devtools/project-core-extension-codestarts/pom.xml
+++ b/devtools/project-core-extension-codestarts/pom.xml
@@ -44,10 +44,10 @@
                                 <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
                             </environmentVariables>
                             <arguments>
-                                <argument>wrapper</argument>
+                                <argument>init</argument>
+                                <argument>--type</argument>
+                                <argument>basic</argument>
                                 <argument>--no-daemon</argument>
-                                <argument>--gradle-version</argument>
-                                <argument>${gradle-wrapper.version}</argument>
                             </arguments>
                             <workingDirectory>target/classes/gradle-wrapper</workingDirectory>
                             <addOutputToClasspath>true</addOutputToClasspath>

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -494,3 +494,16 @@ More information on this topic can be found on the link:cdi-reference#bean_disco
 == Building with `./gradlew build`
 
 Starting from 1.1.0.Final, `./gradlew build` will no longer build the native image. Add `-Dquarkus.package.type=native` build argument explicitly as explained above if needed.
+
+== Publishing your application
+
+In order to make sure the right dependency versions are being used by Gradle, the BOM is declared as an `enforcedPlatform` in your build file.
+By default, the `maven-publish` plugin will prevent you from publishing your application due to this `enforcedPlatform`.
+This validation can be skipped by adding the following configuration in your `build.gradle` file:
+
+[source,groovy]
+----
+tasks.withType(GenerateModuleMetadata).configureEach {
+    suppressedValidationErrors.add('enforced-platform')
+}
+----

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -7,7 +7,7 @@ language:
   base:
     data:
       gradle:
-        version: 6.9
+        version: 7.2
     shared-data:
       buildtool:
         cli: ./gradlew

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -314,7 +314,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "proposed-maven-version": "3.8.1",
         "maven-wrapper-version": "0.7.7",
-        "gradle-wrapper-version": "6.9"
+        "gradle-wrapper-version": "7.2"
       }
     },
     "codestarts-artifacts": [

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -28,7 +28,7 @@
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.1</proposed-maven-version>
         <maven-wrapper.version>0.7.7</maven-wrapper.version>
-        <gradle-wrapper.version>6.9</gradle-wrapper.version>
+        <gradle-wrapper.version>7.2</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
@@ -68,7 +68,6 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
 
     @ParameterizedTest
     @MethodSource("provideLanguages")
-    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testGradle(String language) throws Exception {
         final List<String> codestarts = getExtensionCodestarts();
         generateProjectRunTests("gradle", language, codestarts);

--- a/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
@@ -28,7 +28,7 @@ sourceSets {
             resources.srcDir 'src/funcTest/resources'
         }
 
-        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath + configurations.compileOnly
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
         runtimeClasspath += output + compileClasspath
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation("org.hibernate:hibernate-core:5.4.9")
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     api("org.hibernate:hibernate-core:5.4.9") {
         exclude module: "byte-buddy"
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-b:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-c:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-d:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-e:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-f:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-g:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-g:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-h:runtime')
     implementation project(':ext-k:deployment')

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-k:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-i:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-j:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-k:runtime')
     implementation project(':ext-t:deployment')

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-t:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-l:runtime')
     implementation project(':ext-j:deployment')

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-j:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-m:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-n:runtime')
     implementation project(':ext-i:deployment')

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-i:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-o:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-p:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-r:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-s:runtime')
     implementation project(':ext-u:deployment')

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation project(':ext-u:runtime')
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-t:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation project(':ext-u:runtime')
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/deployment/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+  implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
   implementation 'io.quarkus:quarkus-core-deployment'
   implementation project(":runtime")
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
 publishing {


### PR DESCRIPTION
This branch enables gradle modules build in `jdk-early-access-build` workflow.

close #17081 
close #19256