### PR TITLE
Support boxed boolean properties whose getters starts with "is" in BytecodeRecorder

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
@@ -35,7 +35,7 @@ final class PropertyUtils {
                         getters.put(name, i);
                     }
                 } else if (i.getName().startsWith("is") && i.getName().length() > 3 && i.getParameterCount() == 0
-                        && i.getReturnType() == boolean.class) {
+                        && (i.getReturnType() == boolean.class || i.getReturnType() == Boolean.class)) {
                     String name = Character.toLowerCase(i.getName().charAt(2)) + i.getName().substring(3);
                     getters.put(name, i);
                 } else if (i.getName().startsWith("set") && i.getName().length() > 3 && i.getParameterCount() == 1) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -336,6 +336,26 @@ public class BytecodeRecorderTestCase {
         }, duration);
     }
 
+    // Boxed booleans whose getter starts with `is`, in particular, used to be ignored.
+    @Test
+    public void testJavaBeanWithBoolean() throws Exception {
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            TestJavaBeanWithBoolean newBean = new TestJavaBeanWithBoolean(true, true, true);
+            recorder.bean(newBean);
+        }, new TestJavaBeanWithBoolean(true, true, true));
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            TestJavaBeanWithBoolean newBean = new TestJavaBeanWithBoolean(false, false, false);
+            recorder.bean(newBean);
+        }, new TestJavaBeanWithBoolean(false, false, false));
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            TestJavaBeanWithBoolean newBean = new TestJavaBeanWithBoolean(true, null, null);
+            recorder.bean(newBean);
+        }, new TestJavaBeanWithBoolean(true, null, null));
+    }
+
     void runTest(Consumer<BytecodeRecorderImpl> generator, Object... expected) throws Exception {
         TestRecorder.RESULT.clear();
         TestClassLoader tcl = new TestClassLoader(getClass().getClassLoader());

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/TestJavaBeanWithBoolean.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/TestJavaBeanWithBoolean.java
@@ -1,0 +1,70 @@
+package io.quarkus.deployment.recording;
+
+import java.util.Objects;
+
+public class TestJavaBeanWithBoolean {
+
+    private boolean bool;
+    private Boolean boxedBool;
+    private Boolean boxedBoolWithIsGetter;
+
+    public TestJavaBeanWithBoolean() {
+    }
+
+    public TestJavaBeanWithBoolean(boolean bool, Boolean boxedBool, Boolean boxedBoolWithIsGetter) {
+        this.bool = bool;
+        this.boxedBool = boxedBool;
+        this.boxedBoolWithIsGetter = boxedBoolWithIsGetter;
+    }
+
+    @Override
+    public String toString() {
+        return "TestJavaBeanWithBoolean{" +
+                "bool=" + bool +
+                ", boxedBool=" + boxedBool +
+                ", boxedBoolWithIsGetter=" + boxedBoolWithIsGetter +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        TestJavaBeanWithBoolean that = (TestJavaBeanWithBoolean) o;
+        return bool == that.bool && Objects.equals(boxedBool, that.boxedBool)
+                && Objects.equals(boxedBoolWithIsGetter, that.boxedBoolWithIsGetter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bool, boxedBool, boxedBoolWithIsGetter);
+    }
+
+    public boolean isBool() {
+        return bool;
+    }
+
+    public void setBool(boolean bool) {
+        this.bool = bool;
+    }
+
+    public Boolean getBoxedBool() {
+        return boxedBool;
+    }
+
+    public void setBoxedBool(Boolean boxedBool) {
+        this.boxedBool = boxedBool;
+    }
+
+    // Using the `is` prefix despite the fact this is a boxed Boolean on purpose:
+    // that's how JAXB generates getters...
+    public Boolean isBoxedBoolWithIsGetter() {
+        return boxedBoolWithIsGetter;
+    }
+
+    public void setBoxedBoolWithIsGetter(Boolean boxedBoolWithIsGetter) {
+        this.boxedBoolWithIsGetter = boxedBoolWithIsGetter;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/TestRecorder.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/TestRecorder.java
@@ -59,6 +59,10 @@ public class TestRecorder {
         RESULT.add(bean);
     }
 
+    public void bean(TestJavaBeanWithBoolean bean) {
+        RESULT.add(bean);
+    }
+
     public void bean(NonSerializable bean) {
         RESULT.add(bean);
     }


### PR DESCRIPTION
I do not know if this is legal in the JavaBeans conventions,
but in any case JAXB generates such properties, and we have such
properties in Hibernate ORM's `JaxbColumn` in particular.

This fixes a bug reported by @agoncal [here](https://github.com/quarkusio/quarkus/issues/14762#issuecomment-843242294). The reproducer definitely helped, thanks!