### PR TITLE
Bump kubernetes-client-bom from 5.3.1 to 5.4.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <sentry.version>4.3.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.3.1</kubernetes-client.version>
+        <kubernetes-client.version>5.4.0</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Pods.java
@@ -53,7 +53,8 @@ public class Pods {
         final Pod pod = pods.get(0);
         final String podName = pod.getMetadata().getName();
         // would normally do some kind of meaningful update here
-        Pod updatedPod = new PodBuilder().withNewMetadata().withName(podName).withNewResourceVersion("12345")
+        Pod updatedPod = new PodBuilder().withNewMetadata().withName(podName)
+                .addToAnnotations("test-reference", "12345")
                 .addToLabels("key1", "value1").endMetadata()
                 .build();
 
@@ -67,7 +68,8 @@ public class Pods {
         return Response
                 .ok(kubernetesClient.pods().inNamespace(namespace)
                         .create(new PodBuilder().withNewMetadata()
-                                .withName(UUID.randomUUID().toString()).withResourceVersion("12345")
+                                .withName(UUID.randomUUID().toString())
+                                .addToAnnotations("test-reference", "12345")
                                 .endMetadata().build()))
                 .build();
     }

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
@@ -40,7 +40,7 @@ public class CustomKubernetesTestServerTestResource extends KubernetesServerTest
                 .addToData("application.properties", encodeValue("secret.prop3=val3"))
                 .addToData("application.yaml", encodeValue("secret:\n  prop4: val4")).build());
 
-        server.getClient().inNamespace("test").secrets().create(secretBuilder("s1")
+        server.getClient().inNamespace("test").secrets().createOrReplace(secretBuilder("s1")
                 .addToData("dummysecret", encodeValue("dummysecretFromDemo"))
                 .addToData("overridden.secret", encodeValue("secretFromDemo"))
                 .addToData("secret.prop1", encodeValue("val1FromDemo"))

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -19,13 +19,13 @@ import io.restassured.RestAssured;
  */
 @QuarkusTestResource(value = CustomKubernetesTestServerTestResource.class, restrictToAnnotatedClass = true)
 @QuarkusTest
-public class KubernetesNewClientTest {
+class KubernetesNewClientTest {
 
     @KubernetesTestServer
     private KubernetesServer mockServer;
 
     @Test
-    public void testInteractionWithAPIServer() throws InterruptedException {
+    void testInteractionWithAPIServer() {
         setupMockServerForTest();
 
         RestAssured.when().get("/pod/test").then()


### PR DESCRIPTION
Bump kubernetes-client-bom from 5.3.1 to 5.4.0

- Mock server is less lenient now, .metadata.resourceVersion is
  now actually used and updated by the mock-server.
- Changed that field used as the source for an assertion to use
  an annotation instead.

As specified in the [release notes](https://github.com/fabric8io/kubernetes-client/releases/tag/v5.4.0), 5.4.0 has some breaking changes in the API, so this PR shouldn't be back-ported.

(Supersedes #17396)

cc: @geoand @metacosm 
