### PR TITLE
Amazon S3 guide - Switch to new Mutiny transform() method

### DIFF
--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -511,7 +511,7 @@ public class S3AsyncClientResource extends CommonResource {
         return Uni.createFrom()
                 .completionStage(() -> s3.getObject(buildGetRequest(objectKey), AsyncResponseTransformer.toFile(tempFile)))
                 .onItem()
-                .apply(object -> Response.ok(tempFile)
+                .transform(object -> Response.ok(tempFile)
                         .header("Content-Disposition", "attachment;filename=" + objectKey)
                         .header("Content-Type", object.contentType()).build());
     }


### PR DESCRIPTION
`apply()` has been removed in the latest Mutiny version.