### PR TITLE
Implement a label based discovery for Kafka Dev Service

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -25,6 +25,20 @@ Dev Services for Kafka relies on Docker to start the broker.
 If your environment does not support Docker, you will need to start the broker manually, or connect to an already running broker.
 You can configure the broker address using `kafka.bootstrap.servers`.
 
+== Shared broker
+
+Most of the time you need to share the broker between applications.
+Dev Services for Kafka implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single broker.
+
+NOTE: Dev Services for Kafka starts the container with the `quarkus-dev-service-kafka` label which is used to identify the container.
+
+If you need multiple (shared) brokers, you can configure the `quarkus.kafka.devservices.service-name` attribute and indicate the broker name.
+It looks for a container with the same value, or starts a new one if none can be found.
+The default service name is `kafka`.
+
+Sharing is enabled by default in dev mode, but disabled in test mode.
+You can disable the sharing with `quarkus.kafka.devservices.shared=false`.
+
 == Setting the port
 
 By default, Dev Services for Kafka picks a random port and configures the application.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -2,11 +2,13 @@ package io.quarkus.kafka.client.deployment;
 
 import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -14,6 +16,8 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsDockerWorking;
@@ -35,6 +39,12 @@ public class DevServicesKafkaProcessor {
     private static final Logger log = Logger.getLogger(DevServicesKafkaProcessor.class);
     private static final int KAFKA_PORT = 9092;
     private static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
+
+    /**
+     * Label to add to shared Dev Service for Kafka running in containers.
+     * This allows other applications to discover the running service and use it instead of starting a new instance.
+     */
+    private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-kafka";
 
     static volatile Closeable closeable;
     static volatile KafkaDevServiceCfg cfg;
@@ -64,7 +74,7 @@ public class DevServicesKafkaProcessor {
             cfg = null;
         }
 
-        KafkaBroker kafkaBroker = startKafka(configuration);
+        KafkaBroker kafkaBroker = startKafka(configuration, launchMode);
         DevServicesKafkaBrokerBuildItem bootstrapServers = null;
         if (kafkaBroker != null) {
             closeable = kafkaBroker.getCloseable();
@@ -101,10 +111,13 @@ public class DevServicesKafkaProcessor {
         cfg = configuration;
 
         if (bootstrapServers != null) {
-            log.infof(
-                    "Dev Services for Kafka started. Start applications that need to use the same Kafka broker "
-                            + "using -Dkafka.bootstrap.servers=%s",
-                    bootstrapServers.getBootstrapServers());
+            if (kafkaBroker.isOwner()) {
+                log.infof(
+                        "Dev Services for Kafka started. Other Quarkus applications in dev mode will find the "
+                                + "broker automatically. For Quarkus applications in production mode, you can connect to"
+                                + " this by starting your application with -Dkafka.bootstrap.servers=%s",
+                        bootstrapServers.getBootstrapServers());
+            }
 
             devServicePropertiesProducer.produce(new DevServicesNativeConfigResultBuildItem("kafka.bootstrap.servers",
                     bootstrapServers.getBootstrapServers()));
@@ -125,7 +138,30 @@ public class DevServicesKafkaProcessor {
         }
     }
 
-    private KafkaBroker startKafka(KafkaDevServiceCfg config) {
+    private static Container lookup(String expectedLabelValue) {
+        List<Container> containers = DockerClientFactory.lazyClient().listContainersCmd().exec();
+        for (Container container : containers) {
+            String s = container.getLabels().get(DEV_SERVICE_LABEL);
+            if (expectedLabelValue.equalsIgnoreCase(s)) {
+                return container;
+            }
+        }
+        return null;
+    }
+
+    private static ContainerPort getMappedPort(Container container, int port) {
+        for (ContainerPort p : container.getPorts()) {
+            Integer mapped = p.getPrivatePort();
+            Integer publicPort = p.getPublicPort();
+            if (mapped != null && mapped == port && publicPort != null) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private KafkaBroker startKafka(KafkaDevServiceCfg config,
+            LaunchModeBuildItem launchMode) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting dev services for Kafka, as it has been disabled in the config.");
@@ -145,14 +181,32 @@ public class DevServicesKafkaProcessor {
         }
 
         if (!isDockerWorking.getAsBoolean()) {
-            log.warn("Docker isn't working, please configure the Kafka bootstrap servers property (kafka.bootstrap.servers).");
+            log.warn(
+                    "Docker isn't working, please configure the Kafka bootstrap servers property (kafka.bootstrap.servers).");
             return null;
+        }
+
+        if (config.shared && launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
+            // Detect if there is a broker already started using container labels.
+            Container container = lookup(config.serviceName);
+            if (container != null) {
+                ContainerPort port = getMappedPort(container, KAFKA_PORT);
+                if (port != null) {
+                    String url = port.getIp() + ":" + port.getPublicPort();
+                    log.infof("Dev Services for Kafka container found: %s (%s). "
+                            + "Connecting to: %s.",
+                            container.getId(),
+                            container.getImage(), url);
+                    return new KafkaBroker(url, null);
+                }
+            }
         }
 
         // Starting the broker
         RedPandaKafkaContainer container = new RedPandaKafkaContainer(
                 DockerImageName.parse(config.imageName),
-                config.fixedExposedPort);
+                config.fixedExposedPort,
+                launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null);
         container.start();
 
         return new KafkaBroker(
@@ -186,10 +240,7 @@ public class DevServicesKafkaProcessor {
 
     private KafkaDevServiceCfg getConfiguration(KafkaBuildTimeConfig cfg) {
         KafkaDevServicesBuildTimeConfig devServicesConfig = cfg.devservices;
-        boolean devServicesEnabled = devServicesConfig.enabled.orElse(true);
-        return new KafkaDevServiceCfg(devServicesEnabled,
-                devServicesConfig.imageName,
-                devServicesConfig.port.orElse(0));
+        return new KafkaDevServiceCfg(devServicesConfig);
     }
 
     private static class KafkaBroker {
@@ -199,6 +250,10 @@ public class DevServicesKafkaProcessor {
         public KafkaBroker(String url, Closeable closeable) {
             this.url = url;
             this.closeable = closeable;
+        }
+
+        public boolean isOwner() {
+            return closeable != null;
         }
 
         public String getBootstrapServers() {
@@ -214,11 +269,15 @@ public class DevServicesKafkaProcessor {
         private final boolean devServicesEnabled;
         private final String imageName;
         private final Integer fixedExposedPort;
+        private final boolean shared;
+        private final String serviceName;
 
-        public KafkaDevServiceCfg(boolean devServicesEnabled, String imageName, Integer fixedExposedPort) {
-            this.devServicesEnabled = devServicesEnabled;
-            this.imageName = imageName;
-            this.fixedExposedPort = fixedExposedPort;
+        public KafkaDevServiceCfg(KafkaDevServicesBuildTimeConfig config) {
+            this.devServicesEnabled = config.enabled.orElse(true);
+            this.imageName = config.imageName;
+            this.fixedExposedPort = config.port.orElse(0);
+            this.shared = config.shared;
+            this.serviceName = config.serviceName;
         }
 
         @Override
@@ -250,12 +309,15 @@ public class DevServicesKafkaProcessor {
 
         private static final String STARTER_SCRIPT = "/redpanda.sh";
 
-        private RedPandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort) {
+        private RedPandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName) {
             super(dockerImageName);
             this.port = fixedExposedPort;
             withNetwork(Network.SHARED);
             withExposedPorts(KAFKA_PORT);
-            // For Redpanda, we need to start the broker - see https://vectorized.io/docs/quick-start-docker/
+            if (serviceName != null) { // Only adds the label in dev mode.
+                withLabel(DEV_SERVICE_LABEL, serviceName);
+            }
+            // For redpanda, we need to start the broker - see https://vectorized.io/docs/quick-start-docker/
             if (dockerImageName.getRepository().equals("vectorized/redpanda")) {
                 withCreateContainerCmdModifier(cmd -> {
                     cmd.withEntrypoint("sh");

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -33,4 +33,31 @@ public class KafkaDevServicesBuildTimeConfig {
     @ConfigItem(defaultValue = "vectorized/redpanda:v21.5.5")
     public String imageName;
 
+    /**
+     * Indicates if the Kafka broker managed by Quarkus Dev Services is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services for Kafka starts a new container.
+     * <p>
+     * The discovery uses the {@code quarkus-dev-service-kafka} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code quarkus-dev-service-kafka} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services for Kafka looks for a container with the
+     * {@code quarkus-dev-service-kafka} label
+     * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it
+     * starts a new container with the {@code quarkus-dev-service-kafka} label set to the specified value.
+     * <p>
+     * This property is used when you need multiple shared Kafka brokers.
+     */
+    @ConfigItem(defaultValue = "kafka")
+    public String serviceName;
+
 }


### PR DESCRIPTION
Instead to have to configure the kafka.bootstrap.url, it looks for containers having a specific label and computes the bootstrap server.
Discovery can be disabled in the configuration, and it is only used in dev mode (disabled for test).

@stuartwdouglas we discussed this briefly on the mailing list. It's a draft but works. 

**TODO:**

- [x] update the documentation
- [x] if we decide to go this way, move the label name to a shared class (so every dev service can use it)
- [x] extend configuration to allows configuring the label or value