### PR TITLE
CI: Fix build of TCKS modules not using GIB args & use mvnw from resteasy-reative-testsuite

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -617,7 +617,7 @@ jobs:
 
   tcks-test:
     name: MicroProfile TCKs Tests
-    needs: calculate-test-jobs
+    needs: [build-jdk11, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     runs-on: ubuntu-latest

--- a/tcks/resteasy-reactive/pom.xml
+++ b/tcks/resteasy-reactive/pom.xml
@@ -16,7 +16,7 @@
     <properties>
 
         <!-- to avoid sudden surprises, checkout is pinned to a specific commit -->
-        <resteasy-reactive-testsuite.repo.ref>82698545ef2f09b6b826d650502238cebf9f6171</resteasy-reactive-testsuite.repo.ref>
+        <resteasy-reactive-testsuite.repo.ref>e3cd2c5e5b9262ae5d1197005c542fdd02f9d4ff</resteasy-reactive-testsuite.repo.ref>
 
         <exec.skip>${skipTests}</exec.skip>
         <resteasy-reactive-testsuite.clone.skip>${exec.skip}</resteasy-reactive-testsuite.clone.skip>
@@ -71,8 +71,8 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>mvn</executable>
-                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args} -Dsurefire.excludedEnvironmentVariables=MAVEN_OPTS</commandlineArgs>
+                            <executable>mvnw</executable>
+                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args}</commandlineArgs>
                             <skip>${resteasy-reactive-testsuite.test.skip}</skip>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Relates to https://github.com/quarkusio/resteasy-reactive-testsuite/pull/2