### PR TITLE
CLI: Change default short option to display version from "-V" to "-v"

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -29,6 +29,8 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
 
     static {
         System.setProperty("picocli.endofoptions.description", "End of command line options.");
+        // Change default short option to display version from "-V" to "-v":
+        System.setProperty("picocli.version.name.0", "-v");
     }
 
     @Inject

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
@@ -9,7 +9,7 @@ public class CliVersionTest {
         CliDriver.Result result = CliDriver.execute("version");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute("-V");
+        CliDriver.Result result2 = CliDriver.execute("-v");
         Assertions.assertEquals(result.stdout, result2.stdout, "Version output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
 


### PR DESCRIPTION
The current short option to display the version is "-V" (uppercase): `quarkus -V`. This is set by Picocli, but can be changed using the `picocli.version.name.0` property.

The problem with `-V` is that does not match with the other short options to display version in the extensions and other commands which is "-v".
Also, in other command tools like `mvn`, the option is `-v`.
I did check and I think that the `-v` is not conflicting with other existing options.