### PR TITLE
Change the behavior of InjectionPointInfo.getRequiredType()

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -120,19 +120,19 @@ public class ConfigBuildStep {
                 }
 
                 // Register a custom bean for injection points that are not handled by ConfigProducer
-                Type requiredType = injectionPoint.getRequiredType();
-                if (!isHandledByProducers(requiredType)) {
-                    customBeanTypes.add(requiredType);
+                Type injectedType = injectionPoint.getType();
+                if (!isHandledByProducers(injectedType)) {
+                    customBeanTypes.add(injectedType);
                 }
 
-                if (DotNames.OPTIONAL.equals(requiredType.name())
-                        || DotNames.OPTIONAL_INT.equals(requiredType.name())
-                        || DotNames.OPTIONAL_LONG.equals(requiredType.name())
-                        || DotNames.OPTIONAL_DOUBLE.equals(requiredType.name())
-                        || DotNames.PROVIDER.equals(requiredType.name())
-                        || SUPPLIER_NAME.equals(requiredType.name())
-                        || CONFIG_VALUE_NAME.equals(requiredType.name())
-                        || MP_CONFIG_VALUE_NAME.equals(requiredType.name())) {
+                if (DotNames.OPTIONAL.equals(injectedType.name())
+                        || DotNames.OPTIONAL_INT.equals(injectedType.name())
+                        || DotNames.OPTIONAL_LONG.equals(injectedType.name())
+                        || DotNames.OPTIONAL_DOUBLE.equals(injectedType.name())
+                        || DotNames.PROVIDER.equals(injectedType.name())
+                        || SUPPLIER_NAME.equals(injectedType.name())
+                        || CONFIG_VALUE_NAME.equals(injectedType.name())
+                        || MP_CONFIG_VALUE_NAME.equals(injectedType.name())) {
                     // Never validate container objects
                     continue;
                 }
@@ -143,7 +143,7 @@ public class ConfigBuildStep {
                     propertyDefaultValue = defaultValue.asString();
                 }
 
-                configProperties.produce(new ConfigPropertyBuildItem(propertyName, requiredType, propertyDefaultValue));
+                configProperties.produce(new ConfigPropertyBuildItem(propertyName, injectedType, propertyDefaultValue));
             }
         }
 

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -143,12 +143,6 @@ public class GrpcClientProcessor {
             }
 
             Type injectionType = injectionPoint.getRequiredType();
