### PR TITLE
Changes to ThreadFactory and ExecutorFactory

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ThreadFactoryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ThreadFactoryBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.concurrent.ThreadFactory;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class ThreadFactoryBuildItem extends SimpleBuildItem {
+    private final ThreadFactory threadFactory;
+
+    public ThreadFactoryBuildItem(ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
+    }
+
+    public ThreadFactory getThreadFactory() {
+        return threadFactory;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
@@ -1,11 +1,14 @@
 package io.quarkus.deployment.steps;
 
+import java.util.Optional;
+
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.ThreadFactoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.ThreadPoolConfig;
@@ -19,9 +22,11 @@ public class ThreadPoolSetup {
     @Record(value = ExecutionTime.RUNTIME_INIT)
     public ExecutorBuildItem createExecutor(ExecutorRecorder recorder, ShutdownContextBuildItem shutdownContextBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
-            ThreadPoolConfig threadPoolConfig) {
+            ThreadPoolConfig threadPoolConfig,
+            Optional<ThreadFactoryBuildItem> threadFactoryBuildItem) {
         return new ExecutorBuildItem(
-                recorder.setupRunTime(shutdownContextBuildItem, threadPoolConfig, launchModeBuildItem.getLaunchMode()));
+                recorder.setupRunTime(shutdownContextBuildItem, threadPoolConfig, launchModeBuildItem.getLaunchMode(),
+                        threadFactoryBuildItem.map(ThreadFactoryBuildItem::getThreadFactory).orElse(null)));
     }
 
     @BuildStep

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingAndNonBlockingTest.java
@@ -62,7 +62,7 @@ public class BlockingAndNonBlockingTest {
     @Test
     public void testInvokingABlockingService() {
         HelloReply reply = greeter.sayHello(HelloRequest.newBuilder().setName("neo").build());
-        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+        assertThat(reply.getMessage()).contains("executor-thread", "neo");
     }
 
     @Test

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingMethodsTest.java
@@ -111,7 +111,7 @@ public class BlockingMethodsTest {
         });
         assertThat(list).hasSize(10)
                 .allSatisfy(s -> {
-                    assertThat(s).contains("worker");
+                    assertThat(s).contains("executor");
                 });
     }
 
@@ -165,7 +165,7 @@ public class BlockingMethodsTest {
                 .await().atMost(TIMEOUT);
         assertThat(response).isNotNull().hasSize(4)
                 .allSatisfy(s -> {
-                    assertThat(s).contains("worker");
+                    assertThat(s).contains("executor");
                 });
     }
 
@@ -195,7 +195,7 @@ public class BlockingMethodsTest {
                 .await().atMost(TIMEOUT);
         assertThat(response).isNotNull().hasSize(4)
                 .allSatisfy(s -> {
-                    assertThat(s).contains("worker");
+                    assertThat(s).contains("executor");
                 });
     }
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/blocking/BlockingServiceTest.java
@@ -69,7 +69,7 @@ public class BlockingServiceTest {
     public void testInvokingABlockingService() {
         HelloReply reply = GreeterGrpc.newBlockingStub(channel)
                 .sayHello(HelloRequest.newBuilder().setName("neo").build());
-        assertThat(reply.getMessage()).contains("worker-thread", "neo");
+        assertThat(reply.getMessage()).contains("executor-thread", "neo");
     }
 
     @Test

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/AssertHelper.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/services/AssertHelper.java
@@ -19,7 +19,7 @@ public class AssertHelper {
 
     public static void assertRunOnWorker() {
         assertThat(Vertx.currentContext()).isNotNull();
-        assertThat(Thread.currentThread().getName()).contains("worker");
+        assertThat(Thread.currentThread().getName()).contains("executor");
     }
 
 }

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DispatchedThreadTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DispatchedThreadTest.java
@@ -35,7 +35,7 @@ public class DispatchedThreadTest {
                 .body("status", is("UP"),
                         "checks.status", contains("UP"),
                         "checks.name", contains("my-liveness-check"),
-                        "checks.data.thread[0]", stringContainsInOrder("worker"),
+                        "checks.data.thread[0]", stringContainsInOrder("executor-thread"),
                         "checks.data.thread[0]", not(stringContainsInOrder("loop")),
                         "checks.data.request[0]", is(true));
 
@@ -43,7 +43,7 @@ public class DispatchedThreadTest {
                 .body("status", is("UP"),
                         "checks.status", contains("UP"),
                         "checks.name", contains("my-readiness-check"),
-                        "checks.data.thread[0]", stringContainsInOrder("worker"),
+                        "checks.data.thread[0]", stringContainsInOrder("executor-thread"),
                         "checks.data.thread[0]", not(stringContainsInOrder("loop")),
                         "checks.data.request[0]", is(true));
     }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SmallRyeBlockingSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SmallRyeBlockingSubscriberTest.java
@@ -42,7 +42,7 @@ public class SmallRyeBlockingSubscriberTest {
                 .collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread-")).isTrue();
         }
     }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/BlockingPublisherTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/BlockingPublisherTest.java
@@ -39,7 +39,7 @@ public class BlockingPublisherTest {
         List<String> threadNames = beanReturningPayloads.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread-")).isTrue();
         }
     }
 
@@ -49,7 +49,7 @@ public class BlockingPublisherTest {
         List<String> threadNames = beanReturningMessages.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread-")).isTrue();
         }
     }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/BlockingSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/BlockingSubscriberTest.java
