### PR TITLE
Mailer templates - make it possible to pass template attributes

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -312,7 +312,7 @@ public Uni<Response> send() { <1>
 <1> The method returns a `Uni`
 <2> Transform the `Uni<Void>` returned by `MailTemplate` into `Unit<Response>`
 
-[[testing]]]
+[[testing]]
 == Testing email sending
 
 Because it is very inconvenient to send emails during development and testing, you can set the `quarkus.mailer.mock` boolean

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/i18n/AppMessages.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/i18n/AppMessages.java
@@ -1,0 +1,12 @@
+package io.quarkus.mailer.i18n;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface AppMessages {
+
+    @Message("Hello {name}!")
+    String hello_name(String name);
+
+}

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/i18n/MailMessageBundleTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/i18n/MailMessageBundleTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.mailer.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
+import io.quarkus.mailer.MockMailbox;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MailMessageBundleTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Templates.class, AppMessages.class)
+                    .addAsResource("mock-config.properties", "application.properties")
+                    .addAsResource(new StringAsset(
+                            "hello_name=Hallo {name}!"),
+                            "messages/msg_de.properties")
+                    .addAsResource(new StringAsset(""
+                            + "{msg:hello_name(name)}"), "templates/MailMessageBundleTest/hello.txt"));
+
+    @Inject
+    MockMailbox mailbox;
+
+    @Test
+    public void testSend() {
+        mailbox.clear();
+
+        Templates.hello("Lu").to("quarkus@quarkus.io").subject("Test").send().await().indefinitely();
+
+        List<Mail> sent = mailbox.getMessagesSentTo("quarkus@quarkus.io");
+        assertEquals(1, sent.size());
+        Mail english = sent.get(0);
+        assertEquals("Test", english.getSubject());
+        assertEquals("Hello Lu!", english.getText());
+
+        // Set the locale attribute
+        Templates.hello("Lu").to("quarkus@quarkus.io").subject("Test").setAttribute("locale", Locale.GERMAN).send().await()
+                .indefinitely();
+
+        assertEquals(2, sent.size());
+        Mail german = sent.get(1);
+        assertEquals("Test", german.getSubject());
+        assertEquals("Hallo Lu!", german.getText());
+    }
+
+    @CheckedTemplate
+    static class Templates {
+
+        static native MailTemplateInstance hello(String name);
+
+    }
+
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -52,7 +52,23 @@ public interface MailTemplate {
 
         MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId);
 
+        /**
+         * 
+         * @param key
+         * @param value
+         * @return self
+         * @see io.quarkus.qute.TemplateInstance#data(String, Object)
+         */
         MailTemplateInstance data(String key, Object value);
+
+        /**
+         * 
+         * @param key
+         * @param value
+         * @return self
+         * @see io.quarkus.qute.TemplateInstance#setAttribute(String, Object)
+         */
+        MailTemplateInstance setAttribute(String key, Object value);
 
         Uni<Void> send();
     }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
@@ -92,6 +92,12 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
     }
 
     @Override
+    public MailTemplateInstance setAttribute(String key, Object value) {
+        this.templateInstance.setAttribute(key, value);
+        return this;
+    }
+
+    @Override
     public Uni<Void> send() {
         Object variantsAttr = templateInstance.getAttribute(TemplateInstance.VARIANTS);
         if (variantsAttr != null) {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
@@ -1,6 +1,11 @@
 package io.quarkus.qute.deployment.typesafe;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -18,10 +23,24 @@ public class CheckedTemplateRequireTypeSafeTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(Templates.class)
-                    .addAsResource(new StringAsset("Hello {name}! {any}"),
+                    .addClasses(Templates.class, Fool.class)
+                    .addAsResource(new StringAsset("Hello {name}! {any} {inject:fool.getJoke(identifier)}"),
                             "templates/CheckedTemplateRequireTypeSafeTest/hola.txt"))
-            .setExpectedException(TemplateException.class);
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(te.getMessage().contains("Found template problems (2)"), te.getMessage());
+                assertTrue(te.getMessage().contains("any"), te.getMessage());
+                assertTrue(te.getMessage().contains("identifier"), te.getMessage());
+            });
 
     @Test
     public void testValidation() {
@@ -32,6 +51,16 @@ public class CheckedTemplateRequireTypeSafeTest {
     static class Templates {
 
         static native TemplateInstance hola(String name);
+
+    }
+
+    @Singleton
+    @Named
+    public static class Fool {
+
+        public String getJoke(Integer id) {
+            return "ok";
+        }
 
     }
 


### PR DESCRIPTION
- e.g. to specify locale for type-safe message bundles
- resolves #17185
- also require type-safe expressions in virtual method params for
checked templates