### PR TITLE
Update dokka-maven-plugin and put it into build-parent

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -631,6 +631,30 @@
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>3.2.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <version>1.4.32</version>
+                    <executions>
+                        <execution>
+                            <id>javadoc</id>
+                            <phase>deploy</phase>
+                            <goals>
+                                <goal>javadocJar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <jdkVersion>11</jdkVersion>
+                        <outputFormat>html</outputFormat>
+                        <externalDocumentationLinks>
+                            <link>
+                                <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
+                                <url>https://docs.oracle.com/en/java/javase/11/docs/api/</url>
+                            </link>
+                        </externalDocumentationLinks>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -154,26 +154,6 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>1.4.30</version>
-                <executions>
-                    <execution>
-                        <id>javadoc</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>javadocJar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jdkVersion>11</jdkVersion>
-                    <outputFormat>html</outputFormat>
-                    <externalDocumentationLinks>
-                        <link>
-                            <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
-                            <url>https://docs.oracle.com/en/java/javase/11/docs/api/</url>
-                        </link>
-                    </externalDocumentationLinks>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-kotlin/runtime/pom.xml
@@ -181,26 +181,6 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>1.4.30</version>
-                <executions>
-                    <execution>
-                        <id>javadoc</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>javadocJar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jdkVersion>11</jdkVersion>
-                    <outputFormat>html</outputFormat>
-                    <externalDocumentationLinks>
-                        <link>
-                            <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
-                            <url>https://docs.oracle.com/en/java/javase/11/docs/api/</url>
-                        </link>
-                    </externalDocumentationLinks>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/kotlin/pom.xml
@@ -109,26 +109,6 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>1.4.32</version>
-                <executions>
-                    <execution>
-                        <id>javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>javadocJar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jdkVersion>11</jdkVersion>
-                    <outputFormat>html</outputFormat>
-                    <externalDocumentationLinks>
-                        <link>
-                            <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
-                            <url>https://docs.oracle.com/en/java/javase/11/docs/api/</url>
-                        </link>
-                    </externalDocumentationLinks>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Update dokka-maven-plugin from 1.4.30 to 1.4.32 and put it into build-parent.

dokka-maven-plugin was use 3 times, twice in `deploy` phase, once in `package` phase.
Now synced to `deploy` phase, @gsmet fyi as you did https://github.com/quarkusio/quarkus/commit/98f655a3b89651c1c00295af54cdb5c36dc4e3e7

Update to 1.4.32 version is needed as 1.4.30 depends on kotlinx-html-jvm 0.7.2 which is not available
https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-html-jvm/ ... only 0.7.3 is available