### PR TITLE
Honor `GenerateResourceBuildItem` while building UberJar

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -176,6 +176,10 @@ public class PackageConfig {
                 type.equalsIgnoreCase(PackageConfig.LEGACY));
     }
 
+    public boolean isUberJar() {
+        return type.equalsIgnoreCase(PackageConfig.UBER_JAR);
+    }
+
     @ConfigGroup
     public static class FernflowerConfig {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -355,18 +355,25 @@ public class JarResultBuildStep {
                 }
 
                 for (Path resolvedDep : depArtifact.getPaths()) {
-                    Set<String> transformedFromThisArchive = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
+                    Set<String> existingEntries = new HashSet<>();
+                    Set<String> transformedFilesByJar = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
+                    if (transformedFilesByJar != null) {
+                        existingEntries.addAll(transformedFilesByJar);
+                    }
+                    generatedResources.stream()
+                            .map(GeneratedResourceBuildItem::getName)
+                            .forEach(existingEntries::add);
 
                     if (!Files.isDirectory(resolvedDep)) {
                         try (FileSystem artifactFs = ZipUtils.newFileSystem(resolvedDep)) {
                             for (final Path root : artifactFs.getRootDirectories()) {
                                 walkFileDependencyForDependency(root, runnerZipFs, seen, duplicateCatcher, concatenatedEntries,
-                                        finalIgnoredEntries, appDep, transformedFromThisArchive, mergeResourcePaths);
+                                        finalIgnoredEntries, appDep, existingEntries, mergeResourcePaths);
                             }
                         }
                     } else {
                         walkFileDependencyForDependency(resolvedDep, runnerZipFs, seen, duplicateCatcher,
-                                concatenatedEntries, finalIgnoredEntries, appDep, transformedFromThisArchive,
+                                concatenatedEntries, finalIgnoredEntries, appDep, existingEntries,
                                 mergeResourcePaths);
                     }
                 }
@@ -416,7 +423,7 @@ public class JarResultBuildStep {
 
     private void walkFileDependencyForDependency(Path root, FileSystem runnerZipFs, Map<String, String> seen,
             Map<String, Set<AppDependency>> duplicateCatcher, Map<String, List<byte[]>> concatenatedEntries,
-            Set<String> finalIgnoredEntries, AppDependency appDep, Set<String> transformedFromThisArchive,
+            Set<String> finalIgnoredEntries, AppDependency appDep, Set<String> existingEntries,
             Set<String> mergeResourcePaths) throws IOException {
         final Path metaInfDir = root.resolve("META-INF");
         Files.walkFileTree(root, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
@@ -446,9 +453,7 @@ public class JarResultBuildStep {
                             }
                             return FileVisitResult.CONTINUE;
                         }
-                        boolean transformed = transformedFromThisArchive != null
-                                && transformedFromThisArchive.contains(relativePath);
-                        if (!transformed) {
+                        if (!existingEntries.contains(relativePath)) {
                             if (CONCATENATED_ENTRIES_PREDICATE.test(relativePath)
                                     || mergeResourcePaths.contains(relativePath)) {
                                 concatenatedEntries.computeIfAbsent(relativePath, (u) -> new ArrayList<>())

--- a/core/test-extension/deployment/pom.xml
+++ b/core/test-extension/deployment/pom.xml
@@ -12,6 +12,9 @@
     <artifactId>quarkus-test-extension-deployment</artifactId>
     <name>Quarkus - Core - Test Extension - Deployment</name>
 
+    <properties>
+        <xml-combiner.version>3.0.0</xml-combiner.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -29,6 +32,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-extension</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.atteo</groupId>
+            <artifactId>xml-combiner</artifactId>
+            <version>${xml-combiner.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/UberJarConfigBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/UberJarConfigBuildStep.java
@@ -1,6 +1,22 @@
 package io.quarkus.extest.deployment;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.atteo.xmlcombiner.XmlCombiner;
+import org.xml.sax.SAXException;
+
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.UberJarIgnoredResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
 
@@ -12,6 +28,28 @@ public class UberJarConfigBuildStep {
     @BuildStep
     UberJarMergedResourceBuildItem uberJarMergedResourceBuildItem() {
         return new UberJarMergedResourceBuildItem("META-INF/cxf/bus-extensions.txt");
+    }
+
+    @BuildStep
+    void uberJarMergedResourceBuildItem(BuildProducer<GeneratedResourceBuildItem> generatedResourcesProducer,
+            PackageConfig packageConfig) {
+        if (packageConfig.isUberJar()) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                XmlCombiner combiner = new XmlCombiner();
+                List<URL> resources = Collections
+                        .list(getClass().getClassLoader().getResources("META-INF/wsdl.plugin.xml"));
+                for (URL resource : resources) {
+                    try (InputStream is = resource.openStream()) {
+                        combiner.combine(is);
+                    }
+                }
+                combiner.buildDocument(baos);
+            } catch (ParserConfigurationException | SAXException | TransformerException | IOException e) {
+                e.printStackTrace();
+            }
+            generatedResourcesProducer.produce(new GeneratedResourceBuildItem("META-INF/wsdl.plugin.xml", baos.toByteArray()));
+        }
     }
 
     @BuildStep

--- a/core/test-extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/GeneratedResourceBuildItemTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/GeneratedResourceBuildItemTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.runtime.annotations.QuarkusMain;
+import io.quarkus.test.QuarkusProdModeTest;
+
+class GeneratedResourceBuildItemTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest runner = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties")
+                    .addClass(UberJarMain.class))
+            .setApplicationName("generated-resource")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setRun(true)
+            .setExpectExit(true)
+            .overrideConfigKey("quarkus.package.type", "uber-jar")
+            .setForcedDependencies(
+                    Arrays.asList(
+                            new AppArtifact("org.apache.cxf", "cxf-rt-bindings-xml", "3.4.3"),
+                            new AppArtifact("org.apache.cxf", "cxf-rt-bindings-soap", "3.4.3")));
+
+    @Test
+    public void testXMLResourceWasMerged() throws IOException {
+        assertThat(runner.getStartupConsoleOutput()).contains("RESOURCES: 1",
+                "<entry key=\"xml-javax.wsdl.Port\">org.apache.cxf.binding.xml.wsdl11.HttpAddressPlugin</entry>",
+                "<entry key=\"xml-javax.wsdl.Binding\">org.apache.cxf.binding.xml.wsdl11.XmlBindingPlugin</entry>",
+                "<entry key=\"xml-javax.wsdl.BindingInput\">org.apache.cxf.binding.xml.wsdl11.XmlIoPlugin</entry>",
+                "<entry key=\"xml-javax.wsdl.BindingOutput\">org.apache.cxf.binding.xml.wsdl11.XmlIoPlugin</entry>",
+                "<entry key=\"soap-javax.wsdl.Port\">org.apache.cxf.binding.soap.wsdl11.SoapAddressPlugin</entry>");
+        assertThat(runner.getExitCode()).isZero();
+    }
+
+    @QuarkusMain
+    public static class UberJarMain {
+
+        public static void main(String[] args) throws IOException {
+            List<URL> resources = Collections
+                    .list(UberJarMain.class.getClassLoader().getResources("META-INF/wsdl.plugin.xml"));
+            System.out.println("RESOURCES: " + resources.size());
+            try (InputStream is = resources.get(0).openStream();
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+                reader.lines().forEach(System.out::println);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Uber JARs should contain what's produced by `GenerateResourceBuildItem`s instead of having them overwritten by files inside the transitive dependencies

This is a potential solution for quarkiverse/quarkus-cxf#194

