### PR TITLE
Improve the way OIDC init failures are handled - 1.13

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -93,7 +93,8 @@ public class OidcClientImpl implements OidcClient {
                 Uni<HttpResponse<Buffer>> response = request.sendBuffer(OidcCommonUtils.encodeForm(body))
                         .onFailure(ConnectException.class)
                         .retry()
-                        .atMost(3);
+                        .atMost(oidcConfig.connectionRetryCount)
+                        .onFailure().transform(t -> t.getCause());
                 return response.onItem()
                         .transform(resp -> emitGrantTokens(resp, refresh));
             }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -2,7 +2,6 @@ package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
 import java.net.ConnectException;
-import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -101,16 +100,14 @@ public class OidcClientRecorder {
         try {
             OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false);
         } catch (Throwable t) {
+            LOG.debug(t.getMessage());
             String message = String.format("'%s' client configuration is not initialized", oidcClientId);
-            LOG.debug(message);
             return Uni.createFrom().item(new DisabledOidcClient(message));
         }
 
         String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
-
         WebClientOptions options = new WebClientOptions();
 
-        URI authServerUri = URI.create(authServerUriString); // create uri for parse exception
         OidcCommonUtils.setHttpClientOptions(oidcConfig, tlsConfig, options);
 
         WebClient client = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx.get()), options);