@@ -50,7 +50,7 @@ public class BlockingSubscriberTest {
             assertThat(name.startsWith("my-pool-")).isTrue();
         }
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isFalse();
+            assertThat(name.startsWith("executor-thread-")).isFalse();
         }
     }
 
@@ -66,7 +66,7 @@ public class BlockingSubscriberTest {
             assertThat(name.startsWith("another-pool-")).isTrue();
         }
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isFalse();
+            assertThat(name.startsWith("executor-thread-")).isFalse();
         }
     }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingPublisherTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingPublisherTest.java
@@ -39,7 +39,7 @@ public class SmallRyeBlockingPublisherTest {
         List<String> threadNames = beanReturningPayloads.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread-")).isTrue();
         }
     }
 
@@ -49,7 +49,7 @@ public class SmallRyeBlockingPublisherTest {
         List<String> threadNames = beanReturningMessages.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread-")).isTrue();
         }
     }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingSubscriberTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/blocking/SmallRyeBlockingSubscriberTest.java
@@ -42,7 +42,7 @@ public class SmallRyeBlockingSubscriberTest {
                 .collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
         for (String name : threadNames) {
-            assertThat(name.startsWith("vert.x-worker-thread-")).isTrue();
+            assertThat(name.startsWith("executor-thread")).isTrue();
         }
     }
 

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -17,10 +17,12 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.IOThreadDetectorBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.ThreadFactoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
@@ -104,5 +106,17 @@ class VertxCoreProcessor {
                 .getAllKnownSubclasses(DotName.createSimple(AbstractVerticle.class.getName()))) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ci.toString()));
         }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    ThreadFactoryBuildItem createVertxThreadFactory(VertxCoreRecorder recorder) {
+        return new ThreadFactoryBuildItem(recorder.createThreadFactory());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setSharedExecutorInFactory(VertxCoreRecorder recorder, ExecutorBuildItem executorBuildItem) {
+        recorder.setupExecutorFactory(executorBuildItem.getExecutorProxy());
     }
 }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -1,20 +1,10 @@
 package io.quarkus.vertx.core.runtime;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jboss.logging.Logger;
 import org.jboss.threads.EnhancedQueueExecutor;
 import org.jboss.threads.JBossExecutors;
 import org.wildfly.common.cpu.ProcessorInfo;
