### PR TITLE
Initialize io.vertx.ext.auth.impl.jose.JWT at runtime

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -299,8 +299,10 @@ class VertxHttpProcessor {
     }
 
     @BuildStep
-    RuntimeInitializedClassBuildItem configureNativeCompilation() {
-        return new RuntimeInitializedClassBuildItem("io.vertx.ext.web.handler.sockjs.impl.XhrTransport");
+    void configureNativeCompilation(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
+        runtimeInitializedClasses
+                .produce(new RuntimeInitializedClassBuildItem("io.vertx.ext.web.handler.sockjs.impl.XhrTransport"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem("io.vertx.ext.auth.impl.jose.JWT"));
     }
 
     /**


### PR DESCRIPTION
It contains a Random field so we can't initialize it at static init.

Fixes #17657