### PR TITLE
Add `quarkus.hibernate-orm.scripts.generation.delimiter` config property

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -340,6 +340,8 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_HALT_ON_ERROR, "true");
         }
 
+        runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_DELIMITER,
+                persistenceUnitConfig.scripts.generation.delimiter);
         runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_ACTION,
                 persistenceUnitConfig.scripts.generation.generation);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -108,6 +108,12 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         public String generation = "none";
 
         /**
+         * Specifies the statement delimiter to be used for the generated DDL scripts.
+         */
+        @ConfigItem(defaultValue = ";")
+        public String delimiter;
+
+        /**
          * Filename or URL where the database create DDL file should be generated.
          */
         @ConfigItem
@@ -121,6 +127,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
 
         public boolean isAnyPropertySet() {
             return !"none".equals(generation)
+                    || !";".equals(delimiter)
                     || createTarget.isPresent()
                     || dropTarget.isPresent();
         }

--- a/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
@@ -6,6 +6,7 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.scripts.generation=drop-and-create
+quarkus.hibernate-orm.scripts.generation.delimiter=\n/
 quarkus.hibernate-orm.scripts.generation.create-target=create.sql
 quarkus.hibernate-orm.scripts.generation.drop-target=drop.sql
 

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/DDLGenerationPMT.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/DDLGenerationPMT.java
@@ -3,6 +3,10 @@ package io.quarkus.it.panache;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -33,11 +37,16 @@ public class DDLGenerationPMT {
     private ProdModeTestResults prodModeTestResults;
 
     @Test
-    public void test() {
+    public void test() throws IOException {
         RestAssured.when().get("/no-paging-test").then().body(is("OK"));
 
-        assertThat(prodModeTestResults.getBuildDir().resolve("quarkus-app/create.sql").toFile()).exists();
-        assertThat(prodModeTestResults.getBuildDir().resolve("quarkus-app/drop.sql").toFile()).exists();
+        Path createSqlPath = prodModeTestResults.getBuildDir().resolve("quarkus-app/create.sql");
+        assertThat(createSqlPath.toFile()).exists();
+        assertThat(new String(Files.readAllBytes(createSqlPath))).contains("\n/");
+
+        Path dropSqlPath = prodModeTestResults.getBuildDir().resolve("quarkus-app/drop.sql");
+        assertThat(dropSqlPath.toFile()).exists();
+        assertThat(new String(Files.readAllBytes(dropSqlPath))).contains("\n/");
     }
 
 }


### PR DESCRIPTION
This property represents the statement delimiter used for the generation of the DDL scripts. The property defaults to `;`.

Resolves #17514