### PR TITLE
Cleanup: Remove `isAnnotation(ClassInfo)` utility methods

### DIFF
--- a/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
+++ b/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
@@ -59,12 +59,6 @@ class SpringSecurityProcessor {
     private static final int PARAMETER_EQ_PRINCIPAL_USERNAME_PARAMETER_NAME_GROUP = 1;
     private static final int PARAMETER_EQ_PRINCIPAL_USERNAME_PROPERTY_ACCESSOR_MATCHER_GROUP = 3;
 
-    static final int ANNOTATION = 0x00002000;
-
-    static boolean isAnnotation(final int mod) {
-        return (mod & ANNOTATION) != 0;
-    }
-
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.SPRING_SECURITY);
@@ -209,7 +203,7 @@ class SpringSecurityProcessor {
                 continue;
             }
             ClassInfo classInfo = instance.target().asClass();
-            if (isAnnotation(classInfo.flags())) {
+            if (classInfo.isAnnotation()) {
                 // if the instance is an annotation we need to record it and handle it later
                 metaAnnotations.put(classInfo.name(), classInfo);
                 continue;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,10 +48,6 @@ import org.jboss.logging.Logger.Level;
 public class BeanDeployment {
 
     private static final Logger LOGGER = Logger.getLogger(BeanDeployment.class);
-
-    private static final int ANNOTATION = 0x00002000;
-
-    static final EnumSet<Type.Kind> CLASS_TYPES = EnumSet.of(Type.Kind.CLASS, Type.Kind.PARAMETERIZED_TYPE);
 
     private final BuildContextImpl buildContext;
 
@@ -173,7 +168,7 @@ public class BeanDeployment {
                 builder.additionalStereotypes, annotationStore);
         buildContextPut(Key.STEREOTYPES.asString(), Collections.unmodifiableMap(stereotypes));
 
-        this.transitiveInterceptorBindings = findTransitiveInterceptorBindigs(interceptorBindings.keySet(),
+        this.transitiveInterceptorBindings = findTransitiveInterceptorBindings(interceptorBindings.keySet(),
                 this.beanArchiveIndex,
                 new HashMap<>(), interceptorBindings, annotationStore);
 
@@ -586,7 +581,7 @@ public class BeanDeployment {
         return bindings;
     }
 
-    private static Map<DotName, Set<AnnotationInstance>> findTransitiveInterceptorBindigs(Collection<DotName> initialBindings,
+    private static Map<DotName, Set<AnnotationInstance>> findTransitiveInterceptorBindings(Collection<DotName> initialBindings,
             IndexView index,
             Map<DotName, Set<AnnotationInstance>> result, Map<DotName, ClassInfo> interceptorBindings,
             AnnotationStore annotationStore) {
@@ -738,9 +733,7 @@ public class BeanDeployment {
         for (ClassInfo beanClass : beanArchiveIndex.getKnownClasses()) {
 
             if (Modifier.isInterface(beanClass.flags()) || Modifier.isAbstract(beanClass.flags())
-            // Replace with ClassInfo#isAnnotation() and ClassInfo#isEnum() when using Jandex 2.1.4+
-                    || (beanClass.flags() & ANNOTATION) != 0
-                    || DotNames.ENUM.equals(beanClass.superName())) {
+                    || beanClass.isAnnotation() || beanClass.isEnum()) {
                 // Skip interfaces, abstract classes, annotations and enums
                 continue;
             }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -32,8 +32,6 @@ public class TestResourceManager implements Closeable {
 
     public static final String CLOSEABLE_NAME = TestResourceManager.class.getName() + ".closeable";
 
-    private static final int ANNOTATION = 0x00002000;
-
     private final List<TestResourceEntry> sequentialTestResourceEntries;
     private final List<TestResourceEntry> parallelTestResourceEntries;
     private final List<TestResourceEntry> allTestResourceEntries;
@@ -376,7 +374,7 @@ public class TestResourceManager implements Closeable {
     }
 
     private boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass, Set<String> testClasses) {
-        if (isAnnotation(targetClass)) {
+        if (targetClass.isAnnotation()) {
             // meta-annotations have already been handled in collectMetaAnnotations
             return false;
         }
@@ -385,10 +383,6 @@ public class TestResourceManager implements Closeable {
             return testClasses.contains(targetClass.name().toString('.'));
         }
         return true;
-    }
-
-    private boolean isAnnotation(ClassInfo info) {
-        return (info.flags() & ANNOTATION) != 0;
     }
 
     public static class TestResourceClassEntry {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1162,12 +1162,6 @@ public class QuarkusTestExtension
             List<Consumer<BuildChainBuilder>> allCustomizers = new ArrayList<>(1);
             Consumer<BuildChainBuilder> defaultCustomizer = new Consumer<BuildChainBuilder>() {
 
-                private static final int ANNOTATION = 0x00002000;
-
-                boolean isAnnotation(final int mod) {
-                    return (mod & ANNOTATION) != 0;
-                }
-
                 @Override
                 public void accept(BuildChainBuilder buildChainBuilder) {
                     buildChainBuilder.addBuildStep(new BuildStep() {
@@ -1217,7 +1211,7 @@ public class QuarkusTestExtension
                             continue;
                         }
                         ClassInfo classInfo = annotationInstance.target().asClass();
-                        if (isAnnotation(classInfo.flags())) {
+                        if (classInfo.isAnnotation()) {
                             continue;
                         }
                         Type[] extendsWithTypes = annotationInstance.value().asClassArray();


### PR DESCRIPTION
There is now a dedicated `ClassInfo#isAnnotation()` method.

Also removes no longer used field `BeanDeployment#CLASS_TYPES`.