### PR TITLE
Add OTEL Config Params

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -27,8 +27,8 @@
         <opentracing-jdbc.version>0.2.12</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
-        <opentelemetry.version>1.2.0</opentelemetry.version>
-        <opentelemetry-alpha.version>1.2.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.3.0</opentelemetry.version>
+        <opentelemetry-alpha.version>1.3.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.4.0</jaeger.version>
         <quarkus-http.version>4.1.1</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>

--- a/extensions/opentelemetry/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/deployment/pom.xml
@@ -78,6 +78,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-extension-aws</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-aws</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-resources</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -58,7 +58,9 @@ public class OpenTelemetryProcessor {
 
     @BuildStep(onlyIf = OpenTelemetryEnabled.class)
     @Record(ExecutionTime.STATIC_INIT)
-    void createOpenTelemetry(OpenTelemetryRecorder recorder, Optional<TracerProviderBuildItem> tracerProviderBuildItem,
+    void createOpenTelemetry(OpenTelemetryConfig openTelemetryConfig,
+            OpenTelemetryRecorder recorder,
+            Optional<TracerProviderBuildItem> tracerProviderBuildItem,
             LaunchModeBuildItem launchMode) {
         if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
             recorder.resetGlobalOpenTelemetryForDevMode();
@@ -66,7 +68,7 @@ public class OpenTelemetryProcessor {
 
         RuntimeValue<SdkTracerProvider> tracerProvider = tracerProviderBuildItem.map(TracerProviderBuildItem::getTracerProvider)
                 .orElse(null);
-        recorder.createOpenTelemetry(tracerProvider);
+        recorder.createOpenTelemetry(tracerProvider, openTelemetryConfig);
         recorder.eagerlyCreateContextStorage();
     }
 

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryIdGeneratorTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryIdGeneratorTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.extension.aws.trace.AwsXrayIdGenerator;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetryIdGeneratorTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestUtil.class));
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void test() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        IdGenerator idGenerator = TestUtil.getIdGenerator(openTelemetry);
+
+        assertThat(idGenerator, instanceOf(AwsXrayIdGenerator.class));
+    }
+
+    @ApplicationScoped
+    public static class OtelConfiguration {
+
+        @Produces
+        public IdGenerator idGenerator() {
+            return AwsXrayIdGenerator.getInstance();
+        }
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryPropagatorsTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryPropagatorsTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.aws.AwsXrayPropagator;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetryPropagatorsTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.opentelemetry.propagators", "tracecontext,xray")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestUtil.class));
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void test() throws NoSuchFieldException, IllegalAccessException {
+        TextMapPropagator[] textMapPropagators = TestUtil.getTextMapPropagators(openTelemetry);
+
+        assertThat(textMapPropagators, arrayContainingInAnyOrder(W3CTraceContextPropagator.getInstance(),
+                AwsXrayPropagator.getInstance()));
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.extension.resources.OsResource;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetryResourceTest {
+    private static final String RESOURCE_ATTRIBUTES = "quarkus.opentelemetry.tracer.resource-attributes";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.opentelemetry.tracer.resources", "os")
+            .setBeforeAllCustomizer(() -> System.setProperty(RESOURCE_ATTRIBUTES, "service.name=authservice"))
+            .setAfterAllCustomizer(() -> System.getProperties().remove(RESOURCE_ATTRIBUTES))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestUtil.class)
+                    .addAsResource("resource-config/application.properties"));
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void test() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Resource resource = TestUtil.getResource(openTelemetry);
+
+        assertEquals("authservice", resource.getAttributes().get(ResourceAttributes.SERVICE_NAME));
+        assertThat(resource.getAttributes().get(ResourceAttributes.OS_TYPE), not(emptyOrNullString()));
+    }
+
+    @ApplicationScoped
+    public static class OtelConfiguration {
+
+        @Produces
+        public Resource resource() {
+            return OsResource.get();
+        }
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySamplerBeanTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySamplerBeanTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetrySamplerBeanTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestUtil.class));
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void test() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Sampler sampler = TestUtil.getSampler(openTelemetry);
+
+        assertThat(sampler.getDescription(), stringContainsInOrder("AlwaysOffSampler"));
+    }
+
+    @ApplicationScoped
+    public static class OtelConfiguration {
+
+        @Produces
+        public Sampler sampler() {
+            return Sampler.alwaysOff();
+        }
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySamplerConfigTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySamplerConfigTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetrySamplerConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.opentelemetry.tracer.sampler", "ratio")
+            .overrideConfigKey("quarkus.opentelemetry.tracer.sampler.ratio", "0.5")
+            .overrideConfigKey("quarkus.opentelemetry.tracer.sampler.parent-based", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestUtil.class));
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void test() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Sampler sampler = TestUtil.getSampler(openTelemetry);
+
+        assertEquals(String.format("TraceIdRatioBased{%.6f}", 0.5d), sampler.getDescription());
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TestUtil.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TestUtil.java
@@ -1,0 +1,64 @@
+package io.quarkus.opentelemetry.deployment;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.quarkus.arc.Unremovable;
+
+@Unremovable
+public final class TestUtil {
+    private TestUtil() {
+    }
+
+    public static Object getSharedState(OpenTelemetry openTelemetry)
+            throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        TracerProvider tracerProvider = openTelemetry.getTracerProvider();
+        Method unobfuscateMethod = tracerProvider.getClass().getDeclaredMethod("unobfuscate");
+        unobfuscateMethod.setAccessible(true);
+        SdkTracerProvider sdkTracerProvider = (SdkTracerProvider) unobfuscateMethod.invoke(tracerProvider);
+        Field privateSharedStateField = sdkTracerProvider.getClass().getDeclaredField("sharedState");
+        privateSharedStateField.setAccessible(true);
+        return privateSharedStateField.get(sdkTracerProvider);
+    }
+
+    public static IdGenerator getIdGenerator(OpenTelemetry openTelemetry)
+            throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Object sharedState = getSharedState(openTelemetry);
+        Field privateIdGeneratorField = sharedState.getClass().getDeclaredField("idGenerator");
+        privateIdGeneratorField.setAccessible(true);
+        return (IdGenerator) privateIdGeneratorField.get(sharedState);
+    }
+
+    public static Resource getResource(OpenTelemetry openTelemetry)
+            throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Object sharedState = getSharedState(openTelemetry);
+        Field privateResourceField = sharedState.getClass().getDeclaredField("resource");
+        privateResourceField.setAccessible(true);
+        return (Resource) privateResourceField.get(sharedState);
+    }
+
+    public static Sampler getSampler(OpenTelemetry openTelemetry)
+            throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Object sharedState = getSharedState(openTelemetry);
+        Field privateSamplerField = sharedState.getClass().getDeclaredField("sampler");
+        privateSamplerField.setAccessible(true);
+        return (Sampler) privateSamplerField.get(sharedState);
+    }
+
+    public static TextMapPropagator[] getTextMapPropagators(OpenTelemetry openTelemetry)
+            throws NoSuchFieldException, IllegalAccessException {
+        TextMapPropagator textMapPropagator = openTelemetry.getPropagators().getTextMapPropagator();
+        System.out.println(textMapPropagator);
+        Field privatePropagatorsField = textMapPropagator.getClass().getDeclaredField("textPropagators");
+        privatePropagatorsField.setAccessible(true);
+        return (TextMapPropagator[]) privatePropagatorsField.get(textMapPropagator);
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/VertxOpenTelemetryTest.java
@@ -8,10 +8,15 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_USER_AGENT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -21,7 +26,13 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -30,18 +41,26 @@ public class VertxOpenTelemetryTest {
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(TestSpanExporter.class)
-                    .addClass(TracerRouter.class));
+                    .addClass(TracerRouter.class)
+                    .addClass(TestUtil.class));
 
     @Inject
     TestSpanExporter testSpanExporter;
 
