### PR TITLE
Prevent unlikely NoSuchElementException in continuous testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -268,6 +268,7 @@ public class JunitTestRunner {
                                 }
                             }
                         }
+                        touchedClasses.push(Collections.synchronizedSet(new HashSet<>()));
                     }
 
                     @Override


### PR DESCRIPTION
Fixes: #17824

I was not able to reproduce the original issue consistently, but this should fix it nonetheless