### PR TITLE
Correctly propagate dispatchToWorker to websockets

### DIFF
--- a/extensions/websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/WebsocketRecorder.java
+++ b/extensions/websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/WebsocketRecorder.java
@@ -17,7 +17,6 @@ import io.netty.channel.EventLoopGroup;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.runtime.BeanContainer;
-import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.annotations.Recorder;
 import io.undertow.websockets.UndertowContainerProvider;
 import io.undertow.websockets.WebSocketDeploymentInfo;
@@ -160,15 +159,10 @@ public class WebsocketRecorder {
                         };
                     }
                 }),
-                false,
+                info.isDispatchToWorkerThread(),
                 null,
                 null,
-                new Supplier<Executor>() {
-                    @Override
-                    public Executor get() {
-                        return ExecutorRecorder.getCurrent();
-                    }
-                },
+                info.getExecutor(),
                 Collections.emptyList(),
                 info.getMaxFrameSize());
         for (Class<?> i : info.getAnnotatedEndpoints()) {


### PR DESCRIPTION
Also use the executor included in the container info even if the code
was working ok.

Fixes #17571