### PR TITLE
CLI, maven, gradle: filter extensions by categories

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
@@ -11,7 +11,8 @@ import picocli.CommandLine.Unmatched;
 
 @CommandLine.Command(name = "extension", aliases = {
         "ext" }, sortOptions = false, mixinStandardHelpOptions = false, description = "List, add, and remove extensions of an existing project.", subcommands = {
-                ProjectExtensionsAdd.class, ProjectExtensionsList.class, ProjectExtensionsRemove.class })
+                ProjectExtensionsList.class, ProjectExtensionsCategories.class,
+                ProjectExtensionsAdd.class, ProjectExtensionsRemove.class })
 public class ProjectExtensions extends BaseBuildCommand implements Callable<Integer> {
 
     @Unmatched // avoids throwing errors for unmatched arguments

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
@@ -1,0 +1,124 @@
+package io.quarkus.cli;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BaseBuildCommand;
+import io.quarkus.cli.build.BuildSystemRunner;
+import io.quarkus.cli.common.CategoryListFormatOptions;
+import io.quarkus.cli.common.RunModeOption;
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import picocli.CommandLine;
+import picocli.CommandLine.Mixin;
+
+@CommandLine.Command(name = "categories", aliases = "cat", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, description = "List existing extension categories.")
+public class ProjectExtensionsCategories extends BaseBuildCommand implements Callable<Integer> {
+
+    @Mixin
+    RunModeOption runMode;
+
+    @CommandLine.ArgGroup(heading = "%nOutput format%n")
+    CategoryListFormatOptions format = new CategoryListFormatOptions();
+
+    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version%n")
+    TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
+
+    @Override
+    public Integer call() {
+        try {
+            output.debug("List extension categories with initial parameters: %s", this);
+            output.throwIfUnmatchedArguments(spec.commandLine());
+
+            // Test for an existing project
+            BuildTool buildTool = QuarkusProjectHelper.detectExistingBuildTool(projectRoot()); // nullable
+
+            if (buildTool == null || targetQuarkusVersion.isPlatformSpecified() || targetQuarkusVersion.isStreamSpecified()) {
+                if (runMode.isDryRun()) {
+                    return dryRunList(spec.commandLine().getHelp(), null);
+                }
+
+                Integer exitCode = listPlatformCategories();
+                printHints(!format.isSpecified(), true);
+                return exitCode;
+            } else {
+                BuildSystemRunner runner = getRunner();
+                if (runMode.isDryRun()) {
+                    return dryRunList(spec.commandLine().getHelp(), runner.getBuildTool());
+                }
+
+                Integer exitCode = runner.listExtensionCategories(runMode, format);
+                printHints(!format.isSpecified(), true);
+                return exitCode;
+            }
+        } catch (Exception e) {
+            return output.handleCommandException(e,
+                    "Unable to list extension categories: " + e.getMessage());
+        }
+    }
+
+    Integer dryRunList(CommandLine.Help help, BuildTool buildTool) {
+        Map<String, String> dryRunOutput = new TreeMap<>();
+
+        if (buildTool == null) {
+            output.printText(new String[] {
+                    "\nList extension categories for specified platform\n",
+                    "\t" + targetQuarkusVersion.dryRun()
+            });
+        } else {
+            output.printText(new String[] {
+                    "\nList extension categories for current project\n",
+                    "\t" + projectRoot().toString()
+            });
+            dryRunOutput.put("Build tool", buildTool.name());
+        }
+
+        dryRunOutput.put("Batch (non-interactive mode)", Boolean.toString(runMode.isBatchMode()));
+        dryRunOutput.put("List format", format.getFormatString());
+
+        output.info(help.createTextTable(dryRunOutput).toString());
+        return CommandLine.ExitCode.OK;
+    }
+
+    Integer listPlatformCategories() throws QuarkusCommandException {
+        QuarkusProject qp = registryClient.createQuarkusProject(projectRoot(), targetQuarkusVersion,
+                BuildTool.MAVEN, output);
+
+        QuarkusCommandOutcome outcome = new ListCategories(qp, output)
+                .fromCli(true)
+                .format(format.getFormatString())
+                .batchMode(runMode.isBatchMode())
+                .execute();
+
+        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+    }
+
+    private void printHints(boolean formatHint, boolean extensionListHint) {
+        if (runMode.isBatchMode())
+            return;
+
+        if (formatHint) {
+            output.info("");
+            output.info(ListCategories.MORE_INFO_HINT, "--full");
+        }
+
+        if (extensionListHint) {
+            output.info("");
+            output.info(ListCategories.LIST_EXTENSIONS_HINT,
+                    "`quarkus extensions list --installable --category \"categoryId\"`");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ProjectExtensionsCategories [output=" + output
+                + ", runMode=" + runMode
+                + "]";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -35,6 +35,10 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
             "--search" }, defaultValue = "*", paramLabel = "PATTERN", order = 3, description = "Search filter on extension list (Java Pattern syntax).")
     String searchPattern;
 
+    @CommandLine.Option(names = { "-c",
+            "--category" }, defaultValue = "", paramLabel = "CATEGORY_ID", order = 4, description = "Only list extensions from given category.")
+    String category;
+
     @CommandLine.ArgGroup(heading = "%nOutput format%n")
     ListFormatOptions format = new ListFormatOptions();
 
@@ -46,24 +50,33 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
 
             // Test for an existing project
             BuildTool buildTool = QuarkusProjectHelper.detectExistingBuildTool(projectRoot()); // nullable
+            boolean categorySet = category != null && !category.isBlank();
 
             if (buildTool == null || targetQuarkusVersion.isPlatformSpecified() || targetQuarkusVersion.isStreamSpecified()) {
                 // do not evaluate installables for list of arbitrary version (project-agnostic)
                 installable = false;
+                // check if any format was specified
+                boolean formatSpecified = format.isSpecified();
                 // show origins by default
                 format.useOriginsUnlessSpecified();
 
                 if (runMode.isDryRun()) {
                     return dryRunList(spec.commandLine().getHelp(), null);
                 }
-                return listPlatformExtensions();
+
+                Integer exitCode = listPlatformExtensions();
+                printHints(buildTool, !formatSpecified, !categorySet, buildTool != null);
+                return exitCode;
             } else {
                 BuildSystemRunner runner = getRunner();
 
                 if (runMode.isDryRun()) {
                     return dryRunList(spec.commandLine().getHelp(), runner.getBuildTool());
                 }
-                return runner.listExtensions(runMode, format, installable, searchPattern);
+
+                Integer exitCode = runner.listExtensions(runMode, format, installable, searchPattern, category);
+                printHints(buildTool, !format.isSpecified(), installable && !categorySet, installable);
+                return exitCode;
             }
         } catch (Exception e) {
             return output.handleCommandException(e,
@@ -91,6 +104,7 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
         dryRunOutput.put("List format", format.getFormatString());
         dryRunOutput.put("List installable extensions", Boolean.toString(installable));
         dryRunOutput.put("Search pattern", searchPattern);
+        dryRunOutput.put("Category", category);
 
         output.info(help.createTextTable(dryRunOutput).toString());
         return CommandLine.ExitCode.OK;
@@ -105,9 +119,35 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
                 .all(true)
                 .format(format.getFormatString())
                 .search(searchPattern)
+                .category(category)
+                .batchMode(runMode.isBatchMode())
                 .execute();
 
         return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+    }
+
+    private void printHints(BuildTool buildTool, boolean formatHint, boolean filterHint, boolean addExtensionHint) {
+        if (runMode.isBatchMode())
+            return;
+
+        if (formatHint) {
+            output.info("");
+            output.info(ListExtensions.MORE_INFO_HINT, "--full");
+        }
+
+        if (filterHint) {
+            output.info("");
+            output.info(ListExtensions.FILTER_HINT, "--category \"categoryId\"");
+        }
+
+        if (addExtensionHint) {
+            output.info("");
+            if (BuildTool.GRADLE.equals(buildTool) || BuildTool.GRADLE_KOTLIN_DSL.equals(buildTool)) {
+                output.info(ListExtensions.ADD_EXTENSION_HINT, "build.gradle", "quarkus extension add \"artifactId\"");
+            } else if (BuildTool.MAVEN.equals(buildTool)) {
+                output.info(ListExtensions.ADD_EXTENSION_HINT, "pom.xml", "quarkus extension add \"artifactId\"");
+            }
+        }
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.CategoryListFormatOptions;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
@@ -82,7 +83,11 @@ public interface BuildSystemRunner {
         return getProjectRoot().relativize(absolutePath).toString();
     }
 
-    Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern)
+    Integer listExtensionCategories(RunModeOption runMode, CategoryListFormatOptions format)
+            throws Exception;
+
+    Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern,
+            String category)
             throws Exception;
 
     Integer addExtension(RunModeOption runMode, Set<String> extensions) throws Exception;

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.CategoryListFormatOptions;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
@@ -59,13 +60,28 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern) {
+    public Integer listExtensionCategories(RunModeOption runMode, CategoryListFormatOptions format) {
+        ArrayDeque<String> args = new ArrayDeque<>();
+        setGradleProperties(args, runMode.isBatchMode());
+
+        args.add("listCategories");
+        args.add("--fromCli");
+        args.add("--format=" + format.getFormatString());
+        return run(prependExecutable(args));
+    }
+
+    @Override
+    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern,
+            String category) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setGradleProperties(args, runMode.isBatchMode());
 
         args.add("listExtensions");
         args.add("--fromCli");
         args.add("--format=" + format.getFormatString());
+        if (category != null && !category.isBlank()) {
+            args.add("--category=" + category);
+        }
         if (!installable) {
             args.add("--installed");
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.CategoryListFormatOptions;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
@@ -43,7 +44,13 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern)
+    public Integer listExtensionCategories(RunModeOption runMode, CategoryListFormatOptions format) throws Exception {
+        throw new UnsupportedOperationException("Not there yet. ;)");
+    }
+
+    @Override
+    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern,
+            String category)
             throws Exception {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import io.quarkus.cli.Version;
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.CategoryListFormatOptions;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
@@ -15,6 +16,7 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.commands.AddExtensions;
+import io.quarkus.devtools.commands.ListCategories;
 import io.quarkus.devtools.commands.ListExtensions;
 import io.quarkus.devtools.commands.RemoveExtensions;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
@@ -69,7 +71,20 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern)
+    public Integer listExtensionCategories(RunModeOption runMode, CategoryListFormatOptions format)
+            throws Exception {
+        QuarkusCommandOutcome outcome = new ListCategories(quarkusProject(), output)
+                .fromCli(true)
+                .format(format.getFormatString())
+                .batchMode(runMode.isBatchMode())
+                .execute();
+
+        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+    }
+
+    @Override
+    public Integer listExtensions(RunModeOption runMode, ListFormatOptions format, boolean installable, String searchPattern,
+            String category)
             throws Exception {
         // we do not have to spawn to list extensions for maven
         QuarkusCommandOutcome outcome = new ListExtensions(quarkusProject(), output)
@@ -78,6 +93,8 @@ public class MavenRunner implements BuildSystemRunner {
                 .installed(!installable)
                 .format(format.getFormatString())
                 .search(searchPattern)
+                .category(category)
+                .batchMode(runMode.isBatchMode())
                 .execute();
 
         return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/CategoryListFormatOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/CategoryListFormatOptions.java
@@ -1,0 +1,30 @@
+package io.quarkus.cli.common;
+
+import picocli.CommandLine;
+
+public class CategoryListFormatOptions {
+    @CommandLine.Option(names = { "--id" }, order = 1, description = "Display categoryId column only. (default)")
+    boolean id = false;
+
+    @CommandLine.Option(names = { "--concise" }, order = 2, description = "Display categoryId and name columns.")
+    boolean concise = false;
+
+    @CommandLine.Option(names = { "--full" }, order = 3, description = "Display categoryId, name and description columns.")
+    boolean full = false;
+
+    public String getFormatString() {
+        String format = "id";
+        if (concise)
+            format = "concise";
+        if (full)
+            format = "full";
+        return format;
+    }
+
+    /**
+     * Check if any format has been specified on the command line.
+     */
+    public boolean isSpecified() {
+        return id || concise || full;
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
@@ -3,10 +3,13 @@ package io.quarkus.cli.common;
 import picocli.CommandLine;
 
 public class ListFormatOptions {
-    @CommandLine.Option(names = { "--name" }, order = 4, description = "Display extension name only. (default)")
+    @CommandLine.Option(names = { "--id" }, order = 4, description = "Display extension artifactId only. (default)")
+    boolean id = false;
+
+    @CommandLine.Option(names = { "--name" }, hidden = true, description = "Display extension artifactId only. (deprecated)")
     boolean name = false;
 
-    @CommandLine.Option(names = { "--concise" }, order = 5, description = "Display extension name and description.")
+    @CommandLine.Option(names = { "--concise" }, order = 5, description = "Display extension name and artifactId.")
     boolean concise = false;
 
     @CommandLine.Option(names = {
@@ -22,14 +25,21 @@ public class ListFormatOptions {
      * make origins true. Used with specific platform list.
      */
     public void useOriginsUnlessSpecified() {
-        if (name || concise || full || origins) {
+        if (id || name || concise || full || origins) {
             return;
         }
         origins = true;
     }
 
+    /**
+     * Check if any format has been specified on the command line.
+     */
+    public boolean isSpecified() {
+        return id || name || concise || full || origins;
+    }
+
     public String getFormatString() {
-        String formatString = "name";
+        String formatString = "id";
         if (concise)
             formatString = "concise";
         else if (full)

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -41,6 +41,7 @@ import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusDev;
 import io.quarkus.gradle.tasks.QuarkusGenerateCode;
 import io.quarkus.gradle.tasks.QuarkusGenerateConfig;
+import io.quarkus.gradle.tasks.QuarkusListCategories;
 import io.quarkus.gradle.tasks.QuarkusListExtensions;
 import io.quarkus.gradle.tasks.QuarkusListPlatforms;
 import io.quarkus.gradle.tasks.QuarkusRemoteDev;
@@ -56,6 +57,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
     public static final String EXTENSION_NAME = "quarkus";
     public static final String LIST_EXTENSIONS_TASK_NAME = "listExtensions";
+    public static final String LIST_CATEGORIES_TASK_NAME = "listCategories";
     public static final String LIST_PLATFORMS_TASK_NAME = "listPlatforms";
     public static final String ADD_EXTENSION_TASK_NAME = "addExtension";
     public static final String REMOVE_EXTENSION_TASK_NAME = "removeExtension";
@@ -106,6 +108,7 @@ public class QuarkusPlugin implements Plugin<Project> {
     private void registerTasks(Project project, QuarkusPluginExtension quarkusExt) {
         TaskContainer tasks = project.getTasks();
         tasks.create(LIST_EXTENSIONS_TASK_NAME, QuarkusListExtensions.class);
+        tasks.create(LIST_CATEGORIES_TASK_NAME, QuarkusListCategories.class);
         tasks.create(LIST_PLATFORMS_TASK_NAME, QuarkusListPlatforms.class);
         tasks.create(ADD_EXTENSION_TASK_NAME, QuarkusAddExtension.class);
         tasks.create(REMOVE_EXTENSION_TASK_NAME, QuarkusRemoveExtension.class);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListCategories.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListCategories.java
@@ -1,0 +1,69 @@
+package io.quarkus.gradle.tasks;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.project.QuarkusProject;
+
+public class QuarkusListCategories extends QuarkusPlatformTask {
+
+    private static final String DEFAULT_FORMAT = "concise";
+
+    private boolean fromCli = false;
+    private String format = DEFAULT_FORMAT;
+
+    @Input
+    public boolean isFromCli() {
+        return fromCli;
+    }
+
+    @Option(description = "Indicates that a task is run from the Quarkus CLI.", option = "fromCli")
+    public void setFromCli(boolean fromCli) {
+        this.fromCli = fromCli;
+    }
+
+    @Optional
+    @Input
+    public String getFormat() {
+        return format;
+    }
+
+    @Option(description = "Select the output format among 'id' (display the categoryId only), 'concise' (display name and categoryId) and 'full' (name, categoryId and description columns).", option = "format")
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public QuarkusListCategories() {
+        super("Lists quarkus extensions categories");
+    }
+
+    @TaskAction
+    public void listCategories() {
+        try {
+            final QuarkusProject quarkusProject = getQuarkusProject(false);
+            ListCategories listExtensions = new ListCategories(quarkusProject)
+                    .fromCli(isFromCli())
+                    .format(getFormat());
+            listExtensions.execute();
+
+            if (!fromCli) {
+                GradleMessageWriter log = messageWriter();
+
+                if (DEFAULT_FORMAT.equalsIgnoreCase(format)) {
+                    log.info("");
+                    log.info(ListCategories.MORE_INFO_HINT, "--format=full");
+                }
+
+                log.info("");
+                log.info(ListCategories.LIST_EXTENSIONS_HINT,
+                        "`./gradlew listExtensions --category=\"categoryId\"`");
+            }
+        } catch (Exception e) {
+            throw new GradleException("Unable to list extension categories", e);
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/ListCategoriesMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ListCategoriesMojo.java
@@ -1,0 +1,45 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * List extension categories, which a user can use to filter extensions.
+ */
+@Mojo(name = "list-categories", requiresProject = false)
+public class ListCategoriesMojo extends QuarkusProjectMojoBase {
+
+    private static final String DEFAULT_FORMAT = "concise";
+
+    /**
+     * Select the output format among 'name' (display the name only) and 'full'
+     * (includes a verbose name and a description).
+     */
+    @Parameter(property = "format", defaultValue = DEFAULT_FORMAT)
+    protected String format;
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log) throws MojoExecutionException {
+        try {
+            ListCategories listExtensions = new ListCategories(quarkusProject)
+                    .format(format);
+            listExtensions.execute();
+
+            if (DEFAULT_FORMAT.equalsIgnoreCase(format)) {
+                log.info("");
+                log.info(ListCategories.MORE_INFO_HINT, "-Dformat=full");
+            }
+            log.info("");
+            log.info(ListCategories.LIST_EXTENSIONS_HINT,
+                    "`./mvnw quarkus:list-extensions -Dcategory=\"categoryId\"`");
+
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to list extension categories", e);
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
@@ -17,24 +17,32 @@ import io.quarkus.devtools.project.QuarkusProject;
 @Mojo(name = "list-extensions", requiresProject = false)
 public class ListExtensionsMojo extends QuarkusProjectMojoBase {
 
+    private static final String DEFAULT_FORMAT = "concise";
+
     /**
      * List all extensions or just the installable.
      */
-    @Parameter(property = "quarkus.extension.all", alias = "quarkus.extension.all", defaultValue = "true")
+    @Parameter(property = "all", defaultValue = "true")
     protected boolean all;
 
     /**
-     * Select the output format among 'name' (display the name only), 'concise' (display name and description) and 'full'
+     * Select the output format among 'id' (display the artifactId only), 'concise' (display name and artifactId) and 'full'
      * (concise format and version related columns).
      */
-    @Parameter(property = "quarkus.extension.format", alias = "quarkus.extension.format", defaultValue = "concise")
+    @Parameter(property = "format", defaultValue = DEFAULT_FORMAT)
     protected String format;
 
     /**
      * Search filter on extension list. The format is based on Java Pattern.
      */
-    @Parameter(property = "searchPattern", alias = "quarkus.extension.searchPattern")
+    @Parameter(property = "searchPattern")
     protected String searchPattern;
+
+    /**
+     * Only list extensions from given category.
+     */
+    @Parameter(property = "category")
+    protected String category;
 
     /**
      * List the already installed extensions
@@ -49,8 +57,22 @@ public class ListExtensionsMojo extends QuarkusProjectMojoBase {
                     .all(all)
                     .format(format)
                     .search(searchPattern)
+                    .category(category)
                     .installed(installed);
             listExtensions.execute();
+
+            if (DEFAULT_FORMAT.equalsIgnoreCase(format)) {
+                log.info("");
+                log.info(ListExtensions.MORE_INFO_HINT, "-Dformat=full");
+            }
+            if (!installed && (category == null || category.isBlank())) {
+                log.info("");
+                log.info(ListExtensions.FILTER_HINT, "-Dcategory=\"categoryId\"");
+            }
+            log.info("");
+            log.info(ListExtensions.ADD_EXTENSION_HINT,
+                    "pom.xml", "./mvnw quarkus:add-extension -Dextensions=\"artifactId\"");
+
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to list extensions", e);
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/AddExtensions.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/AddExtensions.java
@@ -9,8 +9,6 @@ import io.quarkus.devtools.commands.handlers.AddExtensionsCommandHandler;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
-import io.quarkus.platform.tools.ToolsConstants;
-import io.quarkus.platform.tools.ToolsUtils;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -19,10 +17,9 @@ import java.util.Set;
  */
 public class AddExtensions {
 
-    public static final String NAME = "add-extensions";
-    public static final String EXTENSIONS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extensions");
-    public static final String OUTCOME_UPDATED = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "outcome", "updated");
-    public static final String EXTENSION_MANAGER = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extension-manager");
+    public static final String EXTENSIONS = "quarkus.add-extensions.extensions";
+    public static final String OUTCOME_UPDATED = "quarkus.add-extensions.outcome-updated";
+    public static final String EXTENSION_MANAGER = "quarkus.add-extensions.extension-manager";
 
     private final QuarkusCommandInvocation invocation;
     private final AddExtensionsCommandHandler handler = new AddExtensionsCommandHandler();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -21,7 +21,6 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.codegen.CreateProjectHelper;
 import io.quarkus.devtools.project.codegen.SourceType;
-import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,13 +36,11 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class CreateProject {
 
-    public static final String NAME = "create-project";
-
-    public static final String NO_DOCKERFILES = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-dockerfiles");
-    public static final String NO_BUILDTOOL_WRAPPER = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-buildtool-wrapper");
-    public static final String NO_CODE = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "no-code");
-    public static final String EXAMPLE = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "example");
-    public static final String EXTRA_CODESTARTS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extra-codestarts");
+    public static final String NO_DOCKERFILES = "quarkus.create-project.no-dockerfiles";
+    public static final String NO_BUILDTOOL_WRAPPER = "quarkus.create-project.no-buildtool-wrapper";
+    public static final String NO_CODE = "quarkus.create-project.no-code";
+    public static final String EXAMPLE = "quarkus.create-project.example";
+    public static final String EXTRA_CODESTARTS = "quarkus.create-project.extra-codestarts";
 
     private QuarkusProject quarkusProject;
     private String javaTarget;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListCategories.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListCategories.java
@@ -1,0 +1,52 @@
+package io.quarkus.devtools.commands;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.commands.handlers.ListCategoriesCommandHandler;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+import java.util.HashMap;
+
+/**
+ * Instances of this class are not thread-safe. They are created per single invocation.
+ */
+public class ListCategories {
+
+    public static final String BATCH_MODE = "quarkus.list-categories.batch-mode";
+    public static final String FROM_CLI = "quarkus.list-categories.from-cli";
+    public static final String FORMAT = "quarkus.list-categories.format";
+
+    public static final String LIST_EXTENSIONS_HINT = "To list extensions in given category, use:\n%s";
+    public static final String MORE_INFO_HINT = "To get more information, append `%s` to your command line.";
+
+    private final QuarkusCommandInvocation invocation;
+    private final ListCategoriesCommandHandler handler = new ListCategoriesCommandHandler();
+
+    public ListCategories(final QuarkusProject quarkusProject) {
+        this.invocation = new QuarkusCommandInvocation(quarkusProject);
+    }
+
+    public ListCategories(final QuarkusProject quarkusProject, final MessageWriter messageWriter) {
+        this.invocation = new QuarkusCommandInvocation(quarkusProject, new HashMap<>(), messageWriter);
+    }
+
+    public ListCategories fromCli(boolean cli) {
+        invocation.setValue(FROM_CLI, cli);
+        return this;
+    }
+
+    public ListCategories format(String format) {
+        invocation.setValue(FORMAT, format);
+        return this;
+    }
+
+    public ListCategories batchMode(boolean batchMode) {
+        invocation.setValue(BATCH_MODE, batchMode);
+        return this;
+    }
+
+    public QuarkusCommandOutcome execute() throws QuarkusCommandException {
+        return handler.execute(invocation);
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListExtensions.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListExtensions.java
@@ -9,22 +9,27 @@ import io.quarkus.devtools.commands.handlers.ListExtensionsCommandHandler;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
-import io.quarkus.platform.tools.ToolsConstants;
-import io.quarkus.platform.tools.ToolsUtils;
 import java.util.HashMap;
 
 /**
  * Instances of this class are not thread-safe. They are created per single invocation.
  */
 public class ListExtensions {
-    public static final String NAME = "list-extensions";
-    private static final String PARAM_PREFIX = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME);
-    public static final String ALL = ToolsUtils.dotJoin(PARAM_PREFIX, "all");
-    public static final String INSTALLED = ToolsUtils.dotJoin(PARAM_PREFIX, "installed");
-    public static final String FROM_CLI = ToolsUtils.dotJoin(PARAM_PREFIX, "fromCli");
-    public static final String FORMAT = ToolsUtils.dotJoin(PARAM_PREFIX, "format");
-    public static final String SEARCH = ToolsUtils.dotJoin(PARAM_PREFIX, "search");
-    public static final String EXTENSION_MANAGER = ToolsUtils.dotJoin(PARAM_PREFIX, "extension-manager");
+
+    public static final String ALL = "quarkus.list-extensions.all";
+    public static final String INSTALLED = "quarkus.list-extensions.installed";
+    public static final String FROM_CLI = "quarkus.list-extensions.from-cli";
+    public static final String FORMAT = "quarkus.list-extensions.format";
+    public static final String SEARCH = "quarkus.list-extensions.search";
+    public static final String CATEGORY = "quarkus.list-extensions.category";
+    public static final String BATCH_MODE = "quarkus.list-extensions.batch-mode";
+    public static final String EXTENSION_MANAGER = "quarkus.list-extensions.extension-manager";
+
+    public static final String MORE_INFO_HINT = "To get more information, append `%s` to your command line.";
+    public static final String FILTER_HINT = "To list only extensions from specific category, append " +
+            "`%s` to your command line.";
+    public static final String ADD_EXTENSION_HINT = "Add an extension to your project by adding the dependency to your " +
+            "%s or use `%s`";
 
     private final QuarkusCommandInvocation invocation;
     private final ListExtensionsCommandHandler handler = new ListExtensionsCommandHandler();
@@ -64,6 +69,16 @@ public class ListExtensions {
 
     public ListExtensions search(String search) {
         invocation.setValue(SEARCH, search);
+        return this;
+    }
+
+    public ListExtensions category(String category) {
+        invocation.setValue(CATEGORY, category);
+        return this;
+    }
+
+    public ListExtensions batchMode(boolean batchMode) {
+        invocation.setValue(BATCH_MODE, batchMode);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/RemoveExtensions.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/RemoveExtensions.java
@@ -9,8 +9,6 @@ import io.quarkus.devtools.commands.handlers.RemoveExtensionsCommandHandler;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
-import io.quarkus.platform.tools.ToolsConstants;
-import io.quarkus.platform.tools.ToolsUtils;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -19,10 +17,9 @@ import java.util.Set;
  */
 public class RemoveExtensions {
 
-    public static final String NAME = "remove-extensions";
-    public static final String EXTENSIONS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extensions");
-    public static final String OUTCOME_UPDATED = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "outcome", "updated");
-    public static final String EXTENSION_MANAGER = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extension-manager");
+    public static final String EXTENSIONS = "quarkus.remove-extensions.extensions";
+    public static final String OUTCOME_UPDATED = "quarkus.remove-extensions.outcome-updated";
+    public static final String EXTENSION_MANAGER = "quarkus.remove-extensions.extension-manager";
 
     private final QuarkusCommandInvocation invocation;
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListCategoriesCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListCategoriesCommandHandler.java
@@ -1,0 +1,71 @@
+package io.quarkus.devtools.commands.handlers;
+
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.registry.catalog.Category;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.function.BiConsumer;
+
+/**
+ * Instances of this class are thread-safe. It lists extension categories according to the options passed in as properties of
+ * {@link QuarkusCommandInvocation}
+ */
+public class ListCategoriesCommandHandler implements QuarkusCommandHandler {
+
+    private static final String ID_FORMAT = "%-20s";
+    private static final String CONCISE_FORMAT = "%-50s %-50s";
+    private static final String FULL_FORMAT = "%-30s %-20s %s";
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+
+        final MessageWriter log = invocation.log();
+        final boolean batchMode = invocation.getValue(ListCategories.BATCH_MODE, false);
+        final String format = invocation.getValue(ListCategories.FORMAT, "");
+
+        final Collection<Category> categories = invocation.getExtensionsCatalog().getCategories();
+
+        if (!batchMode) {
+            log.info("Available Quarkus extension categories: ");
+            log.info("");
+        }
+
+        BiConsumer<MessageWriter, Category> formatter;
+        switch (format.toLowerCase()) {
+            case "full":
+                log.info(String.format(FULL_FORMAT, "Category", "CategoryId", "Description"));
+                formatter = this::fullFormatter;
+                break;
+            case "concise":
+                formatter = this::conciseFormatter;
+                break;
+            case "id":
+            default:
+                formatter = this::idFormatter;
+                break;
+        }
+
+        categories.stream()
+                .sorted(Comparator.comparing(Category::getName))
+                .forEach(c -> formatter.accept(log, c));
+
+        return QuarkusCommandOutcome.success();
+    }
+
+    private void idFormatter(MessageWriter writer, Category category) {
+        writer.info(String.format(ID_FORMAT, category.getId()));
+    }
+
+    private void conciseFormatter(MessageWriter writer, Category category) {
+        writer.info(String.format(CONCISE_FORMAT, category.getName(), category.getId()));
+    }
+
+    private void fullFormatter(MessageWriter writer, Category category) {
+        writer.info(String.format(FULL_FORMAT, category.getName(), category.getId(), category.getDescription()));
+    }
+
+}


### PR DESCRIPTION
* add ability to list extensions by category,
* add command to list categories,
* extensions ordered alphabetically by artifactId,
* consistent maven property names (-Dformat).

Fixes https://github.com/quarkusio/quarkus/issues/16154