### PR TITLE
Bump kubernetes-client-bom from 5.4.0 to 5.4.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -175,7 +175,7 @@
         <sentry.version>4.3.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.4.0</kubernetes-client.version>
+        <kubernetes-client.version>5.4.1</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Bump Kubernetes client to 5.4.1 which fixes some regressions introduced in 5.4.0.

The aim is to include the new version as part of 2.0.0.Final

- https://github.com/fabric8io/kubernetes-client/issues/3189
- https://github.com/fabric8io/kubernetes-client/releases/tag/v5.4.1