### PR TITLE
Fix main CI by aligning jboss-parent in enforcer-rules tests

### DIFF
--- a/independent-projects/enforcer-rules/src/it/smoketest/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>37</version>
+        <version>38</version>
     </parent>
 
     <groupId>io.quarkus</groupId>


### PR DESCRIPTION
https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Main.20is.20broken.20in.20enforcer-rules

Main problem are connectivity issues with repository.jboss.org, but with this PR those enforcer-rules tests should again reuse all of the already existing artifacts in the local repo of the main build.
Since all artifacts from that jboss repo are already present in the GH repo cache for this month, this should be good enough to fix the main CI for now.