### PR TITLE
Remove default Jaeger endpoint

### DIFF
--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterConfig;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterProvider;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerRecorder;
@@ -37,7 +38,8 @@ public class JaegerExporterProcessor {
     @BuildStep(onlyIf = JaegerExporterEnabled.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void installBatchSpanProcessorForJaeger(JaegerRecorder recorder,
+            LaunchModeBuildItem launchModeBuildItem,
             JaegerExporterConfig.JaegerExporterRuntimeConfig runtimeConfig) {
-        recorder.installBatchSpanProcessorForJaeger(runtimeConfig);
+        recorder.installBatchSpanProcessorForJaeger(runtimeConfig, launchModeBuildItem.getLaunchMode());
     }
 }

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/JaegerExporterConfig.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/JaegerExporterConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.opentelemetry.exporter.jaeger.runtime;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -22,11 +23,9 @@ public class JaegerExporterConfig {
     public static class JaegerExporterRuntimeConfig {
         /**
          * The Jaeger endpoint to connect to. The endpoint must start with either http:// or https://.
-         * <p>
-         * Defaults to `http://localhost:14250` if unset.
          */
-        @ConfigItem(defaultValue = "http://localhost:14250")
-        public String endpoint;
+        @ConfigItem
+        public Optional<String> endpoint;
 
         /**
          * The maximum amount of time to wait for the collector to process exported spans before an exception is thrown.

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/JaegerRecorder.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/JaegerRecorder.java
@@ -1,21 +1,30 @@
 package io.quarkus.opentelemetry.exporter.jaeger.runtime;
 
+import java.util.Optional;
+
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.CDI;
 
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class JaegerRecorder {
-    public void installBatchSpanProcessorForJaeger(JaegerExporterConfig.JaegerExporterRuntimeConfig runtimeConfig) {
+    public void installBatchSpanProcessorForJaeger(JaegerExporterConfig.JaegerExporterRuntimeConfig runtimeConfig,
+            LaunchMode launchMode) {
+
+        if (launchMode == LaunchMode.DEVELOPMENT && !runtimeConfig.endpoint.isPresent()) {
+            // Default the endpoint for development only
+            runtimeConfig.endpoint = Optional.of("http://localhost:14250");
+        }
 
         // Only create the JaegerGrpcSpanExporter if an endpoint was set in runtime config
-        if (runtimeConfig.endpoint != null && runtimeConfig.endpoint.trim().length() > 0) {
+        if (runtimeConfig.endpoint.isPresent() && runtimeConfig.endpoint.get().trim().length() > 0) {
             try {
                 JaegerGrpcSpanExporter jaegerSpanExporter = JaegerGrpcSpanExporter.builder()
-                        .setEndpoint(runtimeConfig.endpoint)
+                        .setEndpoint(runtimeConfig.endpoint.get())
                         .setTimeout(runtimeConfig.exportTimeout)
                         .build();
 

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/LateBoundBatchSpanProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/LateBoundBatchSpanProcessor.java
@@ -105,7 +105,7 @@ public class LateBoundBatchSpanProcessor implements SpanProcessor {
      */
     private void logDelegateNotFound() {
         if (!warningLogged) {
-            log.warn("No delegate specified, no action taken.");
+            log.warn("No BatchSpanProcessor delegate specified, no action taken.");
             warningLogged = true;
         }
     }


### PR DESCRIPTION
Resolves #16107

- Remove the default Jaeger endpoint from configuration
- When in DEV mode, default the endpoint to `http://localhost:14250` if it's not set