### PR TITLE
Support OidcClient refresh_token mode only

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -63,7 +63,18 @@ public class OidcClientConfig extends OidcCommonConfig {
              * 'urn:ietf:params:oauth:grant-type:token-exchange' grant requiring an OIDC client authentication as well as
              * at least 'subject_token' parameter which must be passed to OidcClient at the token request time.
              */
-            EXCHANGE("urn:ietf:params:oauth:grant-type:token-exchange");
+            EXCHANGE("urn:ietf:params:oauth:grant-type:token-exchange"),
+
+            /**
+             * 'refresh_token' grant requiring an OIDC client authentication and a refresh token.
+             * Note, OidcClient supports this grant by default if an access token acquisition response contained a refresh
+             * token.
+             * However, in some cases, the refresh token is provided out of band, for example, it can be shared between
+             * several of the confidential client's services, etc.
+             * If 'quarkus.oidc-client.grant-type' is set to 'refresh' then `OidcClient` will only support refreshing the
+             * tokens.
+             */
+            REFRESH("refresh_token");
 
             private String grantType;
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -57,6 +57,10 @@ public class OidcClientImpl implements OidcClient {
 
     @Override
     public Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters) {
+        if (tokenGrantParams == null) {
+            throw new OidcClientException(
+                    "Only 'refresh_token' grant is supported, please call OidcClient#refreshTokens method instead");
+        }
         return getJsonResponse(tokenGrantParams, additionalGrantParameters, false);
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -141,25 +141,29 @@ public class OidcClientRecorder {
                             throw new ConfigurationException(
                                     "OpenId Connect Provider token endpoint URL is not configured and can not be discovered");
                         }
-                        MultiMap tokenGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
-
                         String grantType = oidcConfig.grant.getType().getGrantType();
-                        setGrantClientParams(oidcConfig, tokenGrantParams, grantType);
 
-                        if (oidcConfig.getGrantOptions() != null) {
-                            Map<String, String> grantOptions = oidcConfig.getGrantOptions()
-                                    .get(oidcConfig.grant.getType().name().toLowerCase());
-                            if (grantOptions != null) {
-                                if (oidcConfig.grant.getType() == Grant.Type.PASSWORD) {
-                                    // Without this block `password` will be listed first, before `username`
-                                    // which is not a technical problem but might affect Wiremock tests or the endpoints
-                                    // which expect a specific order.
-                                    tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_USERNAME,
-                                            grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
-                                    tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD,
-                                            grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
-                                } else {
-                                    tokenGrantParams.addAll(grantOptions);
+                        MultiMap tokenGrantParams = null;
+
+                        if (oidcConfig.grant.getType() != Grant.Type.REFRESH) {
+                            tokenGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+                            setGrantClientParams(oidcConfig, tokenGrantParams, grantType);
+
+                            if (oidcConfig.getGrantOptions() != null) {
+                                Map<String, String> grantOptions = oidcConfig.getGrantOptions()
+                                        .get(oidcConfig.grant.getType().name().toLowerCase());
+                                if (grantOptions != null) {
+                                    if (oidcConfig.grant.getType() == Grant.Type.PASSWORD) {
+                                        // Without this block `password` will be listed first, before `username`
+                                        // which is not a technical problem but might affect Wiremock tests or the endpoints
+                                        // which expect a specific order.
+                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_USERNAME,
+                                                grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
+                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD,
+                                                grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
+                                    } else {
+                                        tokenGrantParams.addAll(grantOptions);
+                                    }
                                 }
                             }
                         }

--- a/integration-tests/oidc-client-wiremock/pom.xml
+++ b/integration-tests/oidc-client-wiremock/pom.xml
@@ -60,6 +60,23 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-client-filter</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -3,11 +3,15 @@ package io.quarkus.it.keycloak;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
+import io.smallrye.mutiny.Uni;
 
 @Path("/frontend")
 public class FrontendResource {
@@ -19,6 +23,9 @@ public class FrontendResource {
     @NamedOidcClient("non-standard-response")
     Tokens tokens;
 
+    @Inject
+    OidcClients clients;
+
     @GET
     @Path("echoToken")
     public String echoToken() {
@@ -29,5 +36,13 @@ public class FrontendResource {
     @Path("echoTokenNonStandardResponse")
     public String echoTokenNonStandardResponse() {
         return tokens.getAccessToken() + " " + tokens.getRefreshToken();
+    }
+
+    @GET
+    @Path("echoRefreshTokenOnly")
+    @Produces("text/plain")
+    public Uni<String> echoRefreshTokenOnly(@QueryParam("refreshToken") String refreshToken) {
+        return clients.getClient("refresh").refreshTokens(refreshToken)
+                .onItem().transform(t -> t.getAccessToken());
     }
 }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -19,6 +19,13 @@ quarkus.oidc-client.non-standard-response.grant.expires-in-property=expiresIn
 quarkus.oidc-client.non-standard-response.grant-options.password.username=alice
 quarkus.oidc-client.non-standard-response.grant-options.password.password=alice
 
+quarkus.oidc-client.refresh.auth-server-url=${keycloak.url}
+quarkus.oidc-client.refresh.discovery-enabled=false
+quarkus.oidc-client.refresh.token-path=/refresh-token-only
+quarkus.oidc-client.refresh.client-id=quarkus-app
+quarkus.oidc-client.refresh.credentials.secret=secret
+quarkus.oidc-client.refresh.grant.type=refresh
+
 io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -51,6 +51,14 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withBody(
                                 "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
 
+        server.stubFor(WireMock.post("/refresh-token-only")
+                .withRequestBody(matching("grant_type=refresh_token&refresh_token=shared_refresh_token"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"temp_access_token\", \"expires_in\":4}")));
+
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
 
         Map<String, String> conf = new HashMap<>();

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -61,6 +61,15 @@ public class OidcClientTest {
                 .body(equalTo("access_token_n refresh_token_n"));
     }
 
+    @Test
+    public void testEchoTokensRefreshTokenOnly() {
+        RestAssured.given().queryParam("refreshToken", "shared_refresh_token")
+                .when().get("/frontend/echoRefreshTokenOnly")
+                .then()
+                .statusCode(200)
+                .body(equalTo("temp_access_token"));
+    }
+
     private void checkLog() {
         final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
This PR supports the use of `OidcClient` in cases where a refresh token has been obtained out of band by one of the confidential client application's services and passed to the other one to acquire an access token.

It simply restricts OidcClient to support `OidcClient#refreshTokens` only

CC @ruromero