### PR TITLE
OpenShift: Fix `quarkus.openshift.arguments` property

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -148,11 +148,12 @@ public class OpenshiftProcessor {
             });
             //In all other cases its the responsibility of the image to set those up correctly.
             if (!baseImage.isPresent()) {
-                List<String> args = new ArrayList<>();
-                args.addAll(config.jvmArguments);
-                args.addAll(Arrays.asList("-jar", pathToJar));
+                List<String> cmd = new ArrayList<>();
+                cmd.add("java");
+                cmd.addAll(config.jvmArguments);
+                cmd.addAll(Arrays.asList("-jar", pathToJar));
                 envProducer.produce(KubernetesEnvBuildItem.createSimpleVar("JAVA_APP_JAR", pathToJar, null));
-                commandProducer.produce(new KubernetesCommandBuildItem("java", args.toArray(new String[args.size()])));
+                commandProducer.produce(KubernetesCommandBuildItem.command(cmd));
             }
         }
     }
@@ -202,8 +203,7 @@ public class OpenshiftProcessor {
             });
 
             if (!baseImage.isPresent()) {
-                commandProducer.produce(new KubernetesCommandBuildItem(pathToNativeBinary,
-                        config.nativeArguments.toArray(new String[config.nativeArguments.size()])));
+                commandProducer.produce(KubernetesCommandBuildItem.commandWithArgs(pathToNativeBinary, config.nativeArguments));
             }
         }
     }

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -99,10 +99,6 @@ public class S2iProcessor {
         String jarDirectory = s2iConfig.jarDirectory;
         String pathToJar = concatUnixPaths(jarDirectory, jarFileName);
 
-        List<String> args = new ArrayList<>();
-        args.addAll(Arrays.asList("-jar", pathToJar, "-cp", classpath));
-        args.addAll(s2iConfig.jvmArguments);
-
         builderImageProducer.produce(new BaseImageInfoBuildItem(s2iConfig.baseJvmImage));
         Optional<S2iBaseJavaImage> baseImage = S2iBaseJavaImage.findMatching(s2iConfig.baseJvmImage);
 
@@ -116,7 +112,11 @@ public class S2iProcessor {
         });
 
         if (!baseImage.isPresent()) {
-            commandProducer.produce(new KubernetesCommandBuildItem("java", args.toArray(new String[args.size()])));
+            List<String> cmd = new ArrayList<>();
+            cmd.add("java");
+            cmd.addAll(s2iConfig.jvmArguments);
+            cmd.addAll(Arrays.asList("-jar", pathToJar, "-cp", classpath));
+            commandProducer.produce(KubernetesCommandBuildItem.command(cmd));
         }
     }
 
