### PR TITLE
Upgrade SmallRye GraphQL to 1.2.0 (Initial subscription support)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <smallrye-health.version>3.0.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.4</smallrye-open-api.version>
-        <smallrye-graphql.version>1.1.0</smallrye-graphql.version>
+        <smallrye-graphql.version>1.2.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.0.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.1.1</smallrye-jwt.version>

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -646,6 +646,7 @@ This can easily be a server side generated field that the client may require.
 
 Let's now try deleting an entry:
 
+[source,graphql]
 ----
 mutation DeleteHero {
   deleteHero(id :3){
@@ -657,6 +658,52 @@ mutation DeleteHero {
 
 Similar to the `createHero` mutation method we also retrieve the `name` and
 `surname` of the hero we have deleted which is defined in `{ }`.
+
+== Subscriptions
+
+Subscriptions allows you to subscribe to a query. It allows you to receive events.
+
+NOTE: Subscription is currently still considered experimental.
+
+Example: We want to know when new Heroes are being created:
+
+[source,java]
+----
+
+    BroadcastProcessor<Hero> processor = BroadcastProcessor.create(); // <1>
+
+    @Mutation
+    public Hero createHero(Hero hero) {
+        service.addHero(hero);
+        processor.onNext(hero); // <2>
+        return hero;
+    }
+
+    @Subscription
+    public Multi<Hero> heroCreated(){
+        return processor; // <3>
+    }
+
+----
+
+<1> The `Multi` processor that will broadcast any new Heros
+<2> When adding a new Hero, also broadcast it
+<3> Make the stream available in the schema and as a WebSocket during runtime
+
+
+Any client that now connect to the `/graphql` WebSocket connection will receive events on new Heroes being created:
+
+[source,graphql]
+----
+
+subscription ListenForNewHeroes {
+  heroCreated {
+    name
+    surname
+  }
+}
+
+----
 
 == Creating Queries by fields
 

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/SecurityTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/SecurityTest.java
@@ -95,7 +95,7 @@ public class SecurityTest extends AbstractGraphQLTest {
                 .body("data.foo.bonusBar", nullValue());
     }
 
-    static class Foo {
+    public static class Foo {
 
         private String message;
 

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
@@ -1,0 +1,85 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.smallrye.graphql.execution.ExecutionService;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handler that does the execution of GraphQL Requests
+ */
+public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingContext> {
+
+    private final CurrentIdentityAssociation currentIdentityAssociation;
+    private final CurrentVertxRequest currentVertxRequest;
+
+    private volatile ExecutionService executionService;
+
+    private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
+    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
+
+    public SmallRyeGraphQLAbstractHandler(
+            CurrentIdentityAssociation currentIdentityAssociation,
+            CurrentVertxRequest currentVertxRequest) {
+
+        this.currentIdentityAssociation = currentIdentityAssociation;
+        this.currentVertxRequest = currentVertxRequest;
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        ManagedContext requestContext = Arc.container().requestContext();
+        if (requestContext.isActive()) {
+            handleWithIdentity(ctx);
+        } else {
+            try {
+                requestContext.activate();
+                handleWithIdentity(ctx);
+            } finally {
+                requestContext.terminate();
+            }
+        }
+    }
+
+    private void handleWithIdentity(final RoutingContext ctx) {
+        if (currentIdentityAssociation != null) {
+            QuarkusHttpUser existing = (QuarkusHttpUser) ctx.user();
+            if (existing != null) {
+                SecurityIdentity identity = existing.getSecurityIdentity();
+                currentIdentityAssociation.setIdentity(identity);
+            } else {
+                currentIdentityAssociation.setIdentity(QuarkusHttpUser.getSecurityIdentity(ctx, null));
+            }
+        }
+        currentVertxRequest.setCurrent(ctx);
+        doHandle(ctx);
+    }
+
+    protected abstract void doHandle(final RoutingContext ctx);
+
+    protected JsonObject inputToJsonObject(String input) {
+        try (JsonReader jsonReader = jsonReaderFactory.createReader(new StringReader(input))) {
+            return jsonReader.readObject();
+        }
+    }
+
+    protected ExecutionService getExecutionService() {
+        if (this.executionService == null) {
+            this.executionService = Arc.container().instance(ExecutionService.class).get();
+        }
+        return this.executionService;
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -32,19 +32,17 @@ public class SmallRyeGraphQLRecorder {
 
     public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet) {
         if (initialized.getValue()) {
-            Instance<CurrentIdentityAssociation> identityAssociations = CDI.current()
-                    .select(CurrentIdentityAssociation.class);
-            CurrentIdentityAssociation association;
-            if (identityAssociations.isResolvable()) {
-                association = identityAssociations.get();
-            } else {
-                association = null;
-            }
-            CurrentVertxRequest currentVertxRequest = CDI.current().select(CurrentVertxRequest.class).get();
-            return new SmallRyeGraphQLExecutionHandler(allowGet, association, currentVertxRequest);
+            return new SmallRyeGraphQLExecutionHandler(allowGet, getCurrentIdentityAssociation(),
+                    CDI.current().select(CurrentVertxRequest.class).get());
         } else {
             return new SmallRyeGraphQLNoEndpointHandler();
         }
+    }
+
+    public Handler<RoutingContext> subscriptionHandler(BeanContainer beanContainer, RuntimeValue<Boolean> initialized) {
+        GraphQLConfig config = beanContainer.instance(GraphQLConfig.class);
+        return new SmallRyeGraphQLSubscriptionHandler(config, getCurrentIdentityAssociation(),
+                CDI.current().select(CurrentVertxRequest.class).get());
     }
 
     public Handler<RoutingContext> schemaHandler(RuntimeValue<Boolean> initialized) {
@@ -82,5 +80,14 @@ public class SmallRyeGraphQLRecorder {
                 route.handler(bodyHandler);
             }
         };
+    }
+
+    private CurrentIdentityAssociation getCurrentIdentityAssociation() {
+        Instance<CurrentIdentityAssociation> identityAssociations = CDI.current()
+                .select(CurrentIdentityAssociation.class);
+        if (identityAssociations.isResolvable()) {
+            return identityAssociations.get();
+        }
+        return null;
     }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLSubscriptionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLSubscriptionHandler.java
@@ -1,0 +1,184 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.json.JsonObject;
+
+import org.jboss.logging.Logger;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphqlErrorBuilder;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.graphql.bootstrap.Config;
+import io.smallrye.graphql.execution.ExecutionResponse;
+import io.smallrye.graphql.execution.error.ExecutionErrorsService;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handler that does the execution of GraphQL Requests
+ */
+public class SmallRyeGraphQLSubscriptionHandler extends SmallRyeGraphQLAbstractHandler {
+    private static final Logger log = Logger.getLogger(SmallRyeGraphQLSubscriptionHandler.class);
+    private final ExecutionErrorsService executionErrorsService;
+    private final Config config;
+    private final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+
+    public SmallRyeGraphQLSubscriptionHandler(Config config, CurrentIdentityAssociation currentIdentityAssociation,
+            CurrentVertxRequest currentVertxRequest) {
+        super(currentIdentityAssociation, currentVertxRequest);
+        this.config = config;
+        this.executionErrorsService = new ExecutionErrorsService(config);
+    }
+
+    @Override
+    protected void doHandle(final RoutingContext ctx) {
+        if (ctx.request().headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true) && !ctx.request().isEnded()) {
+            ctx.request().toWebSocket(new SmallRyeWebSocketHandler());
+        } else {
+            ctx.next();
+        }
+    }
+
+    private class SmallRyeWebSocketHandler implements Handler<AsyncResult<ServerWebSocket>> {
+
+        @Override
+        public void handle(AsyncResult<ServerWebSocket> event) {
+            if (event.succeeded()) {
+                ServerWebSocket serverWebSocket = event.result();
+                serverWebSocket.closeHandler(new CloseHandler());
+                serverWebSocket.endHandler(new EndHandler());
+                serverWebSocket.exceptionHandler(new ExceptionHandler());
+                serverWebSocket.textMessageHandler(new TextMessageHandler(serverWebSocket));
+            }
+        }
+    }
+
+    private class CloseHandler implements Handler<Void> {
+        @Override
+        public void handle(Void e) {
+            unsubscribe();
+        }
+    }
+
+    private class EndHandler implements Handler<Void> {
+        @Override
+        public void handle(Void e) {
+            unsubscribe();
+        }
+    }
+
+    private class ExceptionHandler implements Handler<Throwable> {
+        @Override
+        public void handle(Throwable e) {
+            log.error(e.getMessage());
+            unsubscribe();
+        }
+    }
+
+    public void unsubscribe() {
+        if (subscriptionRef.get() != null) {
+            Subscriptions.cancel(subscriptionRef);
+            subscriptionRef.set(null);
+        }
+    }
+
+    private class TextMessageHandler implements Handler<String> {
+        private final SmallRyeGraphQLSubscriptionSubscriber smallRyeGraphQLSubscriptionSubscriber;
+
+        TextMessageHandler(final ServerWebSocket serverWebSocket) {
+            this.smallRyeGraphQLSubscriptionSubscriber = new SmallRyeGraphQLSubscriptionSubscriber(serverWebSocket);
+        }
+
+        @Override
+        public void handle(String message) {
+            JsonObject jsonInput = inputToJsonObject(message);
+            ExecutionResponse executionResponse = getExecutionService()
+                    .execute(jsonInput);
+
+            ExecutionResult executionResult = executionResponse.getExecutionResult();
+            if (executionResult != null) {
+                // If there is error on the query, we can not start a subscription
+                if (executionResult.getErrors() != null && !executionResult.getErrors().isEmpty()) {
+                    smallRyeGraphQLSubscriptionSubscriber.onNext(executionResult);
+                    smallRyeGraphQLSubscriptionSubscriber.closeWebSocket();
+                } else {
+                    Publisher<ExecutionResult> stream = executionResponse.getExecutionResult()
+                            .getData();
+
+                    if (stream != null) {
+
+                        Multi<ExecutionResult> multiStream = Multi.createFrom().publisher(stream);
+
+                        multiStream.onFailure().recoverWithItem(failure -> {
+                            // TODO: Below must move to SmallRye, and once 1.2.1 is releaes we can remove it here
+                            //       Once in SmallRye, this will also follow the propper error rule (show/hide) and add more details.
+                            return new ExecutionResultImpl(GraphqlErrorBuilder.newError()
+                                    .message(failure.getMessage())
+                                    .build());
+                        }).subscribe(smallRyeGraphQLSubscriptionSubscriber);
+                    }
+                }
+            }
+        }
+    }
+
+    private class SmallRyeGraphQLSubscriptionSubscriber implements Subscriber<ExecutionResult> {
+        private final ServerWebSocket serverWebSocket;
+
+        public SmallRyeGraphQLSubscriptionSubscriber(ServerWebSocket serverWebSocket) {
+            this.serverWebSocket = serverWebSocket;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (subscriptionRef.compareAndSet(null, s)) {
+                s.request(1);
+            } else {
+                s.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(ExecutionResult executionResult) {
+            if (serverWebSocket != null && !serverWebSocket.isClosed()) {
+                ExecutionResponse executionResponse = new ExecutionResponse(executionResult, config);
+                serverWebSocket.writeTextMessage(executionResponse.getExecutionResultAsString());
+                Subscription s = subscriptionRef.get();
+                s.request(1);
+            } else {
+                // Connection to client is closed, but we still receive mesages
+                unsubscribe();
+            }
+        }
+
+        @Override
+        public void onError(Throwable thrwbl) {
+            log.error("Error in GraphQL Subscription Websocket", thrwbl);
+            unsubscribe();
+            closeWebSocket();
+        }
+
+        @Override
+        public void onComplete() {
+            unsubscribe();
+            closeWebSocket();
+        }
+
+        public void closeWebSocket() {
+            if (!serverWebSocket.isClosed()) {
+                serverWebSocket.close();
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
@@ -8,6 +8,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.console.ConfiguredPathInfo;
+import io.quarkus.vertx.http.runtime.BasicRoute;
 import io.quarkus.vertx.http.runtime.HandlerType;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
@@ -92,6 +93,25 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
         public Builder routeFunction(Function<Router, Route> routeFunction) {
             throw new RuntimeException(
                     "This method is not supported using this builder. Use #routeFunction(String, Consumer<Route>)");
+        }
+
+        public Builder orderedRoute(String route, Integer order) {
+            route = super.absolutePath = buildItem.resolvePath(route);
+
+            if (route.startsWith(buildItem.getRootPath())) {
+                // relative to http root (leading slash for vert.x route)
+                this.path = "/" + UriNormalizationUtil.relativize(buildItem.getRootPath(), route);
+                this.routeType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
+            } else if (route.startsWith("/")) {
+                // absolute path
+                this.path = route;
+                this.routeType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
+            }
+
+            BasicRoute basicRoute = new BasicRoute(this.path, -1);
+
+            super.routeFunction = basicRoute;
+            return this;
         }
 
         public Builder routeFunction(String route, Consumer<Route> routeFunction) {


### PR DESCRIPTION
This PR upgrade SmallRye GraphQL to version 1.2.0 (see https://github.com/smallrye/smallrye-graphql/releases/tag/1.2.0)

This also add initial experimental support for Subscriptions (`Multi` and `Publisher`)

![subscription2](https://user-images.githubusercontent.com/6836179/118034779-aa4cd780-b36a-11eb-8469-ee3be51852f0.gif)


Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>