### PR TITLE
Refactoring LambdaHttpHandler in quarkus-amazon-lambda-rest

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -19,6 +19,7 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -91,16 +92,17 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                 extractHttpUrlFromRequest(request),
                 quarkusHeaders);
 
+        HttpHeaders nettyRequestHeaders = nettyRequest.headers();
         if (request.getHeaders() != null) { //apparently this can be null if no headers are sent
             for (Map.Entry<String, String> header : request.getHeaders().entrySet()) {
                 if (header.getValue() != null) {
                     for (String val : header.getValue().split(","))
-                        nettyRequest.headers().add(header.getKey(), val);
+                        nettyRequestHeaders.add(header.getKey(), val);
                 }
             }
         }
-        if (!nettyRequest.headers().contains(HttpHeaderNames.HOST)) {
-            nettyRequest.headers().add(HttpHeaderNames.HOST, "localhost");
+        if (!nettyRequestHeaders.contains(HttpHeaderNames.HOST)) {
+            nettyRequestHeaders.add(HttpHeaderNames.HOST, "localhost");
         }
         return nettyRequest;
     }

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -2,19 +2,10 @@ package io.quarkus.amazon.lambda.http;
 
 import static java.util.Optional.ofNullable;
 
-import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import org.jboss.logging.Logger;
 
@@ -25,19 +16,15 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.ReferenceCountUtil;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
-import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
@@ -73,123 +60,6 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
             }
         }
         return null;
