### PR TITLE
Allows to define the loading of jdbc metadata on the .properties or persistence.xml

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -199,6 +199,13 @@ public class HibernateOrmConfigPersistenceUnit {
     @ConfigItem
     public Optional<String> multitenantSchemaDatasource;
 
+    /**
+     * This setting is used to control whether we should consult the JDBC metadata to determine certain Settings default values.
+     * In some specific cases the detection is not necessary and speeds up the application startup.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useJdbcMetadataDefaults;
+
     public boolean isAnyPropertySet() {
         return datasource.isPresent() ||
                 packages.isPresent() ||
@@ -216,7 +223,8 @@ public class HibernateOrmConfigPersistenceUnit {
                 !secondLevelCachingEnabled ||
                 multitenant.isPresent() ||
                 multitenantSchemaDatasource.isPresent() ||
-                fetch.isAnyPropertySet();
+                fetch.isAnyPropertySet() ||
+                !useJdbcMetadataDefaults;
     }
 
     @ConfigGroup

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -142,6 +142,7 @@ public final class HibernateOrmProcessor {
     private static final Logger LOG = Logger.getLogger(HibernateOrmProcessor.class);
 
     private static final String INTEGRATOR_SERVICE_FILE = "META-INF/services/org.hibernate.integrator.spi.Integrator";
+    private static final String USE_JDBC_METADATA_DEFAULTS = "hibernate.temp.use_jdbc_metadata_defaults";
 
     @BuildStep
     void checkTransactionsSupport(Capabilities capabilities) {
@@ -993,6 +994,10 @@ public final class HibernateOrmProcessor {
         if (isMySQLOrMariaDB(dialect.get()) && persistenceUnitConfig.dialect.storageEngine.isPresent()) {
             storageEngineCollector.add(persistenceUnitConfig.dialect.storageEngine.get());
         }
+
+        // JDBC Metadata
+        descriptor.getProperties().setProperty(USE_JDBC_METADATA_DEFAULTS,
+                String.valueOf(persistenceUnitConfig.useJdbcMetadataDefaults));
 
         persistenceUnitDescriptors.produce(
                 new PersistenceUnitDescriptorBuildItem(descriptor, dataSource,

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsDefaultValueTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class)
+                    .addAsResource("application-use-jdbc-metadata-defaults-default-value.properties",
+                            "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @ActivateRequestContext
+    @Test
+    public void testDefaultValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+        assertEquals("true", properties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueWithMultiplePUsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueWithMultiplePUsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsDefaultValueWithMultiplePUsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-pu-use-jdbc-metadata-defaults-default-value.properties",
+                            "application.properties"));
+
+    @PersistenceUnit("users")
+    @Inject
+    EntityManager emUsers;
+
+    @PersistenceUnit("inventory")
+    @Inject
+    EntityManager emInventory;
+
+    @ActivateRequestContext
+    @Test
+    public void testDefaultValue() {
+        Map<String, Object> usersProperties = emUsers.getEntityManagerFactory().getProperties();
+        assertEquals("true", usersProperties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+
+        Map<String, Object> inventoryProperties = emUsers.getEntityManagerFactory().getProperties();
+        assertEquals("true", inventoryProperties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueWithPersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsDefaultValueWithPersistenceXmlTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.xml.persistence.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsDefaultValueWithPersistenceXmlTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class)
+                    .addAsManifestResource("META-INF/persistence-use-jdbc-metadata-defaults-default-value.xml",
+                            "persistence.xml")
+                    .addAsResource("application-datasource-only.properties", "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @ActivateRequestContext
+    @Test
+    public void testDefaultValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+
+        // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
+        assertEquals("templatePU", properties.get("hibernate.ejb.persistenceUnitName"));
+        assertEquals("true", properties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsFalseTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class)
+                    .addAsResource("application-use-jdbc-metadata-defaults-false-value.properties", "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @ActivateRequestContext
+    @Test
+    public void testFalseValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+        assertEquals("false", properties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseValueWithMultiplePUsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseValueWithMultiplePUsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsFalseValueWithMultiplePUsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-pu-use-jdbc-metadata-defaults-false-value.properties",
+                            "application.properties"));
+
+    @PersistenceUnit("users")
+    @Inject
+    EntityManager emUsers;
+
+    @PersistenceUnit("inventory")
+    @Inject
+    EntityManager emInventory;
+
+    @ActivateRequestContext
+    @Test
+    public void testFalseValue() {
+        Map<String, Object> usersProperties = emUsers.getEntityManagerFactory().getProperties();
+        assertEquals("false", usersProperties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+
+        Map<String, Object> inventoryProperties = emUsers.getEntityManagerFactory().getProperties();
+        assertEquals("false", inventoryProperties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseValueWithPersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/use_jdbc_metadata_defaults/UseJdbcMetadataDefaultsFalseValueWithPersistenceXmlTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.hibernate.orm.use_jdbc_metadata_defaults;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.xml.persistence.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UseJdbcMetadataDefaultsFalseValueWithPersistenceXmlTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class)
+                    .addAsManifestResource("META-INF/persistence-use-jdbc-metadata-defaults-false-value.xml", "persistence.xml")
+                    .addAsResource("application-datasource-only.properties", "application.properties"));
+
+    @Inject
+    EntityManager em;
+
+    @ActivateRequestContext
+    @Test
+    public void testFalseValue() {
+        Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
+
+        // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
+        assertEquals("templatePU", properties.get("hibernate.ejb.persistenceUnitName"));
+        assertEquals("false", properties.get("hibernate.temp.use_jdbc_metadata_defaults"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/META-INF/persistence-use-jdbc-metadata-defaults-default-value.xml
+++ b/extensions/hibernate-orm/deployment/src/test/resources/META-INF/persistence-use-jdbc-metadata-defaults-default-value.xml
@@ -1,0 +1,30 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="templatePU" transaction-type="JTA">
+
+        <description>Hibernate test case template Persistence Unit</description>
+
+        <class>io.quarkus.hibernate.orm.xml.persistence.MyEntity</class>
+
+        <properties>
+            <!-- intentionally using worse case so that we can optimise for this -->
+            <property name="hibernate.archive.autodetection" value="class, hbm"/>
+
+            <!-- Connection specific -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!--
+                Optimistically create the tables;
+                will cause background errors being logged if they already exist,
+                but is practical to retain existing data across runs (or create as needed) -->
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+
+            <property name="javax.persistence.validation.mode" value="NONE"/>
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/extensions/hibernate-orm/deployment/src/test/resources/META-INF/persistence-use-jdbc-metadata-defaults-false-value.xml
+++ b/extensions/hibernate-orm/deployment/src/test/resources/META-INF/persistence-use-jdbc-metadata-defaults-false-value.xml
@@ -1,0 +1,33 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="templatePU" transaction-type="JTA">
+
+        <description>Hibernate test case template Persistence Unit</description>
+
+        <class>io.quarkus.hibernate.orm.xml.persistence.MyEntity</class>
+
+        <properties>
+            <!-- intentionally using worse case so that we can optimise for this -->
+            <property name="hibernate.archive.autodetection" value="class, hbm"/>
+
+            <!-- Connection specific -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!-- Change the default value to false -->
+            <property name="hibernate.temp.use_jdbc_metadata_defaults" value="false" />
+            
+            <!--
+                Optimistically create the tables;
+                will cause background errors being logged if they already exist,
+                but is practical to retain existing data across runs (or create as needed) -->
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+
+            <property name="javax.persistence.validation.mode" value="NONE"/>
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-use-jdbc-metadata-defaults-default-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-use-jdbc-metadata-defaults-default-value.properties
@@ -1,0 +1,15 @@
+quarkus.datasource.users.db-kind=h2
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+
+quarkus.datasource.inventory.db-kind=h2
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+
+quarkus.hibernate-orm."users".dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm."users".database.generation=drop-and-create
+quarkus.hibernate-orm."users".datasource=users
+quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
+
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm."inventory".database.generation=drop-and-create
+quarkus.hibernate-orm."inventory".datasource=inventory
+quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-use-jdbc-metadata-defaults-false-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-use-jdbc-metadata-defaults-false-value.properties
@@ -1,0 +1,17 @@
+quarkus.datasource.users.db-kind=h2
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+
+quarkus.datasource.inventory.db-kind=h2
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+
+quarkus.hibernate-orm."users".dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm."users".database.generation=drop-and-create
+quarkus.hibernate-orm."users".datasource=users
+quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user
+quarkus.hibernate-orm."users".use-jdbc-metadata-defaults=false
+
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm."inventory".database.generation=drop-and-create
+quarkus.hibernate-orm."inventory".datasource=inventory
+quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory
+quarkus.hibernate-orm."inventory".use-jdbc-metadata-defaults=false

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-use-jdbc-metadata-defaults-default-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-use-jdbc-metadata-defaults-default-value.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-use-jdbc-metadata-defaults-false-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-use-jdbc-metadata-defaults-false-value.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.use-jdbc-metadata-defaults=false

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -188,8 +188,7 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                 }
             }
 
-            // Allow detection of driver/database capabilities on runtime init (was disabled during static init)
-            runtimeSettingsBuilder.put("hibernate.temp.use_jdbc_metadata_defaults", "true");
+            setJdbcMetadataDefaults(runtimeSettingsBuilder, persistenceUnit);
 
             RuntimeSettings runtimeSettings = runtimeSettingsBuilder.build();
 
@@ -366,6 +365,15 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             runtimeSettingsBuilder.put(AvailableSettings.LOG_JDBC_WARNINGS,
                     persistenceUnitConfig.log.jdbcWarnings.get().toString());
         }
+    }
+
+    /**
+     * Allow/Not Allow detection of driver/database capabilities on runtime init (was disabled during static init).
+     * In some specific cases the detection is slow and not necessary for the application to work correctly.
+     */
+    private static void setJdbcMetadataDefaults(Builder runtimeSettingsBuilder, PersistenceUnitDescriptor persistenceUnit) {
+        runtimeSettingsBuilder.put("hibernate.temp.use_jdbc_metadata_defaults",
+                persistenceUnit.getProperties().getOrDefault("hibernate.temp.use_jdbc_metadata_defaults", "true"));
     }
 
 }


### PR DESCRIPTION
Allow hibernate property "hibernate.temp.use_jdbc_metadata_defaults" to be configured from application.properties or persistence.xml. The jdbc metadata is not always required and loading it may be very slow in some cases.

Resolves #16927