### PR TITLE
Add resteasy extension to generated app in the AMQP guide

### DIFF
--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -51,7 +51,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amqp-quickstart \
-    -Dextensions="amqp" \
+    -Dextensions="resteasy,amqp" \
     -DnoExamples
 cd amqp-quickstart
 ----


### PR DESCRIPTION
In AMQP guide, we are creating [a JAX-RS resource](https://quarkus.io/guides/amqp#the-price-resource) but the [generated app](https://quarkus.io/guides/amqp#creating-the-maven-project) only includes the amqp extension and not REST.