### PR TITLE
Base codestarts: declare mavenCentral() before mavenLocal()

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
@@ -6,8 +6,8 @@ plugins {
 
 {#insert repositories}
 repositories {
-    mavenLocal()
     mavenCentral()
+    mavenLocal()
 {#if gradle.repositories}
 {#for rep in gradle.repositories}
     maven { url = uri("{rep.url}") }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -6,8 +6,8 @@ plugins {
 
 {#insert repositories}
 repositories {
-    mavenLocal()
     mavenCentral()
+    mavenLocal()
 {#if gradle.repositories}
 {#for rep in gradle.repositories}
     maven { url "{rep.url}" }


### PR DESCRIPTION
With the current template I get Scala tests failing, e.g. `mvn clean test -Dtest=QuarkusCodestartBuildIT#testGradle`
````
Execution failed for task ':compileScala'.
> Could not resolve all files for configuration ':detachedConfiguration4'.
   > Could not find compiler-bridge_2.12-1.3.5-sources.jar (org.scala-sbt:compiler-bridge_2.12:1.3.5).
````
If I move `mavenCentral()` before `mavenLocal()` they pass. TBH, I'm not sure what exactly goes wrong there. Perhaps it's related to
````
If Gradle finds a module descriptor in a particular repository, it will attempt to download all of the artifacts for that module from the same repository.
````
quoted from [Declaring multiple repositories](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:declaring_multiple_repositories)

@glefloch do you have any remarks on this change?