### PR TITLE
Dependency doc fix in the OIDC Bearer Token test section

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -486,15 +486,8 @@ Start by adding the following dependencies to your test project:
 [source,xml]
 ----
 <dependency>
-    <groupId>net.sourceforge.htmlunit</groupId>
-    <artifactId>htmlunit</artifactId>
-    <exclusions>
-        <exclusion>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>*</artifactId>
-       </exclusion>
-
-    </exclusions>
+    <groupId>io.rest-assured</groupId>
+    <artifactId>rest-assured</artifactId>
     <scope>test</scope>
 </dependency>
 <dependency>


### PR DESCRIPTION
This PR fixes a 2.0.0.x OIDC doc regression where the `rest-assured` dependency was replaced by the `html-unit` one (with one of the recent updates, copy and paste problem) 