### PR TITLE
gRPC treating clients without configuration as self-calling

### DIFF
--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/ClientWithoutConfigInjectionTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/ClientWithoutConfigInjectionTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.grpc.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloReplyOrBuilder;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.HelloRequestOrBuilder;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ClientWithoutConfigInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MutinyGreeterGrpc.class, GreeterGrpc.class,
+                            MutinyGreeterGrpc.MutinyGreeterStub.class,
+                            HelloService.class, HelloRequest.class, HelloReply.class,
+                            HelloReplyOrBuilder.class, HelloRequestOrBuilder.class));
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @GrpcClient
+    GreeterGrpc.GreeterBlockingStub client;
+    @GrpcClient
+    MutinyGreeterGrpc.MutinyGreeterStub mutinyClient;
+
+    @Test
+    public void testHelloWithBlockingClient() {
+        HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+
+    @Test
+    public void testHelloWithMutinyClient() {
+        Uni<HelloReply> reply = mutinyClient
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.await().atMost(TIMEOUT).getMessage()).isEqualTo("Hello neo");
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/GrpcClient.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/GrpcClient.java
@@ -30,7 +30,7 @@ public @interface GrpcClient {
      */
     String value() default ELEMENT_NAME;
 
-    public final class Literal extends AnnotationLiteral<GrpcClient> implements GrpcClient {
+    final class Literal extends AnnotationLiteral<GrpcClient> implements GrpcClient {
 
         private static final long serialVersionUID = 1L;
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.context.spi.CreationalContext;
@@ -33,6 +35,9 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.grpc.runtime.GrpcClientInterceptorContainer;
 import io.quarkus.grpc.runtime.config.GrpcClientConfiguration;
+import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
+import io.quarkus.grpc.runtime.config.SslClientConfig;
+import io.quarkus.runtime.LaunchMode;
 
 @SuppressWarnings({ "OptionalIsPresent", "Convert2Lambda" })
 public class Channels {
@@ -50,7 +55,17 @@ public class Channels {
             throw new IllegalStateException("Unable to find the GrpcClientConfigProvider");
         }
 
-        GrpcClientConfiguration config = instance.get().getConfiguration(name);
+        GrpcClientConfigProvider configProvider = instance.get();
+        GrpcClientConfiguration config = configProvider.getConfiguration(name);
+
+        if (config == null && LaunchMode.current() == LaunchMode.TEST) {
+            config = testConfig(configProvider.getServerConfiguration());
+        }
+
+        if (config == null) {
+            throw new IllegalStateException("gRPC client " + name + " is missing configuration.");
+        }
+
         String host = config.host;
         int port = config.port;
         boolean plainText = !config.ssl.trustStore.isPresent();
@@ -146,6 +161,40 @@ public class Channels {
         }
 
         return builder.build();
+    }
+
+    private static GrpcClientConfiguration testConfig(GrpcServerConfiguration serverConfiguration) {
+        LOGGER.info("gRPC client created without configuration. We are assuming that it's created to test your gRPC services.");
+        GrpcClientConfiguration config = new GrpcClientConfiguration();
+        config.port = serverConfiguration.testPort;
+        config.host = serverConfiguration.host;
+        config.plainText = Optional.of(serverConfiguration.plainText);
+        config.compression = Optional.empty();
+        config.flowControlWindow = OptionalInt.empty();
+        config.idleTimeout = Optional.empty();
+        config.keepAliveTime = Optional.empty();
+        config.keepAliveTimeout = Optional.empty();
+        config.loadBalancingPolicy = "pick_first";
+        config.maxHedgedAttempts = 5;
+        config.maxInboundMessageSize = OptionalInt.empty();
+        config.maxInboundMetadataSize = OptionalInt.empty();
+        config.maxRetryAttempts = 0;
+        config.maxTraceEvents = OptionalInt.empty();
+        config.negotiationType = "PLAINTEXT";
+        config.overrideAuthority = Optional.empty();
+        config.perRpcBufferLimit = OptionalLong.empty();
+        config.retry = false;
+        config.retryBufferSize = OptionalLong.empty();
+        config.ssl = new SslClientConfig();
+        config.ssl.key = Optional.empty();
+        config.ssl.certificate = Optional.empty();
+        config.ssl.trustStore = Optional.empty();
+        config.userAgent = Optional.empty();
+        if (serverConfiguration.ssl.certificate.isPresent() || serverConfiguration.ssl.keyStore.isPresent()) {
+            LOGGER.warn("gRPC client created without configuration and the gRPC server is configured for SSL. " +
+                    "Configuring SSL for such clients is not supported.");
+        }
+        return config;
     }
 
     private static InputStream streamFor(Path path, String resourceName) {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/GrpcClientConfigProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/GrpcClientConfigProvider.java
@@ -9,6 +9,7 @@ import io.grpc.stub.AbstractStub;
 import io.quarkus.arc.Arc;
 import io.quarkus.grpc.runtime.config.GrpcClientConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcConfiguration;
+import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
 
 /**
  * This bean provides the {@link GrpcClientConfiguration} to {@link Channels}.
@@ -26,6 +27,10 @@ public class GrpcClientConfigProvider {
         } else {
             return clients.get(name);
         }
+    }
+
+    public GrpcServerConfiguration getServerConfiguration() {
+        return config.server;
     }
 
     AbstractStub<?> adjustCallOptions(String serviceName, AbstractStub<?> stub) {


### PR DESCRIPTION
At the moment, gRPC testing experience is worse than REST. A user has to know the port of the gRPC server in tests, and has to configure a client stub for tests in application.properties.

This PR proposes allowing injection of client stubs without config when running in test mode. Such clients are automatically configured to call the exposed gRPC server.

The drawback of this change is that misconfiguration problems may be a bit more difficult to spot in tests.

@cescoffier @mkouba WDYT?