### PR TITLE
Support Vert.x context switching

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -113,7 +113,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.15.4.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
-        <jboss-threads.version>3.2.0.Final</jboss-threads.version>
+        <jboss-threads.version>3.4.0.Final</jboss-threads.version>
         <vertx.version>4.1.0.CR1</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ContextHandlerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ContextHandlerBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.builditem;
+
+import org.jboss.threads.ContextHandler;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class ContextHandlerBuildItem extends SimpleBuildItem {
+    private final ContextHandler<Object> contextHandler;
+
+    public ContextHandlerBuildItem(ContextHandler<Object> contextHandler) {
+        this.contextHandler = contextHandler;
+    }
+
+    public ContextHandler<Object> contextHandler() {
+        return contextHandler;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ContextHandlerBuildItem;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
@@ -23,10 +24,13 @@ public class ThreadPoolSetup {
     public ExecutorBuildItem createExecutor(ExecutorRecorder recorder, ShutdownContextBuildItem shutdownContextBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
             ThreadPoolConfig threadPoolConfig,
-            Optional<ThreadFactoryBuildItem> threadFactoryBuildItem) {
+            Optional<ThreadFactoryBuildItem> threadFactoryBuildItem,
+            Optional<ContextHandlerBuildItem> contextBuildItem) {
         return new ExecutorBuildItem(
                 recorder.setupRunTime(shutdownContextBuildItem, threadPoolConfig, launchModeBuildItem.getLaunchMode(),
-                        threadFactoryBuildItem.map(ThreadFactoryBuildItem::getThreadFactory).orElse(null)));
+                        threadFactoryBuildItem.map(ThreadFactoryBuildItem::getThreadFactory).orElse(null),
+                        contextBuildItem.map(ContextHandlerBuildItem::contextHandler)
+                                .orElse(recorder.getDefaultContextHandler())));
     }
 
     @BuildStep

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
@@ -29,8 +29,7 @@ public class ThreadPoolSetup {
         return new ExecutorBuildItem(
                 recorder.setupRunTime(shutdownContextBuildItem, threadPoolConfig, launchModeBuildItem.getLaunchMode(),
                         threadFactoryBuildItem.map(ThreadFactoryBuildItem::getThreadFactory).orElse(null),
-                        contextBuildItem.map(ContextHandlerBuildItem::contextHandler)
-                                .orElse(recorder.getDefaultContextHandler())));
+                        contextBuildItem.map(ContextHandlerBuildItem::contextHandler).orElse(null)));
     }
 
     @BuildStep

--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -169,20 +169,6 @@ public class ExecutorRecorder {
         return builder.build();
     }
 
-    public ContextHandler<Object> getDefaultContextHandler() {
-        return new ContextHandler<Object>() {
-            @Override
-            public Object captureContext() {
-                return null;
-            }
-
-            @Override
-            public void runWith(Runnable task, Object context) {
-                task.run();
-            }
-        };
-    }
-
     public static Executor getCurrent() {
         return current;
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.logging.Logger;
+import org.jboss.threads.ContextHandler;
 import org.jboss.threads.EnhancedQueueExecutor;
 import org.jboss.threads.JBossExecutors;
 import org.jboss.threads.JBossThreadFactory;
@@ -30,8 +31,8 @@ public class ExecutorRecorder {
     private static volatile Executor current;
 
     public ExecutorService setupRunTime(ShutdownContext shutdownContext, ThreadPoolConfig threadPoolConfig,
-            LaunchMode launchMode, ThreadFactory threadFactory) {
-        final EnhancedQueueExecutor underlying = createExecutor(threadPoolConfig, threadFactory);
+            LaunchMode launchMode, ThreadFactory threadFactory, ContextHandler<Object> contextHandler) {
+        final EnhancedQueueExecutor underlying = createExecutor(threadPoolConfig, threadFactory, contextHandler);
         if (launchMode == LaunchMode.DEVELOPMENT) {
             shutdownContext.addLastShutdownTask(new Runnable() {
                 @Override
@@ -137,7 +138,8 @@ public class ExecutorRecorder {
         };
     }
 
-    private static EnhancedQueueExecutor createExecutor(ThreadPoolConfig threadPoolConfig, ThreadFactory threadFactory) {
+    private static EnhancedQueueExecutor createExecutor(ThreadPoolConfig threadPoolConfig, ThreadFactory threadFactory,
+            ContextHandler<Object> contextHandler) {
         if (threadFactory == null) {
             threadFactory = new JBossThreadFactory(new ThreadGroup("executor"), Boolean.TRUE, null,
                     "executor-thread-%t", JBossExecutors.loggingExceptionHandler("org.jboss.executor.uncaught"), null);
@@ -159,7 +161,26 @@ public class ExecutorRecorder {
         }
         builder.setGrowthResistance(threadPoolConfig.growthResistance);
         builder.setKeepAliveTime(threadPoolConfig.keepAliveTime);
+
+        if (contextHandler != null) {
+            builder.setContextHandler(contextHandler);
+        }
+
         return builder.build();
+    }
+
+    public ContextHandler<Object> getDefaultContextHandler() {
+        return new ContextHandler<Object>() {
+            @Override
+            public Object captureContext() {
+                return null;
+            }
+
+            @Override
+            public void runWith(Runnable task, Object context) {
+                task.run();
+            }
+        };
     }
 
     public static Executor getCurrent() {

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ContextHandlerBuildItem;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.IOThreadDetectorBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -114,5 +115,11 @@ class VertxCoreProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     ThreadFactoryBuildItem createVertxThreadFactory(VertxCoreRecorder recorder) {
         return new ThreadFactoryBuildItem(recorder.createThreadFactory());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    ContextHandlerBuildItem createVertxContextHandlers(VertxCoreRecorder recorder) {
+        return new ContextHandlerBuildItem(recorder.executionContextHandler());
     }
 }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -476,8 +476,8 @@ public class VertxCoreRecorder {
                 if (context != null) {
                     // Only do context handling if it's non null
                     final ContextInternal vertxContext = (ContextInternal) context;
+                    vertxContext.beginDispatch();
                     try {
-                        vertxContext.beginDispatch();
                         task.run();
                     } finally {
                         vertxContext.endDispatch(null);


### PR DESCRIPTION
- Updated to latest JBoss Threads
- Provide default context switcher to run the task without any context switch
- Add context switcher when Vert.x Core is present to use the context from the existing Thread and set it onto the new execution thread