### PR TITLE
Export maven.repo.local for gradle tests

### DIFF
--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -3,6 +3,7 @@ package io.quarkus.cli;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,16 +55,36 @@ public class CliProjectGradleTest {
             gradle = ExecuteUtil.findExecutableFile("gradle");
         }
 
-        CliDriver.Result result = CliDriver.executeArbitraryCommand(gradle.getAbsolutePath(), "--daemon", "-q",
-                "--project-dir=" + project.toAbsolutePath());
+        List<String> args = new ArrayList<>();
+        args.add(gradle.getAbsolutePath());
+        args.add("--daemon");
+        args.add("-q");
+        args.add("--project-dir=" + project.toAbsolutePath());
+
+        String localMavenRepo = System.getProperty("maven.repo.local", null);
+        if (localMavenRepo != null) {
+            args.add("-Dmaven.repo.local=" + localMavenRepo);
+        }
+
+        CliDriver.Result result = CliDriver.executeArbitraryCommand(args.toArray(new String[0]));
         Assertions.assertEquals(0, result.exitCode, "Gradle daemon should start properly");
     }
 
     @AfterEach
     void stopGradleDaemon() throws Exception {
         if (gradle != null) {
-            CliDriver.Result result = CliDriver.executeArbitraryCommand(gradle.getAbsolutePath(), "--stop",
-                    "--project-dir=" + project.toAbsolutePath());
+
+            List<String> args = new ArrayList<>();
+            args.add(gradle.getAbsolutePath());
+            args.add("--stop");
+            args.add("--project-dir=" + project.toAbsolutePath());
+
+            String localMavenRepo = System.getProperty("maven.repo.local", null);
+            if (localMavenRepo != null) {
+                args.add("-Dmaven.repo.local=" + localMavenRepo);
+            }
+
+            CliDriver.Result result = CliDriver.executeArbitraryCommand(args.toArray(new String[0]));
             Assertions.assertEquals(0, result.exitCode, "Gradle daemon should stop properly");
         }
     }


### PR DESCRIPTION
This generate a `gradle.properties` file in `user.home/.gradle`. 
This file contains a system property which will then be used by gradle. 

It should fix gradle tests in the release job.
