### PR TITLE
Update the security NVD section

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -270,4 +270,6 @@ All registered Quarkus CPE names can be found using link:https://nvd.nist.gov/pr
 If a Quarkus tag represented by the given CPE name entry is affected by some CVE then you'll be able to follow a provided link to that CVE.
 
 We will be asking the NVD CPE team to update the list as well as link Quarkus CPE name entries with the related CVEs on a regular basis.
-If you work with a plugin like OWASP plugin which is using NVD feeds to detect the vulnerabilities at the application build time and you see a false positive reported then please re-open link:https://github.com/quarkusio/quarkus/issues/2611[this issue] and provide the details.
+If you work with the link:https://jeremylong.github.io/DependencyCheck/dependency-check-maven/[OWASP Dependency Check Plugin] which is using NVD feeds to detect the vulnerabilities at the application build time and see a false positive reported then please re-open link:https://github.com/quarkusio/quarkus/issues/2611[this issue] and provide the details.
+
+Note link:https://jeremylong.github.io/DependencyCheck/dependency-check-maven/[OWASP Dependency Check Plugin] `6.2.0` or later should be used with Quarkus.


### PR DESCRIPTION
This PR updates the NVD section to recommend using `6.2.0` or later version of OWASP Dependency Check plugin