### PR TITLE
Remove outdated maven-plugin-plugin version

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -10,9 +10,6 @@
     <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
     <name>Quarkus - Bootstrap - Maven plugin</name>
     <packaging>maven-plugin</packaging>
-    <properties>
-        <version.maven-plugin-plugin>3.5.2</version.maven-plugin-plugin>
-    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
The latest currently is 3.6.1 and the default one appears to be 3.6.0.