### PR TITLE
CI: cancel also non-PR runs in forks

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -35,7 +35,7 @@ on:
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'quarkusio/quarkus' }}
 
 env:
   # Workaround testsuite locale issue

--- a/.github/workflows/ci-actions.yml.disabled
+++ b/.github/workflows/ci-actions.yml.disabled
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'quarkusio/quarkus' }}
 
 env:
   # Workaround testsuite locale issue

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'quarkusio/quarkus' }}
 
 jobs:
   ci-sanity-check:


### PR DESCRIPTION
As agreed here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/CI.3A.20cancel-in-progress.20in.20forks

I left out `ci-fork-mvn-cache.yml` since this runs only for "main" and only in forks. So in a way it's similar to the queued `main` runs here in this repo.

/cc @yrodiere 