@@ -24,9 +14,9 @@ import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.spi.ExecutorServiceFactory;
 
 public class QuarkusExecutorFactory implements ExecutorServiceFactory {
-    // TODO Figure out how to share this without breaking shutdown
     static volatile ExecutorService sharedExecutor;
     private static final AtomicInteger executorCount = new AtomicInteger(0);
+    private static final Logger log = Logger.getLogger(QuarkusExecutorFactory.class);
 
     private final VertxConfiguration conf;
     private final LaunchMode launchMode;
@@ -39,152 +29,20 @@ public class QuarkusExecutorFactory implements ExecutorServiceFactory {
     @Override
     public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
         if (executorCount.incrementAndGet() == 1) {
-            if (sharedExecutor == null) {
-                throw new IllegalStateException("Shared executor not set");
-            }
-            if (launchMode == LaunchMode.DEVELOPMENT) {
-                //we use a proxy here, to avoid dev mode lifecycle issues
-                //the underlying executor is replaced on restart
-                //however even if the container is not up we can still execute tasks
-                //this allows hot reload to work even when startup failed
-                return new ExecutorService() {
-                    @Override
-                    public void shutdown() {
-                        //ignore, lifecycle is managed elsewhere
-                    }
-
-                    @Override
-                    public List<Runnable> shutdownNow() {
-                        return Collections.emptyList();
-                    }
-
-                    @Override
-                    public boolean isShutdown() {
-                        return false;
-                    }
-
-                    @Override
-                    public boolean isTerminated() {
-                        return false;
-                    }
-
-                    @Override
-                    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-                        return true;
-                    }
-
-                    @Override
-                    public <T> Future<T> submit(Callable<T> task) {
-                        ExecutorService exec = sharedExecutor;
-                        if (exec != null) {
-                            try {
-                                return exec.submit(task);
-                            } catch (RejectedExecutionException e) {
-                                //ignore
-                            }
-                        }
-                        CompletableFuture<T> ret = new CompletableFuture<>();
-                        threadFactory.newThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    ret.complete(task.call());
-                                } catch (Throwable t) {
-                                    ret.completeExceptionally(t);
-                                }
-                            }
-                        });
-                        return ret;
-                    }
-
-                    @Override
-                    public <T> Future<T> submit(Runnable task, T result) {
-                        ExecutorService exec = sharedExecutor;
-                        if (exec != null) {
-                            try {
-                                return exec.submit(task, result);
-                            } catch (RejectedExecutionException e) {
-                                //ignore
-                            }
-                        }
-                        CompletableFuture<T> ret = new CompletableFuture<>();
-                        threadFactory.newThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    task.run();
-                                    ret.complete(result);
-                                } catch (Throwable t) {
-                                    ret.completeExceptionally(t);
-                                }
-                            }
-                        });
-                        return ret;
-                    }
-
-                    @Override
-                    public Future<?> submit(Runnable task) {
-                        ExecutorService exec = sharedExecutor;
-                        if (exec != null) {
-                            try {
-                                return exec.submit(task);
-                            } catch (RejectedExecutionException e) {
-                                //ignore
-                            }
-                        }
-                        CompletableFuture<?> ret = new CompletableFuture<>();
-                        threadFactory.newThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    task.run();
-                                    ret.complete(null);
-                                } catch (Throwable t) {
-                                    ret.completeExceptionally(t);
-                                }
-                            }
-                        });
-                        return ret;
-                    }
-
-                    @Override
-                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-                        List<Future<T>> ret = new ArrayList<>(tasks.size());
-                        for (Callable<T> i : tasks) {
-                            ret.add(submit(i));
-                        }
-                        return ret;
-                    }
-
-                    @Override
-                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                            throws InterruptedException {
-                        //TODO: this is technically wrong, but should never actually be called when the underlying executor is null
-                        return sharedExecutor.invokeAll(tasks, timeout, unit);
-                    }
-
-                    @Override
-                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-                            throws InterruptedException, ExecutionException {
-                        //TODO: this is technically wrong, but should never actually be called when the underlying executor is null
-                        return sharedExecutor.invokeAny(tasks);
-                    }
-
-                    @Override
-                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                            throws InterruptedException, ExecutionException, TimeoutException {
-                        return sharedExecutor.invokeAny(tasks, timeout, unit);
-                    }
-
-                    @Override
-                    public void execute(Runnable command) {
-                        submit(command);
-                    }
-                };
-            } else {
+            if (launchMode != LaunchMode.DEVELOPMENT) {
+                if (sharedExecutor == null) {
+                    log.warn("Shared executor not set. Unshared executor will be created for blocking work");
+                    // This should only happen in tests using Vertx directly in a unit test
+                    sharedExecutor = internalCreateExecutor(threadFactory, concurrency, maxConcurrency);
+                }
                 return sharedExecutor;
             }
         }