+    @Inject
+    OpenTelemetry openTelemetry;
+
     @Test
-    void trace() {
+    void trace() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         RestAssured.when().get("/tracer").then()
                 .statusCode(200)
                 .body(is("Hello Tracer!"));
 
         List<SpanData> spans = testSpanExporter.getFinishedSpanItems();
+
+        TextMapPropagator[] textMapPropagators = TestUtil.getTextMapPropagators(openTelemetry);
+        IdGenerator idGenerator = TestUtil.getIdGenerator(openTelemetry);
+        Sampler sampler = TestUtil.getSampler(openTelemetry);
 
         assertEquals(2, spans.size());
         assertEquals("io.quarkus.vertx.opentelemetry", spans.get(0).getName());
@@ -52,6 +71,10 @@ public class VertxOpenTelemetryTest {
         assertEquals("http", spans.get(1).getAttributes().get(HTTP_SCHEME));
         assertEquals("localhost:8081", spans.get(1).getAttributes().get(HTTP_HOST));
         assertEquals("127.0.0.1", spans.get(1).getAttributes().get(HTTP_CLIENT_IP));
+        assertThat(textMapPropagators, arrayContainingInAnyOrder(W3CTraceContextPropagator.getInstance(),
+                W3CBaggagePropagator.getInstance()));
+        assertThat(idGenerator, instanceOf(IdGenerator.random().getClass()));
+        assertThat(sampler.getDescription(), stringContainsInOrder("ParentBased", "AlwaysOnSampler"));
         assertNotNull(spans.get(1).getAttributes().get(HTTP_USER_AGENT));
     }
 }

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -1,0 +1,1 @@
+quarkus.application.name=resource-test

