### PR TITLE
Upgrade to SmallRye GraphQL 1.2.5 and MicroProfile GraphQL 1.1.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <smallrye-health.version>3.0.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.5</smallrye-open-api.version>
-        <smallrye-graphql.version>1.2.4</smallrye-graphql.version>
+        <smallrye-graphql.version>1.2.5</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.2.0</smallrye-jwt.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -71,7 +71,7 @@
         <microprofile-opentracing-api.version>2.0</microprofile-opentracing-api.version>
         <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>
         <microprofile-jwt-api.version>1.2</microprofile-jwt-api.version>
-        <microprofile-graphql-api.version>1.0.3</microprofile-graphql-api.version>
+        <microprofile-graphql-api.version>1.1.0</microprofile-graphql-api.version>
 
         <!-- Antlr is used by the PanacheQL parser-->
         <antlr.version>4.7.2</antlr.version>

--- a/docs/src/main/asciidoc/smallrye-graphql-client.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql-client.adoc
@@ -297,7 +297,7 @@ import static io.smallrye.graphql.client.core.Operation.operation;
 // ....
 
 @Inject
-@NamedClient("star-wars-dynamic")    // <1>
+@GraphQLClient("star-wars-dynamic")    // <1>
 DynamicGraphQLClient dynamicClient;
 
 @GET

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -29,7 +29,7 @@ public class SmallRyeGraphQLClientProcessor {
 
     private static final DotName GRAPHQL_CLIENT_API = DotName
             .createSimple("io.smallrye.graphql.client.typesafe.api.GraphQLClientApi");
-    private static final DotName NAMED_CLIENT = DotName.createSimple("io.smallrye.graphql.client.NamedClient");
+    private static final DotName GRAPHQL_CLIENT = DotName.createSimple("io.smallrye.graphql.client.GraphQLClient");
     private static final String NAMED_DYNAMIC_CLIENTS = "io.smallrye.graphql.client.dynamic.cdi.NamedDynamicClients";
 
     @BuildStep
@@ -59,7 +59,7 @@ public class SmallRyeGraphQLClientProcessor {
     void dynamicClientInjection(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<AutoInjectAnnotationBuildItem> autoInject) {
         additionalBeans.produce(new AdditionalBeanBuildItem(NAMED_DYNAMIC_CLIENTS));
-        autoInject.produce(new AutoInjectAnnotationBuildItem(NAMED_CLIENT));
+        autoInject.produce(new AutoInjectAnnotationBuildItem(GRAPHQL_CLIENT));
     }
 
     @BuildStep

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientInjectionTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientInjectionTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.smallrye.graphql.client.deployment.model.Person;
 import io.quarkus.smallrye.graphql.client.deployment.model.TestingGraphQLApi;
 import io.quarkus.test.QuarkusUnitTest;
-import io.smallrye.graphql.client.NamedClient;
+import io.smallrye.graphql.client.GraphQLClient;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.core.Operation;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
@@ -38,7 +38,7 @@ public class DynamicGraphQLClientInjectionTest {
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
     @Inject
-    @NamedClient("people")
+    @GraphQLClient("people")
     DynamicGraphQLClient client;
 
     @Test

--- a/tcks/microprofile-graphql/src/main/resources/overrides/schemaTests.csv
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/schemaTests.csv
@@ -1,2 +1,0 @@
-# testJsonDefault
-59|type Mutation       |   provisionHero(hero: String, item: ItemInput = {dateCreated : "19 February 1900 at 12:00 in Africa/Johannesburg", dateLastUsed : "29 Jan 2020 at 09:45 in zone +0200", height : 1.2, id : 1000, name : "Cape", powerLevel : 3, supernatural : false, weight : 0.3}): SuperHero | Expecting a default value for item for provisionHero


### PR DESCRIPTION
This PR pulls in SmallRye GraphQL 1.2.5 that now builds against MicroProfile GraphQL 1.1.0

see https://github.com/smallrye/smallrye-graphql/releases/tag/1.2.5
see https://github.com/eclipse/microprofile-graphql/releases/tag/1.1.0

This also:
Fix #17733

Please note: Even though the MicroProfile version is a minor bump, technically it's a very small patch release with no breaking changes. Due to the MicroProfile workgroup now under Eclipse, we could not do a 1.0.4 release and had to bump to 1.1.0, where most changes is license requirement for Eclipse Foundation

This is save to backport

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>