### PR TITLE
DevConsoleFilter - query string should not be stripped away

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleFilter.java
@@ -35,12 +35,12 @@ public class DevConsoleFilter implements Handler<RoutingContext> {
             headers.put(entry.getKey(), event.request().headers().getAll(entry.getKey()));
         }
         if (event.getBody() != null) {
-            DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().path(), headers,
+            DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().uri(), headers,
                     event.getBody().getBytes());
             setupFuture(event, request.getResponse());
             DevConsoleManager.sentRequest(request);
         } else if (event.request().isEnded()) {
-            DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().path(), headers,
+            DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().uri(), headers,
                     new byte[0]);
             setupFuture(event, request.getResponse());
             DevConsoleManager.sentRequest(request);
@@ -48,7 +48,7 @@ public class DevConsoleFilter implements Handler<RoutingContext> {
             event.request().bodyHandler(new Handler<Buffer>() {
                 @Override
                 public void handle(Buffer body) {
-                    DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().path(),
+                    DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().uri(),
                             headers, body.getBytes());
                     setupFuture(event, request.getResponse());
                     DevConsoleManager.sentRequest(request);


### PR DESCRIPTION
- otherwise a dev ui handler may not access query params