### PR TITLE
gRPC client injection - fix NPE

### DIFF
--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/MutinyClientInjectionFailureTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/MutinyClientInjectionFailureTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.grpc.client;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.examples.helloworld.GreeterClient;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MutinyClientInjectionFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage()).addClasses(HelloService.class))
+            .withConfigurationResource("hello-config.properties")
+            .setExpectedException(DeploymentException.class);
+
+    @Inject
+    MyConsumer service;
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    @ApplicationScoped
+    static class MyConsumer {
+
+        @GrpcClient("hello-service")
+        GreeterClient service;
+
+    }
+}


### PR DESCRIPTION
- a NPE is thrown when a service client impl (e.g. GreeterClient) is
injected instead of the service interface (e.g. Greeter)
- we do not support injection of the client impl, but it's possible to
cast the injected bean if needed