### PR TITLE
Provide an actionable error message when byte[] is used as a field of the Multipart POJO

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
@@ -14,6 +14,7 @@ final class DotNames {
     static final String POPULATE_METHOD_NAME = "populate";
     static final DotName OBJECT_NAME = DotName.createSimple(Object.class.getName());
     static final DotName STRING_NAME = DotName.createSimple(String.class.getName());
+    static final DotName BYTE_NAME = DotName.createSimple(byte.class.getName());
     static final DotName INPUT_STREAM_NAME = DotName.createSimple(InputStream.class.getName());
     static final DotName INPUT_STREAM_READER_NAME = DotName.createSimple(InputStreamReader.class.getName());
     static final DotName FIELD_UPLOAD_NAME = DotName.createSimple(FileUpload.class.getName());

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartPopulatorGenerator.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MultipartPopulatorGenerator.java
@@ -314,6 +314,15 @@ final class MultipartPopulatorGenerator {
                         // this is a common enough mistake, so let's provide a good error message
                         failIfFileTypeUsedAsGenericType(field, fieldType, fieldDotName);
 
+                        if (fieldType.kind() == Type.Kind.ARRAY) {
+                            if (fieldType.asArrayType().component().name().equals(DotNames.BYTE_NAME)) {
+                                throw new IllegalArgumentException(
+                                        "'byte[]' cannot be used to read multipart file contents. Offending field is '"
+                                                + field.name() + "' of class '"
+                                                + field.declaringClass().name()
+                                                + "'. If you need to read the contents of the uploaded file, use 'Path' or 'File' as the field type and use File IO APIs to read the bytes, while making sure you annotate the endpoint with '@Blocking'");
+                            }
+                        }
                         if (fieldDotName.equals(DotNames.STRING_NAME) && partType.equals(MediaType.TEXT_PLAIN)) {
                             // in this case all we need to do is read the value of the form attribute
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/ErroneousFieldMultipartInputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/ErroneousFieldMultipartInputTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ErroneousFieldMultipartInputTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Input.class);
+                }
+
+            }).setExpectedException(IllegalArgumentException.class);
+
+    @Test
+    public void testSimple() {
+        fail("Should never be called");
+    }
+
+    @Path("test")
+    public static class TestEndpoint {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @POST
+        public int test(@MultipartForm Input formData) {
+            return formData.txtFile.length;
+        }
+    }
+
+    public static class Input {
+        @RestForm
+        private String name;
+
+        @RestForm
+        public byte[] txtFile;
+    }
+
+}


### PR DESCRIPTION
This is done because users can easily assume that `byte[]` is supported when in reality
it is not