### PR TITLE
Make sure that resteasy-reactive uses the same Jackson used in Quarkus

### DIFF
--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,6 +56,7 @@
         <rest-assured.version>4.3.3</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
+        <jackson.version>2.12.3</jackson.version>
     </properties>
 
     <modules>
@@ -67,6 +68,14 @@
     <dependencyManagement>
 
         <dependencies>
+            <!-- Jackson dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
 
             <dependency>
                 <groupId>io.quarkus.resteasy.reactive</groupId>


### PR DESCRIPTION
Jackson 2.11.3 is resolved transitively because of Vert.x, it should use the same used in Quarkus