### PR TITLE
Allows multiple reply-to addresses

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
@@ -17,7 +17,7 @@ public class Mail {
     private List<String> bcc = new ArrayList<>();
     private List<String> cc = new ArrayList<>();
     private String from;
-    private String replyTo;
+    private List<String> replyTo = new ArrayList<>();
     private String bounceAddress;
     private String subject;
     private String text;
@@ -163,10 +163,27 @@ public class Mail {
     }
 
     /**
-     * @return the reply-to address.
+     * @return the reply-to address. In the case of multiple addresses, the comma-separated list is returned, following
+     *         the https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2 recommendation. If no reply-to address has been
+     *         set, it returns {@code null}.
      */
     public String getReplyTo() {
-        return replyTo;
+        if (replyTo == null || replyTo.isEmpty()) {
+            return null;
+        }
+        return String.join(",", replyTo);
+    }
+
+    /**
+     * Adds a reply-to address.
+     *
+     * @param replyTo the address to use as reply-to. Must be a valid email address.
+     * @return the current {@link Mail}
+     * @see #setReplyTo(String)
+     */
+    public Mail addReplyTo(String replyTo) {
+        this.replyTo.add(replyTo);
+        return this;
     }
 
     /**
@@ -174,9 +191,24 @@ public class Mail {
      *
      * @param replyTo the address to use as reply-to. Must be a valid email address.
      * @return the current {@link Mail}
+     * @see #setReplyTo(String[])
      */
     public Mail setReplyTo(String replyTo) {
-        this.replyTo = replyTo;
+        this.replyTo.clear();
+        this.replyTo.add(replyTo);
+        return this;
+    }
+
+    /**
+     * Sets the reply-to addresses.
+     *
+     * @param replyTo the addresses to use as reply-to. Must contain valid email addresses, must contain at least
+     *        one address.
+     * @return the current {@link Mail}
+     */
+    public Mail setReplyTo(String... replyTo) {
+        this.replyTo.clear();
+        Collections.addAll(this.replyTo, replyTo);
         return this;
     }
 
@@ -436,7 +468,8 @@ public class Mail {
      * @param disposition the disposition of the attachment
      * @return the current {@link Mail}
      */
-    public Mail addAttachment(String name, Publisher<Byte> data, String contentType, String description, String disposition) {
+    public Mail addAttachment(String name, Publisher<Byte> data, String contentType, String description,
+            String disposition) {
         this.attachments.add(new Attachment(name, data, contentType, description, disposition));
         return this;
     }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -48,6 +48,8 @@ public interface MailTemplate {
 
         MailTemplateInstance replyTo(String replyTo);
 
+        MailTemplateInstance replyTo(String... replyTo);
+
         MailTemplateInstance bounceAddress(String bounceAddress);
 
         MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId);

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
@@ -74,6 +74,12 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
     }
 
     @Override
+    public MailTemplateInstance replyTo(String... replyTo) {
+        this.mail.setReplyTo(replyTo);
+        return this;
+    }
+
+    @Override
     public MailTemplateInstance bounceAddress(String bounceAddress) {
         this.mail.setBounceAddress(bounceAddress);
         return this;

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
@@ -105,6 +105,7 @@ public class MutinyMailerImpl implements ReactiveMailer {
         message.setHtml(mail.getHtml());
         message.setHeaders(toMultimap(mail.getHeaders()));
         if (mail.getReplyTo() != null) {
+            // getReplyTo produces the comma-separated list.
             message.addHeader("Reply-To", mail.getReplyTo());
         }
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
@@ -171,4 +171,32 @@ class MailTest {
         assertThat(mail.getHeaders()).isEmpty();
     }
 
+    @Test
+    void testMultipleReplyTo() {
+        Mail mail = new Mail().addTo(TO_ADDRESS).setSubject("test").setText(BEGINNING)
+                .setFrom("from@quarkus.io")
+                .setReplyTo("reply-to@quarkus.io", "another@quarkus.io")
+                .setBounceAddress("bounce@quarkus.io");
+        assertThat(mail.getTo()).containsExactly(TO_ADDRESS);
+        assertThat(mail.getSubject()).isEqualTo("test");
+        assertThat(mail.getText()).isEqualTo(BEGINNING);
+        assertThat(mail.getHtml()).isNull();
+        assertThat(mail.getFrom()).isEqualTo("from@quarkus.io");
+        assertThat(mail.getReplyTo()).isEqualTo("reply-to@quarkus.io,another@quarkus.io");
+        assertThat(mail.getBounceAddress()).isEqualTo("bounce@quarkus.io");
+
+        mail = new Mail().addTo(TO_ADDRESS).setSubject("test").setText(BEGINNING)
+                .setFrom("from@quarkus.io")
+                .addReplyTo("another@quarkus.io")
+                .addReplyTo("reply-to@quarkus.io")
+                .setBounceAddress("bounce@quarkus.io");
+        assertThat(mail.getTo()).containsExactly(TO_ADDRESS);
+        assertThat(mail.getSubject()).isEqualTo("test");
+        assertThat(mail.getText()).isEqualTo(BEGINNING);
+        assertThat(mail.getHtml()).isNull();
+        assertThat(mail.getFrom()).isEqualTo("from@quarkus.io");
+        assertThat(mail.getReplyTo()).isEqualTo("another@quarkus.io,reply-to@quarkus.io");
+        assertThat(mail.getBounceAddress()).isEqualTo("bounce@quarkus.io");
+    }
+
 }


### PR DESCRIPTION
This change to not break the API. The only difference is if you pass multiple reply-to address, the getReplyTo will get a comma-separated list (as indicated by the RFC).

Fix #17308
