### PR TITLE
Remove unnecessary dependencies in Gradle projects

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -35,10 +35,8 @@ dependencies {
     implementation "io.quarkus:quarkus-core-deployment:${version}"
 
     testImplementation "io.quarkus:quarkus-project-core-extension-codestarts:${version}"
-    testImplementation 'org.mockito:mockito-core:3.11.0'
     testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    testImplementation 'org.awaitility:awaitility:4.1.0'
     testImplementation "io.quarkus:quarkus-devmode-test-utils:${version}"
     testImplementation gradleTestKit()
 }

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -48,11 +48,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devmode-test-utils</artifactId>
             <scope>test</scope>

--- a/integration-tests/gradle/build.gradle
+++ b/integration-tests/gradle/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     testImplementation "io.quarkus:quarkus-devmode-test-utils:${version}"
     testImplementation "io.quarkus:quarkus-devtools-common:${version}"
     testImplementation "io.quarkus:io.quarkus.gradle.plugin:${version}"
-    testImplementation 'org.mockito:mockito-core:3.11.0'
     testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
     testImplementation 'org.awaitility:awaitility:4.1.0'


### PR DESCRIPTION
This removes unnecessary test dependencies from `gradle` and `integration-test/gradle` modules. 