-    }
-
-    private static class NettyResponseHandler implements VirtualResponseHandler {
-        private static final int BUFFER_SIZE = 8096;
-
-        APIGatewayV2HTTPResponse responseBuilder = new APIGatewayV2HTTPResponse();
-        ByteArrayOutputStream baos;
-        WritableByteChannel byteChannel;
-        final APIGatewayV2HTTPEvent request;
-        CompletableFuture<APIGatewayV2HTTPResponse> future = new CompletableFuture<>();
-
-        public NettyResponseHandler(APIGatewayV2HTTPEvent request) {
-            this.request = request;
-        }
-
-        public CompletableFuture<APIGatewayV2HTTPResponse> getFuture() {
-            return future;
-        }
-
-        @Override
-        public void handleMessage(Object msg) {
-            try {
-                //log.info("Got message: " + msg.getClass().getName());
-
-                if (msg instanceof HttpResponse) {
-                    HttpResponse res = (HttpResponse) msg;
-                    responseBuilder.setStatusCode(res.status().code());
-
-                    final Map<String, String> headers = new HashMap<>();
-                    responseBuilder.setHeaders(headers);
-                    for (String name : res.headers().names()) {
-                        final List<String> allForName = res.headers().getAll(name);
-                        if (allForName == null || allForName.isEmpty()) {
-                            continue;
-                        }
-                        final StringBuilder sb = new StringBuilder();
-                        for (Iterator<String> valueIterator = allForName.iterator(); valueIterator.hasNext();) {
-                            sb.append(valueIterator.next());
-                            if (valueIterator.hasNext()) {
-                                sb.append(",");
-                            }
-                        }
-                        headers.put(name, sb.toString());
-                    }
-                }
-                if (msg instanceof HttpContent) {
-                    HttpContent content = (HttpContent) msg;
-                    int readable = content.content().readableBytes();
-                    if (baos == null && readable > 0) {
-                        baos = createByteStream();
-                    }
-                    for (int i = 0; i < readable; i++) {
-                        baos.write(content.content().readByte());
-                    }
-                }
-                if (msg instanceof FileRegion) {
-                    FileRegion file = (FileRegion) msg;
-                    if (file.count() > 0 && file.transferred() < file.count()) {
-                        if (baos == null)
-                            baos = createByteStream();
-                        if (byteChannel == null)
-                            byteChannel = Channels.newChannel(baos);
-                        file.transferTo(byteChannel, file.transferred());
-                    }
-                }
-                if (msg instanceof LastHttpContent) {
-                    if (baos != null) {
-                        if (isBinary(responseBuilder.getHeaders().get("Content-Type"))) {
-                            responseBuilder.setIsBase64Encoded(true);
-                            responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
-                        } else {
-                            responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
-                        }
-                    }
-                    future.complete(responseBuilder);
-                }
-            } catch (Throwable ex) {
-                future.completeExceptionally(ex);
-            } finally {
-                if (msg != null) {
-                    ReferenceCountUtil.release(msg);
-                }
-            }
-        }
-
-        private ByteArrayOutputStream createByteStream() {
-            ByteArrayOutputStream baos;
-            baos = new ByteArrayOutputStream(BUFFER_SIZE);
-            return baos;
-        }
-
-        static Set<String> binaryTypes = new HashSet<>();
-
-        static {
-            binaryTypes.add("application/octet-stream");
-            binaryTypes.add("image/jpeg");
-            binaryTypes.add("image/png");
-            binaryTypes.add("image/gif");
-        }
-
-        private boolean isBinary(String contentType) {
-            if (contentType != null) {
-                int index = contentType.indexOf(';');
-                if (index >= 0) {
-                    return binaryTypes.contains(contentType.substring(0, index));
-                } else {
-                    return binaryTypes.contains(contentType);
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public void close() {
-            if (!future.isDone())
-                future.completeExceptionally(new RuntimeException("Connection closed"));
-        }
     }
 
     private APIGatewayV2HTTPResponse nettyDispatch(InetSocketAddress clientAddress, APIGatewayV2HTTPEvent request,

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -39,6 +39,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
         ERROR_HEADERS.putSingle("Content-Type", "application/json");
     }
 
+    @Override
     public APIGatewayV2HTTPResponse handleRequest(APIGatewayV2HTTPEvent request, Context context) {
         InetSocketAddress clientAddress = getClientAddress(request);
 

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -33,9 +33,10 @@ import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse> {
     private static final Logger log = Logger.getLogger("quarkus.amazon.lambda.http");
 
-    private static final Headers errorHeaders = new Headers();
+    private static final Headers ERROR_HEADERS = new Headers();
+
     static {
-        errorHeaders.putSingle("Content-Type", "application/json");
+        ERROR_HEADERS.putSingle("Content-Type", "application/json");
     }
 
     public APIGatewayV2HTTPResponse handleRequest(APIGatewayV2HTTPEvent request, Context context) {
@@ -48,7 +49,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
             APIGatewayV2HTTPResponse res = new APIGatewayV2HTTPResponse();
             res.setStatusCode(500);
             res.setBody("{ \"message\": \"Internal Server Error\" }");
-            res.setMultiValueHeaders(errorHeaders);
+            res.setMultiValueHeaders(ERROR_HEADERS);
             return res;
         }
 

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -47,18 +47,13 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
 
     private static final int BUFFER_SIZE = 8096;
 
-    private static Headers errorHeaders = new Headers();
+    private static final Headers errorHeaders = new Headers();
     static {
         errorHeaders.putSingle("Content-Type", "application/json");
     }
 
     public APIGatewayV2HTTPResponse handleRequest(APIGatewayV2HTTPEvent request, Context context) {
-        InetSocketAddress clientAddress = null;
-        if (request.getRequestContext() != null && request.getRequestContext().getHttp() != null) {
-            if (request.getRequestContext().getHttp().getSourceIp() != null) {
-                clientAddress = new InetSocketAddress(request.getRequestContext().getHttp().getSourceIp(), 443);
-            }
-        }
+        InetSocketAddress clientAddress = getClientAddress(request);
 
         try {
             return nettyDispatch(clientAddress, request, context);
@@ -71,6 +66,15 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
             return res;
         }
 
+    }
+
+    private InetSocketAddress getClientAddress(APIGatewayV2HTTPEvent request) {
+        if (request.getRequestContext() != null && request.getRequestContext().getHttp() != null) {
+            if (request.getRequestContext().getHttp().getSourceIp() != null) {
+                return new InetSocketAddress(request.getRequestContext().getHttp().getSourceIp(), 443);
+            }
+        }
+        return null;
     }
 
     private class NettyResponseHandler implements VirtualResponseHandler {

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -70,7 +70,7 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 HttpContent content = (HttpContent) msg;
                 int readable = content.content().readableBytes();
                 if (baos == null && readable > 0) {
-                    baos = createByteStream();
+                    baos = new ByteArrayOutputStream(BUFFER_SIZE);
                 }
                 for (int i = 0; i < readable; i++) {
                     baos.write(content.content().readByte());
@@ -80,7 +80,7 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 FileRegion file = (FileRegion) msg;
                 if (file.count() > 0 && file.transferred() < file.count()) {
                     if (baos == null)
-                        baos = createByteStream();
+                        baos = new ByteArrayOutputStream(BUFFER_SIZE);
                     if (byteChannel == null)
                         byteChannel = Channels.newChannel(baos);
                     file.transferTo(byteChannel, file.transferred());
@@ -104,10 +104,6 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 ReferenceCountUtil.release(msg);
             }
         }
-    }
-
-    private ByteArrayOutputStream createByteStream() {
-        return new ByteArrayOutputStream(BUFFER_SIZE);
     }
 
     static Set<String> binaryTypes = new HashSet<>();

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -1,0 +1,141 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
+
+import io.netty.channel.FileRegion;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
+
+class NettyResponseHandler implements VirtualResponseHandler {
+    private static final int BUFFER_SIZE = 8096;
+
+    APIGatewayV2HTTPResponse responseBuilder = new APIGatewayV2HTTPResponse();
+    ByteArrayOutputStream baos;
+    WritableByteChannel byteChannel;
+    final APIGatewayV2HTTPEvent request;
+    CompletableFuture<APIGatewayV2HTTPResponse> future = new CompletableFuture<>();
+
+    public NettyResponseHandler(APIGatewayV2HTTPEvent request) {
+        this.request = request;
+    }
+
+    public CompletableFuture<APIGatewayV2HTTPResponse> getFuture() {
+        return future;
+    }
+
+    @Override
+    public void handleMessage(Object msg) {
+        try {
+            //log.info("Got message: " + msg.getClass().getName());
+
+            if (msg instanceof HttpResponse) {
+                HttpResponse res = (HttpResponse) msg;
+                responseBuilder.setStatusCode(res.status().code());
+
+                final Map<String, String> headers = new HashMap<>();
+                responseBuilder.setHeaders(headers);
+                for (String name : res.headers().names()) {
+                    final List<String> allForName = res.headers().getAll(name);
+                    if (allForName == null || allForName.isEmpty()) {
+                        continue;
+                    }
+                    final StringBuilder sb = new StringBuilder();
+                    for (Iterator<String> valueIterator = allForName.iterator(); valueIterator.hasNext();) {
+                        sb.append(valueIterator.next());
+                        if (valueIterator.hasNext()) {
+                            sb.append(",");
+                        }
+                    }
+                    headers.put(name, sb.toString());
+                }
+            }
+            if (msg instanceof HttpContent) {
+                HttpContent content = (HttpContent) msg;
+                int readable = content.content().readableBytes();
+                if (baos == null && readable > 0) {
+                    baos = createByteStream();
+                }
+                for (int i = 0; i < readable; i++) {
+                    baos.write(content.content().readByte());
+                }
+            }
+            if (msg instanceof FileRegion) {
+                FileRegion file = (FileRegion) msg;
+                if (file.count() > 0 && file.transferred() < file.count()) {
+                    if (baos == null)
+                        baos = createByteStream();
+                    if (byteChannel == null)
+                        byteChannel = Channels.newChannel(baos);
+                    file.transferTo(byteChannel, file.transferred());
+                }
+            }
+            if (msg instanceof LastHttpContent) {
+                if (baos != null) {
+                    if (isBinary(responseBuilder.getHeaders().get("Content-Type"))) {
+                        responseBuilder.setIsBase64Encoded(true);
+                        responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
+                    } else {
+                        responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
+                    }
+                }
+                future.complete(responseBuilder);
+            }
+        } catch (Throwable ex) {
+            future.completeExceptionally(ex);
+        } finally {
+            if (msg != null) {
+                ReferenceCountUtil.release(msg);
+            }
+        }
+    }
+
+    private ByteArrayOutputStream createByteStream() {
+        ByteArrayOutputStream baos;
+        baos = new ByteArrayOutputStream(BUFFER_SIZE);
+        return baos;
+    }
+
+    static Set<String> binaryTypes = new HashSet<>();
+
+    static {
+        binaryTypes.add("application/octet-stream");
+        binaryTypes.add("image/jpeg");
+        binaryTypes.add("image/png");
+        binaryTypes.add("image/gif");
+    }
+
+    private boolean isBinary(String contentType) {
+        if (contentType != null) {
+            int index = contentType.indexOf(';');
+            if (index >= 0) {
+                return binaryTypes.contains(contentType.substring(0, index));
+            } else {
+                return binaryTypes.contains(contentType);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        if (!future.isDone())
+            future.completeExceptionally(new RuntimeException("Connection closed"));
+    }
+}

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -26,11 +26,11 @@ import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 class NettyResponseHandler implements VirtualResponseHandler {
     private static final int BUFFER_SIZE = 8096;
 
-    APIGatewayV2HTTPResponse responseBuilder = new APIGatewayV2HTTPResponse();
-    ByteArrayOutputStream baos;
-    WritableByteChannel byteChannel;
-    final APIGatewayV2HTTPEvent request;
-    CompletableFuture<APIGatewayV2HTTPResponse> future = new CompletableFuture<>();
+    private final APIGatewayV2HTTPResponse responseBuilder = new APIGatewayV2HTTPResponse();
+    private final CompletableFuture<APIGatewayV2HTTPResponse> future = new CompletableFuture<>();
+    private final APIGatewayV2HTTPEvent request;
+    private ByteArrayOutputStream baos;
+    private WritableByteChannel byteChannel;
 
     public NettyResponseHandler(APIGatewayV2HTTPEvent request) {
         this.request = request;
@@ -107,9 +107,7 @@ class NettyResponseHandler implements VirtualResponseHandler {
     }
 
     private ByteArrayOutputStream createByteStream() {
-        ByteArrayOutputStream baos;
-        baos = new ByteArrayOutputStream(BUFFER_SIZE);
-        return baos;
+        return new ByteArrayOutputStream(BUFFER_SIZE);
     }
 
     static Set<String> binaryTypes = new HashSet<>();
@@ -129,13 +127,15 @@ class NettyResponseHandler implements VirtualResponseHandler {
             } else {
                 return binaryTypes.contains(contentType);
             }
+        } else {
+            return false;
         }
-        return false;
     }
 
     @Override
     public void close() {
-        if (!future.isDone())
+        if (!future.isDone()) {
             future.completeExceptionally(new RuntimeException("Connection closed"));
+        }
     }
 }

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -26,6 +26,15 @@ import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 class NettyResponseHandler implements VirtualResponseHandler {
     private static final int BUFFER_SIZE = 8096;
 
+    private static final Set<String> BINARY_TYPES = new HashSet<>();
+
+    static {
+        BINARY_TYPES.add("application/octet-stream");
+        BINARY_TYPES.add("image/jpeg");
+        BINARY_TYPES.add("image/png");
+        BINARY_TYPES.add("image/gif");
+    }
+
     private final APIGatewayV2HTTPResponse responseBuilder = new APIGatewayV2HTTPResponse();
     private final CompletableFuture<APIGatewayV2HTTPResponse> future = new CompletableFuture<>();
     private final APIGatewayV2HTTPEvent request;
@@ -106,22 +115,13 @@ class NettyResponseHandler implements VirtualResponseHandler {
         }
     }
 
-    static Set<String> binaryTypes = new HashSet<>();
-
-    static {
-        binaryTypes.add("application/octet-stream");
-        binaryTypes.add("image/jpeg");
-        binaryTypes.add("image/png");
-        binaryTypes.add("image/gif");
-    }
-
     private boolean isBinary(String contentType) {
         if (contentType != null) {
             int index = contentType.indexOf(';');
             if (index >= 0) {
-                return binaryTypes.contains(contentType.substring(0, index));
+                return BINARY_TYPES.contains(contentType.substring(0, index));
             } else {
-                return binaryTypes.contains(contentType);
+                return BINARY_TYPES.contains(contentType);
             }
         } else {
             return false;

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -110,8 +110,9 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
                 body = Unpooled.copiedBuffer(request.getBody(), StandardCharsets.UTF_8);
             }
             return new DefaultLastHttpContent(body);
+        } else {
+            return LastHttpContent.EMPTY_LAST_CONTENT;
         }
-        return LastHttpContent.EMPTY_LAST_CONTENT;
     }
 
     private String getPathWithQueryStringFromRequest(AwsProxyRequest request) throws UnsupportedEncodingException {

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -4,13 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
@@ -18,19 +12,22 @@ import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
 import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
+import org.jboss.logging.Logger;
+
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import org.jboss.logging.Logger;
 
 @SuppressWarnings("unused")
 public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
     private static final Logger log = Logger.getLogger("quarkus.amazon.lambda.http");
 
     private static final Headers errorHeaders = new Headers();
+
     static {
         errorHeaders.putSingle("Content-Type", "application/json");
     }
@@ -57,32 +54,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
 
     private AwsProxyResponse nettyDispatch(InetSocketAddress clientAddress, AwsProxyRequest request, Context context)
             throws Exception {
-        String path = request.getPath();
-        //log.info("---- Got lambda request: " + path);
-        if (request.getMultiValueQueryStringParameters() != null && !request.getMultiValueQueryStringParameters().isEmpty()) {
-            StringBuilder sb = new StringBuilder(path);
-            sb.append("?");
-            boolean first = true;
-            for (Map.Entry<String, List<String>> e : request.getMultiValueQueryStringParameters().entrySet()) {
-                for (String v : e.getValue()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        sb.append("&");
-                    }
-                    if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
-                        sb.append(e.getKey());
-                        sb.append("=");
-                        sb.append(v);
-                    } else {
-                        sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8.name()));
-                        sb.append("=");
-                        sb.append(URLEncoder.encode(v, StandardCharsets.UTF_8.name()));
-                    }
-                }
-            }
-            path = sb.toString();
-        }
+        String path = getPathFromRequest(request);
         QuarkusHttpHeaders quarkusHeaders = new QuarkusHttpHeaders();
         quarkusHeaders.setContextObject(Context.class, context);
         quarkusHeaders.setContextObject(AwsProxyRequestContext.class, request.getRequestContext());
@@ -104,13 +76,16 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
                 ByteBuf body = Unpooled.wrappedBuffer(Base64.getMimeDecoder().decode(request.getBody()));
                 requestContent = new DefaultLastHttpContent(body);
             } else {
-                ByteBuf body = Unpooled.copiedBuffer(request.getBody(), StandardCharsets.UTF_8); //TODO: do we need to look at the request encoding?
+                ByteBuf body = Unpooled.copiedBuffer(
+                        request.getBody(),
+                        StandardCharsets.UTF_8
+                ); //TODO: do we need to look at the request encoding?
                 requestContent = new DefaultLastHttpContent(body);
             }
         }
         NettyResponseHandler handler = new NettyResponseHandler(request);
-        VirtualClientConnection connection = VirtualClientConnection.connect(handler, VertxHttpRecorder.VIRTUAL_HTTP,
-                clientAddress);
+        VirtualClientConnection connection = VirtualClientConnection
+                .connect(handler, VertxHttpRecorder.VIRTUAL_HTTP, clientAddress);
 
         connection.sendMessage(nettyRequest);
         connection.sendMessage(requestContent);
@@ -119,5 +94,46 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
         } finally {
             connection.close();
         }
