### PR TITLE
Add Information on How to Assign Properties at Startup

### DIFF
--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -46,14 +46,18 @@ image::config-sources.png[]
 [[system-properties]]
 === System properties
 
-* for a runner jar: `java -Dquarkus.datasource.password=youshallnotpass -jar target/quarkus-app/quarkus-run.jar`
-* for a native executable: `./target/myapp-runner -Dquarkus.datasource.password=youshallnotpass`
+System properties can be handed to the application through the `-D` flag during startup. The following examples assign
+the value `youshallnotpass` to the attribute `quarkus.datasource.password`.
+
+* For Quarkus dev mode: `./mvnw quarkus:dev -Dquarkus.datasource.password=youshallnotpass`
+* For a runner jar: `java -Dquarkus.datasource.password=youshallnotpass -jar target/quarkus-app/quarkus-run.jar`
+* For a native executable: `./target/myapp-runner -Dquarkus.datasource.password=youshallnotpass`
 
 [[environment-variables]]
 === Environment variables
 
-* for a runner jar: `export QUARKUS_DATASOURCE_PASSWORD=youshallnotpass ; java -jar target/quarkus-app/quarkus-run.jar`
-* for a native executable: `export QUARKUS_DATASOURCE_PASSWORD=youshallnotpass ; ./target/myapp-runner`
+* For a runner jar: `export QUARKUS_DATASOURCE_PASSWORD=youshallnotpass ; java -jar target/quarkus-app/quarkus-run.jar`
+* For a native executable: `export QUARKUS_DATASOURCE_PASSWORD=youshallnotpass ; ./target/myapp-runner`
 
 NOTE: Environment variables names follow the conversion rules specified by
 link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources[MicroProfile Config].

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -62,7 +62,7 @@ By default Quarkus will automatically generate a main method, that will bootstra
 shutdown to be initiated. Let's provide our own main method:
 [source,java]
 ----
-package om.acme;
+package com.acme;
 
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.runtime.Quarkus;
@@ -133,6 +133,11 @@ It is possible to inject the arguments that were passed in on the command line:
 String[] args;
 ----
 
+Command line arguments can be passed to the application through the `-D` flag with the property `quarkus.args`:
+
+* For Quarkus dev mode: `./mvnw quarkus:dev -Dquarkus.args=<cmd-args>`
+* For a runner jar: `java -Dquarkus.args=<cmd-args> -jar target/quarkus-app/quarkus-run.jar`
+* For a native executable: `./target/lifecycle-quickstart-1.0-SNAPSHOT-runner -Dquarkus.args=<cmd-args>`
 
 == Listening for startup and shutdown events
 


### PR DESCRIPTION
* Elaborate slightly on usage of `-D` flag in Config Reference Guide
* Complete list about system properties with Quarkus dev mode
* Capitalise starts of bullet points
* Add information on how to assign command line arguments to Lifecylce Guide
* Closes #16969 