### PR TITLE
Rename quarkus.neo4j.pool.metrics-enabled for unification

### DIFF
--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -401,7 +401,7 @@ This behavior can be disabled by setting the `quarkus.neo4j.health.enabled` prop
 
 === Driver metrics
 
-If you are using a metrics extension and specify the config property `quarkus.neo4j.pool.metrics-enabled=true`, the Neo4j extension will
+If you are using a metrics extension and specify the config property `quarkus.neo4j.pool.metrics.enabled=true`, the Neo4j extension will
 expose several metrics related to the Neo4j connection pool.
 
 === Explore Cypher and the Graph

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
@@ -141,7 +141,7 @@ public class Neo4jConfiguration {
         /**
          * Flag, if metrics are enabled.
          */
-        @ConfigItem
+        @ConfigItem(name = "metrics.enabled")
         public boolean metricsEnabled;
 
         /**

--- a/integration-tests/neo4j/src/main/resources/application.properties
+++ b/integration-tests/neo4j/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.neo4j.uri = ${neo4j.uri}
 quarkus.neo4j.authentication.username = ${neo4j.username}
 quarkus.neo4j.authentication.password = ${neo4j.password}
-quarkus.neo4j.pool.metrics-enabled = true
+quarkus.neo4j.pool.metrics.enabled = true
 
 # Disabling SSL is not recommended in production and only needed for this integration test.
 # Disabling SSL will disable encrypted bolt communication.


### PR DESCRIPTION
Partial fix for #17448