### PR TITLE
Keycloak Authorization must block access to the public resource if a matching enforcing policy exists

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -15,7 +15,7 @@ In other words, instead of explicitly enforcing access based on some specific ac
 
 By externalizing authorization from your application, you are allowed to protect your applications using different access control mechanisms as well as avoid re-deploying your application every time your security requirements change, where Keycloak will be acting as a centralized authorization service from where your protected resources and their associated permissions are managed.
 
-See the link:security-openid-connect[Using OpenID Connect to Protect Service Applications] guide for more information about `Bearer Token` authentication mechanism.
+See the link:security-openid-connect[Using OpenID Connect to Protect Service Applications] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
 
 If you are already familiar with Keycloak, you’ll notice that the extension is basically another adapter implementation but specific for Quarkus applications.
 Otherwise, you can find more information in the Keycloak https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_overview[documentation].
@@ -339,6 +339,7 @@ specific operations like managing resources and obtaining permissions directly f
 
 [source,java]
 ----
+public class ProtectedResource {
     @Inject
     AuthzClient authzClient;
 }
@@ -357,11 +358,35 @@ quarkus.keycloak.policy-enforcer.lazy-load-paths=false
 
 Note that, depending on how many resources you have in Keycloak the time taken to fetch them may impact your application startup time. 
 
-== More About Configuring Protected Resources 
+== More About Configuring Protected Resources
 
 In the default configuration, Keycloak is responsible for managing the roles and deciding who can access which routes. 
 
-To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the link:security-openid-connect[Using OpenID Connect Adapter to Protect JAX-RS Applications] guide. For more details, check the link:security[Security guide].
+To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the link:security-openid-connect[Using OpenID Connect Adapter to Protect JAX-RS Applications] and link:security-authorization[Security Authorization] guides. For more details, check the link:security[Security guide].
+
+== Access to Public Resources
+
+If you'd like to access a public resource without `quarkus-keycloak-authorization` trying to apply its policies to it then you need to create a `permit` HTTP Policy configuration in `application.properties` as documented in the link:security-authorization[Security Authorization] guide.
+
+Disabling a policy check using a Keycloak Authorization Policy such as:
+
+[source,properties]
+----
+quarkus.keycloak.policy-enforcer.paths.1.path=/api/public
+quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=DISABLED
+----
+
+is no longer required.
+
+If you'd like to block an access to the public resource to anonymous users then you can create an enforcing Keycloak Authorization Policy:
+
+[source,properties]
+----
+quarkus.keycloak.policy-enforcer.paths.1.path=/api/public-enforcing
+quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=ENFORCING
+----
+
+Note only the default tenant configuration applies when controlling an anonymous access to the public resource is required.
 
 == Multi-Tenancy
 

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/PublicResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/PublicResource.java
@@ -3,11 +3,24 @@ package io.quarkus.it.keycloak;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-@Path("/api/public")
+@Path("/api")
 public class PublicResource {
 
     @GET
+    @Path("public")
     public void serve() {
+        // no-op
+    }
+
+    @GET
+    @Path("public-enforcing")
+    public void serveEnforcing() {
+        // no-op
+    }
+
+    @GET
+    @Path("public-token")
+    public void serveToken() {
         // no-op
     }
 }

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -53,6 +53,12 @@ quarkus.keycloak.policy-enforcer.paths.8.enforcement-mode=DISABLED
 quarkus.keycloak.policy-enforcer.paths.9.name=Scope Permission Resource
 quarkus.keycloak.policy-enforcer.paths.9.path=/api/permission/scope
 
+quarkus.keycloak.policy-enforcer.paths.10.path=/api/public-enforcing
+quarkus.keycloak.policy-enforcer.paths.10.enforcement-mode=ENFORCING
+
+quarkus.keycloak.policy-enforcer.paths.11.path=/api/public-token
+quarkus.keycloak.policy-enforcer.paths.11.enforcement-mode=DISABLED
+
 # Tenant
 
 quarkus.oidc.tenant.auth-server-url=${keycloak.url}/realms/quarkus

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -131,6 +131,30 @@ public class PolicyEnforcerTest {
     }
 
     @Test
+    public void testPublicResourceWithEnforcingPolicy() {
+        RestAssured.given()
+                .when().get("/api/public-enforcing")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testPublicResourceWithEnforcingPolicyAndToken() {
+        RestAssured.given().auth().oauth2(getAccessToken("alice"))
+                .when().get("/api/public-enforcing")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void testPublicResourceWithDisabledPolicyAndToken() {
+        RestAssured.given().auth().oauth2(getAccessToken("alice"))
+                .when().get("/api/public-token")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
     public void testPathConfigurationPrecedenceWhenPathCacheNotDefined() {
         RestAssured.given()
                 .when().get("/api2/resource")


### PR DESCRIPTION
Fixes #17164

Right now, in `2.0.0.Alpha2`/main, access to a public resource with anonymous identity will succeed even if a matching `enforcing` policy is available. Instead `401` should be returned. 

CC @Sgitario 