### PR TITLE
Change ring buffer default length to 3

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/JsonConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/JsonConfigGroup.java
@@ -26,7 +26,7 @@ public class JsonConfigGroup implements MicrometerConfig.CapabilityEnabled {
      * samples. Samples are accumulated to such statistics in ring buffers which rotate after
      * the expiry, with this buffer length.
      */
-    @ConfigItem(defaultValue = "1024")
+    @ConfigItem(defaultValue = "3")
     public Integer bufferLength;
 
     /**


### PR DESCRIPTION
3 is the Micrometer default, 1024 is way
to big and results in excessive memory usage.