### PR TITLE
Use project's Quarkus version when resolving extension catalogs using a registry client

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -73,7 +73,8 @@ public class MavenProjectBuildFile extends BuildFile {
         if (projectPom == null) {
             managedDeps = Collections.emptyList();
             deps = () -> Collections.emptyList();
-            quarkusVersion = defaultQuarkusVersion.get();
+            // TODO allow multiple streams in the same catalog for now
+            quarkusVersion = null;// defaultQuarkusVersion.get();
         } else {
             final ArtifactDescriptorResult descriptor = describe(mvnResolver, projectPom);
             managedDeps = toArtifactCoords(descriptor.getManagedDependencies());
@@ -87,8 +88,8 @@ public class MavenProjectBuildFile extends BuildFile {
                 : ExtensionCatalogResolver.empty();
         if (catalogResolver.hasRegistries()) {
             try {
-                //extensionCatalog = catalogResolver.resolveExtensionCatalog(quarkusVersion);
-                extensionCatalog = catalogResolver.resolveExtensionCatalog();
+                extensionCatalog = quarkusVersion == null ? catalogResolver.resolveExtensionCatalog()
+                        : catalogResolver.resolveExtensionCatalog(quarkusVersion);
             } catch (RegistryResolutionException e) {
                 throw new RuntimeException("Failed to resolve extension catalog", e);
             }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -484,16 +484,17 @@ public class ExtensionCatalogResolver {
             }
             for (Platform p : platforms) {
                 for (PlatformStream s : p.getStreams()) {
-                    final PlatformRelease r = s.getRecommendedRelease();
-                    final String upstreamQuarkusCoreVersion = r.getUpstreamQuarkusCoreVersion();
-                    if (upstreamQuarkusCoreVersion != null
-                            && !registriesByQuarkusCore.containsKey(upstreamQuarkusCoreVersion)) {
-                        upstreamQuarkusVersions.add(upstreamQuarkusCoreVersion);
-                    }
-                    for (ArtifactCoords bom : r.getMemberBoms()) {
-                        final ExtensionCatalog catalog = registry.resolvePlatformExtensions(bom);
-                        if (catalog != null) {
-                            extensionCatalogs.add(catalog);
+                    for (PlatformRelease r : s.getReleases()) {
+                        final String upstreamQuarkusCoreVersion = r.getUpstreamQuarkusCoreVersion();
+                        if (upstreamQuarkusCoreVersion != null
+                                && !registriesByQuarkusCore.containsKey(upstreamQuarkusCoreVersion)) {
+                            upstreamQuarkusVersions.add(upstreamQuarkusCoreVersion);
+                        }
+                        for (ArtifactCoords bom : r.getMemberBoms()) {
+                            final ExtensionCatalog catalog = registry.resolvePlatformExtensions(bom);
+                            if (catalog != null) {
+                                extensionCatalogs.add(catalog);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Without this change registry client-based approach will be ignoring the Quarkus version used in an existing project.