+
+        return internalCreateExecutor(threadFactory, concurrency, maxConcurrency);
+    }
+
+    private ExecutorService internalCreateExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
         final EnhancedQueueExecutor.Builder builder = new EnhancedQueueExecutor.Builder()
                 .setRegisterMBean(false)
                 .setHandoffExecutor(JBossExecutors.rejectingExecutor())
@@ -206,6 +64,12 @@ public class QuarkusExecutorFactory implements ExecutorServiceFactory {
             builder.setKeepAliveTime(conf.keepAliveTime);
         }
 
-        return builder.build();
+        final EnhancedQueueExecutor eqe = builder.build();
+
+        if (conf != null && conf.prefill) {
+            eqe.prestartAllCoreThreads();
+        }
+
+        return eqe;
     }
 }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -1,29 +1,190 @@
 package io.quarkus.vertx.core.runtime;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.threads.EnhancedQueueExecutor;
 import org.jboss.threads.JBossExecutors;
 import org.wildfly.common.cpu.ProcessorInfo;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.spi.ExecutorServiceFactory;
 
 public class QuarkusExecutorFactory implements ExecutorServiceFactory {
     // TODO Figure out how to share this without breaking shutdown
-    static ExecutorService sharedExecutor;
+    static volatile ExecutorService sharedExecutor;
     private static final AtomicInteger executorCount = new AtomicInteger(0);
 
     private final VertxConfiguration conf;
+    private final LaunchMode launchMode;
 
-    public QuarkusExecutorFactory(VertxConfiguration conf) {
+    public QuarkusExecutorFactory(VertxConfiguration conf, LaunchMode launchMode) {
         this.conf = conf;
+        this.launchMode = launchMode;
     }
 
     @Override
     public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
+        if (executorCount.incrementAndGet() == 1) {
+            if (sharedExecutor == null) {
+                throw new IllegalStateException("Shared executor not set");
+            }
+            if (launchMode == LaunchMode.DEVELOPMENT) {
+                //we use a proxy here, to avoid dev mode lifecycle issues
+                //the underlying executor is replaced on restart
+                //however even if the container is not up we can still execute tasks
+                //this allows hot reload to work even when startup failed
+                return new ExecutorService() {
+                    @Override
+                    public void shutdown() {
+                        //ignore, lifecycle is managed elsewhere
+                    }
+
+                    @Override
+                    public List<Runnable> shutdownNow() {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public boolean isShutdown() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isTerminated() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+                        return true;
+                    }
+
+                    @Override
+                    public <T> Future<T> submit(Callable<T> task) {
+                        ExecutorService exec = sharedExecutor;
+                        if (exec != null) {
+                            try {
+                                return exec.submit(task);
+                            } catch (RejectedExecutionException e) {
+                                //ignore
+                            }
+                        }
+                        CompletableFuture<T> ret = new CompletableFuture<>();
+                        threadFactory.newThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    ret.complete(task.call());
+                                } catch (Throwable t) {
+                                    ret.completeExceptionally(t);
+                                }
+                            }
+                        });
+                        return ret;
+                    }
+
+                    @Override
+                    public <T> Future<T> submit(Runnable task, T result) {
+                        ExecutorService exec = sharedExecutor;
+                        if (exec != null) {
+                            try {
+                                return exec.submit(task, result);
+                            } catch (RejectedExecutionException e) {
+                                //ignore
+                            }
+                        }
+                        CompletableFuture<T> ret = new CompletableFuture<>();
+                        threadFactory.newThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    task.run();
+                                    ret.complete(result);
+                                } catch (Throwable t) {
+                                    ret.completeExceptionally(t);
+                                }
+                            }
+                        });
+                        return ret;
+                    }
+
+                    @Override
+                    public Future<?> submit(Runnable task) {
+                        ExecutorService exec = sharedExecutor;
+                        if (exec != null) {
+                            try {
+                                return exec.submit(task);
+                            } catch (RejectedExecutionException e) {
+                                //ignore
+                            }
+                        }
+                        CompletableFuture<?> ret = new CompletableFuture<>();
+                        threadFactory.newThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    task.run();
+                                    ret.complete(null);
+                                } catch (Throwable t) {
+                                    ret.completeExceptionally(t);
+                                }
+                            }
+                        });
+                        return ret;
+                    }
+
+                    @Override
+                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+                        List<Future<T>> ret = new ArrayList<>(tasks.size());
+                        for (Callable<T> i : tasks) {
+                            ret.add(submit(i));
+                        }
+                        return ret;
+                    }
+
+                    @Override
+                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                            throws InterruptedException {
+                        //TODO: this is technically wrong, but should never actually be called when the underlying executor is null
+                        return sharedExecutor.invokeAll(tasks, timeout, unit);
+                    }
+
+                    @Override
+                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                            throws InterruptedException, ExecutionException {
+                        //TODO: this is technically wrong, but should never actually be called when the underlying executor is null
+                        return sharedExecutor.invokeAny(tasks);
+                    }
+
+                    @Override
+                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                            throws InterruptedException, ExecutionException, TimeoutException {
+                        return sharedExecutor.invokeAny(tasks, timeout, unit);
+                    }
+
+                    @Override
+                    public void execute(Runnable command) {
+                        submit(command);
+                    }
+                };
+            } else {
+                return sharedExecutor;
+            }
+        }
         final EnhancedQueueExecutor.Builder builder = new EnhancedQueueExecutor.Builder()
                 .setRegisterMBean(false)
                 .setHandoffExecutor(JBossExecutors.rejectingExecutor())

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -1,0 +1,50 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.threads.EnhancedQueueExecutor;
+import org.jboss.threads.JBossExecutors;
+import org.wildfly.common.cpu.ProcessorInfo;
+
+import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
+import io.vertx.core.spi.ExecutorServiceFactory;
+
+public class QuarkusExecutorFactory implements ExecutorServiceFactory {
+    // TODO Figure out how to share this without breaking shutdown
+    static ExecutorService sharedExecutor;
+    private static final AtomicInteger executorCount = new AtomicInteger(0);
+
+    private final VertxConfiguration conf;
+
+    public QuarkusExecutorFactory(VertxConfiguration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
+        final EnhancedQueueExecutor.Builder builder = new EnhancedQueueExecutor.Builder()
+                .setRegisterMBean(false)
+                .setHandoffExecutor(JBossExecutors.rejectingExecutor())
+                .setThreadFactory(JBossExecutors.resettingThreadFactory(threadFactory));
+        final int cpus = ProcessorInfo.availableProcessors();
+        // run time config variables
+        builder.setCorePoolSize(concurrency);
+        builder.setMaximumPoolSize(maxConcurrency != null ? maxConcurrency : Math.max(8 * cpus, 200));
+
+        if (conf != null) {
+            if (conf.queueSize.isPresent()) {
+                if (conf.queueSize.getAsInt() < 0) {
+                    builder.setMaximumQueueSize(Integer.MAX_VALUE);
+                } else {
+                    builder.setMaximumQueueSize(conf.queueSize.getAsInt());
+                }
+            }
+            builder.setGrowthResistance(conf.growthResistance);
+            builder.setKeepAliveTime(conf.keepAliveTime);
+        }
+
+        return builder.build();
+    }
+}

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -71,20 +71,23 @@ public class VertxCoreRecorder {
     private static volatile String webDeploymentId;
 
     public Supplier<Vertx> configureVertx(VertxConfiguration config,
-            LaunchMode launchMode, ShutdownContext shutdown, List<Consumer<VertxOptions>> customizers) {
+            LaunchMode launchMode, ShutdownContext shutdown, List<Consumer<VertxOptions>> customizers,
+            ExecutorService executorProxy) {
+        QuarkusExecutorFactory.sharedExecutor = executorProxy;
         if (launchMode != LaunchMode.DEVELOPMENT) {
-            vertx = new VertxSupplier(config, customizers, shutdown);
+            vertx = new VertxSupplier(launchMode, config, customizers, shutdown);
             // we need this to be part of the last shutdown tasks because closing it early (basically before Arc)
             // could cause problem to beans that rely on Vert.x and contain shutdown tasks
             shutdown.addLastShutdownTask(new Runnable() {
                 @Override
                 public void run() {
                     destroy();
+                    QuarkusExecutorFactory.sharedExecutor = null;
                 }
             });
         } else {
             if (vertx == null) {
-                vertx = new VertxSupplier(config, customizers, shutdown);
+                vertx = new VertxSupplier(launchMode, config, customizers, shutdown);
             } else if (vertx.v != null) {
                 tryCleanTccl(vertx.v);
             }
@@ -114,6 +117,7 @@ public class VertxCoreRecorder {
                             }
                         }
                     }
+                    QuarkusExecutorFactory.sharedExecutor = null;
                 }
             });
         }
