### PR TITLE
Make support for advanced Jackson features optional in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonFeatureBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonFeatureBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.processor;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Contains the special Jackson features required by the application
+ */
+public final class JacksonFeatureBuildItem extends MultiBuildItem {
+
+    private final Feature feature;
+
+    public JacksonFeatureBuildItem(Feature feature) {
+        this.feature = feature;
+    }
+
+    public Feature getFeature() {
+        return feature;
+    }
+
+    public enum Feature {
+        JSON_VIEW,
+        CUSTOM_SERIALIZATION
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.processor;
 
 import java.util.Collections;
+import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
@@ -10,8 +11,9 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
+import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.BasicServerJacksonMessageBodyWriter;
+import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.FullyFeaturedServerJacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.ServerJacksonMessageBodyReader;
-import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.ServerJacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayMessageBodyReader;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonObjectMessageBodyReader;
@@ -39,13 +41,15 @@ public class ResteasyReactiveJacksonProcessor {
     }
 
     @BuildStep
-    void additionalProviders(BuildProducer<AdditionalBeanBuildItem> additionalBean,
+    void additionalProviders(List<JacksonFeatureBuildItem> jacksonFeatureBuildItems,
+            BuildProducer<AdditionalBeanBuildItem> additionalBean,
             BuildProducer<MessageBodyReaderBuildItem> additionalReaders,
             BuildProducer<MessageBodyWriterBuildItem> additionalWriters) {
-        // make these beans to they can get instantiated with the Quarkus CDI configured Jsonb object
+        boolean applicationNeedsSpecialJacksonFeatures = jacksonFeatureBuildItems.isEmpty();
+        // make these beans to they can get instantiated with the Quarkus CDI configured ObjectMapper object
         additionalBean.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClass(ServerJacksonMessageBodyReader.class.getName())
-                .addBeanClass(ServerJacksonMessageBodyWriter.class.getName())
+                .addBeanClass(getJacksonMessageBodyWriter(applicationNeedsSpecialJacksonFeatures))
                 .setUnremovable().build());
 
         additionalReaders
@@ -60,7 +64,8 @@ public class ResteasyReactiveJacksonProcessor {
                         JsonObject.class.getName(),
                         Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(ServerJacksonMessageBodyWriter.class.getName(), Object.class.getName(),
+                .produce(new MessageBodyWriterBuildItem(getJacksonMessageBodyWriter(applicationNeedsSpecialJacksonFeatures),
+                        Object.class.getName(),
                         Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(VertxJsonArrayMessageBodyWriter.class.getName(),
@@ -70,5 +75,10 @@ public class ResteasyReactiveJacksonProcessor {
                 .produce(new MessageBodyWriterBuildItem(VertxJsonObjectMessageBodyWriter.class.getName(),
                         JsonObject.class.getName(),
                         Collections.singletonList(MediaType.APPLICATION_JSON)));
+    }
+
+    private String getJacksonMessageBodyWriter(boolean applicationNeedsSpecialJacksonFeatures) {
+        return applicationNeedsSpecialJacksonFeatures ? BasicServerJacksonMessageBodyWriter.class.getName()
+                : FullyFeaturedServerJacksonMessageBodyWriter.class.getName();
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.serialisers;
+
+import static io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyWriterUtil.createDefaultWriter;
+import static io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyWriterUtil.doLegacyWrite;
+import static org.jboss.resteasy.reactive.server.vertx.providers.serialisers.json.JsonMessageServerBodyWriterUtil.setContentTypeIfNecessary;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
+
+    private final ObjectWriter defaultWriter;
+
+    @Inject
+    public BasicServerJacksonMessageBodyWriter(ObjectMapper mapper) {
+        this.defaultWriter = createDefaultWriter(mapper);
+    }
+
+    @Override
+    public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
+        setContentTypeIfNecessary(context);
+        OutputStream stream = context.getOrCreateOutputStream();
+        if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
+            stream.write(((String) o).getBytes());
+        } else {
+            defaultWriter.writeValue(stream, o);
+        }
+        // we don't use try-with-resources because that results in writing to the http output without the exception mapping coming into play
+        stream.close();
+    }
+
+    @Override
+    public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        doLegacyWrite(o, annotations, httpHeaders, entityStream, defaultWriter);
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
@@ -28,14 +28,14 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
 
-public class ServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
+public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
     private final ObjectMapper originalMapper;
     private final ObjectWriter defaultWriter;
     private final ConcurrentMap<Method, ObjectWriter> perMethodWriter = new ConcurrentHashMap<>();
 
     @Inject
-    public ServerJacksonMessageBodyWriter(ObjectMapper mapper) {
+    public FullyFeaturedServerJacksonMessageBodyWriter(ObjectMapper mapper) {
         this.originalMapper = mapper;
         this.defaultWriter = createDefaultWriter(mapper);
     }


### PR DESCRIPTION
This is done by only engaging the MessageBodyWriter that supports these features
when the application actually makes use of the features.

The reason for doing this is to not pay the performance cost of checking
if each resource method makes use of these features if we know that
no resource method of the application uses them.