### PR TITLE
Integration tests for Oracle Database: fix Oracle Database connect string, decrease wait time

### DIFF
--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
     <properties>
-        <oracledb.url>jdbc:oracle:thin:@localhost:1521:XE</oracledb.url>
+        <oracledb.url>jdbc:oracle:thin:@localhost:1521/XE</oracledb.url>
         <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->
         <oracle.image>gvenzl/oracle-xe:11-slim</oracle.image>
     </properties>
@@ -158,7 +158,7 @@
                 </property>
             </activation>
             <properties>
-                <oracledb.url>jdbc:oracle:thin:@localhost:1521:XE</oracledb.url>
+                <oracledb.url>jdbc:oracle:thin:@localhost:1521/XE</oracledb.url>
             </properties>
             <build>
                 <plugins>

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -184,7 +184,7 @@
                                         <wait>
                                             <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
-                                            <time>100000</time>
+                                            <time>60000</time>
                                             <log>DATABASE IS READY TO USE!</log>
                                         </wait>
                                     </run>


### PR DESCRIPTION
1) Fix Oracle Database connect string

The current JPA integration test is still using the old-style, discouraged connect string to the Oracle instance itself.
This will cause issues in the future when e.g. the connection should be made to a pluggable database inside the Oracle instance or perhaps even a custom service name.

Instead, the new-style connect string should be used that connects to an Oracle Database Service instead of the Oracle instance itself, see [Thin-style Service Name Syntax](https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A).

2) decrease wait time

The new image is up and running within 40 seconds on a modest machine.
Having to wait 100 seconds seems a waste of time before the test run.
60 seconds should be a safe bet.