+    }
+
+    private String getPathFromRequest(AwsProxyRequest request) throws UnsupportedEncodingException {
+        String path;
+        if (hasQueryParameters(request)) {
+            path = getPathWithQueryParameters(request.getPath(), request);
+        } else {
+            path = request.getPath();
+        }
+        return path;
+    }
+
+    private boolean hasQueryParameters(AwsProxyRequest request) {
+        return request.getMultiValueQueryStringParameters() != null && !request.getMultiValueQueryStringParameters()
+                .isEmpty();
+    }
+
+    private String getPathWithQueryParameters(String path,
+            AwsProxyRequest request) throws UnsupportedEncodingException {
+        StringBuilder sb = new StringBuilder(path);
+        sb.append("?");
+        boolean first = true;
+        for (Map.Entry<String, List<String>> e : request.getMultiValueQueryStringParameters().entrySet()) {
+            for (String v : e.getValue()) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append("&");
+                }
+                if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
+                    sb.append(e.getKey());
+                    sb.append("=");
+                    sb.append(v);
+                } else {
+                    sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8.name()));
+                    sb.append("=");
+                    sb.append(URLEncoder.encode(v, StandardCharsets.UTF_8.name()));
+                }
+            }
+        }
+        return sb.toString();
     }
 }

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -1,38 +1,29 @@
 package io.quarkus.amazon.lambda.http;
 
