### PR TITLE
Allow extensions to suppress build time config change warnings

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/SuppressNonRuntimeConfigChangedWarningBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/SuppressNonRuntimeConfigChangedWarningBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Allows extensions to suppress the runtime warning that Quarkus emits on startup when a non-runtime configuration
+ * options is different at runtime than build time.
+ * An example usage of this is when a user provides some test value in {@code application.properties}
+ * for a build-time only property and only provides the actual value on the command line when building Quarkus.
+ * In such a case we don't want the value set at build time to be revealed at runtime as it could be sensitive.
+ */
+public final class SuppressNonRuntimeConfigChangedWarningBuildItem extends MultiBuildItem {
+
+    private final String configKey;
+
+    public SuppressNonRuntimeConfigChangedWarningBuildItem(String configKey) {
+        this.configKey = configKey;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+}

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
@@ -11,6 +11,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.SuppressNonRuntimeConfigChangedWarningBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeSourcesBuild;
 
@@ -22,7 +23,13 @@ public class ContainerImageProcessor {
     @BuildStep(onlyIf = NativeSourcesBuild.class)
     void failForNativeSources(BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
         throw new IllegalArgumentException(
-                "The Container Imagee extensions are incompatible with the 'native-sources' package type.");
+                "The Container Image extensions are incompatible with the 'native-sources' package type.");
+    }
+
+    @BuildStep
+    public void ignoreCredentialsChange(BuildProducer<SuppressNonRuntimeConfigChangedWarningBuildItem> producer) {
+        producer.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.container-image.username"));
+        producer.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.container-image.password"));
     }
 
     @BuildStep


### PR DESCRIPTION
Fixes: #17519

Based on the example mentioned in that issue, with `main` one would see:

```
2021-05-31 13:56:48,133 WARN  [io.qua.run.con.ConfigChangeRecorder] (main) Build time property cannot be changed at runtime:
 - quarkus.container-image.password was 'SOME_PREPROD_PASSWORD' at build time and is now 'SOME_DEV_PASSWORD'
```

With this PR that warning does not appear