### PR TITLE
Type-safe messages - inspect virtual method params during validation

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AppMessages.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AppMessages.java
@@ -31,4 +31,14 @@ public interface AppMessages {
     @Message(key = "dot.test", value = "Dot test!")
     String dotTest();
 
+    @Message("There {msg:fileStrings(numberOfFiles)} on {disk}.")
+    String files(int numberOfFiles, String disk);
+
+    @Message("{#when numberOfFiles}"
+            + "{#is 0}are no files"
+            + "{#is 1}is one file"
+            + "{#else}are {numberOfFiles} files"
+            + "{/when}")
+    String fileStrings(int numberOfFiles);
+
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
@@ -76,6 +76,14 @@ public class MessageBundleTest {
         assertEquals("Dot test!", engine.parse("{msg:['dot.test']}").render());
         assertEquals("Hello world! Hello Malachi Constant!",
                 engine.getTemplate("dynamic").data("key", "hello_fullname").data("surname", "Constant").render());
+
+        assertEquals("There are no files on C.",
+                engine.parse("{msg:files(0,'C')}").render());
+        assertEquals("There is one file on D.",
+                engine.parse("{msg:files(1,'D')}").render());
+        assertEquals("There are 100 files on E.",
+                engine.parse("{msg:files(100,'E')}").render());
+
     }
 
 }


### PR DESCRIPTION
- i.e. do not log an "unused param" warning if a param is used in a
virtual method