### PR TITLE
Bump kotlin version of integration-test projects

### DIFF
--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.32</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.32</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This update the kotlin version of sample project used in `integration-test`. I went through all modules, every modules look to be in `1.4.32`