### PR TITLE
Minor QOL fix for Quarkus devs

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -47,6 +47,12 @@ public class JarClassPathElement implements ClassPathElement {
             //version 8
         }
         JAVA_VERSION = version;
+        //force this class to be loaded
+        //if quarkus is recompiled it needs to have already
+        //been loaded
+        //this is just a convenience for quarkus devs that means exit
+        //should work properly if you recompile while quarkus is running
+        new ZipFileMayHaveChangedException(null);
     }
 
     private static final Logger log = Logger.getLogger(JarClassPathElement.class);


### PR DESCRIPTION
This fix means that if you recompile quarkus
while you have a dev mode app running against it
the app will be less likely to hang and need to
be killed.