### PR TITLE
Adds argLine to instrument Integration Tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -134,6 +134,12 @@ public class TestConfig {
     Profile profile;
 
     /**
+     * JVM parameters that are used to launch jar based integration tests.
+     */
+    @ConfigItem
+    Optional<String> integrationJvmArgLine;
+
+    /**
      * Configures the hang detection in @QuarkusTest. If no activity happens (i.e. no test callbacks are called) over
      * this period then QuarkusTest will dump all threads stack traces, to help diagnose a potential hang.
      *

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -1,3 +1,4 @@
+
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
@@ -234,6 +235,87 @@ In addition to including the `quarkus-jacoco` extension in your pom you will nee
 WARNING: This config will only work if at least one `@QuarkusTest` is being run. If you are not using `@QuarkusTest` then
 you can simply use the Jacoco plugin in the standard manner with no additional config.
 
+=== Coverage for Integration Tests
+
+To get code coverage data from integration tests, Jacoco needs to be configured, and your `@QuarkusIntegrationTest` classes must be run using a jar package,
+
+In the `pom.xml`, you can add the following plugin configuration for Jacoco. This will append integration test data into the same destination file as unit tests,
+re-build the jacoco report after the integration tests are complete, and thus produce a comprehensive code-coverage report.
+[source, xml]
+----
+<build>
+    ...
+    <plugins>
+        ...
+        <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>default-prepare-agent-integration</id>
+                    <goals>
+                        <goal>prepare-agent-integration</goal>
+                    </goals>
+                    <configuration>
+                        <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                        <append>true</append>
+                        <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>report-it</id>
+                    <phase>post-integration-test</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                    <configuration>
+                        <dataFile>${project.build.directory}/jacoco-quarkus.exec</dataFile>
+                        <outputDirectory>${project.build.directory}/jacoco-report</outputDirectory>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+        ...
+    </plugins>
+    ...
+</build>
+----
+
+In order to run the integration tests as a jar with the Jacoco agent, add the following to your `pom.xml`.
+[source, xml]
+----
+<build>
+    ...
+    <plugins>
+        ...
+        <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>integration-test</goal>
+                        <goal>verify</goal>
+                    </goals>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <maven.home>${maven.home}</maven.home>
+                            <quarkus.test.argLine>${argLine}</quarkus.test.argLine>
+                            <!-- If your integration tests require a different profile, you can set that here as well.
+                            <quarkus.test.native-image-profile>it</quarkus.test.native-image-profile>
+                            -->
+                        </systemPropertyVariables>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+        ...
+    </plugins>
+    ...
+</build>
+
+----
 
 == Conclusion
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/JarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/JarLauncher.java
@@ -26,6 +26,7 @@ public class JarLauncher implements ArtifactLauncher {
 
     private final Path jarPath;
     private final String profile;
+    private final String argLine;
     private Process quarkusProcess;
     private final int httpPort;
     private final int httpsPort;
@@ -39,6 +40,7 @@ public class JarLauncher implements ArtifactLauncher {
                 config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                 config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                 config.getValue("quarkus.test.jar-wait-time", OptionalLong.class).orElse(DEFAULT_JAR_WAIT_TIME),
+                config.getOptionalValue("quarkus.test.argLine", String.class).orElse(null),
                 config.getOptionalValue("quarkus.test.native-image-profile", String.class)
                         .orElse(null));
     }
@@ -47,11 +49,12 @@ public class JarLauncher implements ArtifactLauncher {
         this(jarPath, installAndGetSomeConfig());
     }
 
-    public JarLauncher(Path jarPath, int httpPort, int httpsPort, long jarWaitTime, String profile) {
+    public JarLauncher(Path jarPath, int httpPort, int httpsPort, long jarWaitTime, String argLine, String profile) {
         this.jarPath = jarPath;
         this.httpPort = httpPort;
         this.httpsPort = httpsPort;
         this.jarWaitTime = jarWaitTime;
+        this.argLine = argLine;
         this.profile = profile;
     }
 
@@ -61,6 +64,9 @@ public class JarLauncher implements ArtifactLauncher {
 
         List<String> args = new ArrayList<>();
         args.add("java");
+        if (argLine != null) {
+            args.add(argLine);
+        }
         args.add("-Dquarkus.http.port=" + httpPort);
         args.add("-Dquarkus.http.ssl-port=" + httpsPort);
         // this won't be correct when using the random port but it's really only used by us for the rest client tests


### PR DESCRIPTION
* Fix #7536 by adding the ability to specify an argLine property when running tests.

For Example, in a project I'm building:
```
            <plugin>
                <artifactId>maven-failsafe-plugin</artifactId>
                <version>${surefire-plugin.version}</version>
                <executions>
                    <execution>
                        <goals>
                            <goal>integration-test</goal>
                            <goal>verify</goal>
                        </goals>
                        <configuration>
                            <systemPropertyVariables>
                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                <maven.home>${maven.home}</maven.home>
                                <quarkus.test.native-image-profile>it</quarkus.test.native-image-profile>
                                <quarkus.test.argLine>${argLine}</quarkus.test.argLine>
                            </systemPropertyVariables>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```

Fixes: #17760 