### PR TITLE
Depend on Keycloak 12.0.4 for the moment

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -187,7 +187,7 @@
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.8</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>13.0.0</keycloak.version>
+        <keycloak.version>12.0.4</keycloak.version>
         <logstash-gelf.version>1.14.1</logstash-gelf.version>
         <jsch.version>0.1.55</jsch.version>
         <jzlib.version>1.1.3</jzlib.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -87,7 +87,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml to match the version -->
-        <keycloak.docker.image>quay.io/keycloak/keycloak:13.0.0</keycloak.docker.image>
+        <keycloak.docker.image>quay.io/keycloak/keycloak:12.0.3</keycloak.docker.image>
 
         <unboundid-ldap.version>4.0.13</unboundid-ldap.version>
 


### PR DESCRIPTION
Fixes #17179

CC @pedroigor 

This PR restores the KC `12.0.4` (`12.0.3` for the image to avoid the image cache issue spotted by Guillaume) as `13.0.0` has 2 reported (very likely related) `quarkus-keycloak-authorization` side-effects, and while the workarounds exist (one per each issue, it was confirmed by another user today that both workarounds had to be applied), ideally it should work without having to apply them.

Later we can go from `12.0.4` straight to the post `13.0.0` release containing the fix. 