### PR TITLE
[WIP] Untested impl for Scala 3 dynamic compile

### DIFF
--- a/extensions/scala/deployment/src/main/java/io/quarkus/scala/deployment/ScalaCompilationProvider.java
+++ b/extensions/scala/deployment/src/main/java/io/quarkus/scala/deployment/ScalaCompilationProvider.java
@@ -9,8 +9,18 @@ import java.util.stream.Collectors;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.deployment.dev.CompilationProvider;
 import scala.collection.JavaConverters;
+
 import scala.tools.nsc.Global;
 import scala.tools.nsc.Settings;
+
+import dotty.tools.dotc.config.ScalaSettings;
+import dotty.tools.dotc.core.Contexts.ContextBase;
+import dotty.tools.dotc.interfaces.CompilerCallback;
+import dotty.tools.dotc.Main;
+import dotty.tools.dotc.core.Contexts;
+import dotty.tools.dotc.interfaces.SourceFile;
+import dotty.tools.dotc.reporting.Diagnostic;
+import dotty.tools.dotc.reporting.Reporter;
 
 public class ScalaCompilationProvider implements CompilationProvider {
     @Override
@@ -38,5 +48,63 @@ public class ScalaCompilationProvider implements CompilationProvider {
     @Override
     public Path getSourcePath(Path classFilePath, PathsCollection sourcePaths, String classesPath) {
         return classFilePath;
+    }
+}
+
+
+public class Scala3CompilationProvider implements CompilationProvider {
+    @Override
+    public Set<String> handledExtensions() {
+        return Collections.singleton(".scala");
+    }
+
+    @Override
+    public void compile(Set<File> files, Context context) {
+        var reporter = new CustomReporter();
+        var callback = new CustomCompilerCallback();
+
+        var scalaCtx = new ContextBase().initialCtx().fresh()
+                .setReporter(reporter)
+                .setCompilerCallback(callback);
+
+        // WRONG: This needs to be a string, separated by File.pathSeparator
+        var classPath = context.getClasspath().stream()
+            .map(File::getAbsolutePath)
+            .toString();
+
+        scalaCtx.setSetting(scalaCtx.settings().classpath(), classPath);
+        scalaCtx.setSetting(scalaCtx.settings().outputDir(), context.getOutputDirectory().getAbsolutePath());
+
+        String[] args =  new String[]{};
+        Main.process(args, scalaCtx);
+    }
+
+    @Override
+    public Path getSourcePath(Path classFilePath, Set<String> sourcePaths, String classesPath) {
+        return classFilePath;
+    }
+
+    private class CustomReporter extends Reporter
+            //  with UniqueMessagePositions
+            //  with HideNonSensicalMessages
+    {
+        @Override
+        public void doReport(Diagnostic message, Contexts.Context ctx) {
+            //
+        }
+    }
+
+    private class CustomCompilerCallback implements CompilerCallback {
+        private final ArrayList<String> pathsList = new ArrayList<>();
+
+        public ArrayList<String> getPathsList() {
+            return pathsList;
+        }
+
+        @Override
+        public void onSourceCompiled(SourceFile source) {
+            if (source.jfile().isPresent())
+                pathsList.add(source.jfile().get().getPath());
+        }
     }
 }


### PR DESCRIPTION
For https://github.com/quarkusio/quarkus/issues/17882

I have written Java for two days and never a line of Scala in my life so take this with a grain of salt, but I think this should get the ball rolling at least.

Took the implementation from here and translated it: 

- https://github.com/lampepfl/dotty/blob/master/compiler/test/dotty/tools/dotc/EntryPointsTest.scala.disabled
- https://github.com/lampepfl/dotty/blob/b7d2a122555a6aa44cc7590852a80f12512c535e/compiler/src/dotty/tools/dotc/Driver.scala

One thing to note, I couldn't easily figure out how to do the equivalent of this:
```ts
let classPath: string[] = context.getClasspath()
	.map(it => File.getAbsolutePath(it))
	.join(File.pathSeparator)
```

```java
// WRONG: This needs to be a string, separated by File.pathSeparator
var classPath = context.getClasspath().stream()
    .map(File::getAbsolutePath)
    .toString();
```

This definitely needs to be fixed, this function is used internally in Scala 3 for testing:
https://github.com/lampepfl/dotty/blob/master/compiler/test/dotty/tools/vulpix/TestConfiguration.scala#L52-L57

```scala
  def mkClasspath(classpaths: List[String]): String =
    classpaths.map({ p =>
      val file = new java.io.File(p)
      assert(file.exists, s"File $p couldn't be found.")
      file.getAbsolutePath
    }).mkString(File.pathSeparator)
```


