### PR TITLE
AWS Lambda HTTP Security Integration

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -258,6 +258,7 @@ For the AWS REST API you can inject the AWS variables `com.amazonaws.services.la
 ----
 import javax.ws.rs.core.Context;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 
 
 @Path("/myresource")
@@ -266,7 +267,10 @@ public class MyResource {
     public String ctx(@Context com.amazonaws.services.lambda.runtime.Context ctx) { }
 
     @GET
-    public String req(@Context AwsProxyRequestContext req) { }
+    public String reqContext(@Context AwsProxyRequestContext req) { }
+
+    @GET
+    public String req(@Context AwsProxyRequest req) { }
 
 }
 ----
@@ -276,3 +280,203 @@ public class MyResource {
 If you are building native images, and want to use https://aws.amazon.com/xray[AWS X-Ray Tracing] with your lambda
 you will need to include `quarkus-amazon-lambda-xray` as a dependency in your pom.  The AWS X-Ray
 library is not fully compatible with GraalVM so we had to do some integration work to make this work.
+
+== Security Integration
+
+When you invoke an HTTP request on the API Gateway, the Gateway turns that HTTP request into a JSON event document that is
+forwarded to a Quarkus Lambda.  The Quarkus Lambda parses this json and converts in into an internal representation of an HTTP
+request that can be consumed by any HTTP framework Quarkus supports (JAX-RS, servlet, Vert.x Web).
+
+API Gateway supports many different ways to securely invoke on your HTTP endpoints that are backed by Lambda and Quarkus.
+If you enable it, Quarkus will automatically parse relevant parts of the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html[event json document]
+and look for security based metadata and register a `java.security.Principal` internally that can be looked up in JAX-RS
+by injecting a `javax.ws.rs.core.SecurityContext`, via `HttpServletRequest.getUserPrincipal()` in servlet, and `RouteContext.user()` in Vert.x Web.
+If you want more security information, the `Principal` object can be typecast to
+a class that will give you more information.
+
+To enable this security feature, add this to your `application.properties` file:
+----
+quarkus.lambda-http.enable-security=true
+----
+
+
+Here's how its mapped:
+
+.HTTP `quarkus-amazon-lambda-http`
+[options="header"]
+|=======================
+|Auth Type       |Principal Class                                 |Json path of Principal Name
+|Cognito JWT     |`io.quarkus.amazon.lambda.http.CognitoPrincipal`|`requestContext.authorizer.jwt.claims.cognito:username`
+|IAM             |`io.quarkus.amazon.lambda.http.IAMPrincipal`    |`requestContext.authorizer.iam.userId`
+|Custom Lambda   |`io.quarkus.amazon.lambda.http.CustomPrincipal` |`requestContext.authorizer.lambda.principalId`
+
+|=======================
+
+.REST `quarkus-amazon-lambda-rest`
+[options="header"]
+|=======================
+|Auth Type       |Principal Class                                 |Json path of Principal Name
+|Cognito         |`io.quarkus.amazon.lambda.http.CognitoPrincipal`|`requestContext.authorizer.claims.cognito:username`
+|IAM             |`io.quarkus.amazon.lambda.http.IAMPrincipal`    |`requestContext.identity.user`
+|Custom Lambda   |`io.quarkus.amazon.lambda.http.CustomPrincipal` |`requestContext.authorizer.principalId`
+
+|=======================
+
+== Custom Security Integration
+
+The default support for AWS security only maps the principal name to Quarkus security
+APIs and does nothing to map claims or roles or permissions.  You have can full control
+how security metadata in the lambda HTTP event is mapped to Quarkus security APIs using
+implementations of the `io.quarkus.amazon.lambda.http.LambdaIdentityProvider`
+interface.  By implementing this interface, you can do things like define role mappings for your principal
+or publish additional attributes provided by IAM or Cognito or your Custom Lambda security integration.
+
+.HTTP `quarkus-amazon-lambda-http`
+[source, java]
+----
+package io.quarkus.amazon.lambda.http;
+
+/**
+ * Helper interface that removes some boilerplate for creating
+ * an IdentityProvider that processes APIGatewayV2HTTPEvent
+ */
+public interface LambdaIdentityProvider extends IdentityProvider<LambdaAuthenticationRequest> {
+    @Override
+    default public Class<LambdaAuthenticationRequest> getRequestType() {
+        return LambdaAuthenticationRequest.class;
+    }
+
+    @Override
+    default Uni<SecurityIdentity> authenticate(LambdaAuthenticationRequest request, AuthenticationRequestContext context) {
+        APIGatewayV2HTTPEvent event = request.getEvent();
+        SecurityIdentity identity = authenticate(event);
+        if (identity == null) {
+            return Uni.createFrom().optional(Optional.empty());
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    /**
+     * You must override this method unless you directly override
+     * IdentityProvider.authenticate
+     *
+     * @param event
+     * @return
+     */
+    default SecurityIdentity authenticate(APIGatewayV2HTTPEvent event) {
+        throw new IllegalStateException("You must override this method or IdentityProvider.authenticate");
+    }
+}
+----
+
+For HTTP, the important method to override is `LambdaIdentityProvider.authenticate(APIGatewayV2HTTPEvent event)`.  From this
+you will allocate a SecurityIdentity based on how you want to map security data from `APIGatewayV2HTTPEvent`
+
+.REST `quarkus-amazon-lambda-rest`
+[source, java]
+----
+package io.quarkus.amazon.lambda.http;
+
+import java.util.Optional;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Helper interface that removes some boilerplate for creating
+ * an IdentityProvider that processes APIGatewayV2HTTPEvent
+ */
+public interface LambdaIdentityProvider extends IdentityProvider<LambdaAuthenticationRequest> {
+...
+
+    /**
+     * You must override this method unless you directly override
+     * IdentityProvider.authenticate
+     *
+     * @param event
+     * @return
+     */
+    default SecurityIdentity authenticate(AwsProxyRequest event) {
+        throw new IllegalStateException("You must override this method or IdentityProvider.authenticate");
+    }
+}
+----
+
+For REST, the important method to override is `LambdaIdentityProvider.authenticate(AwsProxyRequest event)`.  From this
+you will allocate a SecurityIdentity based on how you want to map security data from `AwsProxyRequest`.
+
+Your implemented provider must be a CDI bean.  Here's an example:
+
+[source,java]
+----
+package org.acme;
+
+import java.security.Principal;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.amazon.lambda.http.LambdaIdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+@ApplicationScoped
+public class CustomSecurityProvider implements LambdaIdentityProvider {
+    @Override
+    public SecurityIdentity authenticate(APIGatewayV2HTTPEvent event) {
+        if (event.getHeaders() == null || !event.getHeaders().containsKey("x-user"))
+            return null;
+        Principal principal = new QuarkusPrincipal(event.getHeaders().get("x-user"));
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(principal);
+        return builder.build();
+    }
+}
+----
+
+Here's the same example, but with the AWS Gateway REST API:
+
+[source,java]
+----
+package org.acme;
+
+import java.security.Principal;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+
+import io.quarkus.amazon.lambda.http.LambdaIdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+@ApplicationScoped
+public class CustomSecurityProvider implements LambdaIdentityProvider {
+    @Override
+    public SecurityIdentity authenticate(AwsProxyRequest event) {
+        if (event.getMultiValueHeaders() == null || !event.getMultiValueHeaders().containsKey("x-user"))
+            return null;
+        Principal principal = new QuarkusPrincipal(event.getMultiValueHeaders().getFirst("x-user"));
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(principal);
+        return builder.build();
+    }
+}
+----
+
+Quarkus should automatically discover this implementation and use it instead of the default implementation
+discussed earlier.
+
+== Simple SAM Local Principal
+
+If you are testing your application with `sam local` you can
+hardcode a principal name to use when your application runs by setting
+the `QUARKUS_AWS_LAMBDA_FORCE_USER_NAME` environment variable

--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -7,9 +7,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 
 import io.quarkus.amazon.lambda.deployment.LambdaUtil;
 import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
+import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
+import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.amazon.lambda.http.model.MultiValuedTreeMap;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -23,6 +26,19 @@ import io.vertx.core.file.impl.FileResolver;
 
 public class AmazonLambdaHttpProcessor {
     private static final Logger log = Logger.getLogger(AmazonLambdaHttpProcessor.class);
+
+    @BuildStep
+    public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            LambdaHttpBuildTimeConfig config) {
+        if (!config.enableSecurity)
+            return;
+
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();
+
+        builder.addBeanClass(LambdaHttpAuthenticationMechanism.class)
+                .addBeanClass(DefaultLambdaIdentityProvider.class);
+        additionalBeans.produce(builder.build());
+    }
 
     @BuildStep
     public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.amazon.lambda.http.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class LambdaHttpBuildTimeConfig {
+    /**
+     * Enable security mechanisms to process lambda and AWS based security (i.e. Cognito, IAM) from
+     * the http event sent from API Gateway
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableSecurity;
+}

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda</artifactId>
         </dependency>
          <dependency>

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -1,0 +1,30 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+/**
+ * Represents a Cognito JWT used to authenticate request
+ *
+ * Will only be allocated if requestContext.authorizer.jwt.claims.cognito:username is set
+ * in the http event sent by API Gateway
+ */
+public class CognitoPrincipal implements Principal {
+    private APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT jwt;
+    private String name;
+
+    public CognitoPrincipal(APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT jwt) {
+        this.jwt = jwt;
+        this.name = jwt.getClaims().get("cognito:username");
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT getClaims() {
+        return jwt;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CustomPrincipal.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CustomPrincipal.java
@@ -1,0 +1,30 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * Represents a custom principal sent by API Gateway i.e. a Lambda authorizer
+ *
+ * Will only be allocated if requestContext.authorizer.lambda.principalId is set
+ * in the http event sent by API Gateway
+ *
+ */
+public class CustomPrincipal implements Principal {
+    private String name;
+    private Map<String, Object> claims;
+
+    public CustomPrincipal(String name, Map<String, Object> claims) {
+        this.claims = claims;
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, Object> getClaims() {
+        return claims;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaAuthenticationRequest.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaAuthenticationRequest.java
@@ -1,0 +1,20 @@
+package io.quarkus.amazon.lambda.http;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+
+/**
+ * This will execute if and only if there is no identity after invoking a LambdaAuthenticationRequest
+ */
+final public class DefaultLambdaAuthenticationRequest extends BaseAuthenticationRequest {
+    private APIGatewayV2HTTPEvent event;
+
+    public DefaultLambdaAuthenticationRequest(APIGatewayV2HTTPEvent event) {
+        this.event = event;
+    }
+
+    public APIGatewayV2HTTPEvent getEvent() {
+        return event;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
@@ -1,0 +1,90 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+final public class DefaultLambdaIdentityProvider implements IdentityProvider<DefaultLambdaAuthenticationRequest> {
+
+    @Override
+    public Class<DefaultLambdaAuthenticationRequest> getRequestType() {
+        return DefaultLambdaAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(DefaultLambdaAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+        APIGatewayV2HTTPEvent event = request.getEvent();
+        SecurityIdentity identity = authenticate(event);
+        if (identity == null) {
+            return Uni.createFrom().optional(Optional.empty());
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    /**
+     * Create a SecurityIdentity with a principal derived from APIGatewayV2HTTPEvent.
+     * Looks for Cognito JWT, IAM, or Custom Lambda metadata for principal name
+     *
+     * @param event
+     * @return
+     */
+    public static SecurityIdentity authenticate(APIGatewayV2HTTPEvent event) {
+        Principal principal = getPrincipal(event);
+        if (principal == null) {
+            return null;
+        }
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(principal);
+        return builder.build();
+    }
+
+    protected static Principal getPrincipal(APIGatewayV2HTTPEvent request) {
+        final Map<String, String> systemEnvironment = System.getenv();
+        final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
+        final APIGatewayV2HTTPEvent.RequestContext requestContext = request.getRequestContext();
+        if (isSamLocal && (requestContext == null || requestContext.getAuthorizer() == null)) {
+            final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
+            if (forcedUserName != null && !forcedUserName.isEmpty()) {
+                return new QuarkusPrincipal(forcedUserName);
+            }
+        } else {
+            if (requestContext != null) {
+                final APIGatewayV2HTTPEvent.RequestContext.Authorizer authorizer = requestContext.getAuthorizer();
+                if (authorizer != null) {
+                    if (authorizer.getJwt() != null) {
+                        final APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT jwt = authorizer.getJwt();
+                        final Map<String, String> claims = jwt.getClaims();
+                        if (claims != null && claims.containsKey("cognito:username")) {
+                            return new CognitoPrincipal(jwt);
+                        }
+                    } else if (authorizer.getIam() != null) {
+                        if (authorizer.getIam().getUserId() != null) {
+                            return new IAMPrincipal(authorizer.getIam());
+                        }
+                    } else if (authorizer.getLambda() != null) {
+                        Object tmp = authorizer.getLambda().get("principalId");
+                        if (tmp != null && tmp instanceof String) {
+                            String username = (String) tmp;
+                            return new CustomPrincipal(username, authorizer.getLambda());
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/IAMPrincipal.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/IAMPrincipal.java
@@ -1,0 +1,30 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+/**
+ * Used if IAM is used for authentication.
+ *
+ * Will only be allocated if requestContext.authorizer.iam.userId is set
+ * in the http event sent by API Gateway
+ */
+public class IAMPrincipal implements Principal {
+    private String name;
+    private APIGatewayV2HTTPEvent.RequestContext.IAM iam;
+
+    public IAMPrincipal(APIGatewayV2HTTPEvent.RequestContext.IAM iam) {
+        this.iam = iam;
+        this.name = iam.getUserId();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public APIGatewayV2HTTPEvent.RequestContext.IAM getIam() {
+        return iam;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaAuthenticationRequest.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaAuthenticationRequest.java
@@ -1,0 +1,17 @@
+package io.quarkus.amazon.lambda.http;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+
+public class LambdaAuthenticationRequest extends BaseAuthenticationRequest {
+    private APIGatewayV2HTTPEvent event;
+
+    public LambdaAuthenticationRequest(APIGatewayV2HTTPEvent event) {
+        this.event = event;
+    }
+
+    public APIGatewayV2HTTPEvent getEvent() {
+        return event;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
@@ -1,0 +1,101 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class LambdaHttpAuthenticationMechanism implements HttpAuthenticationMechanism {
+    @Inject
+    Instance<IdentityProvider<LambdaAuthenticationRequest>> identityProviders;
+
+    // there is no way in CDI to currently provide a prioritized list of IdentityProvider
+    // So, what we do here is to try to see if anybody has registered one.  If no identity, then
+    // fire off a request that can only be resolved by the DefaultLambdaIdentityProvider
+    boolean useDefault;
+
+    @PostConstruct
+    public void initialize() {
+        useDefault = !identityProviders.iterator().hasNext();
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext routingContext, IdentityProviderManager identityProviderManager) {
+        MultiMap qheaders = routingContext.request().headers();
+        if (qheaders instanceof QuarkusHttpHeaders) {
+            Map<Class<?>, Object> contextObjects = ((QuarkusHttpHeaders) qheaders).getContextObjects();
+            if (contextObjects.containsKey(APIGatewayV2HTTPEvent.class)) {
+                APIGatewayV2HTTPEvent event = (APIGatewayV2HTTPEvent) contextObjects.get(APIGatewayV2HTTPEvent.class);
+                if (isAuthenticatable(event)) {
+                    if (useDefault) {
+                        return identityProviderManager
+                                .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
+                                        new DefaultLambdaAuthenticationRequest(event), routingContext));
+
+                    } else {
+                        return identityProviderManager
+                                .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
+                                        new LambdaAuthenticationRequest(event), routingContext));
+                    }
+                }
+            }
+        }
+        return Uni.createFrom().optional(Optional.empty());
+    }
+
+    private boolean isAuthenticatable(APIGatewayV2HTTPEvent event) {
+        final Map<String, String> systemEnvironment = System.getenv();
+        final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
+        final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
+        return (isSamLocal && forcedUserName != null)
+                || (event.getRequestContext() != null && event.getRequestContext().getAuthorizer() != null);
+    }
+
+    @Override
+    public Uni<Boolean> sendChallenge(RoutingContext context) {
+        return Uni.createFrom().item(false);
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return Uni.createFrom().nullItem();
+    }
+
+    static final Set<Class<? extends AuthenticationRequest>> credentialTypes = new HashSet<>();
+
+    static {
+        credentialTypes.add(LambdaAuthenticationRequest.class);
+        credentialTypes.add(DefaultLambdaAuthenticationRequest.class);
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return credentialTypes;
+    }
+
+    @Override
+    public HttpCredentialTransport getCredentialTransport() {
+        return null;
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -7,7 +7,6 @@ import java.net.InetSocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.security.Principal;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -169,10 +168,6 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
         quarkusHeaders.setContextObject(Context.class, context);
         quarkusHeaders.setContextObject(APIGatewayV2HTTPEvent.class, request);
         quarkusHeaders.setContextObject(APIGatewayV2HTTPEvent.RequestContext.class, request.getRequestContext());
-        final Principal principal = getPrincipal(request);
-        if (principal != null) {
-            quarkusHeaders.setContextObject(Principal.class, principal);
-        }
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.valueOf(request.getRequestContext().getHttp().getMethod()), ofNullable(request.getRawQueryString())
                         .filter(q -> !q.isEmpty()).map(q -> request.getRawPath() + '?' + q).orElse(request.getRawPath()),
@@ -237,47 +232,6 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
             }
         }
         return false;
-    }
-
-    private Principal getPrincipal(APIGatewayV2HTTPEvent request) {
-        final Map<String, String> systemEnvironment = System.getenv();
-        final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
-        if (isSamLocal) {
-            final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
-            if (forcedUserName != null && !forcedUserName.isEmpty()) {
-                log.info("Forcing local user to " + forcedUserName);
-                return new Principal() {
-
-                    @Override
-                    public String getName() {
-                        return forcedUserName;
-                    }
-
-                };
-            }
-        } else {
-            final APIGatewayV2HTTPEvent.RequestContext requestContext = request.getRequestContext();
-            if (requestContext != null) {
-                final APIGatewayV2HTTPEvent.RequestContext.Authorizer authorizer = requestContext.getAuthorizer();
-                if (authorizer != null) {
-                    final APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT jwt = authorizer.getJwt();
-                    if (jwt != null) {
-                        final Map<String, String> claims = jwt.getClaims();
-                        if (claims != null) {
-                            final String jwtUsername = claims.get("cognito:username");
-                            if (jwtUsername != null && !jwtUsername.isEmpty())
-                                return new Principal() {
-                                    @Override
-                                    public String getName() {
-                                        return jwtUsername;
-                                    }
-                                };
-                        }
-                    }
-                }
-            }
-        }
-        return null;
     }
 
 }

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
@@ -1,0 +1,42 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.Optional;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Helper interface that removes some boilerplate for creating
+ * an IdentityProvider that processes APIGatewayV2HTTPEvent
+ */
+public interface LambdaIdentityProvider extends IdentityProvider<LambdaAuthenticationRequest> {
+    @Override
+    default public Class<LambdaAuthenticationRequest> getRequestType() {
+        return LambdaAuthenticationRequest.class;
+    }
+
+    @Override
+    default Uni<SecurityIdentity> authenticate(LambdaAuthenticationRequest request, AuthenticationRequestContext context) {
+        APIGatewayV2HTTPEvent event = request.getEvent();
+        SecurityIdentity identity = authenticate(event);
+        if (identity == null) {
+            return Uni.createFrom().optional(Optional.empty());
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    /**
+     * You must override this method unless you directly override
+     * IdentityProvider.authenticate
+     *
+     * @param event
+     * @return
+     */
+    default SecurityIdentity authenticate(APIGatewayV2HTTPEvent event) {
+        throw new IllegalStateException("You must override this method or IdentityProvider.authenticate");
+    }
+}

--- a/extensions/amazon-lambda-rest/deployment/pom.xml
+++ b/extensions/amazon-lambda-rest/deployment/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -4,6 +4,8 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.amazon.lambda.deployment.LambdaUtil;
 import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
+import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
+import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
 import io.quarkus.amazon.lambda.http.model.AlbContext;
 import io.quarkus.amazon.lambda.http.model.ApiGatewayAuthorizerContext;
@@ -15,6 +17,7 @@ import io.quarkus.amazon.lambda.http.model.CognitoAuthorizerClaims;
 import io.quarkus.amazon.lambda.http.model.ErrorModel;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.amazon.lambda.http.model.MultiValuedTreeMap;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -28,6 +31,19 @@ import io.vertx.core.file.impl.FileResolver;
 
 public class AmazonLambdaHttpProcessor {
     private static final Logger log = Logger.getLogger(AmazonLambdaHttpProcessor.class);
+
+    @BuildStep
+    public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            LambdaHttpBuildTimeConfig config) {
+        if (!config.enableSecurity)
+            return;
+
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();
+
+        builder.addBeanClass(LambdaHttpAuthenticationMechanism.class)
+                .addBeanClass(DefaultLambdaIdentityProvider.class);
+        additionalBeans.produce(builder.build());
+    }
 
     @BuildStep
     public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
@@ -79,5 +95,4 @@ public class AmazonLambdaHttpProcessor {
                 .replace("${lambdaName}", lambdaName);
         LambdaUtil.writeFile(target, "sam.native.yaml", output);
     }
-
 }

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.amazon.lambda.http.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class LambdaHttpBuildTimeConfig {
+    /**
+     * Enable security mechanisms to process lambda and AWS based security (i.e. Cognito, IAM) from
+     * the http event sent from API Gateway
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableSecurity;
+}

--- a/extensions/amazon-lambda-rest/runtime/pom.xml
+++ b/extensions/amazon-lambda-rest/runtime/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda</artifactId>
         </dependency>
          <dependency>

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -1,0 +1,31 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+
+import io.quarkus.amazon.lambda.http.model.CognitoAuthorizerClaims;
+
+/**
+ * Allocated when cognito is used to authenticate user
+ *
+ * Will only be allocated if requestContext.authorizer.claims.cognito:username is set
+ * in the http event sent by API Gateway
+ *
+ */
+public class CognitoPrincipal implements Principal {
+    private CognitoAuthorizerClaims claims;
+    private String name;
+
+    public CognitoPrincipal(CognitoAuthorizerClaims claims) {
+        this.claims = claims;
+        this.name = claims.getUsername();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public CognitoAuthorizerClaims getClaims() {
+        return claims;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CustomPrincipal.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CustomPrincipal.java
@@ -1,0 +1,30 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * Allocated when a custom authorizer (i.e. Lambda) is used to authenticate user
+ *
+ * Will only be allocated if requestContext.authorizer.principalId is set
+ * in the http event sent by API Gateway
+ *
+ */
+public class CustomPrincipal implements Principal {
+    private String name;
+    private Map<String, String> claims;
+
+    public CustomPrincipal(String name, Map<String, String> claims) {
+        this.claims = claims;
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getClaims() {
+        return claims;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaAuthenticationRequest.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaAuthenticationRequest.java
@@ -1,0 +1,19 @@
+package io.quarkus.amazon.lambda.http;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+
+/**
+ * This will execute if and only if there is no identity after invoking a LambdaAuthenticationRequest
+ */
+final public class DefaultLambdaAuthenticationRequest extends BaseAuthenticationRequest {
+    private AwsProxyRequest event;
+
+    public DefaultLambdaAuthenticationRequest(AwsProxyRequest event) {
+        this.event = event;
+    }
+
+    public AwsProxyRequest getEvent() {
+        return event;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
@@ -1,0 +1,81 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+final public class DefaultLambdaIdentityProvider implements IdentityProvider<DefaultLambdaAuthenticationRequest> {
+
+    @Override
+    public Class<DefaultLambdaAuthenticationRequest> getRequestType() {
+        return DefaultLambdaAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(DefaultLambdaAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+        AwsProxyRequest event = request.getEvent();
+        SecurityIdentity identity = authenticate(event);
+        if (identity == null) {
+            return Uni.createFrom().optional(Optional.empty());
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    /**
+     * Create a SecurityIdentity with a principal derived from APIGatewayV2HTTPEvent.
+     * Looks for Cognito JWT, IAM, or Custom Lambda metadata for principal name
+     *
+     * @param event
+     * @return
+     */
+    public static SecurityIdentity authenticate(AwsProxyRequest event) {
+        Principal principal = getPrincipal(event);
+        if (principal == null) {
+            return null;
+        }
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(principal);
+        return builder.build();
+    }
+
+    public static Principal getPrincipal(AwsProxyRequest request) {
+        final Map<String, String> systemEnvironment = System.getenv();
+        final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
+        final AwsProxyRequestContext requestContext = request.getRequestContext();
+        if (isSamLocal && (requestContext == null
+                || (requestContext.getAuthorizer() == null && requestContext.getIdentity() == null))) {
+            final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
+            if (forcedUserName != null && !forcedUserName.isEmpty()) {
+                return new QuarkusPrincipal(forcedUserName);
+            }
+        } else {
+            if (requestContext != null) {
+                if (requestContext.getIdentity() != null && requestContext.getIdentity().getUser() != null) {
+                    return new IAMPrincipal(requestContext.getIdentity());
+                } else if (requestContext.getAuthorizer() != null) {
+                    if (requestContext.getAuthorizer().getClaims() != null) {
+                        return new CognitoPrincipal(requestContext.getAuthorizer().getClaims());
+                    } else if (requestContext.getAuthorizer().getPrincipalId() != null) {
+                        return new CustomPrincipal(requestContext.getAuthorizer().getPrincipalId(),
+                                requestContext.getAuthorizer().getContextProperties());
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/IAMPrincipal.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/IAMPrincipal.java
@@ -1,0 +1,31 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.security.Principal;
+
+import io.quarkus.amazon.lambda.http.model.ApiGatewayRequestIdentity;
+
+/**
+ * Allocated when IAM is used to authenticate user
+ *
+ * Will only be allocated if requestContext.identity.user is set
+ * in the http event sent by API Gateway
+ *
+ */
+public class IAMPrincipal implements Principal {
+    private String name;
+    private ApiGatewayRequestIdentity iam;
+
+    public IAMPrincipal(ApiGatewayRequestIdentity identity) {
+        this.iam = identity;
+        this.name = identity.getUser();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public ApiGatewayRequestIdentity getIam() {
+        return iam;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaAuthenticationRequest.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaAuthenticationRequest.java
@@ -1,0 +1,16 @@
+package io.quarkus.amazon.lambda.http;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+
+public class LambdaAuthenticationRequest extends BaseAuthenticationRequest {
+    private AwsProxyRequest event;
+
+    public LambdaAuthenticationRequest(AwsProxyRequest event) {
+        this.event = event;
+    }
+
+    public AwsProxyRequest getEvent() {
+        return event;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
@@ -1,0 +1,100 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class LambdaHttpAuthenticationMechanism implements HttpAuthenticationMechanism {
+    @Inject
+    Instance<IdentityProvider<LambdaAuthenticationRequest>> identityProviders;
+
+    // there is no way in CDI to currently provide a prioritized list of IdentityProvider
+    // So, what we do here is to try to see if anybody has registered one.  If no identity, then
+    // fire off a request that can only be resolved by the DefaultLambdaIdentityProvider
+    boolean useDefault;
+
+    @PostConstruct
+    public void initialize() {
+        useDefault = !identityProviders.iterator().hasNext();
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext routingContext, IdentityProviderManager identityProviderManager) {
+        MultiMap qheaders = routingContext.request().headers();
+        if (qheaders instanceof QuarkusHttpHeaders) {
+            Map<Class<?>, Object> contextObjects = ((QuarkusHttpHeaders) qheaders).getContextObjects();
+            if (contextObjects.containsKey(AwsProxyRequest.class)) {
+                AwsProxyRequest event = (AwsProxyRequest) contextObjects.get(AwsProxyRequest.class);
+                if (isAuthenticatable(event)) {
+                    if (useDefault) {
+                        return identityProviderManager
+                                .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
+                                        new DefaultLambdaAuthenticationRequest(event), routingContext));
+
+                    } else {
+                        return identityProviderManager
+                                .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
+                                        new LambdaAuthenticationRequest(event), routingContext));
+                    }
+                }
+            }
+        }
+        return Uni.createFrom().optional(Optional.empty());
+    }
+
+    private boolean isAuthenticatable(AwsProxyRequest event) {
+        final Map<String, String> systemEnvironment = System.getenv();
+        final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
+        final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
+        return (isSamLocal && forcedUserName != null) || (event.getRequestContext() != null
+                && (event.getRequestContext().getAuthorizer() != null || event.getRequestContext().getIdentity() != null));
+    }
+
+    @Override
+    public Uni<Boolean> sendChallenge(RoutingContext context) {
+        return Uni.createFrom().item(false);
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return Uni.createFrom().nullItem();
+    }
+
+    static final Set<Class<? extends AuthenticationRequest>> credentialTypes = new HashSet<>();
+
+    static {
+        credentialTypes.add(LambdaAuthenticationRequest.class);
+        credentialTypes.add(DefaultLambdaAuthenticationRequest.class);
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return credentialTypes;
+    }
+
+    @Override
+    public HttpCredentialTransport getCredentialTransport() {
+        return null;
+    }
+}

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -178,6 +178,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
         QuarkusHttpHeaders quarkusHeaders = new QuarkusHttpHeaders();
         quarkusHeaders.setContextObject(Context.class, context);
         quarkusHeaders.setContextObject(AwsProxyRequestContext.class, request.getRequestContext());
+        quarkusHeaders.setContextObject(AwsProxyRequest.class, request);
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.valueOf(request.getHttpMethod()), path, quarkusHeaders);
         if (request.getMultiValueHeaders() != null) { //apparently this can be null if no headers are sent

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
@@ -1,0 +1,43 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.Optional;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Helper interface that removes some boilerplate for creating
+ * an IdentityProvider that processes APIGatewayV2HTTPEvent
+ */
+public interface LambdaIdentityProvider extends IdentityProvider<LambdaAuthenticationRequest> {
+    @Override
+    default public Class<LambdaAuthenticationRequest> getRequestType() {
+        return LambdaAuthenticationRequest.class;
+    }
+
+    @Override
+    default Uni<SecurityIdentity> authenticate(LambdaAuthenticationRequest request, AuthenticationRequestContext context) {
+        AwsProxyRequest event = request.getEvent();
+        SecurityIdentity identity = authenticate(event);
+        if (identity == null) {
+            return Uni.createFrom().optional(Optional.empty());
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    /**
+     * You must override this method unless you directly override
+     * IdentityProvider.authenticate
+     *
+     * @param event
+     * @return
+     */
+    default SecurityIdentity authenticate(AwsProxyRequest event) {
+        throw new IllegalStateException("You must override this method or IdentityProvider.authenticate");
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -223,7 +223,9 @@ public class UndertowDeploymentRecorder {
             public void handleNotification(SecurityNotification notification) {
                 if (notification.getEventType() == SecurityNotification.EventType.AUTHENTICATED) {
                     QuarkusUndertowAccount account = (QuarkusUndertowAccount) notification.getAccount();
-                    CDI.current().select(CurrentIdentityAssociation.class).get().setIdentity(account.getSecurityIdentity());
+                    Instance<CurrentIdentityAssociation> instance = CDI.current().select(CurrentIdentityAssociation.class);
+                    if (instance.isResolvable())
+                        instance.get().setIdentity(account.getSecurityIdentity());
                 }
             }
         });

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -44,21 +44,21 @@ public class HttpAuthenticator {
             Instance<IdentityProvider<?>> providers) {
         List<HttpAuthenticationMechanism> mechanisms = new ArrayList<>();
         for (HttpAuthenticationMechanism mechanism : instance) {
-            boolean notFound = false;
+            boolean found = false;
             for (Class<? extends AuthenticationRequest> mechType : mechanism.getCredentialTypes()) {
-                boolean found = false;
                 for (IdentityProvider<?> i : providers) {
                     if (i.getRequestType().equals(mechType)) {
                         found = true;
                         break;
                     }
                 }
-                if (!found) {
-                    notFound = true;
+                if (found == true) {
                     break;
                 }
             }
-            if (!notFound) {
+            // Add mechanism if there is a provider with matching credential type
+            // If the mechanism has no credential types, just add it anyways
+            if (found || mechanism.getCredentialTypes().isEmpty()) {
                 mechanisms.add(mechanism);
             }
         }

--- a/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/CustomSecurityProvider.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/CustomSecurityProvider.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.amazon.lambda;
+
+import java.security.Principal;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.amazon.lambda.http.LambdaIdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+@ApplicationScoped
+public class CustomSecurityProvider implements LambdaIdentityProvider {
+    @Override
+    public SecurityIdentity authenticate(APIGatewayV2HTTPEvent event) {
+        if (event.getHeaders() == null || !event.getHeaders().containsKey("x-user"))
+            return null;
+        Principal principal = new QuarkusPrincipal(event.getHeaders().get("x-user"));
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(principal);
+        return builder.build();
+    }
+}

--- a/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckResource.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.amazon.lambda;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("security")
+public class SecurityCheckResource {
+
+    @GET
+    @Produces("text/plain")
+    @Path("username")
+    public String getUsername(@Context SecurityContext ctx) {
+        return ctx.getUserPrincipal().getName();
+    }
+}

--- a/integration-tests/amazon-lambda-http-resteasy/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-http-resteasy/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.lambda.enable-polling-jvm-mode=true
+quarkus.lambda-http.enable-security=true
 quarkus.http.virtual=true

--- a/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -18,6 +18,18 @@ import io.quarkus.test.junit.QuarkusTest;
 public class AmazonLambdaSimpleTestCase {
 
     @Test
+    public void testCustomIDPSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/security/username");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setLambda(new HashMap<String, Object>());
+        request.getRequestContext().getAuthorizer().getLambda().put("test", "test");
+        request.getHeaders().put("x-user", "John");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "John");
+    }
+
+    @Test
     public void testContext() throws Exception {
         APIGatewayV2HTTPEvent request = new APIGatewayV2HTTPEvent();
         request.setRawPath("/hello/context");
@@ -49,6 +61,7 @@ public class AmazonLambdaSimpleTestCase {
 
     private APIGatewayV2HTTPEvent request(String path) {
         APIGatewayV2HTTPEvent request = new APIGatewayV2HTTPEvent();
+        request.setHeaders(new HashMap<>());
         request.setRawPath(path);
         request.setRequestContext(new APIGatewayV2HTTPEvent.RequestContext());
         request.getRequestContext().setHttp(new APIGatewayV2HTTPEvent.RequestContext.Http());

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckResource.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.amazon.lambda;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("security")
+public class SecurityCheckResource {
+
+    @GET
+    @Produces("text/plain")
+    @Path("username")
+    public String getUsername(@Context SecurityContext ctx) {
+        return ctx.getUserPrincipal().getName();
+    }
+}

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckVertx.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityCheckVertx.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.amazon.lambda;
+
+import static io.quarkus.vertx.web.Route.HttpMethod.GET;
+
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.quarkus.vertx.web.Route;
+import io.vertx.ext.web.RoutingContext;
+
+public class SecurityCheckVertx {
+    @Route(path = "/vertx/security", methods = GET)
+    void hello(RoutingContext context) {
+        context.response().headers().set("Content-Type", "text/plain");
+        context.response().setStatusCode(200)
+                .end(((QuarkusHttpUser) context.user()).getSecurityIdentity().getPrincipal().getName());
+    }
+}

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityServlet.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/SecurityServlet.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.amazon.lambda;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "ServletSecurity", urlPatterns = "/servlet/security")
+public class SecurityServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(200);
+        resp.addHeader("Content-Type", "text/plain");
+        resp.getWriter().write(req.getUserPrincipal().getName());
+    }
+}

--- a/integration-tests/amazon-lambda-http/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-http/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 quarkus.lambda.enable-polling-jvm-mode=true
 quarkus.http.virtual=true
+quarkus.lambda-http.enable-security=true
 quarkus.swagger-ui.always-include=true

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -31,6 +31,64 @@ public class AmazonLambdaSimpleTestCase {
     }
 
     @Test
+    public void testJaxrsCognitoJWTSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/security/username");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setJwt(new APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT());
+        request.getRequestContext().getAuthorizer().getJwt().setClaims(new HashMap<>());
+        request.getRequestContext().getAuthorizer().getJwt().getClaims().put("cognito:username", "Bill");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "Bill");
+    }
+
+    @Test
+    public void testJaxrsIAMSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/security/username");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setIam(new APIGatewayV2HTTPEvent.RequestContext.IAM());
+        request.getRequestContext().getAuthorizer().getIam().setUserId("Bill");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "Bill");
+    }
+
+    @Test
+    public void testJaxrsCustomLambdaSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/security/username");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setLambda(new HashMap<>());
+        request.getRequestContext().getAuthorizer().getLambda().put("principalId", "Bill");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "Bill");
+    }
+
+    @Test
+    public void testServletCognitoJWTSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/servlet/security");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setJwt(new APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT());
+        request.getRequestContext().getAuthorizer().getJwt().setClaims(new HashMap<>());
+        request.getRequestContext().getAuthorizer().getJwt().getClaims().put("cognito:username", "Bill");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "Bill");
+    }
+
+    @Test
+    public void testVertxCognitoJWTSecurityContext() throws Exception {
+        APIGatewayV2HTTPEvent request = request("/vertx/security");
+        request.getRequestContext().setAuthorizer(new APIGatewayV2HTTPEvent.RequestContext.Authorizer());
+        request.getRequestContext().getAuthorizer().setJwt(new APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT());
+        request.getRequestContext().getAuthorizer().getJwt().setClaims(new HashMap<>());
+        request.getRequestContext().getAuthorizer().getJwt().getClaims().put("cognito:username", "Bill");
+        APIGatewayV2HTTPResponse out = LambdaClient.invoke(APIGatewayV2HTTPResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), "Bill");
+    }
+
+    @Test
     public void testGetText() throws Exception {
         testGetText("/vertx/hello");
         testGetText("/servlet/hello");

--- a/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityCheckResource.java
+++ b/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityCheckResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.amazon.lambda.v1;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("security")
+public class SecurityCheckResource {
+
+    @GET
+    @Produces("text/plain")
+    @Path("username")
+    public String getUsername(@Context SecurityContext ctx) {
+        return ctx.getUserPrincipal().getName();
+    }
+}

--- a/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityCheckVertx.java
+++ b/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityCheckVertx.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.amazon.lambda.v1;
+
+import static io.quarkus.vertx.web.Route.HttpMethod.GET;
+
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.quarkus.vertx.web.Route;
+import io.vertx.ext.web.RoutingContext;
+
+public class SecurityCheckVertx {
+    @Route(path = "/vertx/security", methods = GET)
+    void hello(RoutingContext context) {
+        context.response().headers().set("Content-Type", "text/plain");
+        context.response().setStatusCode(200)
+                .end(((QuarkusHttpUser) context.user()).getSecurityIdentity().getPrincipal().getName());
+    }
+}

--- a/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityServlet.java
+++ b/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/SecurityServlet.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.amazon.lambda.v1;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "ServletSecurity", urlPatterns = "/servlet/security")
+public class SecurityServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(200);
+        resp.addHeader("Content-Type", "text/plain");
+        resp.getWriter().write(req.getUserPrincipal().getName());
+    }
+}

--- a/integration-tests/amazon-lambda-rest/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-rest/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 quarkus.lambda.enable-polling-jvm-mode=true
 quarkus.http.virtual=true
+quarkus.lambda-http.enable-security=true
 quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
Provide some security integration for the _quarkus-amazon-lambda-http_ and rest extensions.  It extracts security metadata from the lambda http event to generate a _io.quarkus.security.identity.SecurityIdentity_ which it attaches to the context objects in QuarkusHttpHeaders.  The extension automatically adds a Vertx Web filter that will extract the SecurityIdentity and attach it to the RouteContext so that every other Quarkus HTTP framework can access it in it's standard way.