### PR TITLE
Flyway: Fix Scanner constructor substitution for Flyway 7.9.0

### DIFF
--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/ScannerSubstitutions.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/ScannerSubstitutions.java
@@ -19,8 +19,10 @@ public final class ScannerSubstitutions {
     @Substitute
     public ScannerSubstitutions(Class<?> implementedInterface, Collection<Location> locations, ClassLoader classLoader,
             Charset encoding,
+            boolean detectEncoding,
             boolean stream,
-            ResourceNameCache resourceNameCache, LocationScannerCache locationScannerCache) {
+            ResourceNameCache resourceNameCache, LocationScannerCache locationScannerCache,
+            boolean throwOnMissingLocations) {
         throw new IllegalStateException("'org.flywaydb.core.internal.scanner.Scanner' is never used in Quarkus");
     }
 }


### PR DESCRIPTION
Fixes native image test failures caused after upgrading to Flyway 7.9.0 in #17282 