### PR TITLE
Update Vert.x to version 4.1.0 and related dependencies

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,8 +52,8 @@
         <smallrye-jwt.version>3.2.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-reactive-utils.version>2.5.1</smallrye-reactive-utils.version>
-        <smallrye-reactive-messaging.version>3.3.2</smallrye-reactive-messaging.version>
+        <smallrye-reactive-utils.version>2.6.0</smallrye-reactive-utils.version>
+        <smallrye-reactive-messaging.version>3.4.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>1.15.4.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.4.0.Final</jboss-threads.version>
-        <vertx.version>4.1.0.CR2</vertx.version>
+        <vertx.version>4.1.0</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>


### PR DESCRIPTION
* Update Vert.x to version 4.1.0
* Update Vert.x Mutiny bindings to version 2.6.0
* Update SmallRye Reactive Messaging to version: 3.4.0