### PR TITLE
Switch from Skipped to Aborted and properly display them

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -374,17 +374,17 @@ public class JunitTestRunner {
         for (String clazz : classes) {
             List<TestResult> passing = new ArrayList<>();
             List<TestResult> failing = new ArrayList<>();
-            List<TestResult> skipped = new ArrayList<>();
+            List<TestResult> aborted = new ArrayList<>();
             for (TestResult i : Optional.ofNullable(resultsByClass.get(clazz)).orElse(Collections.emptyMap()).values()) {
                 if (i.getTestExecutionResult().getStatus() == TestExecutionResult.Status.FAILED) {
                     failing.add(i);
                 } else if (i.getTestExecutionResult().getStatus() == TestExecutionResult.Status.ABORTED) {
-                    skipped.add(i);
+                    aborted.add(i);
                 } else {
                     passing.add(i);
                 }
             }
-            resultMap.put(clazz, new TestClassResult(clazz, passing, failing, skipped));
+            resultMap.put(clazz, new TestClassResult(clazz, passing, failing, aborted));
         }
         return resultMap;
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassResult.java
@@ -7,14 +7,14 @@ public class TestClassResult implements Comparable<TestClassResult> {
     final String className;
     final List<TestResult> passing;
     final List<TestResult> failing;
-    final List<TestResult> skipped;
+    final List<TestResult> aborted;
     final long latestRunId;
 
-    public TestClassResult(String className, List<TestResult> passing, List<TestResult> failing, List<TestResult> skipped) {
+    public TestClassResult(String className, List<TestResult> passing, List<TestResult> failing, List<TestResult> aborted) {
         this.className = className;
         this.passing = passing;
         this.failing = failing;
-        this.skipped = skipped;
+        this.aborted = aborted;
         long runId = 0;
         for (TestResult i : passing) {
             runId = Math.max(i.runId, runId);
@@ -37,8 +37,8 @@ public class TestClassResult implements Comparable<TestClassResult> {
         return failing;
     }
 
-    public List<TestResult> getSkipped() {
-        return skipped;
+    public List<TestResult> getAborted() {
+        return aborted;
     }
 
     public long getLatestRunId() {
@@ -54,7 +54,7 @@ public class TestClassResult implements Comparable<TestClassResult> {
         List<TestResult> ret = new ArrayList<>();
         ret.addAll(passing);
         ret.addAll(failing);
-        ret.addAll(skipped);
+        ret.addAll(aborted);
         return ret;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunResults.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunResults.java
@@ -35,13 +35,13 @@ public class TestRunResults {
     private final Map<String, TestClassResult> historicPassing = new HashMap<>();
     private final List<TestClassResult> failing = new ArrayList<>();
     private final List<TestClassResult> passing = new ArrayList<>();
-    private final List<TestClassResult> skipped = new ArrayList<>();
+    private final List<TestClassResult> aborted = new ArrayList<>();
     private final long passedCount;
     private final long failedCount;
-    private final long skippedCount;
+    private final long abortedCount;
     private final long currentPassedCount;
     private final long currentFailedCount;
-    private final long currentSkippedCount;
+    private final long currentAbortedCount;
 
     public TestRunResults(long id, ClassScanResult trigger, boolean full, long started, long completed,
             Map<String, TestClassResult> results) {
@@ -53,17 +53,17 @@ public class TestRunResults {
         this.results = new HashMap<>(results);
         long passedCount = 0;
         long failedCount = 0;
-        long skippedCount = 0;
+        long abortedCount = 0;
         long currentPassedCount = 0;
         long currentFailedCount = 0;
-        long currentSkippedCount = 0;
+        long currentAbortedCount = 0;
         for (Map.Entry<String, TestClassResult> i : results.entrySet()) {
             passedCount += i.getValue().getPassing().stream().filter(TestResult::isTest).count();
             failedCount += i.getValue().getFailing().stream().filter(TestResult::isTest).count();
-            skippedCount += i.getValue().getSkipped().stream().filter(TestResult::isTest).count();
+            abortedCount += i.getValue().getAborted().stream().filter(TestResult::isTest).count();
             currentPassedCount += i.getValue().getPassing().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
             currentFailedCount += i.getValue().getFailing().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
-            currentSkippedCount += i.getValue().getSkipped().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
+            currentAbortedCount += i.getValue().getAborted().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
             boolean current = i.getValue().getLatestRunId() == id;
             if (current) {
                 if (!i.getValue().getFailing().isEmpty()) {
@@ -73,7 +73,7 @@ public class TestRunResults {
                     currentPassing.put(i.getKey(), i.getValue());
                     passing.add(i.getValue());
                 } else {
-                    skipped.add(i.getValue());
+                    aborted.add(i.getValue());
                 }
             } else {
                 if (!i.getValue().getFailing().isEmpty()) {
@@ -83,19 +83,19 @@ public class TestRunResults {
                     historicPassing.put(i.getKey(), i.getValue());
                     passing.add(i.getValue());
                 } else {
-                    skipped.add(i.getValue());
+                    aborted.add(i.getValue());
                 }
             }
         }
         Collections.sort(passing);
         Collections.sort(failing);
-        Collections.sort(skipped);
+        Collections.sort(aborted);
         this.failedCount = failedCount;
         this.passedCount = passedCount;
-        this.skippedCount = skippedCount;
+        this.abortedCount = abortedCount;
         this.currentFailedCount = currentFailedCount;
         this.currentPassedCount = currentPassedCount;
-        this.currentSkippedCount = currentSkippedCount;
+        this.currentAbortedCount = currentAbortedCount;
     }
 
     public long getId() {
@@ -150,8 +150,8 @@ public class TestRunResults {
         return passing;
     }
 
-    public List<TestClassResult> getSkipped() {
-        return skipped;
+    public List<TestClassResult> getAborted() {
+        return aborted;
     }
 
     public long getPassedCount() {
@@ -162,8 +162,8 @@ public class TestRunResults {
         return failedCount;
     }
 
-    public long getSkippedCount() {
-        return skippedCount;
+    public long getAbortedCount() {
+        return abortedCount;
     }
 
     public long getCurrentPassedCount() {
@@ -174,15 +174,15 @@ public class TestRunResults {
         return currentFailedCount;
     }
 
-    public long getCurrentSkippedCount() {
-        return currentSkippedCount;
+    public long getCurrentAbortedCount() {
+        return currentAbortedCount;
     }
 
     public long getTotalCount() {
-        return getPassedCount() + getFailedCount() + getSkippedCount();
+        return getPassedCount() + getFailedCount() + getAbortedCount();
     }
 
     public long getCurrentTotalCount() {
-        return getCurrentPassedCount() + getCurrentFailedCount() + getCurrentSkippedCount();
+        return getCurrentPassedCount() + getCurrentFailedCount() + getCurrentAbortedCount();
     }
 }

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/ContinuousTestingWebsocketListener.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/ContinuousTestingWebsocketListener.java
@@ -34,7 +34,7 @@ public class ContinuousTestingWebsocketListener {
     public static void setInProgress(boolean inProgress) {
         State state = lastState;
         if (state != null) {
-            setLastState(new State(state.running, inProgress, state.run, state.passed, state.failed, state.skipped,
+            setLastState(new State(state.running, inProgress, state.run, state.passed, state.failed, state.aborted,
                     state.isBrokenOnly, state.isTestOutput, state.isInstrumentationBasedReload));
         }
     }
@@ -42,7 +42,7 @@ public class ContinuousTestingWebsocketListener {
     public static void setRunning(boolean running) {
         State state = lastState;
         if (state != null) {
-            setLastState(new State(running, running && state.inProgress, state.run, state.passed, state.failed, state.skipped,
+            setLastState(new State(running, running && state.inProgress, state.run, state.passed, state.failed, state.aborted,
                     state.isBrokenOnly, state.isTestOutput, state.isInstrumentationBasedReload));
         }
     }
@@ -50,7 +50,7 @@ public class ContinuousTestingWebsocketListener {
     public static void setBrokenOnly(boolean brokenOnly) {
         State state = lastState;
         if (state != null) {
-            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.skipped,
+            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.aborted,
                     brokenOnly, state.isTestOutput, state.isInstrumentationBasedReload));
         }
     }
@@ -58,7 +58,7 @@ public class ContinuousTestingWebsocketListener {
     public static void setTestOutput(boolean testOutput) {
         State state = lastState;
         if (state != null) {
-            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.skipped,
+            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.aborted,
                     state.isBrokenOnly, testOutput, state.isInstrumentationBasedReload));
         }
     }
@@ -66,7 +66,7 @@ public class ContinuousTestingWebsocketListener {
     public static void setInstrumentationBasedReload(boolean instrumentationBasedReload) {
         State state = lastState;
         if (state != null) {
-            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.skipped,
+            setLastState(new State(state.running, state.inProgress, state.run, state.passed, state.failed, state.aborted,
                     state.isBrokenOnly, state.isTestOutput, instrumentationBasedReload));
         }
     }
@@ -77,19 +77,19 @@ public class ContinuousTestingWebsocketListener {
         public final long run;
         public final long passed;
         public final long failed;
-        public final long skipped;
+        public final long aborted;
         public final boolean isBrokenOnly;
         public final boolean isTestOutput;
         public final boolean isInstrumentationBasedReload;
 
-        public State(boolean running, boolean inProgress, long run, long passed, long failed, long skipped,
+        public State(boolean running, boolean inProgress, long run, long passed, long failed, long aborted,
                 boolean isBrokenOnly, boolean isTestOutput, boolean isInstrumentationBasedReload) {
             this.running = running;
             this.inProgress = inProgress;
             this.run = run;
             this.passed = passed;
             this.failed = failed;
-            this.skipped = skipped;
+            this.aborted = aborted;
             this.isBrokenOnly = isBrokenOnly;
             this.isTestOutput = isTestOutput;
             this.isInstrumentationBasedReload = isInstrumentationBasedReload;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadTestCase.java
@@ -87,7 +87,7 @@ public class HibernateHotReloadTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         TEST.modifyTestResourceFile("import.sql", new Function<String, String>() {
@@ -100,7 +100,7 @@ public class HibernateHotReloadTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         TEST.modifyTestSourceFile(HibernateET.class, new Function<String, String>() {
@@ -113,7 +113,7 @@ public class HibernateHotReloadTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ContinuousTestingWebSocketListener.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ContinuousTestingWebSocketListener.java
@@ -50,9 +50,9 @@ public class ContinuousTestingWebSocketListener implements TestListener {
                         new ContinuousTestingWebsocketListener.State(true, false,
                                 testRunResults.getPassedCount() +
                                         testRunResults.getFailedCount() +
-                                        testRunResults.getSkippedCount(),
+                                        testRunResults.getAbortedCount(),
                                 testRunResults.getPassedCount(),
-                                testRunResults.getFailedCount(), testRunResults.getSkippedCount(),
+                                testRunResults.getFailedCount(), testRunResults.getAbortedCount(),
                                 ContinuousTestingWebsocketListener.getLastState().isBrokenOnly,
                                 ContinuousTestingWebsocketListener.getLastState().isTestOutput,
                                 ContinuousTestingWebsocketListener.getLastState().isInstrumentationBasedReload));

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/ClassResult.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/ClassResult.java
@@ -10,14 +10,14 @@ public class ClassResult implements Comparable<ClassResult> {
     String className;
     List<Result> passing;
     List<Result> failing;
-    List<Result> skipped;
+    List<Result> aborted;
     long latestRunId;
 
-    public ClassResult(String className, List<Result> passing, List<Result> failing, List<Result> skipped) {
+    public ClassResult(String className, List<Result> passing, List<Result> failing, List<Result> aborted) {
         this.className = className;
         this.passing = passing;
         this.failing = failing;
-        this.skipped = skipped;
+        this.aborted = aborted;
         long runId = 0;
         for (Result i : passing) {
             runId = Math.max(i.getRunId(), runId);
@@ -32,7 +32,7 @@ public class ClassResult implements Comparable<ClassResult> {
         this.className = res.getClassName();
         this.failing = res.getFailing().stream().map(Result::new).collect(Collectors.toList());
         this.passing = res.getPassing().stream().filter(TestResult::isTest).map(Result::new).collect(Collectors.toList());
-        this.skipped = res.getSkipped().stream().filter(TestResult::isTest).map(Result::new).collect(Collectors.toList());
+        this.aborted = res.getAborted().stream().filter(TestResult::isTest).map(Result::new).collect(Collectors.toList());
         this.latestRunId = res.getLatestRunId();
     }
 
@@ -52,8 +52,8 @@ public class ClassResult implements Comparable<ClassResult> {
         return failing;
     }
 
-    public List<Result> getSkipped() {
-        return skipped;
+    public List<Result> getAborted() {
+        return aborted;
     }
 
     public long getLatestRunId() {
@@ -75,8 +75,8 @@ public class ClassResult implements Comparable<ClassResult> {
         return this;
     }
 
-    public ClassResult setSkipped(List<Result> skipped) {
-        this.skipped = skipped;
+    public ClassResult setAborted(List<Result> aborted) {
+        this.aborted = aborted;
         return this;
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestStatus.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestStatus.java
@@ -12,7 +12,7 @@ public class TestStatus {
 
     private long testsFailed = -1;
 
-    private long testsSkipped = -1;
+    private long testsAborted = -1;
 
     public TestStatus() {
     }
@@ -23,7 +23,7 @@ public class TestStatus {
         this.testsRun = testsRun;
         this.testsPassed = testsPassed;
         this.testsFailed = testsFailed;
-        this.testsSkipped = testsSkipped;
+        this.testsAborted = testsSkipped;
     }
 
     public long getLastRun() {
@@ -71,12 +71,12 @@ public class TestStatus {
         return this;
     }
 
-    public long getTestsSkipped() {
-        return testsSkipped;
+    public long getTestsAborted() {
+        return testsAborted;
     }
 
-    public TestStatus setTestsSkipped(long testsSkipped) {
-        this.testsSkipped = testsSkipped;
+    public TestStatus setTestsAborted(long testsAborted) {
+        this.testsAborted = testsAborted;
         return this;
     }
 
@@ -88,7 +88,7 @@ public class TestStatus {
                 ", testsRun=" + testsRun +
                 ", testsPassed=" + testsPassed +
                 ", testsFailed=" + testsFailed +
-                ", testsSkipped=" + testsSkipped +
+                ", testsAborted=" + testsAborted +
                 '}';
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
@@ -84,7 +84,7 @@ public class TestsProcessor {
                     TestRunResults result = ts.get().getResults();
                     testStatus.setTestsFailed(result.getCurrentFailedCount());
                     testStatus.setTestsPassed(result.getCurrentPassedCount());
-                    testStatus.setTestsSkipped(result.getCurrentSkippedCount());
+                    testStatus.setTestsAborted(result.getCurrentAbortedCount());
                     testStatus.setTestsRun(result.getFailedCount() + result.getPassedCount());
                 }
                 event.response().end(JsonObject.mapFrom(testStatus).encode());

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/tests.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/tests.html
@@ -117,16 +117,16 @@
                     {/if}
                 {/for}    
 
-                {#for r in cn.skipped}
+                {#for r in cn.aborted}
                     {#if r.test}
                     <li class="list-group-item">
   
-                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#failedTests{parentCount}LogSkipped{count}" aria-expanded="false" aria-controls="failedTests{parentCount}LogSkipped{count}">
+                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#failedTests{parentCount}LogAborted{count}" aria-expanded="false" aria-controls="failedTests{parentCount}LogAborted{count}">
                             <span class="float-left"><i class="fas fa-minus-circle"></i> {r.displayName}</span>
                         </a>
                         
                     
-                        <div id="failedTests{parentCount}LogSkipped{count}" class="collapse">
+                        <div id="failedTests{parentCount}LogAborted{count}" class="collapse">
                             <br/>
                             <div class="bg-dark p-2">
                                 <samp class="text-wrap " style="font-size: 0.9em;">
@@ -181,16 +181,16 @@
                     {/if}
                 {/for}    
 
-                {#for r in cn.skipped}
+                {#for r in cn.aborted}
                     {#if r.test}
                     <li class="list-group-item">
   
-                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#passedTests{parentCount}LogSkipped{count}" aria-expanded="false" aria-controls="passedTests{parentCount}LogSkipped{count}">
+                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#passedTests{parentCount}LogAborted{count}" aria-expanded="false" aria-controls="passedTests{parentCount}LogAborted{count}">
                             <span class="float-left"><i class="fas fa-minus-circle"></i> {r.displayName}</span>
                         </a>
                         
                     
-                        <div id="passedTests{parentCount}LogSkipped{count}" class="collapse">
+                        <div id="passedTests{parentCount}LogAborted{count}" class="collapse">
                             <br/>
                             <div class="bg-dark p-2">
                                 <samp class="text-wrap " style="font-size: 0.9em;">
@@ -212,27 +212,27 @@
     {/for}
     
     
-    {#for cn in info:tests.results.skipped.orEmpty}
+    {#for cn in info:tests.results.aborted.orEmpty}
     {#set parentCount=count}
     
     <div class="row p-1">
         <div class="col-sm">
-            <button class="btn btn-secondary btn-block" type="button" data-toggle="collapse" data-target="#skippedTests{parentCount}" aria-expanded="false" aria-controls="skippedTests{parentCount}">
+            <button class="btn btn-secondary btn-block" type="button" data-toggle="collapse" data-target="#abortedTests{parentCount}" aria-expanded="false" aria-controls="abortedTests{parentCount}">
                 <span class="float-left"><i class="fas fa-minus-circle"></i> {cn.className}</span>
             </button>
-            <div class="collapse" id="skippedTests{parentCount}">
+            <div class="collapse" id="abortedTests{parentCount}">
                 <ul class="list-group">
                 
-                {#for r in cn.skipped}
+                {#for r in cn.aborted}
                     {#if r.test}
                     <li class="list-group-item">
   
-                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#skippedTests{parentCount}LogSkipped{count}" aria-expanded="false" aria-controls="skippedTests{parentCount}LogSkipped{count}">
+                        <a class="btn btn-link btn-block text-secondary" data-toggle="collapse" data-target="#abortedTests{parentCount}LogAborted{count}" aria-expanded="false" aria-controls="abortedTests{parentCount}LogAborted{count}">
                             <span class="float-left"><i class="fas fa-minus-circle"></i> {r.displayName}</span>
                         </a>
                         
                     
-                        <div id="skippedTests{parentCount}LogSkipped{count}" class="collapse">
+                        <div id="aborteddTests{parentCount}LogAborted{count}" class="collapse">
                             <br/>
                             <div class="bg-dark p-2">
                                 <samp class="text-wrap " style="font-size: 0.9em;">

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/QuarkusTestTypeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/QuarkusTestTypeTestCase.java
@@ -37,7 +37,7 @@ public class QuarkusTestTypeTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestChangeTrackingWhenStartFailsTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestChangeTrackingWhenStartFailsTestCase.java
@@ -38,7 +38,7 @@ public class TestChangeTrackingWhenStartFailsTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //fail the startup
@@ -52,7 +52,7 @@ public class TestChangeTrackingWhenStartFailsTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
-        Assertions.assertEquals(3L, ts.getTestsSkipped());
+        Assertions.assertEquals(3L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
         //fail again
         test.modifySourceFile(StartupFailer.class, new Function<String, String>() {
@@ -65,7 +65,7 @@ public class TestChangeTrackingWhenStartFailsTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
-        Assertions.assertEquals(3L, ts.getTestsSkipped());
+        Assertions.assertEquals(3L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
         //now lets pass
         test.modifySourceFile(StartupFailer.class, new Function<String, String>() {
@@ -78,7 +78,7 @@ public class TestChangeTrackingWhenStartFailsTestCase {
         Assertions.assertEquals(4L, ts.getLastRun());
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
@@ -41,7 +41,7 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         SuiteResult suiteResult = RestAssured.get("q/dev/io.quarkus.quarkus-vertx-http/tests/result")
@@ -70,7 +70,7 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //fix the unit test
@@ -85,7 +85,7 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/UnitTestTypeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/UnitTestTypeTestCase.java
@@ -37,7 +37,7 @@ public class UnitTestTypeTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/brokenonly/TestBrokenOnlyTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/brokenonly/TestBrokenOnlyTestCase.java
@@ -40,7 +40,7 @@ public class TestBrokenOnlyTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //start broken only mode
@@ -56,7 +56,7 @@ public class TestBrokenOnlyTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed()); //passing test should not have been run
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifySourceFile(BrokenOnlyResource.class, new Function<String, String>() {
@@ -69,7 +69,7 @@ public class TestBrokenOnlyTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //now add a new failing test
@@ -83,7 +83,7 @@ public class TestBrokenOnlyTestCase {
         Assertions.assertEquals(4L, ts.getLastRun());
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //now make it pass
@@ -97,7 +97,7 @@ public class TestBrokenOnlyTestCase {
         Assertions.assertEquals(5L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/ExcludePatternTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/ExcludePatternTestCase.java
@@ -41,7 +41,7 @@ public class ExcludePatternTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -54,7 +54,7 @@ public class ExcludePatternTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -67,7 +67,7 @@ public class ExcludePatternTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/IncludePatternTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/IncludePatternTestCase.java
@@ -41,7 +41,7 @@ public class IncludePatternTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -54,7 +54,7 @@ public class IncludePatternTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -67,7 +67,7 @@ public class IncludePatternTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/ExcludeTagsTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/ExcludeTagsTestCase.java
@@ -40,7 +40,7 @@ public class ExcludeTagsTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(3L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -56,7 +56,7 @@ public class ExcludeTagsTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(4L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -69,7 +69,7 @@ public class ExcludeTagsTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(5L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/IncludeTagsTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/IncludeTagsTestCase.java
@@ -40,7 +40,7 @@ public class IncludeTagsTestCase {
         Assertions.assertEquals(1L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -53,7 +53,7 @@ public class IncludeTagsTestCase {
         Assertions.assertEquals(2L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         test.modifyResourceFile("application.properties", new Function<String, String>() {
@@ -66,7 +66,7 @@ public class IncludeTagsTestCase {
         Assertions.assertEquals(3L, ts.getLastRun());
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(5L, ts.getTestsPassed());
-        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTestsAborted());
         Assertions.assertEquals(-1L, ts.getRunning());
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ContinuousTestWebSocketHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ContinuousTestWebSocketHandler.java
@@ -30,7 +30,7 @@ public class ContinuousTestWebSocketHandler implements Handler<RoutingContext> {
                 response.put("run", state.run);
                 response.put("passed", state.passed);
                 response.put("failed", state.failed);
-                response.put("skipped", state.skipped);
+                response.put("aborted", state.aborted);
                 response.put("isBrokenOnly", state.isBrokenOnly);
                 response.put("isTestOutput", state.isTestOutput);
                 response.put("isInstrumentationBasedReload", state.isInstrumentationBasedReload);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/17340

- Clean message color and formatting
- "aborted" test results are part of "aborted" test class when they all are "aborted", else they are part of the "failed" test class, so we need to display both (else they are not displayed if one other test is failing)
- Switch from skipped to aborted all the way down

Failed with one aborted:
![image](https://user-images.githubusercontent.com/2223984/118875078-e98ba300-b8eb-11eb-9913-d2e69667523b.png)

All aborted:
![image](https://user-images.githubusercontent.com/2223984/118875207-0de77f80-b8ec-11eb-8ba9-8193d893a12c.png)

No aborted:
![image](https://user-images.githubusercontent.com/2223984/118875418-52731b00-b8ec-11eb-9013-b844ff82d68c.png)


