### PR TITLE
Replace deprecated serviceAccount with serviceAccountName in Knative plugin

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyServiceAccountNameToRevisionSpecDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyServiceAccountNameToRevisionSpecDecorator.java
@@ -8,29 +8,29 @@ import io.dekorate.utils.Strings;
 import io.fabric8.knative.serving.v1.RevisionSpecFluent;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 
-public class ApplyServiceAccountToRevisionSpecDecorator extends NamedResourceDecorator<RevisionSpecFluent<?>> {
+public class ApplyServiceAccountNameToRevisionSpecDecorator extends NamedResourceDecorator<RevisionSpecFluent<?>> {
     private static final String NONE = null;
-    private final String serviceAccount;
+    private final String serviceAccountName;
 
-    public ApplyServiceAccountToRevisionSpecDecorator() {
+    public ApplyServiceAccountNameToRevisionSpecDecorator() {
         this(ANY, NONE);
     }
 
-    public ApplyServiceAccountToRevisionSpecDecorator(String serviceAccount) {
+    public ApplyServiceAccountNameToRevisionSpecDecorator(String serviceAccountName) {
         super(ANY);
-        this.serviceAccount = serviceAccount;
+        this.serviceAccountName = serviceAccountName;
     }
 
-    public ApplyServiceAccountToRevisionSpecDecorator(String resourceName, String serviceAccount) {
+    public ApplyServiceAccountNameToRevisionSpecDecorator(String resourceName, String serviceAccountName) {
         super(resourceName);
-        this.serviceAccount = serviceAccount;
+        this.serviceAccountName = serviceAccountName;
     }
 
     public void andThenVisit(RevisionSpecFluent<?> spec, ObjectMeta resourceMeta) {
-        if (Strings.isNotNullOrEmpty(this.serviceAccount)) {
-            spec.withServiceAccount(this.serviceAccount);
+        if (Strings.isNotNullOrEmpty(this.serviceAccountName)) {
+            spec.withServiceAccountName(this.serviceAccountName);
         } else {
-            spec.withServiceAccount(resourceMeta.getName());
+            spec.withServiceAccountName(resourceMeta.getName());
         }
 
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -231,7 +231,7 @@ public class KnativeProcessor {
         });
 
         if (!roleBindings.isEmpty()) {
-            result.add(new DecoratorBuildItem(new ApplyServiceAccountToRevisionSpecDecorator()));
+            result.add(new DecoratorBuildItem(new ApplyServiceAccountNameToRevisionSpecDecorator()));
         }
 
         return result;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithSecretConfigTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithSecretConfigTest.java
@@ -60,7 +60,7 @@ public class KnativeWithSecretConfigTest {
                     assertThat(((Service) s).getSpec()).satisfies(serviceSpec -> {
                         assertThat(serviceSpec.getTemplate()).satisfies(revisionTemplateSpec -> {
                             assertThat(revisionTemplateSpec.getSpec()).satisfies(revisionSpec -> {
-                                assertThat(revisionSpec.getServiceAccount()).isEqualTo("knative-with-secret-config");
+                                assertThat(revisionSpec.getServiceAccountName()).isEqualTo("knative-with-secret-config");
                             });
                         });
                     });


### PR DESCRIPTION
As per title really. Knative Serving doesn't support `serviceAccount` and it's deprecated in Kubernetes since ages anyway. See https://github.com/kubernetes/kubernetes/pull/11389 from **2015**.

**Note:** This is somewhat blindly coded as my Java setup is not top-notch currently. :crossed_fingers: it just works.