### PR TITLE
Fix large blank space in stack traces

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -84,7 +84,7 @@ public class TestConsoleHandler implements TestListener {
     @Override
     public void listenerRegistered(TestController testController) {
         this.testController = testController;
-        promptHandler.setStatus(PAUSED_PROMPT);
+        promptHandler.setPrompt(PAUSED_PROMPT);
     }
 
     public void printUsage() {


### PR DESCRIPTION
A bug in AeshConsole can mess up console
output when a large number of lines is
written.