### PR TITLE
ArC - build fails if an injection point of raw type Instance is defined

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -454,15 +454,19 @@ final class Beans {
         }
         BuiltinBean builtinBean = BuiltinBean.resolve(injectionPoint);
         if (builtinBean != null) {
-            if (BuiltinBean.INJECTION_POINT.equals(builtinBean)
+            if (BuiltinBean.INJECTION_POINT == builtinBean
                     && (target.kind() != TargetKind.BEAN || !BuiltinScope.DEPENDENT.is(target.asBean().getScope()))) {
                 errors.add(new DefinitionException("Only @Dependent beans can access metadata about an injection point: "
                         + injectionPoint.getTargetInfo()));
-            }
-            if (BuiltinBean.EVENT_METADATA.equals(builtinBean)
+            } else if (BuiltinBean.EVENT_METADATA == builtinBean
                     && target.kind() != TargetKind.OBSERVER) {
                 errors.add(new DefinitionException("EventMetadata can be only injected into an observer method: "
                         + injectionPoint.getTargetInfo()));
+            } else if (BuiltinBean.INSTANCE == builtinBean
+                    && injectionPoint.getRequiredType().kind() != Kind.PARAMETERIZED_TYPE) {
+                errors.add(
+                        new DefinitionException("An injection point of raw type javax.enterprise.inject.Instance is defined: "
+                                + injectionPoint.getTargetInfo()));
             }
             // Skip built-in beans
             return;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/RawTypeInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/RawTypeInstanceTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.instance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RawTypeInstanceTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class).shouldFail().build();
+
+    @Test
+    public void testDefinitionError() {
+        Throwable failure = container.getFailure();
+        assertNotNull(failure);
+        assertEquals(DefinitionException.class, failure.getClass());
+        assertTrue(failure.getMessage().contains(Instance.class.getName()));
+        assertTrue(failure.getMessage().contains("Alpha#instance"));
+    }
+
+    @Singleton
+    static class Alpha {
+
+        @SuppressWarnings("rawtypes")
+        @Inject
+        Instance instance;
+
+    }
+
+}


### PR DESCRIPTION
- this behavior is defined by the spec