### PR TITLE
Unify NativeBuildReport usage via jbang in GH workflows

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -54,17 +54,13 @@ jobs:
 
       - name: Report
         if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
-          STATUS: ${{ job.status }}
-          ISSUE_NUMBER: "12111"
+        shell: bash
         run: |
-          echo "The report step got status: ${STATUS}"
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
-            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-          sudo apt-get install -y gnupg2 gnupg-agent
-          echo Installing SDKMAN
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
-          sdk install jbang 0.36.1
-          jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="${GITHUB_REPOSITORY}" issueNumber="${ISSUE_NUMBER}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          ~/.jbang/bin/jbang .github/NativeBuildReport.java \
+            issueNumber=12111 \
+            runId=${{ github.run_id }} \
+            status=${{ job.status }} \
+            token=${{ secrets.GITHUB_API_TOKEN }} \
+            issueRepo=${{ github.repository }} \
+            thisRepo=${{ github.repository }}

--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -59,18 +59,14 @@ jobs:
 
       - name: Report
         if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
-          STATUS: ${{ job.status }}
-          JAVA_VERSION: ${{ matrix.java }}
+        shell: bash
         run: |
-          echo "The report step got status: ${STATUS}"
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
-            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-          sudo apt-get install -y gnupg2 gnupg-agent
-          echo Installing SDKMAN
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
-          sdk install jbang 0.21.0
           [[ ${JAVA_VERSION} = 8 ]] && ISSUE_NUMBER="6717" || ISSUE_NUMBER="6723"
-          jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="${GITHUB_REPOSITORY}" issueNumber="${ISSUE_NUMBER}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          ~/.jbang/bin/jbang .github/NativeBuildReport.java \
+            issueNumber=${ISSUE_NUMBER} \
+            runId=${{ github.run_id }} \
+            status=${{ job.status }} \
+            token=${{ secrets.GITHUB_API_TOKEN }} \
+            issueRepo=${{ github.repository }} \
+            thisRepo=${{ github.repository }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -34,17 +34,13 @@ jobs:
             clean install
       - name: Report
         if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
-          STATUS: ${{ job.status }}
-          ISSUE_NUMBER: "13058"
+        shell: bash
         run: |
-          echo "The report step got status: ${STATUS}"
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
-            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-          sudo apt-get install -y gnupg2 gnupg-agent
-          echo Installing SDKMAN
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
-          sdk install jbang 0.52.1
-          jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="${GITHUB_REPOSITORY}" issueNumber="${ISSUE_NUMBER}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          ~/.jbang/bin/jbang .github/NativeBuildReport.java \
+            issueNumber=13058 \
+            runId=${{ github.run_id }} \
+            status=${{ job.status }} \
+            token=${{ secrets.GITHUB_API_TOKEN }} \
+            issueRepo=${{ github.repository }} \
+            thisRepo=${{ github.repository }}


### PR DESCRIPTION
Way simpler (IMO), with latest jbang version. Just like here: https://github.com/quarkusio/quarkus/blob/main/.github/workflows/jdk-early-access-build.yml#L109-L120