### PR TITLE
Manage kotlinx-coroutines-core in addition to kotlinx-coroutines-core-jvm

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4851,6 +4851,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core</artifactId>
+                <version>${kotlin.coroutine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-coroutines-core-jvm</artifactId>
                 <version>${kotlin.coroutine.version}</version>
             </dependency>


### PR DESCRIPTION
kotlinx-coroutines-core depends on kotlinx-coroutines-core-jvm that we manage already. This is to solve some alignment issues we have in Camel Quarkus.