### PR TITLE
Handle Class.getMethods() returning multiple getters with just the return type differring

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
@@ -28,7 +28,12 @@ final class PropertyUtils {
                 if (i.getName().startsWith("get") && i.getName().length() > 3 && i.getParameterCount() == 0
                         && i.getReturnType() != void.class) {
                     String name = Character.toLowerCase(i.getName().charAt(3)) + i.getName().substring(4);
-                    getters.put(name, i);
+                    Method existingGetter = getters.get(name);
+                    // In some cases the overridden methods from supertypes can also appear in the array (for some reason).
+                    // We want the most specific methods.
+                    if (existingGetter == null || existingGetter.getReturnType().isAssignableFrom(i.getReturnType())) {
+                        getters.put(name, i);
+                    }
                 } else if (i.getName().startsWith("is") && i.getName().length() > 3 && i.getParameterCount() == 0
                         && i.getReturnType() == boolean.class) {
                     String name = Character.toLowerCase(i.getName().charAt(2)) + i.getName().substring(3);


### PR DESCRIPTION
This can happen when getters are defined in an implement interface with a different return type (a supertype); in that case we get two getters for the same property in the array returned by `Class.getMethods()`.

Since the order of methods in that array is unspecified, in some cases it will work (super method then overridden method => we keep the overridden method), and in others it won't (overridden method then super method => we keep the super method).

Changing the loop to keep the most specific getter only fixes the problem.

I wasn't able to reproduce the problem in a unit test, but I know it happens with my JVM (OpenJDK 11) for `JaxbEmbeddable.getAttributes()`, and it caused `BytecodeRecorder` to fail, especially with the tests added by #16630 .

Fixes #16954