### PR TITLE
Java 16+: Don't exec AllConfigGenerator as long as --add-opens is required

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2853,5 +2853,26 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk16-workarounds</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- It seems there is no way preventing add-opens to be propagated to AllConfigGenerator
+                         which fails due to https://github.com/quarkusio/quarkus/issues/16862
+                         (and add-opens is only required until https://github.com/quarkusio/quarkus/issues/16806#issuecomment-834788411).
+                         So skip the entire plugin until then. -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This is currently the only reason the EA job is failing: https://github.com/quarkusio/quarkus/actions/workflows/jdk-early-access-build.yml

The EA job is on `17-ea` already but turns out that this problem already exists with Java 16 (must have slipped through).

Once (if) merged, I will add a note to #16862 and/or #16806.