### PR TITLE
Log presence of Docker at DEBUG level, not INFO

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -42,7 +42,7 @@ public class IsDockerWorking implements BooleanSupplier {
         try {
             OutputFilter filter = new OutputFilter();
             if (ExecUtil.exec(new File("."), filter, "docker", "version", "--format", "'{{.Server.Version}}'")) {
-                LOGGER.info("Docker daemon found. Version:" + filter.getOutput());
+                LOGGER.debugf("Docker daemon found. Version: %s", filter.getOutput());
                 return true;
             } else {
                 if (!silent) {


### PR DESCRIPTION
Logging at INFO level is unnecessary verbose given it will be displayed
for each build.