### PR TITLE
Upgrade to Jandex 2.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <smallrye-health.version>3.0.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.5</smallrye-open-api.version>
-        <smallrye-graphql.version>1.2.3</smallrye-graphql.version>
+        <smallrye-graphql.version>1.2.4</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.2.0</smallrye-jwt.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -17,7 +17,7 @@
         <bouncycastle.version>1.68</bouncycastle.version>
         <bouncycastle.fips.version>1.0.2.1</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>1.0.11.4</bouncycastle.tls.fips.version>
-        <jandex.version>2.2.3.Final</jandex.version>
+        <jandex.version>2.3.0.Final</jandex.version>
         <resteasy.version>4.6.0.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-jaxrs.version>1.0.0</opentracing-jaxrs.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -548,7 +548,7 @@
                 <plugin>
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
-                    <version>1.0.8</version>
+                    <version>1.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
@@ -912,7 +912,7 @@
                                                     jandex-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [1.0.5,)
+                                                    [1.1.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>jandex</goal>

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -53,7 +53,7 @@ To generate the index just add the following to your `pom.xml`:
     <plugin>
       <groupId>org.jboss.jandex</groupId>
       <artifactId>jandex-maven-plugin</artifactId>
-      <version>1.0.7</version>
+      <version>1.1.0</version>
       <executions>
         <execution>
           <id>make-index</id>

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -72,7 +72,7 @@ If you are are using gradle, you can apply the following plugin to your `build.g
 [source,groovy]
 ----
 plugins {
-    id 'org.kordamp.gradle.jandex' version '0.10.0'
+    id 'org.kordamp.gradle.jandex' version '0.11.0'
 }
 ----
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -551,7 +551,7 @@ unless it is the main application module already configured with the quarkus-mav
     <plugin>
       <groupId>org.jboss.jandex</groupId>
       <artifactId>jandex-maven-plugin</artifactId>
-      <version>1.0.7</version>
+      <version>1.1.0</version>
       <executions>
         <execution>
           <id>make-index</id>

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -273,37 +273,26 @@ class HibernateValidatorProcessor {
                     contributeClass(classNamesToBeValidated, indexView, annotation.target().asClass().name());
                     // no need for reflection in the case of a class level constraint
                 } else if (annotation.target().kind() == AnnotationTarget.Kind.TYPE) {
-                    // there is a bug in Jandex regarding enclosingTarget() when annotations are on constructors located in a separate indexed library
-                    // (enclosing target is a ClassInfo instead of a MethodInfo and enclosingTarget() tries to catch it to a MethodInfo
-                    // leading to a ClassCastException)
-                    // for now we swallow the exception, pending a bugfix in Jandex
-                    // see https://github.com/quarkusio/quarkus/issues/17491
-                    try {
-                        // container element constraints
-                        AnnotationTarget enclosingTarget = annotation.target().asType().enclosingTarget();
-                        if (enclosingTarget.kind() == AnnotationTarget.Kind.FIELD) {
-                            contributeClass(classNamesToBeValidated, indexView,
-                                    enclosingTarget.asField().declaringClass().name());
-                            reflectiveFields.produce(new ReflectiveFieldBuildItem(enclosingTarget.asField()));
-                            if (annotation.target().asType().target() != null) {
-                                contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
-                                        consideredAnnotation,
-                                        annotation.target().asType().target());
-                            }
-                        } else if (enclosingTarget.kind() == AnnotationTarget.Kind.METHOD) {
-                            contributeClass(classNamesToBeValidated, indexView,
-                                    enclosingTarget.asMethod().declaringClass().name());
-                            reflectiveMethods.produce(new ReflectiveMethodBuildItem(enclosingTarget.asMethod()));
-                            if (annotation.target().asType().target() != null) {
-                                contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
-                                        consideredAnnotation,
-                                        annotation.target().asType().target());
-                            }
-                            contributeMethodsWithInheritedValidation(methodsWithInheritedValidation, indexView,
-                                    enclosingTarget.asMethod());
+                    // container element constraints
+                    AnnotationTarget enclosingTarget = annotation.target().asType().enclosingTarget();
+                    if (enclosingTarget.kind() == AnnotationTarget.Kind.FIELD) {
+                        contributeClass(classNamesToBeValidated, indexView, enclosingTarget.asField().declaringClass().name());
+                        reflectiveFields.produce(new ReflectiveFieldBuildItem(enclosingTarget.asField()));
+                        if (annotation.target().asType().target() != null) {
+                            contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
+                                    consideredAnnotation,
+                                    annotation.target().asType().target());
                         }
-                    } catch (Exception e) {
-                        // ignore
+                    } else if (enclosingTarget.kind() == AnnotationTarget.Kind.METHOD) {
+                        contributeClass(classNamesToBeValidated, indexView, enclosingTarget.asMethod().declaringClass().name());
+                        reflectiveMethods.produce(new ReflectiveMethodBuildItem(enclosingTarget.asMethod()));
+                        if (annotation.target().asType().target() != null) {
+                            contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
+                                    consideredAnnotation,
+                                    annotation.target().asType().target());
+                        }
+                        contributeMethodsWithInheritedValidation(methodsWithInheritedValidation, indexView,
+                                enclosingTarget.asMethod());
                     }
                 }
             }

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -38,7 +38,7 @@
         <!-- Versions -->
         <version.cdi>2.0.2</version.cdi>
         <version.jta>1.3.3</version.jta>
-        <version.jandex>2.2.3.Final</version.jandex>
+        <version.jandex>2.3.0.Final</version.jandex>
         <version.junit5>5.7.2</version.junit5>
         <version.maven>3.8.1</version.maven>
         <version.assertj>3.19.0</version.assertj>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Versions -->
         <version.cdi>2.0.2</version.cdi>
-        <version.jandex>2.2.3.Final</version.jandex>
+        <version.jandex>2.3.0.Final</version.jandex>
         <version.junit5>5.7.2</version.junit5>
         <version.maven>3.8.1</version.maven>
         <version.assertj>3.19.0</version.assertj>

--- a/independent-projects/tools/artifact-api/pom.xml
+++ b/independent-projects/tools/artifact-api/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.0.8</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/independent-projects/tools/registry-client/pom.xml
+++ b/independent-projects/tools/registry-client/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.0.8</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/common/build.gradle
+++ b/integration-tests/gradle/src/test/resources/jandex-basic-multi-module-project/common/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.quarkus'
     id 'java-library'
-    id "org.kordamp.gradle.jandex" version "0.10.0"
+    id "org.kordamp.gradle.jandex" version "0.11.0"
 }
 
 dependencies {

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -88,7 +88,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.0.8</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
Fixes #17491 by upgrading to Jandex 2.3.0, which includes https://github.com/wildfly/jandex/pull/121 

Draft because we're waiting for:

* ~The Gradle plugin: https://github.com/kordamp/jandex-gradle-plugin/pull/13 + wait for release~ => Done
* ~The Maven plugin: https://github.com/wildfly/jandex-maven-plugin/pull/28 + wait for release~ => Done