### PR TITLE
Spring extension documentation graduation to stable

### DIFF
--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -6,12 +6,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Accessing application properties with Spring Boot properties API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 If you prefer to use Spring Boot `@ConfigurationProperties` annotated class to access application properties instead of a
 Quarkus native `@ConfigProperties` or a MicroProfile `@ConfigProperty` approach, you can do that with this extension.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -6,13 +6,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Quarkus Extension for Spring Cache API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use link:cache[Quarkus annotations for caching], Quarkus nevertheless provides a compatibility layer for Spring Cache annotations in the form of the `spring-cache` extension.
 
 This guide explains how a Quarkus application can leverage the well known Spring Cache annotations to enable application data caching for their Spring beans.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -6,11 +6,8 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Reading properties from Spring Cloud Config Server
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 This guide explains how your Quarkus application can read configuration properties at runtime from the https://cloud.spring.io/spring-cloud-config[Spring Cloud Config Server].
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -6,12 +6,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Extension for Spring Data API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use Hibernate ORM with Panache for Relational Database access, Quarkus provides a compatibility layer for
 Spring Data JPA repositories in the form of the `spring-data-jpa` extension.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Extension for Spring Data REST
 
 include::./attributes.adoc[]
-:extension-status: experimental
+:extension-status: preview
 
 While users are encouraged to use REST Data with Panache for the REST data access endpoints generation,
 Quarkus provides a compatibility layer for Spring Data REST in the form of the `spring-data-rest` extension.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -6,13 +6,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Quarkus Extension for Spring DI API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use CDI annotations for injection, Quarkus provides a compatibility layer for Spring dependency injection in the form of the `spring-di` extension.
 
 This guide explains how a Quarkus application can leverage the well known Dependency Injection annotations included in the Spring Framework.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -6,13 +6,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Quarkus Extension for Spring Scheduling API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use link:scheduler#standard-scheduling[regular Quarkus scheduler], Quarkus provides a compatibility layer for Spring Scheduled in the form of the `spring-scheduled` extension.
 
 This guide explains how a Quarkus application can leverage the well known Spring Scheduled annotation to configure and schedule tasks.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -6,13 +6,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Quarkus Extension for Spring Security API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use link:security#standard-security-annotations[Java standard annotations for security authorizations], Quarkus provides a compatibility layer for Spring Security in the form of the `spring-security` extension.
 
 This guide explains how a Quarkus application can leverage the well known Spring Security annotations to define authorizations on RESTful services using roles.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -6,13 +6,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus - Quarkus Extension for Spring Web API
 
 include::./attributes.adoc[]
-:extension-status: preview
 
 While users are encouraged to use JAX-RS annotation for defining REST endpoints, Quarkus provides a compatibility layer for Spring Web in the form of the `spring-web` extension.
 
 This guide explains how a Quarkus application can leverage the well known Spring Web annotations to define RESTful services.
-
-include::./status-include.adoc[]
 
 == Prerequisites
 

--- a/extensions/spring-boot-properties/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-boot-properties/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-boot-properties"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-cache"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-cloud-config-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-cloud-config-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,4 +10,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-cloud-config-client"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-data-jpa"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-data-rest/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-data-rest/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,4 +11,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-data-rest"
   categories:
     - "compatibility"
-  status: "experimental"
+  status: "preview"

--- a/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-di"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-scheduled/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-scheduled/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,4 +7,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-scheduled"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   guide: "https://quarkus.io/guides/spring-security"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"

--- a/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,7 +7,7 @@ metadata:
   guide: "https://quarkus.io/guides/spring-web"
   categories:
   - "compatibility"
-  status: "preview"
+  status: "stable"
   codestart:
     name: "spring-web"
     languages:


### PR DESCRIPTION
On code.quarkus.redhat.com most of the Spring extensions are marked as supported (https://code.quarkus.redhat.com/?extension-search=spring), whereas on code.quarkus.io they are still marked "preview" (https://code.quarkus.io/?extension-search=spring). The extension documentation for each (https://quarkus.io/guides/spring-web) also mentions them as preview.

This PR syncs code.quarkus.io to match code.quarkus.redhat.com and updates the guide for each as well.