### PR TITLE
Bump gradle jandex plugin version in test and doc

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -72,7 +72,7 @@ If you are are using gradle, you can apply the following plugin to your `build.g
 [source,groovy]
 ----
 plugins {
-    id 'org.kordamp.gradle.jandex' version '0.6.0'
+    id 'org.kordamp.gradle.jandex' version '0.10.0'
 }
 ----
 

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/common/build.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/common/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.quarkus'
     id 'java-library'
-    id "org.kordamp.gradle.jandex" version "0.6.0"
+    id "org.kordamp.gradle.jandex" version "0.10.0"
 }
 
 dependencies {


### PR DESCRIPTION
This branch update the jandex plugin version in test and documentation. 

The latest version use the same jandex version (2.2.3.Final) as the one used in quarkus. 

