### PR TITLE
Disable mongodb-client IT in windows as they are unreliable

### DIFF
--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -9,6 +9,8 @@ import javax.json.bind.Jsonb;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -18,6 +20,7 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(MongoTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
 public class BookResourceTest {
     private static Jsonb jsonb;
 

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceWithParameterInjectionTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceWithParameterInjectionTest.java
@@ -5,6 +5,8 @@ import javax.json.bind.Jsonb;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,6 +14,7 @@ import io.quarkus.test.mongodb.MongoTestResource;
 
 @QuarkusTest
 @QuarkusTestResource(MongoTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
 public class BookResourceWithParameterInjectionTest {
 
     private static Jsonb jsonb;


### PR DESCRIPTION
#17227 already exists to re-enabled them