### PR TITLE
Inner classes mapped as entity should be static

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsClassLevelAnnotationTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsClassLevelAnnotationTest.java
@@ -32,7 +32,7 @@ public class MultiplePersistenceUnitsClassLevelAnnotationTest {
 
     @Entity
     @PersistenceUnit("inventory")
-    public class EntityWithClassLevelPersistenceUnit {
+    public static class EntityWithClassLevelPersistenceUnit {
 
         private long id;
 


### PR DESCRIPTION
This was working fine in isolation as the intent of this test was to fail to boot, yet the test entity is being picked up by other tests causing obscure errors.

Relates to #16630 