### PR TITLE
Improve adding extension xp in all tooling

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.commands.handlers;
 
 import static io.quarkus.devtools.commands.AddExtensions.EXTENSION_MANAGER;
+import static io.quarkus.devtools.messagewriter.MessageIcons.ERROR_ICON;
 import static io.quarkus.devtools.messagewriter.MessageIcons.NOK_ICON;
 
 import io.quarkus.devtools.commands.AddExtensions;
@@ -42,17 +43,38 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                 invocation.getQuarkusProject().getExtensionManager());
         try {
             ExtensionInstallPlan extensionInstallPlan = planInstallation(invocation, extensionsQuery);
-            if (extensionInstallPlan.isNotEmpty()) {
+            if (extensionInstallPlan.isInstallable()) {
                 final InstallResult result = extensionManager.install(extensionInstallPlan);
-                result.getInstalled()
+                result.getInstalledPlatforms()
+                        .forEach(a -> invocation.log()
+                                .info(MessageIcons.OK_ICON + " Platform " + a.getGroupId() + ":" + a.getArtifactId()
+                                        + " has been installed"));
+                result.getInstalledManagedExtensions()
                         .forEach(a -> invocation.log()
                                 .info(MessageIcons.OK_ICON + " Extension " + a.getGroupId() + ":" + a.getArtifactId()
                                         + " has been installed"));
+                result.getInstalledIndependentExtensions()
+                        .forEach(a -> invocation.log()
+                                .info(MessageIcons.OK_ICON + " Extension " + a.getGroupId() + ":" + a.getArtifactId() + ":"
+                                        + a.getVersion()
+                                        + " has been installed"));
+                result.getAlreadyInstalled()
+                        .forEach(a -> invocation.log()
+                                .info(MessageIcons.NOOP_ICON + " Extension " + a.getGroupId() + ":" + a.getArtifactId()
+                                        + " was already installed"));
                 return new QuarkusCommandOutcome(true).setValue(AddExtensions.OUTCOME_UPDATED, result.isSourceUpdated());
+            } else if (!extensionInstallPlan.getUnmatchedKeywords().isEmpty()) {
+                invocation.log()
+                        .info(ERROR_ICON + " Nothing installed because keyword(s) '"
+                                + String.join("', '", extensionInstallPlan.getUnmatchedKeywords())
+                                + "' were not matched in the catalog.");
+            } else {
+                invocation.log()
+                        .info(NOK_ICON + " The provided keyword(s) did not match any extension from the catalog.");
             }
         } catch (MultipleExtensionsFoundException m) {
             StringBuilder sb = new StringBuilder();
-            sb.append(NOK_ICON + " Multiple extensions matching '").append(m.getKeyword()).append("'");
+            sb.append(ERROR_ICON + " Multiple extensions matching '").append(m.getKeyword()).append("'");
             m.getExtensions()
                     .forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
                             .append(extension.managementKey()));
@@ -68,12 +90,14 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
 
     public ExtensionInstallPlan planInstallation(QuarkusCommandInvocation invocation, Collection<String> keywords)
             throws IOException {
+        if (keywords.isEmpty()) {
+            return ExtensionInstallPlan.EMPTY;
+        }
         final ExtensionCatalog catalog = invocation.getExtensionsCatalog();
         final String quarkusCore = catalog.getQuarkusCoreVersion();
         final Collection<ArtifactCoords> importedPlatforms = invocation.getQuarkusProject().getExtensionManager()
                 .getInstalledPlatforms();
         ExtensionInstallPlan.Builder builder = ExtensionInstallPlan.builder();
-        boolean multipleKeywords = keywords.size() > 1;
         for (String keyword : keywords) {
             int countColons = StringUtils.countMatches(keyword, ":");
             // Check if it's just groupId:artifactId
@@ -87,9 +111,9 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                 continue;
             }
             List<Extension> listed = listInternalExtensions(quarkusCore, keyword, catalog.getExtensions());
-            if (listed.size() != 1 && multipleKeywords) {
-                // No extension found for this keyword. Return empty immediately
-                return ExtensionInstallPlan.EMPTY;
+            if (listed.isEmpty()) {
+                // No extension found for this keyword.
+                builder.addUnmatchedKeyword(keyword);
             }
             // If it's a pattern allow multiple results
             // See https://github.com/quarkusio/quarkus/issues/11086#issuecomment-666360783

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
@@ -81,7 +81,13 @@ public class MavenBuildFile extends BuildFile {
             if (model.getDependencies()
                     .stream()
                     .noneMatch(thisDep -> d.getManagementKey().equals(thisDep.getManagementKey()))) {
-                model.addDependency(d);
+                final int index = getIndexToAddExtension();
+                if (index >= 0) {
+                    model.getDependencies().add(index, d);
+                } else {
+                    model.getDependencies().add(d);
+                }
+
                 return true;
             }
         }
@@ -150,6 +156,16 @@ public class MavenBuildFile extends BuildFile {
             }
             return model;
         });
+    }
+
+    private int getIndexToAddExtension() {
+        final List<Dependency> dependencies = getModel().getDependencies();
+        for (int i = 0; i < dependencies.size(); i++) {
+            if ("test".equals(dependencies.get(i).getScope())) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private Model initModel() throws IOException {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -221,7 +221,13 @@ public class MavenProjectBuildFile extends BuildFile {
         } else if (model().getDependencies()
                 .stream()
                 .noneMatch(thisDep -> d.getManagementKey().equals(thisDep.getManagementKey()))) {
-            model().addDependency(d);
+            final int index = getIndexToAddExtension();
+            if (index >= 0) {
+                model().getDependencies().add(index, d);
+            } else {
+                model().getDependencies().add(d);
+            }
+
             // it could still be a transitive dependency or inherited from the parent
             if (!getDependencies().contains(coords)) {
                 getDependencies().add(coords);
@@ -241,8 +247,8 @@ public class MavenProjectBuildFile extends BuildFile {
                     i.remove();
                     break;
                 }
-                model().getDependencies().removeIf(d -> Objects.equals(toKey(d), key));
             }
+            model().getDependencies().removeIf(d -> Objects.equals(toKey(d), key));
         }
     }
 
@@ -291,6 +297,16 @@ public class MavenProjectBuildFile extends BuildFile {
 
     @Override
     protected void refreshData() {
+    }
+
+    private int getIndexToAddExtension() {
+        final List<Dependency> dependencies = model().getDependencies();
+        for (int i = 0; i < dependencies.size(); i++) {
+            if ("test".equals(dependencies.get(i).getScope())) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private Model model() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.project.extensions;
 
 import io.quarkus.maven.ArtifactCoords;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -11,23 +12,31 @@ public class ExtensionInstallPlan {
     public static final ExtensionInstallPlan EMPTY = new ExtensionInstallPlan(
             Collections.emptySet(),
             Collections.emptySet(),
+            Collections.emptySet(),
             Collections.emptySet());
 
     private final Set<ArtifactCoords> platforms;
     private final Set<ArtifactCoords> managedExtensions;
     private final Set<ArtifactCoords> independentExtensions;
+    private final Collection<String> unmatchedKeywords;
 
     private ExtensionInstallPlan(Set<ArtifactCoords> platforms,
             Set<ArtifactCoords> managedExtensions,
-            Set<ArtifactCoords> independentExtensions) {
+            Set<ArtifactCoords> independentExtensions,
+            Collection<String> unmatchedKeywords) {
         this.platforms = platforms;
         this.managedExtensions = managedExtensions;
         this.independentExtensions = independentExtensions;
+        this.unmatchedKeywords = unmatchedKeywords;
     }
 
     public boolean isNotEmpty() {
         return !this.platforms.isEmpty() || !this.managedExtensions.isEmpty()
                 || !this.independentExtensions.isEmpty();
+    }
+
+    public boolean isInstallable() {
+        return isNotEmpty() && unmatchedKeywords.isEmpty();
     }
 
     /**
@@ -63,12 +72,17 @@ public class ExtensionInstallPlan {
         return independentExtensions;
     }
 
+    public Collection<String> getUnmatchedKeywords() {
+        return unmatchedKeywords;
+    }
+
     @Override
     public String toString() {
         return "InstallRequest{" +
                 "platforms=" + platforms +
                 ", managedExtensions=" + managedExtensions +
                 ", independentExtensions=" + independentExtensions +
+                ", unmatchedKeywords=" + unmatchedKeywords +
                 '}';
     }
 
@@ -81,9 +95,10 @@ public class ExtensionInstallPlan {
         private final Set<ArtifactCoords> platforms = new LinkedHashSet<>();
         private final Set<ArtifactCoords> extensionsInPlatforms = new LinkedHashSet<>();
         private final Set<ArtifactCoords> independentExtensions = new LinkedHashSet<>();
+        private final Collection<String> unmatchedKeywords = new ArrayList<>();
 
         public ExtensionInstallPlan build() {
-            return new ExtensionInstallPlan(platforms, extensionsInPlatforms, independentExtensions);
+            return new ExtensionInstallPlan(platforms, extensionsInPlatforms, independentExtensions, unmatchedKeywords);
         }
 
         public Builder addIndependentExtension(ArtifactCoords artifactCoords) {
@@ -98,6 +113,11 @@ public class ExtensionInstallPlan {
 
         public Builder addPlatform(ArtifactCoords artifactCoords) {
             this.platforms.add(artifactCoords);
+            return this;
+        }
+
+        public Builder addUnmatchedKeyword(String unmatchedKeyword) {
+            this.unmatchedKeywords.add(unmatchedKeyword);
             return this;
         }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionManager.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionManager.java
@@ -76,7 +76,7 @@ public interface ExtensionManager {
     /**
      * This is going to uninstall/remove all the specified extensions from the project build file(s).
      *
-     * This is ignoring the {@link Extension} version
+     * This is ignoring the version
      *
      * @param keys the set of {@link ArtifactKey} for the extensions to uninstall
      * @return the {@link InstallResult}
@@ -85,18 +85,39 @@ public interface ExtensionManager {
     UninstallResult uninstall(Collection<ArtifactKey> keys) throws IOException;
 
     class InstallResult {
-        private final Collection<ArtifactCoords> installed;
+        private final Collection<ArtifactCoords> installedPlatforms;
+        private final Collection<ArtifactCoords> installedManagedExtensions;
+        private final Collection<ArtifactCoords> installedIndependentExtensions;
+        private final Collection<ArtifactKey> alreadyInstalled;
 
-        public InstallResult(Collection<ArtifactCoords> installed) {
-            this.installed = installed;
+        public InstallResult(Collection<ArtifactCoords> installedPlatforms,
+                Collection<ArtifactCoords> installedManagedExtensions,
+                Collection<ArtifactCoords> installedIndependentExtensions, Collection<ArtifactKey> alreadyInstalled) {
+            this.installedPlatforms = installedPlatforms;
+            this.installedManagedExtensions = installedManagedExtensions;
+            this.installedIndependentExtensions = installedIndependentExtensions;
+            this.alreadyInstalled = alreadyInstalled;
         }
 
-        public Collection<ArtifactCoords> getInstalled() {
-            return installed;
+        public Collection<ArtifactCoords> getInstalledManagedExtensions() {
+            return installedManagedExtensions;
+        }
+
+        public Collection<ArtifactCoords> getInstalledIndependentExtensions() {
+            return installedIndependentExtensions;
+        }
+
+        public Collection<ArtifactCoords> getInstalledPlatforms() {
+            return installedPlatforms;
+        }
+
+        public Collection<ArtifactKey> getAlreadyInstalled() {
+            return alreadyInstalled;
         }
 
         public boolean isSourceUpdated() {
-            return installed.size() > 0;
+            return !installedPlatforms.isEmpty() || !installedManagedExtensions.isEmpty()
+                    || !installedIndependentExtensions.isEmpty();
         }
     }
 


### PR DESCRIPTION
- Extensions are now added at just before the first test dependency of the pom.xml (and not after test dependencies) #6108
- Show a message when a one or more keyword is not matched:
```shell
$ qss add resteasy foo bar        
[ERROR] ❗ Nothing installed because some keyword(s) 'foo', 'bar' were not matched in our catalog.
```
- Show detailed info about how extensions have been added (platform or extension) and which were already installed:
```shell
$ qss add resteasy resteasy-qute quarkus-hibernate-validator
[SUCCESS] ✅ Extension io.quarkus:quarkus-resteasy-qute has been installed
 👍 Extension io.quarkus:quarkus-hibernate-validator was already installed
 👍 Extension io.quarkus:quarkus-resteasy was already installed
```


Closes #16353 
Closes #6108