### PR TITLE
Update to SmallRye JWT 3.2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -49,7 +49,7 @@
         <smallrye-graphql.version>1.2.3</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>3.1.1</smallrye-jwt.version>
+        <smallrye-jwt.version>3.2.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-utils.version>2.5.1</smallrye-reactive-utils.version>


### PR DESCRIPTION
The only reason it is `3.2.0` is because it includes MP JWT 1.2.1 - which itself only includes a few spec text and doc typo fixes and other minor text updates. Two JWT Build API optimizations are included as well 