@@ -118,9 +115,9 @@ public class OidcClientRecorder {
         Uni<String> tokenRequestUriUni = null;
         if (!oidcConfig.discoveryEnabled) {
             tokenRequestUriUni = Uni.createFrom()
-                    .item(OidcCommonUtils.getOidcEndpointUrl(authServerUri.toString(), oidcConfig.tokenPath));
+                    .item(OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.tokenPath));
         } else {
-            tokenRequestUriUni = discoverTokenRequestUri(client, authServerUri.toString(), oidcConfig);
+            tokenRequestUriUni = discoverTokenRequestUri(client, authServerUriString.toString(), oidcConfig);
         }
         return tokenRequestUriUni.onItemOrFailure()
                 .transform(new BiFunction<String, Throwable, OidcClient>() {
@@ -128,7 +125,7 @@ public class OidcClientRecorder {
                     @Override
                     public OidcClient apply(String tokenRequestUri, Throwable t) {
                         if (t != null) {
-                            throw toOidcClientException(authServerUri.toString(), t);
+                            throw toOidcClientException(authServerUriString, t);
                         }
 
                         if (tokenRequestUri == null) {
@@ -195,7 +192,8 @@ public class OidcClientRecorder {
         }).onFailure(ConnectException.class)
                 .retry()
                 .withBackOff(CONNECTION_BACKOFF_DURATION, CONNECTION_BACKOFF_DURATION)
-                .expireIn(expireInDelay);
+                .expireIn(expireInDelay)
+                .onFailure().transform(t -> t.getCause());
     }
 
     protected static OidcClientException toOidcClientException(String authServerUrlString, Throwable cause) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -42,13 +42,29 @@ public class OidcCommonConfig {
      * The number of times the connection request will be repeated is calculated by dividing the value of this property by 2.
      * For example, setting it to `20S` will allow for requesting the connection up to 10 times with a 2 seconds delay between
      * the retries.
-     * Note the `connection-timeout` property does not affect this amount of time.
+     * Note this property is only effective when the initial OIDC connection is created,
+     * for example, when requesting a well-known OIDC configuration.
+     * Use the 'connection-retry-count' property to support trying to re-establish an already available connection which may
+     * have been
+     * dropped.
      */
     @ConfigItem
     public Optional<Duration> connectionDelay = Optional.empty();
 
     /**
-     * The amount of time after which the connection request to the currently unavailable OIDC server will time out.
+     * The number of times an attempt to re-establish an already available connection will be repeated for.
+     * Note this property is different to the `connection-delay` property which is only effective during the initial OIDC
+     * connection creation.
+     * This property is used to try to recover the existing connection which may have been temporarily lost.
+     * For example, if a request to the OIDC token endpoint fails due to a connection exception then the request will be retried
+     * for
+     * a number of times configured by this property.
+     */
+    @ConfigItem(defaultValue = "3")
+    public int connectionRetryCount = 3;
+
+    /**
+     * The amount of time after which the current OIDC connection request will time out.
      */
     @ConfigItem(defaultValue = "10s")
     public Duration connectionTimeout = Duration.ofSeconds(10);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.common.runtime;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -43,6 +44,13 @@ public class OidcCommonUtils {
                             configPrefix));
         }
 
+        try {
+            // Verify that auth-server-url is a valid URL
+            URI.create(oidcConfig.getAuthServerUrl().get()).toURL();
+        } catch (Throwable ex) {
+            throw new ConfigurationException(
+                    String.format("'%sauth-server-url' is invalid", configPrefix), ex);
+        }
         Credentials creds = oidcConfig.getCredentials();
         if (creds.secret.isPresent() && creds.clientSecret.value.isPresent()) {
             throw new ConfigurationException(

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -113,7 +113,7 @@ public class OidcProviderClient {
         Uni<HttpResponse<Buffer>> response = request.sendBuffer(OidcCommonUtils.encodeForm(formBody))
                 .onFailure(ConnectException.class)
                 .retry()
-                .atMost(3);
+                .atMost(oidcConfig.connectionRetryCount).onFailure().transform(t -> t.getCause());
         return response.onItem();
     }
 

--- a/integration-tests/oidc-wiremock/pom.xml
+++ b/integration-tests/oidc-wiremock/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - OpenID Connect Adapter WireMock</name>
     <description>Module that contains OpenID Connect related tests using WireMock</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -93,19 +89,9 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <keycloak.url>${keycloak.url}</keycloak.url>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <keycloak.url>${keycloak.url}</keycloak.url>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -12,7 +12,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@Path("/api/admin")
+@Path("/api/admin/bearer")
 public class AdminResource {
 
     @Inject

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -14,6 +14,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow")) {
             return "code-flow";
         }
+        if (path.endsWith("bearer")) {
+            return "bearer";
+        }
         return null;
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueAdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueAdminResource.java
@@ -12,7 +12,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@Path("/opaque/api/admin")
+@Path("/opaque/api/admin/bearer")
 public class OpaqueAdminResource {
 
     @Inject

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueUsersResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueUsersResource.java
@@ -20,7 +20,7 @@ public class OpaqueUsersResource {
     SecurityIdentity identity;
 
     @GET
-    @Path("/me")
+    @Path("/me/bearer")
     @RolesAllowed("user")
     @Produces(MediaType.APPLICATION_JSON)
     public User principalName() {
@@ -28,7 +28,7 @@ public class OpaqueUsersResource {
     }
 
     @GET
-    @Path("/preferredUserName")
+    @Path("/preferredUserName/bearer")
     @RolesAllowed("user")
     @Produces(MediaType.APPLICATION_JSON)
     public User opaquePreferredUserName() {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResourceOidcRecovered.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResourceOidcRecovered.java
@@ -15,22 +15,14 @@ import io.quarkus.security.identity.SecurityIdentity;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@Path("/api/users")
-public class UsersResource {
+@Path("/recovered/api/users")
+public class UsersResourceOidcRecovered {
 
     @Inject
     SecurityIdentity identity;
 
     @GET
-    @Path("/me/bearer")
-    @RolesAllowed("user")
-    @Produces(MediaType.APPLICATION_JSON)
-    public User principalName() {
-        return new User(identity.getPrincipal().getName());
-    }
-
-    @GET
-    @Path("/preferredUserName/bearer")
+    @Path("/preferredUserName")
     @RolesAllowed("user")
     @Produces(MediaType.APPLICATION_JSON)
     public User preferredUserName() {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Configuration file
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus2/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email,phone
@@ -8,9 +8,15 @@ quarkus.oidc.code-flow.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow.client-id=quarkus-web-app
 quarkus.oidc.code-flow.credentials.secret=secret
 quarkus.oidc.code-flow.application-type=web-app
+
+quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer.client-id=quarkus-app
+quarkus.oidc.bearer.credentials.secret=secret
+quarkus.oidc.bearer.authentication.scopes=profile,email,phone
+quarkus.oidc.bearer.token.audience=https://service.example.com
+
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
 
-quarkus.oidc.token.audience=https://service.example.com
-
 smallrye.jwt.sign.key.location=privateKey.jwk
+

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
@@ -21,7 +21,7 @@ public class BearerOpaqueTokenAuthorizationTest {
         for (String username : Arrays.asList("alice", "admin")) {
             RestAssured.given()
                     .header("Authorization", "Bearer " + username)
-                    .when().get("/opaque/api/users/preferredUserName")
+                    .when().get("/opaque/api/users/preferredUserName/bearer")
                     .then()
                     .statusCode(200)
                     .body("userName", equalTo(username));
@@ -32,7 +32,7 @@ public class BearerOpaqueTokenAuthorizationTest {
     public void testAccessAdminResource() {
         RestAssured.given()
                 .header("Authorization", "Bearer " + "admin")
-                .when().get("/opaque/api/admin")
+                .when().get("/opaque/api/admin/bearer")
                 .then()
                 .statusCode(200)
                 .body(Matchers.containsString("admin"));
@@ -42,7 +42,7 @@ public class BearerOpaqueTokenAuthorizationTest {
     public void testDeniedAccessAdminResource() {
         RestAssured.given()
                 .header("Authorization", "Bearer " + "alice")
-                .when().get("/opaque/api/admin")
+                .when().get("/opaque/api/admin/bearer")
                 .then()
                 .statusCode(403);
     }
@@ -50,7 +50,7 @@ public class BearerOpaqueTokenAuthorizationTest {
     @Test
     public void testDeniedNoBearerToken() {
         RestAssured.given()
-                .when().get("/opaque/api/users/me").then()
+                .when().get("/opaque/api/users/me/bearer").then()
                 .statusCode(401);
     }
 
@@ -59,7 +59,7 @@ public class BearerOpaqueTokenAuthorizationTest {
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + "expired")
-                .get("/opaque/api/users/me")
+                .get("/opaque/api/users/me/bearer")
                 .then()
                 .statusCode(401);
     }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -24,7 +24,7 @@ public class BearerTokenAuthorizationTest {
     public void testSecureAccessSuccessPreferredUsername() {
         for (String username : Arrays.asList("alice", "admin")) {
             RestAssured.given().auth().oauth2(getAccessToken(username, new HashSet<>(Arrays.asList("user", "admin"))))
-                    .when().get("/api/users/preferredUserName")
+                    .when().get("/api/users/preferredUserName/bearer")
                     .then()
                     .statusCode(200)
                     .body("userName", equalTo(username));
@@ -34,7 +34,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testAccessAdminResource() {
         RestAssured.given().auth().oauth2(getAccessToken("admin", new HashSet<>(Arrays.asList("admin"))))
-                .when().get("/api/admin")
+                .when().get("/api/admin/bearer")
                 .then()
                 .statusCode(200)
                 .body(Matchers.containsString("admin"));
@@ -43,7 +43,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testAccessAdminResourceAudienceArray() {
         RestAssured.given().auth().oauth2(getAccessTokenAudienceArray("admin", new HashSet<>(Arrays.asList("admin"))))
-                .when().get("/api/admin")
+                .when().get("/api/admin/bearer")
                 .then()
                 .statusCode(200)
                 .body(Matchers.containsString("admin"));
@@ -52,7 +52,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testDeniedAccessAdminResource() {
         RestAssured.given().auth().oauth2(getAccessToken("alice", new HashSet<>(Arrays.asList("user"))))
-                .when().get("/api/admin")
+                .when().get("/api/admin/bearer")
                 .then()
                 .statusCode(403);
     }
@@ -60,7 +60,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testDeniedNoBearerToken() {
         RestAssured.given()
-                .when().get("/api/users/me").then()
+                .when().get("/api/users/me/bearer").then()
                 .statusCode(401);
     }
 
@@ -69,7 +69,7 @@ public class BearerTokenAuthorizationTest {
         String token = getExpiredAccessToken("alice", new HashSet<>(Arrays.asList("user")));
 
         RestAssured.given().auth().oauth2(token).when()
-                .get("/api/users/me")
+                .get("/api/users/me/bearer")
                 .then()
                 .statusCode(401);
     }
@@ -79,7 +79,7 @@ public class BearerTokenAuthorizationTest {
         String token = getAccessTokenWrongIssuer("alice", new HashSet<>(Arrays.asList("user")));
 
         RestAssured.given().auth().oauth2(token).when()
-                .get("/api/users/me")
+                .get("/api/users/me/bearer")
                 .then()
                 .statusCode(401);
     }
@@ -89,7 +89,7 @@ public class BearerTokenAuthorizationTest {
         String token = getAccessTokenWrongAudience("alice", new HashSet<>(Arrays.asList("user")));
 
         RestAssured.given().auth().oauth2(token).when()
-                .get("/api/users/me")
+                .get("/api/users/me/bearer")
                 .then()
                 .statusCode(401);
     }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenOidcRecoveredTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenOidcRecoveredTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.keycloak;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.smallrye.jwt.build.Jwt;
+
+@QuarkusTest
+public class BearerTokenOidcRecoveredTest {
+
+    @Test
+    public void testSecureAccessSuccessPreferredUsername() {
+
+        WiremockTestResource server = new WiremockTestResource();
+        server.start();
+        try {
+            RestAssured.given().auth().oauth2(getAccessToken("alice", new HashSet<>(Arrays.asList("user", "admin"))))
+                    .when().get("/recovered/api/users/preferredUserName")
+                    .then()
+                    .statusCode(200)
+                    .body("userName", equalTo("alice"));
+        } finally {
+            server.stop();
+        }
+    }
+
+    private String getAccessToken(String userName, Set<String> groups) {
+        return Jwt.preferredUserName(userName)
+                .groups(groups)
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .jws()
+                .keyId("1")
+                .sign();
+    }
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.keycloak;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import org.jboss.logging.Logger;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public class WiremockTestResource {
+
+    private static final Logger LOG = Logger.getLogger(WiremockTestResource.class);
+
+    private WireMockServer server;
+
+    public void start() {
+
+        server = new WireMockServer(
+                wireMockConfig()
+                        .port(8180));
+        server.start();
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "    \"jwks_uri\": \"" + server.baseUrl()
+                                        + "/auth/realms/quarkus2/protocol/openid-connect/certs\""
+                                        + "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus2/protocol/openid-connect/certs"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"keys\" : [\n" +
+                                        "    {\n" +
+                                        "      \"kid\": \"1\",\n" +
+                                        "      \"kty\":\"RSA\",\n" +
+                                        "      \"n\":\"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ\",\n"
+                                        +
+                                        "      \"e\":\"AQAB\"\n" +
+                                        "    }\n" +
+                                        "  ]\n" +
+                                        "}")));
+
+        LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
+    }
+
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop();
+            LOG.info("Keycloak was shut down");
+            server = null;
+        }
+    }
+
+}

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -123,9 +123,7 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
 
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
         Map<String, String> conf = new HashMap<>();
-        conf.put("quarkus.oidc.auth-server-url", server.baseUrl() + "/auth/realms/quarkus");
-        conf.put("quarkus.oidc.code-flow.auth-server-url", server.baseUrl() + "/auth/realms/quarkus");
-        conf.put("keycloak-url", server.baseUrl());
+        conf.put("keycloak.url", server.baseUrl() + "/auth");
 
         return conf;
     }


### PR DESCRIPTION
This backports #16773 with the following differences:

- Keeps Keycloak test resource manager as it is still needed in `1.13.x`
- Fixes OidcWiremock test resource to use a correct `keycloak.url` property - it has been fixed in the `main` as part of some other PR - it is needed for the PR related `oidc-wiremock` tests to pass in `1.13.x` 