@@ -158,7 +158,7 @@ public class S2iProcessor {
         });
 
         if (!baseImage.isPresent()) {
-            commandProducer.produce(new KubernetesCommandBuildItem(pathToNativeBinary, nativeArguments.toArray(new String[0])));
+            commandProducer.produce(KubernetesCommandBuildItem.commandWithArgs(pathToNativeBinary, nativeArguments));
         }
     }
 

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesCommandBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesCommandBuildItem.java
@@ -1,22 +1,38 @@
 package io.quarkus.kubernetes.spi;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class KubernetesCommandBuildItem extends SimpleBuildItem {
 
-    private final String command;
-    private final String[] args;
+    private final List<String> command;
+    private final List<String> args;
 
-    public KubernetesCommandBuildItem(String command, String... args) {
+    public KubernetesCommandBuildItem(List<String> command, List<String> args) {
         this.command = command;
         this.args = args;
     }
 
-    public String getCommand() {
+    public List<String> getCommand() {
         return command;
     }
 
-    public String[] getArgs() {
+    public List<String> getArgs() {
         return args;
+    }
+
+    public static KubernetesCommandBuildItem command(String... cmd) {
+        return command(Arrays.asList(cmd));
+    }
+
+    public static KubernetesCommandBuildItem command(List<String> cmd) {
+        return new KubernetesCommandBuildItem(cmd, Collections.emptyList());
+    }
+
+    public static KubernetesCommandBuildItem commandWithArgs(String cmd, List<String> args) {
+        return new KubernetesCommandBuildItem(Collections.singletonList(cmd), args);
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -165,11 +165,8 @@ public class KubernetesCommonHelper {
         result.addAll(createMountAndVolumeDecorators(project, target, name, config));
         result.addAll(createAppConfigVolumeAndEnvDecorators(project, target, name, config));
 
-        //Handle Command and arguments
-        command.ifPresent(c -> {
-            result.add(new DecoratorBuildItem(new ApplyCommandDecorator(name, new String[] { c.getCommand() })));
-            result.add(new DecoratorBuildItem(new ApplyArgsDecorator(name, c.getArgs())));
-        });
+        result.addAll(createCommandDecorator(project, target, name, config, command));
+        result.addAll(createArgsDecorator(project, target, name, config, command));
 
         //Handle Probes
         result.addAll(createProbeDecorators(name, target, config.getLivenessProbe(), config.getReadinessProbe(),
@@ -184,6 +181,55 @@ public class KubernetesCommonHelper {
                     new AddRoleBindingResourceDecorator(rb.getName(), null, rb.getRole(), rb.isClusterWide()
                             ? AddRoleBindingResourceDecorator.RoleKind.ClusterRole
                             : AddRoleBindingResourceDecorator.RoleKind.Role))));
+        }
+
+        return result;
+    }
+
+    /**
+     * If user defines a custom command via configuration, this is used.
+     * If not, it will use the one from other extensions.
+     *
+     * @param target The deployment target (e.g. kubernetes, openshift, knative)
+     * @param name The name of the resource to accept the configuration
+     * @param config The {@link PlatformConfiguration} instance
+     * @param command Optional command item from other extensions
+     */
+    private static List<DecoratorBuildItem> createCommandDecorator(Optional<Project> project, String target, String name,
+            PlatformConfiguration config, Optional<KubernetesCommandBuildItem> command) {
+        List<DecoratorBuildItem> result = new ArrayList<>();
+        if (config.getCommand().isPresent()) {
+            // If command has been set in configuration, we use it
+            result.add(new DecoratorBuildItem(target,
+                    new ApplyCommandDecorator(name, config.getCommand().get().toArray(new String[0]))));
+        } else if (command.isPresent()) {
+            // If not, we use the command that has been provided in other extensions (if any).
+            result.add(new DecoratorBuildItem(target,
+                    new ApplyCommandDecorator(name, command.get().getCommand().toArray(new String[0]))));
+        }
+
+        return result;
+    }
+
+    /**
+     * If user defines arguments via configuration, then these will be merged to the ones from other extensions.
+     * If not, then only the arguments from other extensions will be used if any.
+     *
+     * @param target The deployment target (e.g. kubernetes, openshift, knative)
+     * @param name The name of the resource to accept the configuration
+     * @param config The {@link PlatformConfiguration} instance
+     * @param command Optional command item from other extensions
+     */
+    private static List<DecoratorBuildItem> createArgsDecorator(Optional<Project> project, String target, String name,
+            PlatformConfiguration config, Optional<KubernetesCommandBuildItem> command) {
+        List<DecoratorBuildItem> result = new ArrayList<>();
+
+        List<String> args = new ArrayList<>();
+        command.ifPresent(cmd -> args.addAll(cmd.getArgs()));
+        config.getArguments().ifPresent(args::addAll);
+
+        if (!args.isEmpty()) {
+            result.add(new DecoratorBuildItem(target, new ApplyArgsDecorator(name, args.toArray(new String[args.size()]))));
         }
 
         return result;
@@ -206,14 +252,6 @@ public class KubernetesCommonHelper {
 
         config.getWorkingDir().ifPresent(w -> {
             result.add(new DecoratorBuildItem(target, new ApplyWorkingDirDecorator(name, w)));
-        });
-
-        config.getCommand().ifPresent(c -> {
-            result.add(new DecoratorBuildItem(target, new ApplyCommandDecorator(name, c.toArray(new String[0]))));
-        });
-
-        config.getArguments().ifPresent(a -> {
-            result.add(new DecoratorBuildItem(target, new ApplyArgsDecorator(name, a.toArray(new String[0]))));
         });
 
         return result;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithArgumentsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithArgumentsTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithArgumentsTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-with-arguments")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-arguments.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("kubernetes-with-arguments");
+                assertThat(m.getNamespace()).isNull();
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getName()).isEqualTo("kubernetes-with-arguments");
+                            assertThat(container.getArgs()).containsExactly("A", "B");
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCommandTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCommandTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithCommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-with-command")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-command.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("kubernetes-with-command");
+                assertThat(m.getNamespace()).isNull();
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getName()).isEqualTo("kubernetes-with-command");
+                            assertThat(container.getCommand()).containsExactly("my-command");
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithArgumentsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithArgumentsTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithArgumentsTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-with-arguments")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("openshift-with-arguments.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList.get(0)).isInstanceOfSatisfying(DeploymentConfig.class, dc -> {
+            assertThat(dc.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-with-arguments");
+            });
+            assertThat(dc.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getName()).isEqualTo("openshift-with-arguments");
+                            assertThat(container.getArgs()).containsExactly("A", "B");
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCommandTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCommandTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithCommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-with-command")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("openshift-with-command.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList.get(0)).isInstanceOfSatisfying(DeploymentConfig.class, dc -> {
+            assertThat(dc.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-with-command");
+            });
+            assertThat(dc.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getName()).isEqualTo("openshift-with-command");
+                            assertThat(container.getCommand()).containsExactly("my-command");
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-arguments.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-arguments.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes.arguments=A,B

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-command.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-command.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes.command=my-command

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-arguments.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-arguments.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.arguments=A,B

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-command.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-command.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.command=my-command


### PR DESCRIPTION
At the moment, when using the `quarkus.openshift.arguments` property and an unknown base image, it's replacing the arguments that are required for the Java command and hence making the application fail. For example, with no arguments are supplied, the OpenShift.yaml looks like:

```
command: java
args:
    - '-Dquarkus.http.host=0.0.0.0'
    - '-Djava.util.logging.manager=org.jboss.logmanager.LogManager'
    - '-jar'
    - /deployments/quarkus-run.jar
```

If we now set `quarkus.openshift.arguments=A,B`, then it changes to:

```
command: java
args:
    - 'A'
    - 'B'
```

And then, the above configuration would make our deployment fail (because the jar is missing).

This PR addresses the above situation by moving the required JAVA arguments to be part of the command and leaving the args field empty:

```
command: 
    - java
    - '-Dquarkus.http.host=0.0.0.0'
    - '-Djava.util.logging.manager=org.jboss.logmanager.LogManager'
    - '-jar'
    - /deployments/quarkus-run.jar
```

And now if we supply the arguments: `quarkus.openshift.arguments=A,B`, then:

```
command: 
    - java
    - '-Dquarkus.http.host=0.0.0.0'
    - '-Djava.util.logging.manager=org.jboss.logmanager.LogManager'
    - '-jar'
    - /deployments/quarkus-run.jar
args:
    - 'A'
    - 'B'
```

Users would still be able to replace the whole command by using the command property: `quarkus.openshift.command` which I think it's the expected behaviour. Now the command and argument properties work the same in Kubernetes and OpenShift deployments, regardless the base image we use. 

I've covered these changes using integration tests with the following scenarios:
- Kubernetes when using arguments
- Kubernetes when using command
- OpenShift when using arguments
- OpenShift when using default command
- OpenShift when using commands

Also, I've verified these changes manually by deploying a sample application (Rest ++ Command Line application) and now it works fine when supplying or not supplying custom arguments.

Fix https://github.com/quarkusio/quarkus/issues/15943