### PR TITLE
Scheduler - use an application class predicate when generating invokers

### DIFF
--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -15,6 +15,8 @@ import io.quarkus.scheduler.Scheduled.Schedules;
 /**
  * Marks a business method to be automatically scheduled and invoked by the container.
  * <p>
+ * The target business method must be non-private and non-static.
+ * <p>
  * The schedule is defined either by {@link #cron()} or by {@link #every()} attribute. If both are specified, the cron
  * expression takes precedence.
  *


### PR DESCRIPTION
- until now all invokers were considered application classes, i.e. they
were always loaded by the Runtime Class Loader in the dev mode and so a
package-private scheduled method defined in a dependency resulted in an
IllegalAccessError
- resolves #17492