-import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.ReferenceCountUtil;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
-import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
-import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import org.jboss.logging.Logger;
 
 @SuppressWarnings("unused")
@@ -62,108 +53,6 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
             }
         }
         return null;
-    }
-
-    private static class NettyResponseHandler implements VirtualResponseHandler {
-        private static final int BUFFER_SIZE = 8096;
-
-        AwsProxyResponse responseBuilder = new AwsProxyResponse();
-        ByteArrayOutputStream baos;
-        WritableByteChannel byteChannel;
-        final AwsProxyRequest request;
-        CompletableFuture<AwsProxyResponse> future = new CompletableFuture<>();
-
-        public NettyResponseHandler(AwsProxyRequest request) {
-            this.request = request;
-        }
-
-        public CompletableFuture<AwsProxyResponse> getFuture() {
-            return future;
-        }
-
-        @Override
-        public void handleMessage(Object msg) {
-            try {
-                //log.info("Got message: " + msg.getClass().getName());
-
-                if (msg instanceof HttpResponse) {
-                    HttpResponse res = (HttpResponse) msg;
-                    responseBuilder.setStatusCode(res.status().code());
-
-                    if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
-                        responseBuilder.setStatusDescription(res.status().reasonPhrase());
-                    }
-                    responseBuilder.setMultiValueHeaders(new Headers());
-                    for (String name : res.headers().names()) {
-                        for (String v : res.headers().getAll(name)) {
-                            responseBuilder.getMultiValueHeaders().add(name, v);
-                        }
-                    }
-                }
-                if (msg instanceof HttpContent) {
-                    HttpContent content = (HttpContent) msg;
-                    int readable = content.content().readableBytes();
-                    if (baos == null && readable > 0) {
-                        baos = createByteStream();
-                    }
-                    for (int i = 0; i < readable; i++) {
-                        baos.write(content.content().readByte());
-                    }
-                }
-                if (msg instanceof FileRegion) {
-                    FileRegion file = (FileRegion) msg;
-                    if (file.count() > 0 && file.transferred() < file.count()) {
-                        if (baos == null)
-                            baos = createByteStream();
-                        if (byteChannel == null)
-                            byteChannel = Channels.newChannel(baos);
-                        file.transferTo(byteChannel, file.transferred());
-                    }
-                }
-                if (msg instanceof LastHttpContent) {
-                    if (baos != null) {
-                        if (isBinary(responseBuilder.getMultiValueHeaders().getFirst("Content-Type"))) {
-                            responseBuilder.setBase64Encoded(true);
-                            responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
-                        } else {
-                            responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
-                        }
-                    }
-                    future.complete(responseBuilder);
-                }
-            } catch (Throwable ex) {
-                future.completeExceptionally(ex);
-            } finally {
-                if (msg != null) {
-                    ReferenceCountUtil.release(msg);
-                }
-            }
-        }
-
-        private ByteArrayOutputStream createByteStream() {
-            ByteArrayOutputStream baos;
-            baos = new ByteArrayOutputStream(BUFFER_SIZE);
-            return baos;
-        }
-
-        private boolean isBinary(String contentType) {
-            if (contentType != null) {
-                int index = contentType.indexOf(';');
-                if (index >= 0) {
-                    return LambdaContainerHandler.getContainerConfig()
-                            .isBinaryContentType(contentType.substring(0, index));
-                } else {
-                    return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public void close() {
-            if (!future.isDone())
-                future.completeExceptionally(new RuntimeException("Connection closed"));
-        }
     }
 
     private AwsProxyResponse nettyDispatch(InetSocketAddress clientAddress, AwsProxyRequest request, Context context)

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -36,10 +36,10 @@ import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
     private static final Logger log = Logger.getLogger("quarkus.amazon.lambda.http");
 
-    private static final Headers errorHeaders = new Headers();
+    private static final Headers ERROR_HEADERS = new Headers();
 
     static {
-        errorHeaders.putSingle("Content-Type", "application/json");
+        ERROR_HEADERS.putSingle("Content-Type", "application/json");
     }
 
     @Override
@@ -49,7 +49,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
             return nettyDispatch(clientAddress, request, context);
         } catch (Exception e) {
             log.error("Request Failure", e);
-            return new AwsProxyResponse(500, errorHeaders, "{ \"message\": \"Internal Server Error\" }");
+            return new AwsProxyResponse(500, ERROR_HEADERS, "{ \"message\": \"Internal Server Error\" }");
         }
     }
 

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -70,19 +70,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
             nettyRequest.headers().add(HttpHeaderNames.HOST, "localhost");
         }
 
