### PR TITLE
Fix double slash issue in not found page

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
@@ -179,7 +179,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
                         if (basePath.endsWith("/")) {
                             fullPath += subPath;
                         } else {
-                            fullPath = basePath + "/" + subPath;
+                            fullPath = basePath + (subPath.startsWith("/") ? "" : "/") + subPath;
                         }
                     }
                     description.addMethod(fullPath, method);


### PR DESCRIPTION
Goes from:

![bad](https://user-images.githubusercontent.com/4374975/118623992-6fff9200-b7d1-11eb-919c-1955d61ef4ef.png)

To:

![good](https://user-images.githubusercontent.com/4374975/118624014-74c44600-b7d1-11eb-9667-b6b560b24957.png)

I also checked if RESTEasy Reactive needed a fix and it doesn't
