### PR TITLE
SmallRye GraphQL Client: remove hard dependency on Rest client

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/pom.xml
+++ b/extensions/smallrye-graphql-client/deployment/pom.xml
@@ -27,12 +27,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Testing applications act as GraphQL server as well -->

--- a/extensions/smallrye-graphql-client/runtime/pom.xml
+++ b/extensions/smallrye-graphql-client/runtime/pom.xml
@@ -28,10 +28,6 @@
             <artifactId>smallrye-graphql-client-implementation-jaxrs</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
         </dependency>

--- a/integration-tests/smallrye-graphql-client/pom.xml
+++ b/integration-tests/smallrye-graphql-client/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This PR removes the hard dependency on Rest Client, so that client can choose the client they want to use (normal/reactive)

Future releases of SmallRye GraphQL Client will remove the dependency on Rest Client.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>