-        HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
-        if (request.getBody() != null) {
-            if (request.isBase64Encoded()) {
-                ByteBuf body = Unpooled.wrappedBuffer(Base64.getMimeDecoder().decode(request.getBody()));
-                requestContent = new DefaultLastHttpContent(body);
-            } else {
-                ByteBuf body = Unpooled.copiedBuffer(
-                        request.getBody(),
-                        StandardCharsets.UTF_8
-                ); //TODO: do we need to look at the request encoding?
-                requestContent = new DefaultLastHttpContent(body);
-            }
-        }
+        HttpContent requestContent = createRequestContent(request);
         NettyResponseHandler handler = new NettyResponseHandler(request);
         VirtualClientConnection connection = VirtualClientConnection
                 .connect(handler, VertxHttpRecorder.VIRTUAL_HTTP, clientAddress);
@@ -94,6 +82,20 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
         } finally {
             connection.close();
         }
+    }
+
+    private HttpContent createRequestContent(AwsProxyRequest request) {
+        if (request.getBody() != null) {
+            ByteBuf body;
+            if (request.isBase64Encoded()) {
+                body = Unpooled.wrappedBuffer(Base64.getMimeDecoder().decode(request.getBody()));
+            } else {
+                //TODO: do we need to look at the request encoding?
+                body = Unpooled.copiedBuffer(request.getBody(), StandardCharsets.UTF_8);
+            }
+            return new DefaultLastHttpContent(body);
+        }
+        return LastHttpContent.EMPTY_LAST_CONTENT;
     }
 
     private String getPathFromRequest(AwsProxyRequest request) throws UnsupportedEncodingException {

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -1,19 +1,5 @@
 package io.quarkus.amazon.lambda.http;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.*;
-import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
-import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
-import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
-import io.quarkus.amazon.lambda.http.model.Headers;
-import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
-import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
-import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
-import org.jboss.logging.Logger;
-
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
@@ -21,6 +7,30 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
+import io.quarkus.amazon.lambda.http.model.Headers;
+import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
+import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
+import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
 @SuppressWarnings("unused")
 public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -1,7 +1,15 @@
 package io.quarkus.amazon.lambda.http;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+
 import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.model.ContainerConfig;
+
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
@@ -11,12 +19,6 @@ import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
-import java.io.ByteArrayOutputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.concurrent.CompletableFuture;
 
 class NettyResponseHandler implements VirtualResponseHandler {
     private static final int BUFFER_SIZE = 8096;

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -38,8 +38,6 @@ class NettyResponseHandler implements VirtualResponseHandler {
     @Override
     public void handleMessage(Object msg) {
         try {
-            //log.info("Got message: " + msg.getClass().getName());
-
             if (msg instanceof HttpResponse) {
                 HttpResponse res = (HttpResponse) msg;
                 responseBuilder.setStatusCode(res.status().code());
@@ -58,7 +56,7 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 HttpContent content = (HttpContent) msg;
                 int readable = content.content().readableBytes();
                 if (baos == null && readable > 0) {
-                    baos = createByteStream();
+                    baos = new ByteArrayOutputStream(BUFFER_SIZE);
                 }
                 for (int i = 0; i < readable; i++) {
                     baos.write(content.content().readByte());
@@ -68,7 +66,7 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 FileRegion file = (FileRegion) msg;
                 if (file.count() > 0 && file.transferred() < file.count()) {
                     if (baos == null) {
-                        baos = createByteStream();
+                        baos = new ByteArrayOutputStream(BUFFER_SIZE);
                     }
                     if (byteChannel == null) {
                         byteChannel = Channels.newChannel(baos);
@@ -94,10 +92,6 @@ class NettyResponseHandler implements VirtualResponseHandler {
                 ReferenceCountUtil.release(msg);
             }
         }
-    }
-
-    private ByteArrayOutputStream createByteStream() {
-        return new ByteArrayOutputStream(BUFFER_SIZE);
     }
 
     private boolean isBinary(String contentType) {

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/NettyResponseHandler.java
@@ -1,0 +1,122 @@
+package io.quarkus.amazon.lambda.http;
+
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
+import io.netty.channel.FileRegion;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
+import io.quarkus.amazon.lambda.http.model.Headers;
+import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+
+class NettyResponseHandler implements VirtualResponseHandler {
+    private static final int BUFFER_SIZE = 8096;
+
+    AwsProxyResponse responseBuilder = new AwsProxyResponse();
+    ByteArrayOutputStream baos;
+    WritableByteChannel byteChannel;
+    final AwsProxyRequest request;
+    CompletableFuture<AwsProxyResponse> future = new CompletableFuture<>();
+
+    public NettyResponseHandler(AwsProxyRequest request) {
+        this.request = request;
+    }
+
+    public CompletableFuture<AwsProxyResponse> getFuture() {
+        return future;
+    }
+
+    @Override
+    public void handleMessage(Object msg) {
+        try {
+            //log.info("Got message: " + msg.getClass().getName());
+
+            if (msg instanceof HttpResponse) {
+                HttpResponse res = (HttpResponse) msg;
+                responseBuilder.setStatusCode(res.status().code());
+
+                if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
+                    responseBuilder.setStatusDescription(res.status().reasonPhrase());
+                }
+                responseBuilder.setMultiValueHeaders(new Headers());
+                for (String name : res.headers().names()) {
+                    for (String v : res.headers().getAll(name)) {
+                        responseBuilder.getMultiValueHeaders().add(name, v);
+                    }
+                }
+            }
+            if (msg instanceof HttpContent) {
+                HttpContent content = (HttpContent) msg;
+                int readable = content.content().readableBytes();
+                if (baos == null && readable > 0) {
+                    baos = createByteStream();
+                }
+                for (int i = 0; i < readable; i++) {
+                    baos.write(content.content().readByte());
+                }
+            }
+            if (msg instanceof FileRegion) {
+                FileRegion file = (FileRegion) msg;
+                if (file.count() > 0 && file.transferred() < file.count()) {
+                    if (baos == null) {
+                        baos = createByteStream();
+                    }
+                    if (byteChannel == null) {
+                        byteChannel = Channels.newChannel(baos);
+                    }
+                    file.transferTo(byteChannel, file.transferred());
+                }
+            }
+            if (msg instanceof LastHttpContent) {
+                if (baos != null) {
+                    if (isBinary(responseBuilder.getMultiValueHeaders().getFirst("Content-Type"))) {
+                        responseBuilder.setBase64Encoded(true);
+                        responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
+                    } else {
+                        responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
+                    }
+                }
+                future.complete(responseBuilder);
+            }
+        } catch (Throwable ex) {
+            future.completeExceptionally(ex);
+        } finally {
+            if (msg != null) {
+                ReferenceCountUtil.release(msg);
+            }
+        }
+    }
+
+    private ByteArrayOutputStream createByteStream() {
+        ByteArrayOutputStream baos;
+        baos = new ByteArrayOutputStream(BUFFER_SIZE);
+        return baos;
+    }
+
+    private boolean isBinary(String contentType) {
+        if (contentType != null) {
+            int index = contentType.indexOf(';');
+            if (index >= 0) {
+                return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType.substring(0, index));
+            } else {
+                return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        if (!future.isDone()) {
+            future.completeExceptionally(new RuntimeException("Connection closed"));
+        }
+    }
+}


### PR DESCRIPTION
This PR is a refactoring of the LambdaHttpHandler of the amazon-lambda-rest extension aiming to improve readability. I left the individual commits for easy verification of the correctness of the changes but I can squash them down to a single commit if preferred.

I looked at the code and saw a couple of improvements (from my point of view) I could contribute. This is my first contribution to the quarkus project and to any (big) open source project in general.