### PR TITLE
Fallback on jar file for dev mode if gradle project is not found

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -321,18 +321,22 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             final DependencyImpl dep = initDependency(a);
             if ((LaunchMode.DEVELOPMENT.equals(mode) || LaunchMode.TEST.equals(mode)) &&
                     a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
-                IncludedBuild includedBuild = includedBuild(project, a.getName());
                 if ("test-fixtures".equals(a.getClassifier()) || "test".equals(a.getClassifier())) {
                     //TODO: test-fixtures are broken under the new ClassLoading model
                     dep.addPath(a.getFile());
                 } else {
+                    IncludedBuild includedBuild = includedBuild(project.getRootProject(), a.getName());
                     if (includedBuild != null) {
                         addSubstitutedProject(dep, includedBuild.getProjectDir());
                     } else {
                         Project projectDep = project.getRootProject()
                                 .findProject(
                                         ((ProjectComponentIdentifier) a.getId().getComponentIdentifier()).getProjectPath());
-                        addDevModePaths(dep, a, projectDep);
+                        if (projectDep != null) {
+                            addDevModePaths(dep, a, projectDep);
+                        } else {
+                            dep.addPath(a.getFile());
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Currently we look for composite build based on the name of the artifact which can be differ from the module name. 

I haven't found a way to find get `includedBuild` information yet. 
At least, this fix add the jar file of the module,  `quarkusDev` starts but devmode won't detect modification in the composite module. 

close #17367