### PR TITLE
DevTools glogal registry client enabling system property and env var

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -32,18 +32,14 @@ import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public abstract class QuarkusPlatformTask extends QuarkusTask {
 
-    private static boolean isEnableRegistryClient() {
-        final String value = System.getProperty("enableRegistryClient");
-        return value == null ? System.getProperties().containsKey("enableRegistryClient") : Boolean.parseBoolean(value);
-    }
-
     QuarkusPlatformTask(String description) {
         super(description);
     }
 
     private ExtensionCatalog extensionsCatalog(boolean limitExtensionsToImportedPlatforms, MessageWriter log) {
         final List<ArtifactCoords> platforms = importedPlatforms();
-        final ExtensionCatalogResolver catalogResolver = isEnableRegistryClient() ? QuarkusProjectHelper.getCatalogResolver(log)
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                ? QuarkusProjectHelper.getCatalogResolver(log)
                 : ExtensionCatalogResolver.empty();
         if (catalogResolver.hasRegistries()) {
             try {

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -184,9 +184,6 @@ public class CreateProjectMojo extends AbstractMojo {
     @Component
     RemoteRepositoryManager remoteRepoManager;
 
-    @Parameter(property = "enableRegistryClient")
-    private boolean enableRegistryClient;
-
     @Parameter(property = "appConfig")
     private String appConfig;
 
@@ -214,7 +211,7 @@ public class CreateProjectMojo extends AbstractMojo {
             throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
         }
         final MojoMessageWriter log = new MojoMessageWriter(getLog());
-        final ExtensionCatalogResolver catalogResolver = enableRegistryClient
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
                 ? QuarkusProjectHelper.getCatalogResolver(mvn, log)
                 : ExtensionCatalogResolver.empty();
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -67,9 +67,6 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
     @Component
     RemoteRepositoryManager remoteRepositoryManager;
 
-    @Parameter(property = "enableRegistryClient")
-    private boolean enableRegistryClient;
-
     private List<ArtifactCoords> importedPlatforms;
 
     private Artifact projectArtifact;
@@ -114,7 +111,8 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
     }
 
     private ExtensionCatalog resolveExtensionsCatalog() throws MojoExecutionException {
-        final ExtensionCatalogResolver catalogResolver = enableRegistryClient ? getExtensionCatalogResolver()
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                ? getExtensionCatalogResolver()
                 : ExtensionCatalogResolver.empty();
         if (catalogResolver.hasRegistries()) {
             try {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -21,6 +21,19 @@ public class QuarkusProjectHelper {
     private static MavenArtifactResolver artifactResolver;
     private static ExtensionCatalogResolver catalogResolver;
 
+    private static final boolean registryClientEnabled;
+    static {
+        String value = System.getProperty("quarkusRegistryClient");
+        if (value == null) {
+            value = System.getenv("QUARKUS_REGISTRY_CLIENT");
+        }
+        registryClientEnabled = Boolean.parseBoolean(value);
+    }
+
+    public static boolean isRegistryClientEnabled() {
+        return registryClientEnabled;
+    }
+
     public static QuarkusProject getProject(Path projectDir) {
         BuildTool buildTool = QuarkusProject.resolveExistingProjectBuildTool(projectDir);
         if (buildTool == null) {
@@ -50,9 +63,9 @@ public class QuarkusProjectHelper {
     @Deprecated
     public static ExtensionCatalog getExtensionCatalog(String quarkusVersion) {
         // TODO remove this method once the default registry becomes available
-        final ExtensionCatalogResolver catalogResolver = getCatalogResolver();
         try {
-            return catalogResolver.hasRegistries() ? catalogResolver.resolveExtensionCatalog(quarkusVersion)
+            return registryClientEnabled && getCatalogResolver().hasRegistries()
+                    ? getCatalogResolver().resolveExtensionCatalog(quarkusVersion)
                     : ToolsUtils.resolvePlatformDescriptorDirectly(null, null, quarkusVersion, artifactResolver(),
                             messageWriter());
         } catch (Exception e) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -81,7 +81,9 @@ public class MavenProjectBuildFile extends BuildFile {
         }
 
         final ExtensionCatalog extensionCatalog;
-        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.getCatalogResolver(mvnResolver, log);
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                ? QuarkusProjectHelper.getCatalogResolver(mvnResolver, log)
+                : ExtensionCatalogResolver.empty();
         if (catalogResolver.hasRegistries()) {
             try {
                 extensionCatalog = catalogResolver.resolveExtensionCatalog(quarkusVersion);

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/RegistryClientTestHelper.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/RegistryClientTestHelper.java
@@ -43,6 +43,7 @@ public class RegistryClientTestHelper {
 
         properties.setProperty("io.quarkus.maven.secondary-local-repo", registryRepoPath.toString());
         properties.setProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY, toolsConfigPath.toString());
+        properties.setProperty("quarkusRegistryClient", "true");
     }
 
     private static void generatePlatformCatalog(final Path groupIdDir) {
@@ -134,5 +135,6 @@ public class RegistryClientTestHelper {
     public static void disableRegistryClientTestConfig(Properties properties) {
         properties.remove("io.quarkus.maven.secondary-local-repo");
         properties.remove(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY);
+        properties.remove("quarkusRegistryClient");
     }
 }


### PR DESCRIPTION
This PR introduces all devtools global system property and env var that enables the registry client. It is especially critical for the CLI which is currently trying to use the registry client by default and falls back to the legacy platform resolution if the registry client isn't available.