### PR TITLE
Upgrade to SmallRye GraphQL 1.2.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <smallrye-health.version>3.0.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.4</smallrye-open-api.version>
-        <smallrye-graphql.version>1.2.1</smallrye-graphql.version>
+        <smallrye-graphql.version>1.2.2</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.1.1</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -42,6 +42,18 @@ public class SmallRyeGraphQLConfig {
     boolean eventsEnabled;
 
     /**
+     * Enable GET Requests. Allow queries via HTTP GET.
+     */
+    @ConfigItem(name = "http.get.enabled")
+    Optional<Boolean> httpGetEnabled;
+
+    /**
+     * Enable Query parameter on POST Requests. Allow POST request to override or supply values in a query parameter.
+     */
+    @ConfigItem(name = "http.post.queryparameters.enabled")
+    Optional<Boolean> httpPostQueryParametersEnabled;
+
+    /**
      * Change the type naming strategy.
      */
     @ConfigItem(defaultValue = "Default")

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -236,9 +236,11 @@ public class SmallRyeGraphQLProcessor {
                 .build());
 
         // Queries and Mutations
-        Boolean allowGet = ConfigProvider.getConfig().getOptionalValue(ConfigKey.ALLOW_GET, boolean.class).orElse(false);
+        boolean allowGet = getBooleanConfigValue(graphQLConfig.httpGetEnabled, ConfigKey.ALLOW_GET, false);
+        boolean allowQueryParametersOnPost = getBooleanConfigValue(graphQLConfig.httpPostQueryParametersEnabled,
+                ConfigKey.ALLOW_POST_WITH_QUERY_PARAMETERS, false);
         Handler<RoutingContext> executionHandler = recorder.executionHandler(graphQLInitializedBuildItem.getInitialized(),
-                allowGet);
+                allowGet, allowQueryParametersOnPost);
         routeProducer.produce(httpRootPathBuildItem.routeBuilder()
                 .routeFunction(graphQLConfig.rootPath, recorder.routeFunction(bodyHandlerBuildItem.getHandler()))
                 .handler(executionHandler)
@@ -247,6 +249,11 @@ public class SmallRyeGraphQLProcessor {
                 .blockingRoute()
                 .build());
 
+    }
+
+    private boolean getBooleanConfigValue(Optional<Boolean> quarkusConfig, String smallryeKey, boolean defaultValue) {
+        return quarkusConfig
+                .orElse(ConfigProvider.getConfig().getOptionalValue(smallryeKey, boolean.class).orElse(defaultValue));
     }
 
     private String[] getSchemaJavaClasses(Schema schema) {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
@@ -1,12 +1,15 @@
 package io.quarkus.smallrye.graphql.deployment;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Properties;
 
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
 
 import org.hamcrest.CoreMatchers;
 
@@ -45,20 +48,29 @@ public abstract class AbstractGraphQLTest {
     }
 
     protected String getPayload(String query) {
-        JsonObject jsonObject = createRequestBody(query);
+        return getPayload(query, null);
+    }
+
+    protected String getPayload(String query, String variables) {
+        JsonObject jsonObject = createRequestBody(query, variables);
         return jsonObject.toString();
     }
 
-    protected JsonObject createRequestBody(String graphQL) {
-        return createRequestBody(graphQL, null);
-    }
-
-    protected JsonObject createRequestBody(String graphQL, JsonObject variables) {
+    protected JsonObject createRequestBody(String graphQL, String variables) {
         // Create the request
-        if (variables == null || variables.isEmpty()) {
-            variables = Json.createObjectBuilder().build();
+        JsonObject vjo = Json.createObjectBuilder().build();
+        if (variables != null && !variables.isEmpty()) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(variables))) {
+                vjo = jsonReader.readObject();
+            }
         }
-        return Json.createObjectBuilder().add(QUERY, graphQL).add(VARIABLES, variables).build();
+
+        JsonObjectBuilder job = Json.createObjectBuilder();
+        if (graphQL != null && !graphQL.isEmpty()) {
+            job.add(QUERY, graphQL);
+        }
+
+        return job.add(VARIABLES, vjo).build();
     }
 
     protected static String getPropertyAsString() {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpApi.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpApi.java
@@ -1,0 +1,19 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Id;
+import org.eclipse.microprofile.graphql.Query;
+
+/**
+ * This is to test compatibility with the GraphQL over HTTP Spec
+ * 
+ * @see <a href="https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md">GraphQL over HTTP<a/>
+ */
+@GraphQLApi
+public class GraphQLOverHttpApi {
+
+    @Query
+    public User getUser(@Id String id) {
+        return new User(id, "Koos", "van der Merwe");
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpTest.java
@@ -1,0 +1,161 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+/**
+ * This test compatibility with the GraphQL over HTTP Spec
+ */
+public class GraphQLOverHttpTest extends AbstractGraphQLTest {
+
+    private static final Logger LOG = Logger.getLogger(GraphQLOverHttpTest.class);
+    private static final String MEDIATYPE_GRAPHQL = "application/graphql";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GraphQLOverHttpApi.class, User.class)
+                    .addAsResource(new StringAsset(getPropertyAsString(configuration())), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void httpGetTest() {
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .get("/graphql?query=query(%24id%3A%20ID!)%7Buser(id%3A%24id)%7Bname%7D%7D&variables=%7B%22id%22%3A%22QVBJcy5ndXJ1%22%7D")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("{\"data\":{\"user\":{\"name\":\"Koos\"}}}"));
+    }
+
+    @Test
+    public void httpPostWithQueryInQueryParamTest() throws Exception {
+
+        Map<String, String> queryparams = new HashMap<>();
+        queryparams.put("query", "query ($id: ID!) {  user(id:$id) {    id    name  surname}}");
+
+        String variables = "{\"id\": \"1\"}";
+
+        post(null, queryparams, variables,
+                "{\"data\":{\"user\":{\"id\":\"1\",\"name\":\"Koos\",\"surname\":\"van der Merwe\"}}}"); // query in query parameter
+    }
+
+    @Test
+    public void httpPostWithQueryInQueryParamAndBodyTest() throws Exception {
+
+        Map<String, String> queryparams = new HashMap<>();
+        queryparams.put("query", "query ($id: ID!) {  user(id:$id) {    id    name  surname}}");
+
+        String variables = "{\"id\": \"1\"}";
+
+        String request = "query ($id: ID!) {\n" +
+                "  user(id:$id) {\n" +
+                "    name\n" +
+                "  }\n" +
+                "}";
+
+        post(request, queryparams, variables,
+                "{\"data\":{\"user\":{\"id\":\"1\",\"name\":\"Koos\",\"surname\":\"van der Merwe\"}}}"); // query in query parameter win
+    }
+
+    @Test
+    public void httpPostWithVariablesQueryParamTest() throws Exception {
+
+        String request = "query ($id: ID!) {\n" +
+                "  user(id:$id) {\n" +
+                "    id\n" +
+                "    name\n" +
+                "  }\n" +
+                "}";
+
+        String variables = "{\"id\": \"1\"}";
+
+        Map<String, String> queryparams = new HashMap<>();
+        queryparams.put("variables", "{\"id\": \"QVBJcy5ndXJ1\"}");
+
+        post(request, queryparams, variables, "{\"data\":{\"user\":{\"id\":\"QVBJcy5ndXJ1\",\"name\":\"Koos\"}}}"); // id in query parameter win
+    }
+
+    @Test
+    public void httpPostWithContentTypeHeader() throws Exception {
+
+        Map<String, String> queryparams = new HashMap<>();
+        queryparams.put("variables", "{\"id\": \"QVBJcy5ndXJ1\"}");
+
+        String request = "query ($id: ID!) {\n" +
+                "  user(id:$id) {\n" +
+                "    id\n" +
+                "    name\n" +
+                "    surname\n" +
+                "  }\n" +
+                "}";
+
+        postAsGraphQL(request, queryparams,
+                "{\"data\":{\"user\":{\"id\":\"QVBJcy5ndXJ1\",\"name\":\"Koos\",\"surname\":\"van der Merwe\"}}}");
+    }
+
+    private static Map<String, String> configuration() {
+        Map<String, String> m = new HashMap<>();
+        m.put("quarkus.smallrye-graphql.http.get.enabled", "true");
+        m.put("quarkus.smallrye-graphql.http.post.queryparameters.enabled", "true");
+        return m;
+    }
+
+    private void post(String request, Map<String, ?> queryparams, String variables, String expected) {
+        RequestSpecification requestSpecification = RestAssured.given();
+        if (queryparams != null) {
+            requestSpecification = requestSpecification.queryParams(queryparams);
+        }
+
+        requestSpecification.when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(getPayload(request, variables))
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString(expected));
+    }
+
+    private void postAsGraphQL(String request, Map<String, ?> queryparams, String expected) {
+        RequestSpecification requestSpecification = RestAssured.given().config(RestAssured.config()
+                .encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(MEDIATYPE_GRAPHQL, ContentType.TEXT)))
+                .contentType(MEDIATYPE_GRAPHQL);
+        if (queryparams != null) {
+            requestSpecification = requestSpecification.queryParams(queryparams);
+        }
+
+        requestSpecification.when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_GRAPHQL)
+                .body(request) // This is the important part.
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString(expected));
+
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/User.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/User.java
@@ -1,0 +1,67 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.util.Objects;
+
+public class User {
+    private String id;
+    private String name;
+    private String surname;
+
+    public User() {
+    }
+
+    public User(String id, String name, String surname) {
+        this.id = id;
+        this.name = name;
+        this.surname = surname;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 71 * hash + Objects.hashCode(this.id);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final User other = (User) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -30,9 +30,10 @@ public class SmallRyeGraphQLRecorder {
         return new RuntimeValue<>(graphQLSchema != null);
     }
 
-    public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet) {
+    public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet,
+            boolean allowPostWithQueryParameters) {
         if (initialized.getValue()) {
-            return new SmallRyeGraphQLExecutionHandler(allowGet, getCurrentIdentityAssociation(),
+            return new SmallRyeGraphQLExecutionHandler(allowGet, allowPostWithQueryParameters, getCurrentIdentityAssociation(),
                     CDI.current().select(CurrentVertxRequest.class).get());
         } else {
             return new SmallRyeGraphQLNoEndpointHandler();


### PR DESCRIPTION
This PR updates SmallRye GraphQL to version 1.2.2 (see https://github.com/smallrye/smallrye-graphql/releases/tag/1.2.2)
and also implements the "GraphQL over HTTP" spec properly (see https://github.com/graphql/graphql-over-http)

Fix #17349

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>