### PR TITLE
Ignore warnings on specific missing sources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -34,6 +34,7 @@ public class JavaCompilationProvider implements CompilationProvider {
     // -parameters is used to generate metadata for reflection on method parameters
     // this is useful when people using debuggers against their hot-reloaded app
     private static final Set<String> COMPILER_OPTIONS = new HashSet<>(Arrays.asList("-g", "-parameters"));
+    private static final Set<String> IGNORE_NAMESPACES = new HashSet<>(Collections.singletonList("org.osgi"));
 
     JavaCompiler compiler;
     StandardJavaFileManager fileManager;
@@ -74,17 +75,10 @@ public class JavaCompilationProvider implements CompilationProvider {
                 throw new RuntimeException("Compilation failed" + diagnostics.getDiagnostics());
             }
 
-            for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-                log.logf(diagnostic.getKind() == Diagnostic.Kind.ERROR ? Logger.Level.ERROR : Logger.Level.WARN,
-                        "%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
-                        diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
-            }
+            logDiagnostics(diagnostics);
+
             if (!fileManagerDiagnostics.getDiagnostics().isEmpty()) {
-                for (Diagnostic<? extends JavaFileObject> diagnostic : fileManagerDiagnostics.getDiagnostics()) {
-                    log.logf(diagnostic.getKind() == Diagnostic.Kind.ERROR ? Logger.Level.ERROR : Logger.Level.WARN,
-                            "%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
-                            diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
-                }
+                logDiagnostics(fileManagerDiagnostics);
                 fileManager.close();
                 fileManagerDiagnostics = null;
                 fileManager = null;
@@ -115,6 +109,28 @@ public class JavaCompilationProvider implements CompilationProvider {
             fileManager = null;
             fileManagerDiagnostics = null;
         }
+    }
+
+    private void logDiagnostics(final DiagnosticCollector<JavaFileObject> diagnostics) {
+        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+            Logger.Level level = diagnostic.getKind() == Diagnostic.Kind.ERROR ? Logger.Level.ERROR : Logger.Level.WARN;
+            String message = diagnostic.getMessage(null);
+            if (level.equals(Logger.Level.WARN) && ignoreWarningForNamespace(message)) {
+                continue;
+            }
+
+            log.logf(level, "%s, line %d in %s", message, diagnostic.getLineNumber(),
+                    diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
+        }
+    }
+
+    private static boolean ignoreWarningForNamespace(String message) {
+        for (String ignoreNamespace : IGNORE_NAMESPACES) {
+            if (message.contains(ignoreNamespace)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static class RuntimeUpdatesClassVisitor extends ClassVisitor {


### PR DESCRIPTION
- Fixes #17618

I'm wondering if we should be more smart and look into provided dependencies and ignore everything coming from there. Also, I don't particularly enjoy the solution, but I couldn't find any other way.