### PR TITLE
Ensure that VertxInputStream doesn't result in infinite attempts to read data

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -131,7 +131,7 @@ public class VertxInputStream extends InputStream {
             throw new IOException("Stream is closed");
         }
         if (finished) {
-            return -1;
+            return 0;
         }
 
         return exchange.readBytesAvailable();

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -130,7 +130,7 @@ public class VertxInputStream extends InputStream {
             throw new IOException("Stream is closed");
         }
         if (finished) {
-            return -1;
+            return 0;
         }
 
         return exchange.readBytesAvailable();


### PR DESCRIPTION
This change is needed because Netty now calls available to determine
whether or not more bytes are available, before calling read.
The negative value that we used to use does not play well with
PushbackInputStream which is used by Netty to wrap the stream.
For a full description of how I can came to this, see
https://github.com/quarkusio/quarkus/issues/17506#issuecomment-851365258

Fixes: #17506