### PR TITLE
Qute type-safe validation - various fixes

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
@@ -24,7 +24,14 @@ public class CheckedTemplateRequireTypeSafeTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Templates.class, Fool.class)
-                    .addAsResource(new StringAsset("Hello {name}! {any} {inject:fool.getJoke(identifier)}"),
+                    .addAsResource(new StringAsset(
+                            "Hello {name}!"
+                                    + "{any} "
+                                    + "{inject:fool.getJoke(identifier)} "
+                                    + "{#each name.chars.iterator}"
+                                    + "{! {index} is not considered an error because the binding is registered by the loop section !}"
+                                    + "{index}. {it}"
+                                    + "{/each}"),
                             "templates/CheckedTemplateRequireTypeSafeTest/hola.txt"))
             .assertException(t -> {
                 Throwable e = t;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -42,9 +42,7 @@ final class ExpressionImpl implements Expression {
         }
         return new ExpressionImpl(id, null,
                 Collections.singletonList(new PartImpl(literal,
-                        value != null
-                                ? Expressions.TYPE_INFO_SEPARATOR + value.getClass().getName() + Expressions.TYPE_INFO_SEPARATOR
-                                : null)),
+                        value != null ? Expressions.typeInfoFrom(value.getClass().getName()) : null)),
                 value, origin);
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
@@ -140,6 +140,10 @@ public final class Expressions {
         return parts.build();
     }
 
+    public static String typeInfoFrom(String typeName) {
+        return TYPE_INFO_SEPARATOR + typeName + TYPE_INFO_SEPARATOR;
+    }
+
     /**
      * 
      * @param buffer

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -172,6 +172,15 @@ public class LoopSectionHelper implements SectionHelper {
                     alias = alias.equals(Parameter.EMPTY) ? DEFAULT_ALIAS : alias;
                     Scope newScope = new Scope(previousScope);
                     newScope.putBinding(alias, alias + HINT_PREFIX + iterableExpr.getGeneratedId() + ">");
+                    // Put bindings for iteration metadata
+                    newScope.putBinding("count", Expressions.typeInfoFrom(Integer.class.getName()));
+                    newScope.putBinding("index", Expressions.typeInfoFrom(Integer.class.getName()));
+                    newScope.putBinding("indexParity", Expressions.typeInfoFrom(String.class.getName()));
+                    newScope.putBinding("hasNext", Expressions.typeInfoFrom(Boolean.class.getName()));
+                    newScope.putBinding("odd", Expressions.typeInfoFrom(Boolean.class.getName()));
+                    newScope.putBinding("isOdd", Expressions.typeInfoFrom(Boolean.class.getName()));
+                    newScope.putBinding("even", Expressions.typeInfoFrom(Boolean.class.getName()));
+                    newScope.putBinding("isEven", Expressions.typeInfoFrom(Boolean.class.getName()));
                     return newScope;
                 } else {
                     // Make sure we do not try to validate against the parent context

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -479,7 +479,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
             int spaceIdx = content.indexOf(" ");
             String key = content.substring(spaceIdx + 1, content.length());
             String value = content.substring(1, spaceIdx);
-            currentScope.putBinding(key, Expressions.TYPE_INFO_SEPARATOR + value + Expressions.TYPE_INFO_SEPARATOR);
+            currentScope.putBinding(key, Expressions.typeInfoFrom(value));
             sectionStack.peek().currentBlock().addNode(new ParameterDeclarationNode(content, origin(0)));
         } else {
             // Expression
@@ -989,7 +989,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
     public void addParameter(String name, String type) {
         // {@org.acme.Foo foo}
         Scope currentScope = scopeStack.peek();
-        currentScope.putBinding(name, Expressions.TYPE_INFO_SEPARATOR + type + Expressions.TYPE_INFO_SEPARATOR);
+        currentScope.putBinding(name, Expressions.typeInfoFrom(type));
     }
 
     @Override


### PR DESCRIPTION
- fix NPE when a loop element hint refers to a literal value
- put bindings for iteration metadata inside a loop section; previously
iteration metadata expressions together with type-safe templates caused
a build failure by default