### PR TITLE
Check for WebSocket Upgrade in `hotReplacementHandler`

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -348,8 +348,12 @@ public class VertxHttpRecorder {
                 httpRouteRouter.route().order(Integer.MIN_VALUE).handler(new Handler<RoutingContext>() {
                     @Override
                     public void handle(RoutingContext event) {
-                        Thread.currentThread().setContextClassLoader(currentCl);
-                        hotReplacementHandler.handle(event);
+                        if (event.request().headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true)) {
+                            event.next();
+                        } else {
+                            Thread.currentThread().setContextClassLoader(currentCl);
+                            hotReplacementHandler.handle(event);
+                        }
                     }
                 });
             }
@@ -363,8 +367,12 @@ public class VertxHttpRecorder {
                 mainRouter.route().order(Integer.MIN_VALUE).handler(new Handler<RoutingContext>() {
                     @Override
                     public void handle(RoutingContext event) {
-                        Thread.currentThread().setContextClassLoader(currentCl);
-                        hotReplacementHandler.handle(event);
+                        if (event.request().headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true)) {
+                            event.next();
+                        } else {
+                            Thread.currentThread().setContextClassLoader(currentCl);
+                            hotReplacementHandler.handle(event);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Fix #17327

The handler currently block WebSockets Upgrade requests in Dev Mode. This change basically just check for that.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>