### PR TITLE
Disable single parsing of compiler graphs in native-image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -662,6 +662,11 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:+DashboardAll");
                 }
 
+                // Disable single parsing of compiler graphs till https://github.com/oracle/graal/issues/3435 gets fixed
+                if (graalVMVersion.isNewerThan(GraalVM.Version.VERSION_21_1)) {
+                    nativeImageArgs.add("-H:-ParseOnce");
+                }
+
                 nativeImageArgs.add(nativeImageName);
 
                 return new NativeImageInvokerInfo(nativeImageArgs);


### PR DESCRIPTION
GraalVM 21.2-dev (currently graal's `master`) introduces a new enhancement (enabled by default) to avoid parsing compiler graphs twice. This enhancement however results in increased memory usage at the moment (https://github.com/oracle/graal/issues/3435) which then results in Quarkus' Integration Test failures in CI.

Tested with graal `master` in https://github.com/graalvm/mandrel/actions/runs/907537588. 
The failures will be tracked and investigated separately.