### PR TITLE
Introduce build item to override weak reflection semantics

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ForceNonWeakReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ForceNonWeakReflectiveClassBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Forces classes that have been registered for reflection using weak semantics, to revert to normal reflection registration
+ * semantics.
+ * Essentially if this build item is used for a class that has been registered with {@link ReflectiveClassBuildItem},
+ * the {@code weak} field of that class is effectively false, no matter what value was supplied when creating
+ * {@code ReflectiveClassBuildItem}
+ */
+public final class ForceNonWeakReflectiveClassBuildItem extends MultiBuildItem {
+
+    private final String className;
+
+    public ForceNonWeakReflectiveClassBuildItem(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
@@ -22,6 +22,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ForceNonWeakReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -82,6 +83,7 @@ public class NativeImageAutoFeatureStep {
             List<ReflectiveMethodBuildItem> reflectiveMethods,
             List<ReflectiveFieldBuildItem> reflectiveFields,
             List<ReflectiveClassBuildItem> reflectiveClassBuildItems,
+            List<ForceNonWeakReflectiveClassBuildItem> nonWeakReflectiveClassBuildItems,
             List<ServiceProviderBuildItem> serviceProviderBuildItems,
             List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields,
             List<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses) {
@@ -259,8 +261,13 @@ public class NativeImageAutoFeatureStep {
         int count = 0;
 
         final Map<String, ReflectionInfo> reflectiveClasses = new LinkedHashMap<>();
+        final Set<String> forcedNonWeakClasses = new HashSet<>();
+        for (ForceNonWeakReflectiveClassBuildItem nonWeakReflectiveClassBuildItem : nonWeakReflectiveClassBuildItems) {
+            forcedNonWeakClasses.add(nonWeakReflectiveClassBuildItem.getClassName());
+        }
         for (ReflectiveClassBuildItem i : reflectiveClassBuildItems) {
-            addReflectiveClass(reflectiveClasses, i.isConstructors(), i.isMethods(), i.isFields(), i.areFinalFieldsWritable(),
+            addReflectiveClass(reflectiveClasses, forcedNonWeakClasses, i.isConstructors(), i.isMethods(), i.isFields(),
+                    i.areFinalFieldsWritable(),
                     i.isWeak(),
                     i.getClassNames().toArray(new String[0]));
         }
@@ -272,7 +279,7 @@ public class NativeImageAutoFeatureStep {
         }
 
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
-            addReflectiveClass(reflectiveClasses, true, false, false, false, false,
+            addReflectiveClass(reflectiveClasses, forcedNonWeakClasses, true, false, false, false, false,
                     i.providers().toArray(new String[] {}));
         }
 
@@ -445,13 +452,15 @@ public class NativeImageAutoFeatureStep {
         }
     }
 
-    public void addReflectiveClass(Map<String, ReflectionInfo> reflectiveClasses, boolean constructors, boolean method,
+    public void addReflectiveClass(Map<String, ReflectionInfo> reflectiveClasses, Set<String> forcedNonWeakClasses,
+            boolean constructors, boolean method,
             boolean fields, boolean finalFieldsWritable, boolean weak,
             String... className) {
         for (String cl : className) {
             ReflectionInfo existing = reflectiveClasses.get(cl);
             if (existing == null) {
-                reflectiveClasses.put(cl, new ReflectionInfo(constructors, method, fields, finalFieldsWritable, weak));
+                reflectiveClasses.put(cl, new ReflectionInfo(constructors, method, fields, finalFieldsWritable,
+                        !forcedNonWeakClasses.contains(cl) && weak));
             } else {
                 if (constructors) {
                     existing.constructors = true;


### PR DESCRIPTION
This is needed in cases where an extension might have more precise information that extension that originated the weak reflection semantics.

cc @goldmann who's kubernetes related use case lead to this (your extension would need to generate these build items for every Kubernetes API type it recognizes)