### PR TITLE
Support setting maxPoolSize for OIDC WebClients

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.common.runtime;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -68,6 +69,12 @@ public class OidcCommonConfig {
      */
     @ConfigItem(defaultValue = "10s")
     public Duration connectionTimeout = Duration.ofSeconds(10);
+
+    /**
+     * The maximum size of the connection pool used by the WebClient
+     */
+    @ConfigItem
+    public OptionalInt maxPoolSize = OptionalInt.empty();
 
     /**
      * Credentials which the OIDC adapter will use to authenticate to the OIDC server.
@@ -372,5 +379,13 @@ public class OidcCommonConfig {
 
     public void setConnectionTimeout(Duration connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
+    }
+
+    public OptionalInt getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = OptionalInt.of(maxPoolSize);
     }
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -10,6 +10,7 @@ import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import javax.crypto.SecretKey;
 
@@ -108,6 +109,12 @@ public class OidcCommonUtils {
         if (proxyOpt.isPresent()) {
             options.setProxyOptions(proxyOpt.get());
         }
+
+        OptionalInt maxPoolSize = oidcConfig.maxPoolSize;
+        if (maxPoolSize.isPresent()) {
+            options.setMaxPoolSize(maxPoolSize.getAsInt());
+        }
+
         options.setConnectTimeout((int) oidcConfig.getConnectionTimeout().toMillis());
     }
 


### PR DESCRIPTION
This allows a user setting the maxPoolSize of the Web client. 

close #17666