@@ -180,7 +184,8 @@ public class VertxCoreRecorder {
         return vertx;
     }
 
-    public static Vertx initialize(VertxConfiguration conf, VertxOptionsCustomizer customizer, ShutdownContext shutdown) {
+    public static Vertx initialize(VertxConfiguration conf, VertxOptionsCustomizer customizer, ShutdownContext shutdown,
+            LaunchMode launchMode) {
 
         VertxOptions options = new VertxOptions();
 
@@ -198,7 +203,7 @@ public class VertxCoreRecorder {
         if (conf != null && conf.cluster != null && conf.cluster.clustered) {
             CompletableFuture<Vertx> latch = new CompletableFuture<>();
             new VertxBuilder(options)
-                    .executorServiceFactory(new QuarkusExecutorFactory(conf))
+                    .executorServiceFactory(new QuarkusExecutorFactory(conf, launchMode))
                     .init().clusteredVertx(new Handler<AsyncResult<Vertx>>() {
                         @Override
                         public void handle(AsyncResult<Vertx> ar) {
@@ -212,7 +217,7 @@ public class VertxCoreRecorder {
             vertx = latch.join();
         } else {
             vertx = new VertxBuilder(options)
-                    .executorServiceFactory(new QuarkusExecutorFactory(conf))
+                    .executorServiceFactory(new QuarkusExecutorFactory(conf, launchMode))
                     .init().vertx();
         }
 
@@ -457,23 +462,21 @@ public class VertxCoreRecorder {
         };
     }
 
-    public void setupExecutorFactory(ExecutorService executorProxy) {
-        QuarkusExecutorFactory.sharedExecutor = executorProxy;
-    }
-
     public static Supplier<Vertx> recoverFailedStart(VertxConfiguration config) {
-        return vertx = new VertxSupplier(config, Collections.emptyList(), null);
+        return vertx = new VertxSupplier(LaunchMode.DEVELOPMENT, config, Collections.emptyList(), null);
 
     }
 
     static class VertxSupplier implements Supplier<Vertx> {
+        final LaunchMode launchMode;
         final VertxConfiguration config;
         final VertxOptionsCustomizer customizer;
         final ShutdownContext shutdown;
         Vertx v;
 
-        VertxSupplier(VertxConfiguration config, List<Consumer<VertxOptions>> customizers,
+        VertxSupplier(LaunchMode launchMode, VertxConfiguration config, List<Consumer<VertxOptions>> customizers,
                 ShutdownContext shutdown) {
+            this.launchMode = launchMode;
             this.config = config;
             this.customizer = new VertxOptionsCustomizer(customizers);
             this.shutdown = shutdown;
@@ -482,7 +485,7 @@ public class VertxCoreRecorder {
         @Override
         public synchronized Vertx get() {
             if (v == null) {
-                v = initialize(config, customizer, shutdown);
+                v = initialize(config, customizer, shutdown, launchMode);
             }
             return v;
         }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -59,6 +59,29 @@ public class VertxConfiguration {
     public int internalBlockingPoolSize;
 
     /**
+     * The queue size. For most applications this should be unbounded
+     */
+    @ConfigItem
+    public OptionalInt queueSize;
+
+    /**
+     * The executor growth resistance.
+     *
+     * A resistance factor applied after the core pool is full; values applied here will cause that fraction
+     * of submissions to create new threads when no idle thread is available. A value of {@code 0.0f} implies that
+     * threads beyond the core size should be created as aggressively as threads within it; a value of {@code 1.0f}
+     * implies that threads beyond the core size should never be created.
+     */
+    @ConfigItem
+    public float growthResistance;
+
+    /**
+     * The amount of time a thread will stay alive with no work.
+     */
+    @ConfigItem(defaultValue = "30")
+    public Duration keepAliveTime;
+
+    /**
      * Enables the async DNS resolver.
      */
     @ConfigItem

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -82,6 +82,14 @@ public class VertxConfiguration {
     public Duration keepAliveTime;
 
     /**
+     * Prefill thread pool when creating a new Executor.
+     * When {@see io.vertx.core.spi.ExecutorServiceFactory.createExecutor} is called,
+     * initialise with the number of defined threads at startup
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean prefill;
+
+    /**
      * Enables the async DNS resolver.
      */
     @ConfigItem

--- a/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
 import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
 import io.quarkus.vertx.core.runtime.config.ClusterConfiguration;
@@ -55,7 +56,7 @@ public class VertxCoreProducerTest {
         configuration.cluster = cc;
 
         try {
-            VertxCoreRecorder.initialize(configuration, null, null);
+            VertxCoreRecorder.initialize(configuration, null, null, LaunchMode.TEST);
             Assertions.fail("It should not have a cluster manager on the classpath, and so fail the creation");
         } catch (IllegalStateException e) {
             Assertions.assertTrue(e.getMessage().contains("No ClusterManagerFactory"),
@@ -82,7 +83,7 @@ public class VertxCoreProducerTest {
                     }
                 }));
 
-        VertxCoreRecorder.initialize(configuration, customizers, null);
+        VertxCoreRecorder.initialize(configuration, customizers, null, LaunchMode.TEST);
     }
 
     @Test
@@ -95,7 +96,7 @@ public class VertxCoreProducerTest {
                         called.set(true);
                     }
                 }));
-        Vertx v = VertxCoreRecorder.initialize(createDefaultConfiguration(), customizers, null);
+        Vertx v = VertxCoreRecorder.initialize(createDefaultConfiguration(), customizers, null, LaunchMode.TEST);
         Assertions.assertTrue(called.get(), "Customizer should get called during initialization");
     }
 

--- a/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -109,6 +109,8 @@ public class VertxCoreProducerTest {
         vc.workerPoolSize = 20;
         vc.maxWorkerExecuteTime = Duration.ofSeconds(1);
         vc.internalBlockingPoolSize = 20;
+        vc.queueSize = OptionalInt.empty();
+        vc.keepAliveTime = Duration.ofSeconds(30);
         vc.useAsyncDNS = false;
         vc.preferNativeTransport = false;
         vc.eventbus = new EventBusConfiguration();

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/blocking/BlockingRouteTest.java
@@ -30,7 +30,7 @@ public class BlockingRouteTest {
 
         get("/blocking")
                 .then().statusCode(200)
-                .body(containsString("blocking-"), containsString("worker"));
+                .body(containsString("blocking-"), containsString("executor"));
 
         get("/worker")
                 .then().statusCode(200)

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.vertx.core.Vertx;
 
@@ -28,7 +29,7 @@ public class VertxProducerTest {
 
     @Test
     public void shouldNotFailWithoutConfig() {
-        verifyProducer(VertxCoreRecorder.initialize(null, null, null));
+        verifyProducer(VertxCoreRecorder.initialize(null, null, null, LaunchMode.TEST));
     }
 
     private void verifyProducer(Vertx v) {


### PR DESCRIPTION
Make some adjustments in terms of how executors and threads are created and by what.

- Modify the JBoss `EnhancedQueueExecutor` to take a `ThreadFactory` from an optional build item. If one isn't present, create a `JBossThreadFactory` as previously done.
- Produce a `ThreadFactoryBuildItem` from Vert.x core extension containing a `ThreadFactory` producing `VertxThread` instances
- Modify the initialization of Vert.x to use the JBoss `EnhancedQueueExecutor` as the executor factory for any thread pools that Vert.x creates