### PR TITLE
Let OIDC users block the opaque tokens if only JWT tokens are expected

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -744,6 +744,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem(defaultValue = "true")
         public boolean allowJwtIntrospection = true;
 
+        /**
+         * Allow the remote introspection of the opaque tokens.
+         *
+         * Set this property to 'false' if only JWT tokens are expected.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean allowOpaqueTokenIntrospection = true;
+
         public Optional<String> getIssuer() {
             return issuer;
         }
@@ -822,6 +830,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setAllowJwtIntrospection(boolean allowJwtIntrospection) {
             this.allowJwtIntrospection = allowJwtIntrospection;
+        }
+
+        public boolean isAllowOpaqueTokenIntrospection() {
+            return allowOpaqueTokenIntrospection;
+        }
+
+        public void setAllowOpaqueTokenIntrospection(boolean allowOpaqueTokenIntrospection) {
+            this.allowOpaqueTokenIntrospection = allowOpaqueTokenIntrospection;
         }
     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -58,6 +58,15 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.token.setAllowJwtIntrospection(false);
             config.setClientId("client");
             return config;
+        } else if ("tenant-oidc-no-opaque-token".equals(tenantId)) {
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("tenant-oidc-no-opaque-token");
+            String uri = context.request().absoluteURI();
+            String authServerUri = uri.replace("/tenant-opaque/tenant-oidc-no-opaque-token/api/user", "/oidc");
+            config.setAuthServerUrl(authServerUri);
+            config.token.setAllowOpaqueTokenIntrospection(false);
+            config.setClientId("client");
+            return config;
         } else if ("tenant-web-app-dynamic".equals(tenantId)) {
             OidcTenantConfig config = new OidcTenantConfig();
             config.setTenantId("tenant-web-app-dynamic");

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
@@ -10,7 +10,7 @@ import io.quarkus.oidc.OIDCException;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
-@Path("/tenant-opaque/tenant-oidc/api/user")
+@Path("/tenant-opaque")
 @Authenticated
 public class TenantOpaqueResource {
 
@@ -21,10 +21,17 @@ public class TenantOpaqueResource {
 
     @GET
     @RolesAllowed("user")
+    @Path("tenant-oidc/api/user")
     public String userName() {
         if (!identity.getCredential(AccessTokenCredential.class).isOpaque()) {
             throw new OIDCException("Opaque token is expected");
         }
         return "tenant-oidc-opaque:" + identity.getPrincipal().getName();
+    }
+
+    @GET
+    @Path("tenant-oidc-no-opaque-token/api/user")
+    public String userNameNoOpaqueToken() {
+        throw new OIDCException("This method must not be invoked because the opaque tokens are not allowed");
     }
 }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -357,6 +357,20 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testOpaqueTokenIntrospectionDisallowed() {
+        RestAssured.when().post("/oidc/introspection-endpoint-call-count").then().body(equalTo("0"));
+
+        // Verify the the opaque token is rejected with 401 
+        RestAssured.given().auth().oauth2(getOpaqueAccessTokenFromSimpleOidc())
+                .when().get("/tenant-opaque/tenant-oidc-no-opaque-token/api/user")
+                .then()
+                .statusCode(401);
+
+        // Confirm no introspection request has been made
+        RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("0"));
+    }
+
+    @Test
     public void testResolveTenantIdentifierWebAppDynamic() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app-dynamic/api/user/webapp");


### PR DESCRIPTION
Fixes #17457.

This PR introduces a new `quarkus.oidc.token.allow-opaque-token-introspection` property to support the secure deployments expecting JWT tokens only and wishing to avoid any potential slowing down of the endpoint when an opaque (possibly intentionally misformatted JWT sequence) token is sent to Quarkus - since the only way to verify the opaque token is to attempt to verify it remotely 