### PR TITLE
Continuous testing display fixes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -161,18 +161,16 @@ public class TestConsoleHandler implements TestListener {
             @Override
             public void runComplete(TestRunResults results) {
                 firstRun = false;
-                if (results.getCurrentFailing().isEmpty()) {
+                if (results.getCurrentTotalCount() == 0) {
+                    lastStatus = "\u001B[33mNo tests found\u001b[0m";
+                } else if (results.getFailedCount() == 0 && results.getPassedCount() == 0) {
+                    lastStatus = String.format("\u001B[33mAll %d tests were skipped\u001b[0m", results.getSkippedCount());
+                } else if (results.getCurrentFailing().isEmpty()) {
                     lastStatus = String.format(
                             "\u001B[32mAll %d tests are passing (%d skipped), %d tests were run in %dms.\u001b[0m",
                             results.getPassedCount(),
                             results.getSkippedCount(),
                             results.getCurrentTotalCount(), results.getTotalTime());
-                    log.info(
-                            "====================\u001B[32m TEST REPORT #" + results.getId()
-                                    + "\u001b[0m ====================");
-                    log.info(
-                            ">>>>>>>>>>>>>>>>>>>>\u001B[32m " + results.getCurrentPassedCount()
-                                    + " TESTS PASSED\u001b[0m <<<<<<<<<<<<<<<<<<<<");
                 } else {
                     //TODO: this should not use the logger, it should print a nicer status
                     log.error(
@@ -199,7 +197,7 @@ public class TestConsoleHandler implements TestListener {
             }
 
             @Override
-            public void noTests() {
+            public void noTests(TestRunResults results) {
                 firstRun = false;
                 lastStatus = "No tests to run";
                 promptHandler.setStatus(lastStatus);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunListener.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunListener.java
@@ -24,7 +24,7 @@ public interface TestRunListener {
 
     }
 
-    default void noTests() {
+    default void noTests(TestRunResults results) {
 
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
@@ -232,7 +232,11 @@ public class TestRunner {
                 @Override
                 public void runComplete(TestRunResults results) {
                     testSupport.testRunResults = results;
+                }
 
+                @Override
+                public void noTests(TestRunResults results) {
+                    testSupport.testRunResults = results;
                 }
             });
             runner = builder

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestState.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestState.java
@@ -131,4 +131,12 @@ public class TestState {
     public boolean isFailed(TestDescriptor testDescriptor) {
         return failing.contains(testDescriptor.getUniqueId());
     }
+
+    public void pruneDeletedTests(Set<UniqueId> allDiscoveredIds) {
+        failing.removeIf(i -> !allDiscoveredIds.contains(i));
+        for (Map.Entry<String, Map<UniqueId, TestResult>> cr : resultsByClass.entrySet()) {
+            cr.getValue().entrySet().removeIf(s -> !allDiscoveredIds.contains(s.getKey()));
+        }
+        resultsByClass.entrySet().removeIf(s -> s.getValue().isEmpty());
+    }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestStatus.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestStatus.java
@@ -14,16 +14,27 @@ public class TestStatus {
 
     private long testsSkipped = -1;
 
+    private long totalTestsPassed = -1;
+
+    private long totalTestsFailed = -1;
+
+    private long totalTestsSkipped = -1;
+
     public TestStatus() {
     }
 
-    public TestStatus(long lastRun, long running, long testsRun, long testsPassed, long testsFailed, long testsSkipped) {
+    public TestStatus(long lastRun, long running, long testsRun, long testsPassed, long testsFailed, long testsSkipped,
+            long totalTestsPassed, long totalTestsFailed, long totalTestsSkipped) {
         this.lastRun = lastRun;
         this.running = running;
         this.testsRun = testsRun;
         this.testsPassed = testsPassed;
         this.testsFailed = testsFailed;
         this.testsSkipped = testsSkipped;
+        this.totalTestsPassed = totalTestsPassed;
+        this.totalTestsFailed = totalTestsFailed;
+        this.totalTestsSkipped = totalTestsSkipped;
+
     }
 
     public long getLastRun() {
@@ -77,6 +88,33 @@ public class TestStatus {
 
     public TestStatus setTestsSkipped(long testsSkipped) {
         this.testsSkipped = testsSkipped;
+        return this;
+    }
+
+    public long getTotalTestsPassed() {
+        return totalTestsPassed;
+    }
+
+    public TestStatus setTotalTestsPassed(long totalTestsPassed) {
+        this.totalTestsPassed = totalTestsPassed;
+        return this;
+    }
+
+    public long getTotalTestsFailed() {
+        return totalTestsFailed;
+    }
+
+    public TestStatus setTotalTestsFailed(long totalTestsFailed) {
+        this.totalTestsFailed = totalTestsFailed;
+        return this;
+    }
+
+    public long getTotalTestsSkipped() {
+        return totalTestsSkipped;
+    }
+
+    public TestStatus setTotalTestsSkipped(long totalTestsSkipped) {
+        this.totalTestsSkipped = totalTestsSkipped;
         return this;
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
@@ -86,6 +86,9 @@ public class TestsProcessor {
                     testStatus.setTestsPassed(result.getCurrentPassedCount());
                     testStatus.setTestsSkipped(result.getCurrentSkippedCount());
                     testStatus.setTestsRun(result.getFailedCount() + result.getPassedCount());
+                    testStatus.setTotalTestsFailed(result.getFailedCount());
+                    testStatus.setTotalTestsPassed(result.getPassedCount());
+                    testStatus.setTotalTestsSkipped(result.getSkippedCount());
                 }
                 event.response().end(JsonObject.mapFrom(testStatus).encode());
             }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
@@ -42,6 +42,9 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(2L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(1L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         SuiteResult suiteResult = RestAssured.get("q/dev/io.quarkus.quarkus-vertx-http/tests/result")
@@ -71,6 +74,9 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(1L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(2L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
         Assertions.assertEquals(-1L, ts.getRunning());
 
         //fix the unit test
@@ -86,6 +92,43 @@ public class TestRunnerSmokeTestCase {
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(3L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
+        Assertions.assertEquals(-1L, ts.getRunning());
+
+        //disable the unit test
+        test.modifyTestSourceFile(UnitET.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("@Test", "@Test @org.junit.jupiter.api.Disabled");
+            }
+        });
+        ts = ContinuousTestingTestUtils.waitForRun(4);
+        Assertions.assertEquals(4L, ts.getLastRun());
+        Assertions.assertEquals(0L, ts.getTestsFailed());
+        Assertions.assertEquals(0L, ts.getTestsPassed());
+        Assertions.assertEquals(1L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(2L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(1L, ts.getTotalTestsSkipped());
+        Assertions.assertEquals(-1L, ts.getRunning());
+
+        //delete the unit test
+        test.modifyTestSourceFile(UnitET.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("@Test", "//@Test");
+            }
+        });
+        ts = ContinuousTestingTestUtils.waitForRun(5);
+        Assertions.assertEquals(5L, ts.getLastRun());
+        Assertions.assertEquals(0L, ts.getTestsFailed());
+        Assertions.assertEquals(0L, ts.getTestsPassed());
+        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(2L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
         Assertions.assertEquals(-1L, ts.getRunning());
 
     }


### PR DESCRIPTION
- Don't polute the log on sucessful run
- Handle tests being deleted
- Handle @Disabled tests correctly
- Better output if all tests skipped