### PR TITLE
Fix Minor Errors in Blaze Persistence Guide

### DIFF
--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -193,12 +193,12 @@ public class GiftResource {
     @Path("{id}")
     @Transactional
     public GiftView updateGift(@EntityViewId("id") GiftUpdateView view) {
-        evm.save(em, view);
-        return evm.find(em, GiftView.class, view.getId());
+        entityViewManager.save(entityManager, view);
+        return entityViewManager.find(entityManager, GiftView.class, view.getId());
     }
 
-    @Path("{id"})
     @GET
+    @Path("{id"})
     @Produces(MediaType.APPLICATION_JSON)
     public GiftView getGift(@PathParam("id") Long id) {
         return return entityViewManager.find(entityManager, GiftView.class, view.getId());


### PR DESCRIPTION
* Change name of objects in displayed code to correct name
* Change order of annotations to ensure consistency