### PR TITLE
Fixed qute TemplateException in RESTEasy Reactive Endpoint Page

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-templates/endpoints.html
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-templates/endpoints.html
@@ -43,7 +43,7 @@ h5{
  {/if}
  {/for}
  <h5>Static Resources</h5>
- {#for resource in info:staticResourceInfo.resourceMap.get("/").children}
+ {#for resource in info:staticResourceInfo.resourceMap.get("/").children.orEmpty}
  <div class="row">
   <div class="col">
    {#if resource.isFolder}


### PR DESCRIPTION
For the issue reported by @mkouba - 

**_Copied problem description from Martin_** 

I've just tried to display the resteasy reactive endpoints page and got:

`Caused by: io.quarkus.qute.TemplateException: Iteration error in template [io.quarkus.quarkus-resteasy-reactive/endpoints] on line 46: {info:staticResourceInfo.resourceMap.get("/").children} not found, use {info:staticResourceInfo.resourceMap.get("/").children.orEmpty} to ignore this error
`
it works fine if I add at least one static resource file in the META-INF/resources. 

CC @FroMage 
Thanks