### PR TITLE
Configure GitHub Actions concurrency

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -33,6 +33,10 @@ on:
       - '.github/*.conf'
   workflow_dispatch:
 
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8

--- a/.github/workflows/ci-actions.yml.disabled
+++ b/.github/workflows/ci-actions.yml.disabled
@@ -30,6 +30,10 @@ on:
       - '.github/*.java'
       - '.github/*.conf'
 
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8

--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -21,6 +21,10 @@ on:
     # first day of month at 12:10am
     - cron: '10 0 1 * *'
 
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LANG: en_US.UTF-8
 jobs:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/src/main/asciidoc/**'
       - '.github/workflows/doc-build.yml'
 
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ci-sanity-check:


### PR DESCRIPTION
See
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
for the documentation of this feature.

Essentially, this gives the following behavior:

* For pull requests, only the most recent HEAD gets built. Builds for
  previous HEADs get cancelled automatically.
* For branches (main, ...), we can only ever have two concurrent builds for the same branch + workflow combination:
  one running, and one (more recent) pending.
  *  If a build is running and another one gets requested (because of a
     push), the second one will be pending and wait for the first one to
     finish.
  * If a third build gets requested before the first one finishes,
    the second build gets cancelled and the third build will be pending
    until the first build finishes.

@gsmet as discussed on Zulip. I tested this configuration on https://github.com/yrodiere/quarkus-bot-java-playground/actions . You can probably do the same on your repository if you want to double-check the behavior.

I believe we can remove the workflow cancellation feature from the bot once this gets merged. I will send a PR.