### PR TITLE
Suspend GET requests as well

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -143,10 +143,7 @@ public class VertxHttpRecorder {
             //as it is possible filters such as the auth filter can do blocking tasks
             //as the underlying handler has not had a chance to install a read handler yet
             //and data that arrives while the blocking task is being processed will be lost
-            if (httpServerRequest.method() != HttpMethod.GET) {
-                //we don't pause for GET requests, as there is no data
-                httpServerRequest.pause();
-            }
+            httpServerRequest.pause();
             Handler<HttpServerRequest> rh = VertxHttpRecorder.rootHandler;
             if (rh != null) {
                 rh.handle(httpServerRequest);


### PR DESCRIPTION
If they are not suspended and there is a dispatch it can break
vert.x websockets.

Fixes #17327