### PR TITLE
Updated SmallRye GraphQL to 1.2.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <smallrye-health.version>3.0.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.4</smallrye-open-api.version>
-        <smallrye-graphql.version>1.2.2</smallrye-graphql.version>
+        <smallrye-graphql.version>1.2.3</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.1.1</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.graphql.deployment;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -58,6 +59,35 @@ public class SmallRyeGraphQLConfig {
      */
     @ConfigItem(defaultValue = "Default")
     TypeAutoNameStrategy autoNameStrategy;
+
+    /**
+     * List of extension fields that should be included in the error response.
+     * By default none will be included. Examples of valid values include
+     * [exception,classification,code,description,validationErrorType,queryPath]
+     */
+    @ConfigItem
+    Optional<List<String>> errorExtensionFields;
+
+    /**
+     * List of Runtime Exceptions class names that should show the error message.
+     * By default Runtime Exception messages will be hidden and a generic `Server Error` message will be returned.
+     */
+    @ConfigItem
+    Optional<List<String>> showRuntimeExceptionMessage;
+
+    /**
+     * List of Checked Exceptions class names that should hide the error message.
+     * By default Checked Exception messages will show the exception message.
+     */
+    @ConfigItem
+    Optional<List<String>> hideCheckedExceptionMessage;
+
+    /**
+     * The default error message that will be used for hidden exception messages.
+     * Defaults to "Server Error"
+     */
+    @ConfigItem
+    Optional<String> defaultErrorMessage;
 
     /**
      * SmallRye GraphQL UI configuration

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -66,7 +66,6 @@ import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Group;
 import io.smallrye.graphql.schema.model.InputType;
-import io.smallrye.graphql.schema.model.InterfaceType;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.Schema;
@@ -333,9 +332,9 @@ public class SmallRyeGraphQLProcessor {
         return classes;
     }
 
-    private Set<String> getInterfaceClassNames(Collection<InterfaceType> complexGraphQLTypes) {
+    private Set<String> getInterfaceClassNames(Collection<Type> complexGraphQLTypes) {
         Set<String> classes = new HashSet<>();
-        for (InterfaceType complexGraphQLType : complexGraphQLTypes) {
+        for (Type complexGraphQLType : complexGraphQLTypes) {
             classes.add(complexGraphQLType.getClassName());
             classes.addAll(getFieldClassNames(complexGraphQLType.getFields()));
         }
@@ -361,6 +360,34 @@ public class SmallRyeGraphQLProcessor {
             }
         }
         return classes;
+    }
+
+    // Other Config Mappings
+
+    @BuildStep
+    void configMapping(SmallRyeGraphQLConfig graphQLConfig,
+            BuildProducer<SystemPropertyBuildItem> systemProperties) {
+
+        if (graphQLConfig.errorExtensionFields.isPresent()) {
+            systemProperties.produce(new SystemPropertyBuildItem(ConfigKey.ERROR_EXTENSION_FIELDS,
+                    graphQLConfig.errorExtensionFields.get().stream().collect(Collectors.joining(", "))));
+        }
+
+        if (graphQLConfig.showRuntimeExceptionMessage.isPresent()) {
+            systemProperties.produce(new SystemPropertyBuildItem("mp.graphql.showErrorMessage",
+                    graphQLConfig.showRuntimeExceptionMessage.get().stream().collect(Collectors.joining(", "))));
+        }
+
+        if (graphQLConfig.hideCheckedExceptionMessage.isPresent()) {
+            systemProperties.produce(new SystemPropertyBuildItem("mp.graphql.hideErrorMessage",
+                    graphQLConfig.hideCheckedExceptionMessage.get().stream().collect(Collectors.joining(", "))));
+        }
+
+        if (graphQLConfig.defaultErrorMessage.isPresent()) {
+            systemProperties.produce(
+                    new SystemPropertyBuildItem(ConfigKey.DEFAULT_ERROR_MESSAGE, graphQLConfig.defaultErrorMessage.get()));
+        }
+
     }
 
     // Services Integrations

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -19,9 +19,7 @@
         <module>microprofile-fault-tolerance</module>
         <module>microprofile-health</module>
         <module>microprofile-jwt</module>
-        <!-- TODO - MP4 - Require SR GraphQL update
         <module>microprofile-graphql</module>
-        -->
         <module>microprofile-metrics</module>
         <module>microprofile-reactive-messaging</module>
         <module>microprofile-rest-client</module>


### PR DESCRIPTION
This PR Update SmallRye GraphQL to version 1.2.3 (see https://github.com/smallrye/smallrye-graphql/releases/tag/1.2.3)

Also, as discussed on Zulip, adding more configuration mapping w.r.t Errors and Exceptions.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>