### PR TITLE
Simplify iteration and transformation of Vert.x headers

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
@@ -3,7 +3,6 @@ package io.quarkus.resteasy.runtime.standalone;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -16,6 +15,7 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import io.netty.buffer.ByteBuf;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -116,21 +116,21 @@ public class VertxHttpResponse implements HttpResponse {
         outputHeaders.clear();
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static void transformHeaders(VertxHttpResponse vertxResponse, HttpServerResponse response,
-            ResteasyProviderFactory factory) {
-        for (Map.Entry<String, List<Object>> entry : vertxResponse.getOutputHeaders().entrySet()) {
-            String key = entry.getKey();
-            for (Object value : entry.getValue()) {
-                if (value == null) {
-                    response.headers().add(key, "");
+    private void transformHeaders() {
+        getOutputHeaders().forEach(this::transformHeadersList);
+    }
+
+    private void transformHeadersList(final String key, final List<Object> valueList) {
+        final MultiMap headers = response.headers();
+        for (Object value : valueList) {
+            if (value == null) {
+                headers.add(key, "");
+            } else {
+                RuntimeDelegate.HeaderDelegate delegate = providerFactory.getHeaderDelegate(value.getClass());
+                if (delegate != null) {
+                    headers.add(key, delegate.toString(value));
                 } else {
-                    RuntimeDelegate.HeaderDelegate delegate = factory.getHeaderDelegate(value.getClass());
-                    if (delegate != null) {
-                        response.headers().add(key, delegate.toString(value));
-                    } else {
-                        response.headers().add(key, value.toString());
-                    }
+                    headers.add(key, value.toString());
                 }
             }
         }
@@ -146,7 +146,7 @@ public class VertxHttpResponse implements HttpResponse {
             } else {
                 committed = true;
                 response.setStatusCode(getStatus());
-                transformHeaders(this, response, providerFactory);
+                transformHeaders();
                 routingContext.addHeadersEndHandler(h -> {
                     response.headers().remove(HttpHeaders.CONTENT_LENGTH);
                     response.headers().set(HttpHeaders.CONNECTION, HttpHeaders.KEEP_ALIVE);
@@ -197,7 +197,7 @@ public class VertxHttpResponse implements HttpResponse {
             } else {
                 response.setChunked(true);
             }
-            transformHeaders(this, response, providerFactory);
+            transformHeaders();
         }
         if (finished)
             this.finished = true;


### PR DESCRIPTION
This is a very minor efficiency improvement, which I also happen to think improves code readability.

Essentially it removes the outer iterator on the hashset elements.