--- a/extensions/opentelemetry/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/runtime/pom.xml
@@ -46,6 +46,16 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryConfig.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.opentelemetry.runtime;
 
+import java.util.List;
+
 import io.quarkus.opentelemetry.runtime.tracing.TracerConfig;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -14,6 +16,16 @@ public final class OpenTelemetryConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
+
+    /**
+     * Comma separated list of OpenTelemetry propagators which must be supported.
+     * <p>
+     * Valid values are {@code b3, b3multi, baggage, jaeger, ottrace, tracecontext, xray}.
+     * <p>
+     * Default value is {@code traceContext,baggage}
+     */
+    @ConfigItem(defaultValue = "tracecontext,baggage")
+    public List<String> propagators;
 
     /** Build / static runtime config for tracer */
     public TracerConfig tracer;

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
@@ -3,9 +3,7 @@ package io.quarkus.opentelemetry.runtime;
 import java.util.function.Supplier;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.ContextStorage;
-import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -23,7 +21,7 @@ public class OpenTelemetryRecorder {
     }
 
     /* STATIC INIT */
-    public void createOpenTelemetry(RuntimeValue<SdkTracerProvider> tracerProvider) {
+    public void createOpenTelemetry(RuntimeValue<SdkTracerProvider> tracerProvider, OpenTelemetryConfig openTelemetryConfig) {
         OpenTelemetrySdkBuilder builder = OpenTelemetrySdk.builder();
 
         // Set tracer provider if present
@@ -31,8 +29,7 @@ public class OpenTelemetryRecorder {
             builder.setTracerProvider(tracerProvider.getValue());
         }
 
-        // Add propagators. //TODO Need a way to handle this with config
-        builder.setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()));
+        builder.setPropagators(OpenTelemetryUtil.mapPropagators(openTelemetryConfig.propagators));
 
         builder.buildAndRegisterGlobal();
     }

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
@@ -1,0 +1,51 @@
+package io.quarkus.opentelemetry.runtime;
+
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+public final class OpenTelemetryUtil {
+    private OpenTelemetryUtil() {
+    }
+
+    private static TextMapPropagator getPropagator(
+            String name, Map<String, TextMapPropagator> spiPropagators) {
+        if ("tracecontext".equals(name)) {
+            return W3CTraceContextPropagator.getInstance();
+        }
+        if ("baggage".equals(name)) {
+            return W3CBaggagePropagator.getInstance();
+        }
+
+        TextMapPropagator spiPropagator = spiPropagators.get(name);
+        if (spiPropagator != null) {
+            return spiPropagator;
+        }
+        throw new IllegalArgumentException(
+                "Unrecognized value for propagator: " + name
+                        + ". Make sure the artifact including the propagator is on the classpath.");
+    }
+
+    public static ContextPropagators mapPropagators(List<String> propagators) {
+        Map<String, TextMapPropagator> spiPropagators = StreamSupport.stream(
+                ServiceLoader.load(ConfigurablePropagatorProvider.class).spliterator(), false)
+                .collect(
+                        Collectors.toMap(ConfigurablePropagatorProvider::getName,
+                                ConfigurablePropagatorProvider::getPropagator));
+
+        Set<TextMapPropagator> selectedPropagators = propagators.stream()
+                .map(propagator -> getPropagator(propagator.trim(), spiPropagators))
+                .collect(Collectors.toSet());
+
+        return ContextPropagators.create(TextMapPropagator.composite(selectedPropagators));
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/OpenTelemetrySdkAutoConfiguration.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/OpenTelemetrySdkAutoConfiguration.java
@@ -1,0 +1,20 @@
+package io.quarkus.opentelemetry.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+// We can remove this substitution once AutoConfigure SPI is a separate artifact
+@TargetClass(className = "io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration")
+@Substitute
+public final class OpenTelemetrySdkAutoConfiguration {
+    @Substitute
+    private OpenTelemetrySdkAutoConfiguration() {
+    }
+
+    @Substitute
+    public static OpenTelemetrySdk initialize() {
+        return null;
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DelayedAttributes.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DelayedAttributes.java
@@ -1,0 +1,96 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+/**
+ * Class enabling Quarkus to instantiate a {@link io.opentelemetry.api.trace.TracerProvider}
+ * during static initialization and set a {@link Attributes} delegate during runtime initialization.
+ */
+public class DelayedAttributes implements Attributes {
+    private static final Logger log = Logger.getLogger(DelayedAttributes.class);
+    private boolean warningLogged = false;
+
+    private Attributes delegate;
+
+    /**
+     * Set the actual {@link Attributes} to use as the delegate.
+     *
+     * @param delegate Properly constructed {@link Attributes}.
+     */
+    public void setAttributesDelegate(Attributes delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <T> T get(AttributeKey<T> attributeKey) {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return null;
+        }
+        return delegate.get(attributeKey);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> biConsumer) {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return;
+        }
+        delegate.forEach(biConsumer);
+    }
+
+    @Override
+    public int size() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return 0;
+        }
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return true;
+        }
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public Map<AttributeKey<?>, Object> asMap() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return Collections.emptyMap();
+        }
+        return delegate.asMap();
+    }
+
+    @Override
+    public AttributesBuilder toBuilder() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return Attributes.builder();
+        }
+        return delegate.toBuilder();
+    }
+
+    /**
+     * If we haven't previously logged an error,
+     * log an error about a missing {@code delegate} and set {@code warningLogged=true}
+     */
+    private void logDelegateNotFound() {
+        if (!warningLogged) {
+            log.warn("No Attributes delegate specified, no action taken.");
+            warningLogged = true;
+        }
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/LateBoundSampler.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/LateBoundSampler.java
@@ -1,0 +1,67 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+/**
+ * Class enabling Quarkus to instantiate a {@link io.opentelemetry.api.trace.TracerProvider}
+ * during static initialization and set a {@link Sampler} delegate during runtime initialization.
+ */
+public class LateBoundSampler implements Sampler {
+    private static final Logger log = Logger.getLogger(LateBoundSampler.class);
+    private boolean warningLogged = false;
+
+    private Sampler delegate;
+
+    /**
+     * Set the actual {@link Sampler} to use as the delegate.
+     *
+     * @param delegate Properly constructed {@link Sampler}.
+     */
+    public void setSamplerDelegate(Sampler delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SamplingResult shouldSample(Context parentContext,
+            String traceId,
+            String name,
+            SpanKind spanKind,
+            Attributes attributes,
+            List<LinkData> parentLinks) {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE);
+        }
+        return delegate.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+    }
+
+    @Override
+    public String getDescription() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return "";
+        }
+        return delegate.getDescription();
+    }
+
+    /**
+     * If we haven't previously logged an error,
+     * log an error about a missing {@code delegate} and set {@code warningLogged=true}
+     */
+    private void logDelegateNotFound() {
+        if (!warningLogged) {
+            log.warn("No Sampler delegate specified, no action taken.");
+            warningLogged = true;
+        }
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerConfig.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -18,6 +19,16 @@ public class TracerConfig {
 
     /** Build / static runtime config for span exporters */
     public SpanExporterConfig exporter;
+
+    /**
+     * Comma separated list of resources that represents the entity that is
+     * producing telemetry.
+     * <p>
+     * Valid values are {@code beanstalk, ec2, ecs, eks, host, lambda, os,
+     * process, processruntime}.
+     */
+    @ConfigItem
+    public Optional<List<String>> resources;
 
     /** Build / static runtime config for span exporters */
     @ConfigGroup

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerProducer.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerProducer.java
@@ -11,6 +11,18 @@ import io.quarkus.arc.DefaultBean;
 public class TracerProducer {
     @Produces
     @Singleton
+    public DelayedAttributes getDelayedAttributes() {
+        return new DelayedAttributes();
+    }
+
+    @Produces
+    @Singleton
+    public LateBoundSampler getLateBoundSampler() {
+        return new LateBoundSampler();
+    }
+
+    @Produces
+    @Singleton
     @DefaultBean
     public Tracer getTracer() {
         return GlobalOpenTelemetry.getTracer("io.quarkus.opentelemetry");

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRecorder.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRecorder.java
@@ -1,18 +1,22 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import io.quarkus.arc.Arc;
 import io.quarkus.opentelemetry.runtime.tracing.vertx.VertxTracingAdapter;
@@ -31,19 +35,40 @@ public class TracerRecorder {
     }
 
     /* STATIC INIT */
-    public RuntimeValue<SdkTracerProvider> createTracerProvider(String serviceName, String serviceVersion,
+    public RuntimeValue<SdkTracerProvider> createTracerProvider(TracerConfig config,
+            String serviceName,
+            String serviceVersion,
             ShutdownContext shutdownContext) {
         BeanManager beanManager = Arc.container().beanManager();
+
+        Instance<IdGenerator> idGenerator = beanManager.createInstance()
+                .select(IdGenerator.class, Any.Literal.INSTANCE);
+
         SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
 
+        // Define ID Generator if present
+        if (idGenerator.isResolvable()) {
+            builder.setIdGenerator(idGenerator.get());
+        }
+
+        DelayedAttributes delayedAttributes = beanManager.createInstance()
+                .select(DelayedAttributes.class, Any.Literal.INSTANCE).get();
+
+        delayedAttributes.setAttributesDelegate(Resource.getDefault()
+                .merge(Resource.create(
+                        Attributes.of(
+                                ResourceAttributes.SERVICE_NAME, serviceName,
+                                ResourceAttributes.SERVICE_VERSION, serviceVersion)))
+                .getAttributes());
+
         // Define Service Resource
-        builder.setResource(
-                Resource.getDefault()
-                        .merge(
-                                Resource.create(
-                                        Attributes.of(
-                                                ResourceAttributes.SERVICE_NAME, serviceName,
-                                                ResourceAttributes.SERVICE_VERSION, serviceVersion))));
+        builder.setResource(Resource.create(delayedAttributes));
+
+        LateBoundSampler lateBoundSampler = beanManager.createInstance()
+                .select(LateBoundSampler.class, Any.Literal.INSTANCE).get();
+
+        // Set LateBoundSampler
+        builder.setSampler(lateBoundSampler);
 
         // Find all SpanExporter instances
         Instance<SpanExporter> allExporters = beanManager.createInstance()
@@ -69,5 +94,50 @@ public class TracerRecorder {
     /* RUNTIME INIT */
     public void setupVertxTracer() {
         vertxTracingAdapter.init();
+    }
+
+    /* RUNTIME INIT */
+    public void setupResources(TracerRuntimeConfig config) {
+        // Find all Resource instances
+        Instance<Resource> allResources = CDI.current()
+                .getBeanManager()
+                .createInstance()
+                .select(Resource.class, Any.Literal.INSTANCE);
+
+        // Merge resource instances with env attributes
+        Resource resource = allResources.stream()
+                .reduce(Resource.empty(), Resource::merge)
+                .merge(config.resourceAttributes
+                        .map(TracerUtil::mapResourceAttributes)
+                        .orElseGet(Resource::empty));
+
+        // Update Delayed attributes to contain new runtime attributes if necessary
+        if (resource.getAttributes().size() > 0) {
+            DelayedAttributes delayedAttributes = CDI.current()
+                    .select(DelayedAttributes.class).get();
+
+            delayedAttributes.setAttributesDelegate(
+                    delayedAttributes.toBuilder()
+                            .putAll(resource.getAttributes())
+                            .build());
+        }
+    }
+
+    /* RUNTIME INIT */
+    public void setupSampler(TracerRuntimeConfig config) {
+        LateBoundSampler lateBoundSampler = CDI.current().select(LateBoundSampler.class, Any.Literal.INSTANCE).get();
+        Optional<Sampler> samplerBean = CDI.current()
+                .select(Sampler.class, Any.Literal.INSTANCE)
+                .stream()
+                .filter(o -> !(o instanceof LateBoundSampler))
+                .findFirst();
+
+        // Define Sampler using bean if present
+        if (samplerBean.isPresent()) {
+            lateBoundSampler.setSamplerDelegate(samplerBean.get());
+        } else {
+            // Define Sampler using config
+            lateBoundSampler.setSamplerDelegate(TracerUtil.mapSampler(config.sampler));
+        }
     }
 }

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRuntimeConfig.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRuntimeConfig.java
@@ -1,0 +1,54 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "opentelemetry.tracer", phase = ConfigPhase.RUN_TIME)
+public class TracerRuntimeConfig {
+
+    /**
+     * A comma separated list of name=value resource attributes that
+     * represents the entity producing telemetry
+     * (eg. {@code service.name=authservice}).
+     */
+    @ConfigItem
+    Optional<List<String>> resourceAttributes;
+
+    /** Config for sampler */
+    public SamplerConfig sampler;
+
+    @ConfigGroup
+    public static class SamplerConfig {
+        /**
+         * The sampler to use for tracing
+         * <p>
+         * Valid values are {@code off, on, ratio}.
+         * <p>
+         * Defaults to {@code on}.
+         */
+        @ConfigItem(name = ConfigItem.PARENT, defaultValue = "on")
+        public String samplerName;
+
+        /**
+         * The sampler ratio to use for tracing
+         * <p>
+         * Only supported by the {@code ratio} sampler.
+         */
+        public Optional<Double> ratio;
+
+        /**
+         * If the sampler to use for tracing is parent based
+         * <p>
+         * Valid values are {@code true, false}.
+         * <p>
+         * Defaults to {@code true}.
+         */
+        @ConfigItem(defaultValue = "true")
+        public Boolean parentBased;
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
@@ -1,0 +1,53 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public class TracerUtil {
+    private TracerUtil() {
+    }
+
+    public static Resource mapResourceAttributes(List<String> resourceAttributes) {
+        AttributesBuilder attributesBuilder = Attributes.builder();
+
+        resourceAttributes.stream()
+                .map(keyValuePair -> keyValuePair.split("=", 2))
+                .map(keyValuePair -> new AbstractMap.SimpleImmutableEntry<>(keyValuePair[0].trim(), keyValuePair[1].trim()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (first, next) -> next, LinkedHashMap::new))
+                .forEach(attributesBuilder::put);
+
+        return Resource.create(attributesBuilder.build());
+    }
+
+    private static Sampler getBaseSampler(String samplerName, Optional<Double> ratio) {
+        switch (samplerName) {
+            case "on":
+                return Sampler.alwaysOn();
+            case "off":
+                return Sampler.alwaysOff();
+            case "ratio":
+                return Sampler.traceIdRatioBased(ratio.orElse(1.0d));
+            default:
+                throw new IllegalArgumentException("Unrecognized value for sampler: " + samplerName);
+        }
+    }
+
+    public static Sampler mapSampler(TracerRuntimeConfig.SamplerConfig samplerConfig) {
+        Sampler sampler = getBaseSampler(samplerConfig.samplerName, samplerConfig.ratio);
+
+        if (samplerConfig.parentBased) {
+            return Sampler.parentBased(sampler);
+        }
+
+        return sampler;
+    }
+}


### PR DESCRIPTION
Adds additional config params for OpenTelemetry (addresses features requests in #17640).
This PR adds a way of setting resources, propagators and id generator from the OTEL library using application properties 