### PR TITLE
Don't run maven IT names by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -56,18 +56,20 @@ public class TestConfig {
     public Optional<List<String>> excludeTags;
 
     /**
-     * Tests that should be included for continuous testing. This is a regular expression.
+     * Tests that should be included for continuous testing. This is a regular expression and
+     * is matched against the test class name (not the file name).
      */
     @ConfigItem
     public Optional<String> includePattern;
 
     /**
-     * Tests that should be excluded with continuous testing. This is a regular expression.
+     * Tests that should be excluded with continuous testing. This is a regular expression and
+     * is matched against the test class name (not the file name).
      *
      * This is ignored if include-pattern has been set.
      *
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = ".*\\.IT[^.]+|.*IT|.*ITCase")
     public Optional<String> excludePattern;
     /**
      * Disable the testing status/prompt message at the bottom of the console


### PR DESCRIPTION
This is not perfect, as this information
should be read from the plugin config,
but it will prevent many issues.

Relates to #17558