### PR TITLE
Gradle: create quarkusDeploymentOnlyClasspath configuration

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>readline</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -66,6 +66,7 @@ import io.quarkus.runtime.util.HashUtil;
 
 public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<ModelParameter> {
 
+    private static final String QUARKUS_DEPLOYMENT_ONLY_CLASSPATH = "quarkusDeploymentOnlyClasspath";
     private static final String MAIN_RESOURCES_OUTPUT = "build/resources/main";
     private static final String CLASSES_OUTPUT = "build/classes";
 
@@ -291,8 +292,13 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
             Collection<org.gradle.api.artifacts.Dependency> extensions) {
         final List<Dependency> platformDependencies = new LinkedList<>();
 
-        final Configuration deploymentConfig = project.getConfigurations()
-                .detachedConfiguration(extensions.toArray(new org.gradle.api.artifacts.Dependency[0]));
+        Configuration deploymentConfig = project.getConfigurations().findByName(QUARKUS_DEPLOYMENT_ONLY_CLASSPATH);
+        if (deploymentConfig == null) {
+            deploymentConfig = project.getConfigurations().create(QUARKUS_DEPLOYMENT_ONLY_CLASSPATH)
+                    .defaultDependencies(a -> {
+                        a.addAll(extensions);
+                    });
+        }
         final ResolvedConfiguration rc = deploymentConfig.getResolvedConfiguration();
         for (ResolvedArtifact a : rc.getResolvedArtifacts()) {
             if (!isDependency(a)) {

--- a/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-multi-module/application/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
 
     // Library-2 has to be dependency as implementation and test fixture
     implementation(project(':library-2'))


### PR DESCRIPTION
Currently the exclusions configured in the Gradle scripts are ignored when resolving the deployment dependencies.
Switching to the detached configuration to a named one seems to fix it.

@glefloch this may not be needed with the refactoring you are working on but until it's merged we need this.