### PR TITLE
Introduce TestJwtSecurity and TestOidcSecurity

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2433,6 +2433,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-security-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-security</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/TestSecurityTestCase.java
+++ b/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/TestSecurityTestCase.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.SecurityAttribute;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.common.SecurityAttribute;
 
 @QuarkusTest
 class TestSecurityTestCase {

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.SecurityAttribute;
-import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.TestOidcSecurity;
 import io.restassured.RestAssured;
 
 @QuarkusTest
@@ -15,15 +15,15 @@ import io.restassured.RestAssured;
 public class TestSecurityLazyAuthTest {
 
     @Test
-    @TestSecurity(user = "user1", roles = "viewer")
+    @TestOidcSecurity(user = "user1", roles = "viewer")
     public void testWithDummyUser() {
         RestAssured.when().get("test-security").then()
                 .body(is("user1"));
     }
 
     @Test
-    @TestSecurity(user = "userOidc", roles = "viewer", attributes = {
-            @SecurityAttribute(key = "claim.email", value = "user@gmail.com")
+    @TestOidcSecurity(user = "userOidc", roles = "viewer", claims = {
+            @Claim(key = "email", value = "user@gmail.com")
     })
     public void testJwtWithDummyUser() {
         RestAssured.when().get("test-security-oidc").then()

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.SecurityAttribute;
-import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.TestOidcSecurity;
 import io.restassured.RestAssured;
 
 @QuarkusTest
@@ -15,15 +15,15 @@ import io.restassured.RestAssured;
 public class TestSecurityLazyAuthTest {
 
     @Test
-    @TestSecurity(user = "user1", roles = "viewer")
+    @TestOidcSecurity(user = "user1", roles = "viewer")
     public void testWithDummyUser() {
         RestAssured.when().get("test-security").then()
                 .body(is("user1"));
     }
 
     @Test
-    @TestSecurity(user = "userJwt", roles = "viewer", attributes = {
-            @SecurityAttribute(key = "claim.email", value = "user@gmail.com")
+    @TestOidcSecurity(user = "userJwt", roles = "viewer", claims = {
+            @Claim(key = "email", value = "user@gmail.com")
     })
     public void testJwtWithDummyUser() {
         RestAssured.when().get("test-security-jwt").then()

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.SecurityAttribute;
-import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.TestJwtSecurity;
 import io.restassured.RestAssured;
 
 @QuarkusTest
@@ -15,15 +15,15 @@ import io.restassured.RestAssured;
 public class TestSecurityLazyAuthTest {
 
     @Test
-    @TestSecurity(user = "user1", roles = "viewer")
+    @TestJwtSecurity(user = "user1", roles = "viewer")
     public void testWithDummyUser() {
         RestAssured.when().get("test-security").then()
                 .body(is("user1"));
     }
 
     @Test
-    @TestSecurity(user = "userJwt", roles = "viewer", attributes = {
-            @SecurityAttribute(key = "claim.email", value = "user@gmail.com")
+    @TestJwtSecurity(user = "userJwt", roles = "viewer", claims = {
+            @Claim(key = "email", value = "user@gmail.com")
     })
     public void testJwtWithDummyUser() {
         RestAssured.when().get("test-security-jwt").then()

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -34,6 +34,7 @@
         <module>maven</module>
         <module>vault</module>
         <module>ldap</module>
+        <module>security-common</module>
         <module>security</module>
         <module>security-jwt</module>
         <module>security-oidc</module>

--- a/test-framework/security-common/pom.xml
+++ b/test-framework/security-common/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>quarkus-test-security-jwt</artifactId>
-    <name>Quarkus - Test Framework - Security JWT</name>
-    <description>Module that contains utilities to test Quarkus security with JWT token</description>
+    <artifactId>quarkus-test-security-common</artifactId>
+    <name>Quarkus - Test Framework - Security Common</name>
+    <description>Module that contains common utilities to test Quarkus security</description>
 
     <dependencies>
         <dependency>
@@ -21,17 +21,22 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-security-common</artifactId>
+            <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.jwt</groupId>
-            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <!-- The entity classes need to be indexed -->
+            <!-- The entity classes needs to be indexed -->
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/AbstractSecurityTestExtension.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/AbstractSecurityTestExtension.java
@@ -1,0 +1,102 @@
+package io.quarkus.test.security.common;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+public abstract class AbstractSecurityTestExtension implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {
+
+    @Override
+    public void afterEach(QuarkusTestMethodContext context) {
+        CDI.current().select(TestAuthController.class).get().setEnabled(true);
+        CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(null);
+    }
+
+    @Override
+    public void beforeEach(QuarkusTestMethodContext context) {
+        try {
+            //the usual ClassLoader hacks to get our copy of the TestSecurity annotation
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            Class<?> original = cl.loadClass(context.getTestMethod().getDeclaringClass().getName());
+            Method method = original.getDeclaredMethod(context.getTestMethod().getName(),
+                    Arrays.stream(context.getTestMethod().getParameterTypes()).map(s -> {
+                        if (s.isPrimitive()) {
+                            return s;
+                        }
+                        try {
+                            return Class.forName(s.getName(), false, cl);
+                        } catch (ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).toArray(Class<?>[]::new));
+
+            TestSecurityProperties testSecurity = getTestSecurityProperties(original, method);
+            if (testSecurity == null) {
+                return;
+            }
+
+            CDI.current().select(TestAuthController.class).get().setEnabled(testSecurity.isAuthorizationEnabled());
+            if (testSecurity.getUser().isEmpty()) {
+                if (testSecurity.getRoles().length != 0) {
+                    throw new RuntimeException("Cannot specify roles without a username in @TestSecurity");
+                }
+            } else {
+                QuarkusSecurityIdentity.Builder user = QuarkusSecurityIdentity.builder()
+                        .setPrincipal(new QuarkusPrincipal(testSecurity.getUser()))
+                        .addRoles(new HashSet<>(Arrays.asList(testSecurity.getRoles())));
+
+                if (testSecurity.getAttributes() != null) {
+                    user.addAttributes(Arrays.stream(testSecurity.getAttributes())
+                            .collect(Collectors.toMap(s -> s.key(), s -> s.value())));
+                }
+                if (testSecurity.getExtraProperties() != null) {
+                    for (Map.Entry<String, String> entry : testSecurity.getExtraProperties().entrySet()) {
+                        user.addAttribute(entry.getKey(), entry.getValue());
+                    }
+                }
+
+                SecurityIdentity userIdentity = augment(user.build());
+                CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(userIdentity);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to setup TestSecurity", e);
+        }
+
+    }
+
+    private SecurityIdentity augment(SecurityIdentity identity) {
+        Instance<TestSecurityIdentityAugmentor> producer = CDI.current().select(TestSecurityIdentityAugmentor.class);
+        if (producer.isResolvable()) {
+            return producer.get().augment(identity);
+        }
+        return identity;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T getTestSecurityAnnotation(Class<? extends Annotation> annotationClass, Class<?> original, Method method) {
+        Annotation testSecurity = method.getAnnotation(annotationClass);
+        if (testSecurity == null) {
+            testSecurity = original.getAnnotation(annotationClass);
+            while (testSecurity == null && original != Object.class) {
+                original = original.getSuperclass();
+                testSecurity = original.getAnnotation(annotationClass);
+            }
+        }
+        return (T) testSecurity;
+    }
+
+    protected abstract TestSecurityProperties getTestSecurityProperties(Class<?> original, Method method);
+}

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/SecurityAttribute.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/SecurityAttribute.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.security.common;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface SecurityAttribute {
+    String key();
+
+    String value();
+}

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestAuthController.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestAuthController.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.common;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestHttpAuthenticationMechanism.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestHttpAuthenticationMechanism.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.common;
 
 import java.util.Collections;
 import java.util.Set;

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestIdentityAssociation.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestIdentityAssociation.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.common;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestSecurityIdentityAugmentor.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestSecurityIdentityAugmentor.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.common;
 
 import io.quarkus.security.identity.SecurityIdentity;
 

--- a/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestSecurityProperties.java
+++ b/test-framework/security-common/src/main/java/io/quarkus/test/security/common/TestSecurityProperties.java
@@ -1,0 +1,56 @@
+package io.quarkus.test.security.common;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class TestSecurityProperties {
+    /**
+     * If this is non-zero then the test will be run with a SecurityIdentity with the specified username.
+     */
+    private final String user;
+
+    private final String[] roles;
+
+    private final SecurityAttribute[] attributes;
+
+    private final Map<String, String> extraProperties;
+
+    /**
+     * If this is false then all security constraints are disabled.
+     */
+    private final boolean authorizationEnabled;
+
+    public TestSecurityProperties(String user, String[] roles,
+            SecurityAttribute[] attributes, boolean authorizationEnabled) {
+        this(user, roles, attributes, authorizationEnabled, Collections.emptyMap());
+    }
+
+    public TestSecurityProperties(String user, String[] roles,
+            SecurityAttribute[] attributes, boolean authorizationEnabled, Map<String, String> extraProperties) {
+        this.user = user;
+        this.roles = roles;
+        this.attributes = attributes;
+        this.authorizationEnabled = authorizationEnabled;
+        this.extraProperties = extraProperties;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String[] getRoles() {
+        return roles;
+    }
+
+    public SecurityAttribute[] getAttributes() {
+        return attributes;
+    }
+
+    public boolean isAuthorizationEnabled() {
+        return authorizationEnabled;
+    }
+
+    public Map<String, String> getExtraProperties() {
+        return extraProperties;
+    }
+}

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.security.jwt;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Claim {
+    String key();
+
+    String value();
+}

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorProducer.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorProducer.java
@@ -12,7 +12,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
-import io.quarkus.test.security.TestSecurityIdentityAugmentor;
+import io.quarkus.test.security.common.TestSecurityIdentityAugmentor;
 
 @ApplicationScoped
 public class JwtTestSecurityIdentityAugmentorProducer {

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/QuarkusSecurityTestExtension.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/QuarkusSecurityTestExtension.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.security.jwt;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.security.common.AbstractSecurityTestExtension;
+import io.quarkus.test.security.common.TestSecurityProperties;
+
+public class QuarkusSecurityTestExtension extends AbstractSecurityTestExtension {
+
+    protected TestSecurityProperties getTestSecurityProperties(Class<?> original, Method method) {
+        TestJwtSecurity testSecurity = super.getTestSecurityAnnotation(TestJwtSecurity.class, original, method);
+        if (testSecurity == null) {
+            return null;
+        }
+        Map<String, String> extraProperties = new HashMap<>();
+        if (testSecurity.claims() != null) {
+            for (Claim c : testSecurity.claims()) {
+                extraProperties.put("claim." + c.key(), c.value());
+            }
+        }
+        return new TestSecurityProperties(
+                testSecurity.user(), testSecurity.roles(), testSecurity.attributes(), testSecurity.authorizationEnabled(),
+                extraProperties);
+    }
+}

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/TestJwtSecurity.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/TestJwtSecurity.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.jwt;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +9,7 @@ import io.quarkus.test.security.common.SecurityAttribute;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
-public @interface TestSecurity {
+public @interface TestJwtSecurity {
 
     /**
      * If this is false then all security constraints are disabled.
@@ -27,4 +27,6 @@ public @interface TestSecurity {
     String[] roles() default {};
 
     SecurityAttribute[] attributes() default {};
+
+    Claim[] claims() default {};
 }

--- a/test-framework/security-jwt/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-framework/security-jwt/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.security.jwt.QuarkusSecurityTestExtension

--- a/test-framework/security-jwt/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
+++ b/test-framework/security-jwt/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.security.jwt.QuarkusSecurityTestExtension

--- a/test-framework/security-oidc/pom.xml
+++ b/test-framework/security-oidc/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-security</artifactId>
+            <artifactId>quarkus-test-security-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.security.oidc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Claim {
+    String key();
+
+    String value();
+}

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/ConfigMetadata.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/ConfigMetadata.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.oidc;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
-public @interface SecurityAttribute {
+public @interface ConfigMetadata {
     String key();
 
     String value();

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorProducer.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorProducer.java
@@ -16,7 +16,7 @@ import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
-import io.quarkus.test.security.TestSecurityIdentityAugmentor;
+import io.quarkus.test.security.common.TestSecurityIdentityAugmentor;
 import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.util.KeyUtils;
 

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/QuarkusSecurityTestExtension.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/QuarkusSecurityTestExtension.java
@@ -1,0 +1,37 @@
+package io.quarkus.test.security.oidc;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.security.common.AbstractSecurityTestExtension;
+import io.quarkus.test.security.common.TestSecurityProperties;
+
+public class QuarkusSecurityTestExtension extends AbstractSecurityTestExtension {
+
+    protected TestSecurityProperties getTestSecurityProperties(Class<?> original, Method method) {
+        TestOidcSecurity testSecurity = super.getTestSecurityAnnotation(TestOidcSecurity.class, original, method);
+        if (testSecurity == null) {
+            return null;
+        }
+        Map<String, String> extraProperties = new HashMap<>();
+        if (testSecurity.claims() != null) {
+            for (Claim c : testSecurity.claims()) {
+                extraProperties.put("claim." + c.key(), c.value());
+            }
+        }
+        if (testSecurity.userinfo() != null) {
+            for (UserInfo ui : testSecurity.userinfo()) {
+                extraProperties.put("userinfo." + ui.key(), ui.value());
+            }
+        }
+        if (testSecurity.config() != null) {
+            for (ConfigMetadata c : testSecurity.config()) {
+                extraProperties.put("config." + c.key(), c.value());
+            }
+        }
+        return new TestSecurityProperties(
+                testSecurity.user(), testSecurity.roles(), testSecurity.attributes(), testSecurity.authorizationEnabled(),
+                extraProperties);
+    }
+}

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/TestOidcSecurity.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/TestOidcSecurity.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.security;
+package io.quarkus.test.security.oidc;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +9,7 @@ import io.quarkus.test.security.common.SecurityAttribute;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
-public @interface TestSecurity {
+public @interface TestOidcSecurity {
 
     /**
      * If this is false then all security constraints are disabled.
@@ -27,4 +27,10 @@ public @interface TestSecurity {
     String[] roles() default {};
 
     SecurityAttribute[] attributes() default {};
+
+    Claim[] claims() default {};
+
+    UserInfo[] userinfo() default {};
+
+    ConfigMetadata[] config() default {};
 }

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/UserInfo.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/UserInfo.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.security.oidc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface UserInfo {
+    String key();
+
+    String value();
+}

--- a/test-framework/security-oidc/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-framework/security-oidc/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.security.oidc.QuarkusSecurityTestExtension

--- a/test-framework/security-oidc/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
+++ b/test-framework/security-oidc/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.security.oidc.QuarkusSecurityTestExtension

--- a/test-framework/security/pom.xml
+++ b/test-framework/security/pom.xml
@@ -21,11 +21,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http</artifactId>
+            <artifactId>quarkus-test-security-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
@@ -1,85 +1,17 @@
 package io.quarkus.test.security;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.stream.Collectors;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.CDI;
+import io.quarkus.test.security.common.AbstractSecurityTestExtension;
+import io.quarkus.test.security.common.TestSecurityProperties;
 
-import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.runtime.QuarkusPrincipal;
-import io.quarkus.security.runtime.QuarkusSecurityIdentity;
-import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
-import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
-import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+public class QuarkusSecurityTestExtension extends AbstractSecurityTestExtension {
 
-public class QuarkusSecurityTestExtension implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {
-
-    @Override
-    public void afterEach(QuarkusTestMethodContext context) {
-        CDI.current().select(TestAuthController.class).get().setEnabled(true);
-        CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(null);
-    }
-
-    @Override
-    public void beforeEach(QuarkusTestMethodContext context) {
-        try {
-            //the usual ClassLoader hacks to get our copy of the TestSecurity annotation
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Class<?> original = cl.loadClass(context.getTestMethod().getDeclaringClass().getName());
-            Method method = original.getDeclaredMethod(context.getTestMethod().getName(),
-                    Arrays.stream(context.getTestMethod().getParameterTypes()).map(s -> {
-                        if (s.isPrimitive()) {
-                            return s;
-                        }
-                        try {
-                            return Class.forName(s.getName(), false, cl);
-                        } catch (ClassNotFoundException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }).toArray(Class<?>[]::new));
-            TestSecurity testSecurity = method.getAnnotation(TestSecurity.class);
-            if (testSecurity == null) {
-                testSecurity = original.getAnnotation(TestSecurity.class);
-                while (testSecurity == null && original != Object.class) {
-                    original = original.getSuperclass();
-                    testSecurity = original.getAnnotation(TestSecurity.class);
-                }
-            }
-            if (testSecurity == null) {
-                return;
-            }
-            CDI.current().select(TestAuthController.class).get().setEnabled(testSecurity.authorizationEnabled());
-            if (testSecurity.user().isEmpty()) {
-                if (testSecurity.roles().length != 0) {
-                    throw new RuntimeException("Cannot specify roles without a username in @TestSecurity");
-                }
-            } else {
-                QuarkusSecurityIdentity.Builder user = QuarkusSecurityIdentity.builder()
-                        .setPrincipal(new QuarkusPrincipal(testSecurity.user()))
-                        .addRoles(new HashSet<>(Arrays.asList(testSecurity.roles())));
-
-                if (testSecurity.attributes() != null) {
-                    user.addAttributes(Arrays.stream(testSecurity.attributes())
-                            .collect(Collectors.toMap(s -> s.key(), s -> s.value())));
-                }
-
-                SecurityIdentity userIdentity = augment(user.build());
-                CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(userIdentity);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to setup @TestSecurity", e);
-        }
-
-    }
-
-    private SecurityIdentity augment(SecurityIdentity identity) {
-        Instance<TestSecurityIdentityAugmentor> producer = CDI.current().select(TestSecurityIdentityAugmentor.class);
-        if (producer.isResolvable()) {
-            return producer.get().augment(identity);
-        }
-        return identity;
+    protected TestSecurityProperties getTestSecurityProperties(Class<?> original, Method method) {
+        TestSecurity testSecurity = super.getTestSecurityAnnotation(TestSecurity.class, original, method);
+        return testSecurity == null ? null
+                : new TestSecurityProperties(
+                        testSecurity.user(), testSecurity.roles(), testSecurity.attributes(),
+                        testSecurity.authorizationEnabled());
     }
 }


### PR DESCRIPTION
@stuartwdouglas, 
Hi Stuart, here is an attempt to have a typed `Claim` attribute to support testing `quarkus-smallrye-jwt`/`quarkus-oidc` with  `@TestJwtSecurity`. Additionally, `@TestOidcSecurity` supports `@UserInfo` and `@ConfigMetadata`.
The way this PR does it is as follows:
- add `test-security-common`
- `security`/`security-jwt`/`security-oidc` check their specific annotations and return `TestSecurityProperties` and let the common code do most of the work. `TestSecurityProperties` is a medium to turn `@Claim` into `"claim." + claim.name()` attributes internally for `security-jwt`/`security-oidc` test augmentors to turn them into `JsonWebToken`/etc.
- Pros: typed `Claim`/etc (as opposed to #17074) - and will work with more security extension specific injections to be supported for testing
- Cons: `@Claim` is duplicated in `security-jwt`/`security-oidc`; `SecurityAttribute` package has changed for it to be reused by all 3 test extensions; `@TestSecurity` is mostly duplicated by `@TestJwtSecurity`/`@TestOidcSecurity` mixing any of these 3 test extensions together will cause the confusion.

I'm not sure yet whether I like it or not, #17075 's convention to use `SecurityAttribute` for all security extension specific injections is not cool but certainly simpler; this PR offers a cleaner security annotation API