### PR TITLE
Introduce `quarkus.jackson.accept-case-insensitive-enums`

### DIFF
--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAcceptCaseInsensitiveEnumsTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonAcceptCaseInsensitiveEnumsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonAcceptCaseInsensitiveEnumsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-accept-case-insensitive-enums.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testAcceptCaseInsensitiveEnums() throws JsonProcessingException {
+        // Test upper case
+        TestObject uppercase = objectMapper.readValue("{ \"testEnum\": \"ONE\" }", TestObject.class);
+        assertThat(uppercase.testEnum).isEqualTo(TestEnum.ONE);
+
+        // Test lower case
+        TestObject lowercase = objectMapper.readValue("{ \"testEnum\": \"one\" }", TestObject.class);
+        assertThat(lowercase.testEnum).isEqualTo(TestEnum.ONE);
+
+        // Test mixed case
+        TestObject mixedcase = objectMapper.readValue("{ \"testEnum\": \"oNe\" }", TestObject.class);
+        assertThat(mixedcase.testEnum).isEqualTo(TestEnum.ONE);
+    }
+
+    private enum TestEnum {
+        ONE,
+        TWO
+    }
+
+    private static class TestObject {
+        public TestEnum testEnum;
+    }
+
+}

--- a/extensions/jackson/deployment/src/test/resources/application-accept-case-insensitive-enums.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-accept-case-insensitive-enums.properties
@@ -1,0 +1,1 @@
+quarkus.jackson.accept-case-insensitive-enums=true

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -24,6 +24,12 @@ public class JacksonBuildTimeConfig {
     public boolean writeDatesAsTimestamps;
 
     /**
+     * If enabled, Jackson will ignore case during Enum deserialization.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean acceptCaseInsensitiveEnums;
+
+    /**
      * If set, Jackson will default to using the specified timezone when formatting dates.
      * Some examples values are "Asia/Jakarta" and "GMT+3".
      * If not set, Jackson will use its own default.

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonConfigSupport.java
@@ -8,11 +8,15 @@ public class JacksonConfigSupport {
 
     private final boolean writeDatesAsTimestamps;
 
+    private final boolean acceptCaseInsensitiveEnums;
+
     private final ZoneId timeZone;
 
-    public JacksonConfigSupport(boolean failOnUnknownProperties, boolean writeDatesAsTimestamps, ZoneId timeZone) {
+    public JacksonConfigSupport(boolean failOnUnknownProperties, boolean writeDatesAsTimestamps,
+            boolean acceptCaseInsensitiveEnums, ZoneId timeZone) {
         this.failOnUnknownProperties = failOnUnknownProperties;
         this.writeDatesAsTimestamps = writeDatesAsTimestamps;
+        this.acceptCaseInsensitiveEnums = acceptCaseInsensitiveEnums;
         this.timeZone = timeZone;
     }
 
@@ -22,6 +26,10 @@ public class JacksonConfigSupport {
 
     public boolean isWriteDatesAsTimestamps() {
         return writeDatesAsTimestamps;
+    }
+
+    public boolean isAcceptCaseInsensitiveEnums() {
+        return acceptCaseInsensitiveEnums;
     }
 
     public ZoneId getTimeZone() {

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonRecorder.java
@@ -13,7 +13,8 @@ public class JacksonRecorder {
             @Override
             public JacksonConfigSupport get() {
                 return new JacksonConfigSupport(jacksonBuildTimeConfig.failOnUnknownProperties,
-                        jacksonBuildTimeConfig.writeDatesAsTimestamps, jacksonBuildTimeConfig.timezone.orElse(null));
+                        jacksonBuildTimeConfig.writeDatesAsTimestamps, jacksonBuildTimeConfig.acceptCaseInsensitiveEnums,
+                        jacksonBuildTimeConfig.timezone.orElse(null));
             }
         };
     }

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -12,6 +12,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -34,6 +35,9 @@ public class ObjectMapperProducer {
         if (!jacksonConfigSupport.isWriteDatesAsTimestamps()) {
             // this feature is enabled by default, so we disable it
             objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        }
+        if (jacksonConfigSupport.isAcceptCaseInsensitiveEnums()) {
+            objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         }
         ZoneId zoneId = jacksonConfigSupport.getTimeZone();
         if ((zoneId != null) && !zoneId.getId().equals("UTC")) { // Jackson uses UTC as the default, so let's not reset it


### PR DESCRIPTION
If enabled, Jackson will ignore case during Enum deserialization.