### PR TITLE
DevUI: Ignore keybindings if input

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/js/logstream.js
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/js/logstream.js
@@ -163,7 +163,9 @@ function addControlCListener(){
     });
 
     $(document).keydown(function (e) {
-        if (ctrlDown && (e.keyCode === cKey))stopLog();
+        if (e.target.tagName === "BODY") {
+            if (ctrlDown && (e.keyCode === cKey))stopLog();
+        }
     });
 }
 
@@ -181,32 +183,38 @@ function addScrollListener(){
 }
 
 function addLineSpaceListener(){
-    $(document).keydown(function (event) {
-        if (event.shiftKey && event.keyCode === 38) {
-            lineSpaceIncreaseEvent();
-        }else if (event.shiftKey && event.keyCode === 40) {
-            lineSpaceDecreaseEvent();
+    $(document).keydown(function (e) {
+        if (e.target.tagName === "BODY") {
+            if (e.shiftKey && e.keyCode === 38) {
+                lineSpaceIncreaseEvent();
+            }else if (e.shiftKey && e.keyCode === 40) {
+                lineSpaceDecreaseEvent();
+            }
         }
     });
 }
 
 function addTabSizeListener(){
-    $(document).keydown(function (event) {
-        if (event.shiftKey && event.keyCode === 39) {
-            tabSpaceIncreaseEvent();
-        }else if (event.shiftKey && event.keyCode === 37) {
-            tabSpaceDecreaseEvent();
+    $(document).keydown(function (e) {
+        if (e.target.tagName === "BODY") {
+            if (e.shiftKey && e.keyCode === 39) {
+                tabSpaceIncreaseEvent();
+            }else if (e.shiftKey && e.keyCode === 37) {
+                tabSpaceDecreaseEvent();
+            }
         }
     });
 }
 
 function addEnterListener(){
     $(document).keydown(function (e) {
-        if (e.keyCode === 13 && !$('#logstreamFilterModal').hasClass('show')){
-            writeResponse("</br>");
-            var element = document.getElementById("logstreamLogTerminal");
-            element.scrollIntoView({block: "end"});
-        } 
+        if (e.target.tagName === "BODY") {
+            if (e.keyCode === 13 && !$('#logstreamFilterModal').hasClass('show')){
+                writeResponse("</br>");
+                var element = document.getElementById("logstreamLogTerminal");
+                element.scrollIntoView({block: "end"});
+            } 
+        }
     });
 }
 

--- a/extensions/vertx-http/deployment/src/main/resources/dev-static/js/tests.js
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-static/js/tests.js
@@ -115,26 +115,28 @@ function addTestsKeyListeners(){
     var p = 80; // Pause tests
     
     $(document).keydown(function (e) {
-        if (e.keyCode === r){
-            if(testsIsRunning){
-                rerunAllTests();
-            }else{
-                startTests();
+        if (e.target.tagName === "BODY") {
+            if (e.keyCode === r){
+                if(testsIsRunning){
+                    rerunAllTests();
+                }else{
+                    startTests();
+                }
+            } else if (e.keyCode === f){
+                rerunFailedTests();
+            } else if (e.keyCode === b){
+                toggleBrokenOnly();
+            } else if (e.keyCode === v){
+                printFailures();
+            } else if (e.keyCode === o){
+                toggleTestOutput();
+            } else if (e.keyCode === i){
+                toggleInstrumentationReload();
+            } else if (e.keyCode === h){
+                displayTestsHelp();
+            } else if (e.keyCode === p){
+                pauseTests();
             }
-        } else if (e.keyCode === f){
-            rerunFailedTests();
-        } else if (e.keyCode === b){
-            toggleBrokenOnly();
-        } else if (e.keyCode === v){
-            printFailures();
-        } else if (e.keyCode === o){
-            toggleTestOutput();
-        } else if (e.keyCode === i){
-            toggleInstrumentationReload();
-        } else if (e.keyCode === h){
-            displayTestsHelp();
-        } else if (e.keyCode === p){
-            pauseTests();
         }
     });
 }


### PR DESCRIPTION
As discussed, when typing into a input field in Dev UI, the key bindings should be ignored.
 
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>