### PR TITLE
Export maven.repo.local property for Jbang cli tests

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -72,6 +72,7 @@ public class JBangRunner implements BuildSystemRunner {
             args.add("--native");
         }
         args.add("build");
+        setJbangProperties(args, false);
         args.addAll(params);
         args.add(getMainPath());
         return prependExecutable(args);


### PR DESCRIPTION
This branch exports `maven.repo.local` system property. 

This will generate a the following build command: `jbang build -Dmaven.repo.local=/some/path src/main.java`

This should fix the release build github action.