-
-            // Programmatic lookup - take the param type
-            if (DotNames.INSTANCE.equals(injectionType.name()) || DotNames.INJECTABLE_INSTANCE.equals(injectionType.name())) {
-                injectionType = injectionType.asParameterizedType().arguments().get(0);
-            }
-
             if (injectionType.name().equals(GrpcDotNames.CHANNEL)) {
                 // No need to add the stub class for Channel
                 continue;

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -138,9 +138,9 @@ class SmallRyeJwtProcessor {
                 continue;
             }
             AnnotationInstance claimQualifier = injectionPoint.getRequiredQualifier(CLAIM_NAME);
-            if (claimQualifier != null && injectionPoint.getRequiredType().name().equals(DotNames.PROVIDER)) {
+            if (claimQualifier != null && injectionPoint.getType().name().equals(DotNames.PROVIDER)) {
                 // Classes from javax.json are handled specially
-                Type actualType = injectionPoint.getRequiredType().asParameterizedType().arguments().get(0);
+                Type actualType = injectionPoint.getRequiredType();
                 if (actualType.name().equals(DotNames.OPTIONAL) && !actualType.name().toString()
                         .startsWith("javax.json")) {
                     additionalTypes.add(actualType);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -307,7 +307,7 @@ public class BeanDeployment {
                 // Instance<Foo>
                 for (InjectionPointInfo injectionPoint : instanceInjectionPoints) {
                     if (Beans.hasQualifiers(bean, injectionPoint.getRequiredQualifiers()) && Beans.matchesType(bean,
-                            injectionPoint.getRequiredType().asParameterizedType().arguments().get(0))) {
+                            injectionPoint.getType().asParameterizedType().arguments().get(0))) {
                         continue test;
                     }
                 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1007,7 +1007,7 @@ public class BeanGenerator extends AbstractGenerator {
 
             // 1. constructor injection points
             for (int i = 0; i < injectionPoints.size(); i++) {
-                paramTypes.add(injectionPoints.get(i).getRequiredType().name().toString());
+                paramTypes.add(injectionPoints.get(i).getType().name().toString());
                 paramHandles.add(providerHandles.get(i));
             }
             // 2. ctx
@@ -1038,7 +1038,7 @@ public class BeanGenerator extends AbstractGenerator {
                 ResultHandle argsArray = creator.newArray(Object.class, creator.load(providerHandles.size()));
                 for (int i = 0; i < injectionPoints.size(); i++) {
                     creator.writeArrayValue(paramTypesArray, i,
-                            creator.loadClass(injectionPoints.get(i).getRequiredType().name().toString()));
+                            creator.loadClass(injectionPoints.get(i).getType().name().toString()));
                     creator.writeArrayValue(argsArray, i, providerHandles.get(i));
                 }
                 registration.registerMethod(constructor);
@@ -1050,7 +1050,7 @@ public class BeanGenerator extends AbstractGenerator {
                 String[] paramTypes = new String[injectionPoints.size()];
                 for (ListIterator<InjectionPointInfo> iterator = injectionPoints.listIterator(); iterator.hasNext();) {
                     InjectionPointInfo injectionPoint = iterator.next();
-                    paramTypes[iterator.previousIndex()] = DescriptorUtils.typeToString(injectionPoint.getRequiredType());
+                    paramTypes[iterator.previousIndex()] = DescriptorUtils.typeToString(injectionPoint.getType());
                 }
                 return creator.newInstance(MethodDescriptor.ofConstructor(providerTypeName, paramTypes),
                         providerHandles.toArray(new ResultHandle[0]));
@@ -1350,7 +1350,7 @@ public class BeanGenerator extends AbstractGenerator {
             if (constructorInjection.isPresent()) {
                 List<String> paramTypes = new ArrayList<>();
                 for (InjectionPointInfo injectionPoint : constructorInjection.get().injectionPoints) {
-                    paramTypes.add(injectionPoint.getRequiredType().name().toString());
+                    paramTypes.add(injectionPoint.getType().name().toString());
                 }
                 ResultHandle[] paramsHandles = new ResultHandle[2];
                 paramsHandles[0] = create.loadClass(providerType.className());
@@ -1794,7 +1794,7 @@ public class BeanGenerator extends AbstractGenerator {
                         Supplier.class, java.lang.reflect.Type.class,
                         Set.class, Set.class, Member.class, int.class),
                 constructor.getThis(), constructor.getMethodParam(paramIdx),
-                Types.getTypeHandle(constructor, injectionPoint.getRequiredType(), tccl),
+                Types.getTypeHandle(constructor, injectionPoint.getType(), tccl),
                 requiredQualifiersHandle, annotationsHandle, javaMemberHandle, constructor.load(injectionPoint.getPosition()));
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanRegistrar.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanRegistrar.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import java.util.Collection;
 import org.jboss.jandex.DotName;
 
 /**
@@ -44,6 +45,10 @@ public interface BeanRegistrar extends BuildExtension {
          * @return a new stream of beans
          */
         BeanStream beans();
+
+        default Collection<InjectionPointInfo> getInjectionPoints() {
+            return get(BuildExtension.Key.INJECTION_POINTS);
+        }
 
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -463,7 +463,7 @@ final class Beans {
                 errors.add(new DefinitionException("EventMetadata can be only injected into an observer method: "
                         + injectionPoint.getTargetInfo()));
             } else if (BuiltinBean.INSTANCE == builtinBean
-                    && injectionPoint.getRequiredType().kind() != Kind.PARAMETERIZED_TYPE) {
+                    && injectionPoint.getType().kind() != Kind.PARAMETERIZED_TYPE) {
                 errors.add(
                         new DefinitionException("An injection point of raw type javax.enterprise.inject.Instance is defined: "
                                 + injectionPoint.getTargetInfo()));
@@ -510,7 +510,7 @@ final class Beans {
 
     private static void addStandardErroneousDependencyMessage(InjectionTargetInfo target, InjectionPointInfo injectionPoint,
             StringBuilder message) {
-        message.append(injectionPoint.getRequiredType());
+        message.append(injectionPoint.getType());
         message.append(" and qualifiers ");
         message.append(injectionPoint.getRequiredQualifiers());
         message.append("\n\t- java member: ");

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -36,7 +36,7 @@ enum BuiltinBean {
         ResultHandle qualifiers = BeanGenerator.collectInjectionPointQualifiers(ctx.classOutput, ctx.clazzCreator,
                 ctx.beanDeployment,
                 ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals);
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getRequiredType());
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
         ResultHandle annotationsHandle = BeanGenerator.collectInjectionPointAnnotations(ctx.classOutput, ctx.clazzCreator,
                 ctx.beanDeployment,
                 ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals, ctx.injectionPointAnnotationsPredicate);
@@ -149,7 +149,7 @@ enum BuiltinBean {
                 }
             }
         }
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getRequiredType());
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
         ResultHandle eventProvider = ctx.constructor.newInstance(
                 MethodDescriptor.ofConstructor(EventProvider.class, java.lang.reflect.Type.class,
                         Set.class),
@@ -175,7 +175,7 @@ enum BuiltinBean {
                                 Types.getPackageName(ctx.clazzCreator.getClassName())));
             }
         }
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getRequiredType());
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
         ResultHandle resourceProvider = ctx.constructor.newInstance(
                 MethodDescriptor.ofConstructor(ResourceProvider.class, java.lang.reflect.Type.class,
                         Set.class),
@@ -283,7 +283,7 @@ enum BuiltinBean {
             return false;
         }
         for (DotName rawTypeDotName : rawTypeDotNames) {
-            if (rawTypeDotName.equals(injectionPoint.getRequiredType().name())) {
+            if (rawTypeDotName.equals(injectionPoint.getType().name())) {
                 return true;
             }
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -121,8 +121,36 @@ public class InjectionPointInfo {
         return kind;
     }
 
+    /**
+     * Note that for programmatic lookup, the required type is the type parameter specified at the injection point. For example,
+     * the required type for an injection point of type {@code Instance<org.acme.Foo>} is {@code org.acme.Foo}.
+     * 
+     * @return the required type of this injection point
+     */
     public Type getRequiredType() {
+        Type requiredType = typeAndQualifiers.type;
+        if (isProgrammaticLookup() && requiredType.kind() == org.jboss.jandex.Type.Kind.PARAMETERIZED_TYPE) {
+            requiredType = requiredType.asParameterizedType().arguments().get(0);
+        }
+        return requiredType;
+    }
+
+    /**
+     * This method always returns the original type declared on the injection point, unlike {@link #getRequiredType()}.
+     * 
+     * @return the type specified at the injection point
+     */
+    public Type getType() {
         return typeAndQualifiers.type;
+    }
+
+    /**
+     * @return <code>true</code> if this injection represents a dynamically obtained instance, <code>false</code> otherwise
+     */
+    public boolean isProgrammaticLookup() {
+        DotName requiredTypeName = typeAndQualifiers.type.name();
+        return DotNames.INSTANCE.equals(requiredTypeName) || DotNames.INJECTABLE_INSTANCE.equals(requiredTypeName)
+                || DotNames.PROVIDER.equals(requiredTypeName);
     }
 
     public Set<AnnotationInstance> getRequiredQualifiers() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -517,7 +517,7 @@ public class ObserverGenerator extends AbstractGenerator {
                                         Supplier.class, java.lang.reflect.Type.class,
                                         Set.class, Set.class, Member.class, int.class),
                                 constructor.loadNull(), delegateSupplier,
-                                Types.getTypeHandle(constructor, injectionPoint.getRequiredType()),
+                                Types.getTypeHandle(constructor, injectionPoint.getType()),
                                 requiredQualifiersHandle, annotationsHandle, javaMemberHandle,
                                 constructor.load(injectionPoint.getPosition()));
                         ResultHandle wrapSupplierHandle = constructor.newInstance(

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -132,7 +132,7 @@ public class SubclassGenerator extends AbstractGenerator {
         Optional<Injection> constructorInjection = bean.getConstructorInjection();
         if (constructorInjection.isPresent()) {
             for (InjectionPointInfo injectionPoint : constructorInjection.get().injectionPoints) {
-                parameterTypes.add(injectionPoint.getRequiredType().name().toString());
+                parameterTypes.add(injectionPoint.getType().name().toString());
             }
         }
         int superParamsSize = parameterTypes.size();

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/validator/BeanDeploymentValidatorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/validator/BeanDeploymentValidatorTest.java
@@ -9,6 +9,7 @@ import io.quarkus.arc.BeanCreator;
 import io.quarkus.arc.processor.BeanDeploymentValidator;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.arc.processor.ObserverInfo;
 import io.quarkus.arc.test.ArcTestContainer;
 import java.util.Collection;
@@ -20,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.jboss.jandex.DotName;
@@ -56,6 +58,11 @@ public class BeanDeploymentValidatorTest {
 
         @Override
         public void validate(ValidationContext context) {
+            assertTrue(context.getInjectionPoints().stream().filter(InjectionPointInfo::isProgrammaticLookup)
+                    .filter(ip -> ip.getTarget().kind() == org.jboss.jandex.AnnotationTarget.Kind.FIELD
+                            && ip.getTarget().asField().name().equals("foo"))
+                    .findFirst().isPresent());
+
             assertFalse(context.removedBeans().withBeanClass(UselessBean.class).isEmpty());
 
             assertFalse(context.beans().classBeans().withBeanClass(Alpha.class).isEmpty());
@@ -87,6 +94,9 @@ public class BeanDeploymentValidatorTest {
 
         @Inject
         List<String> strings;
+
+        @Inject
+        Instance<String> foo;
 
         void observeAppContextInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
         }


### PR DESCRIPTION
- InjectionPointInfo.getRequiredType() should return the type parameter
for programmatic lookup
- resolves #17835