### PR TITLE
Panache: Support collections in Hibernate Filters

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.panache.common.runtime;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -356,7 +357,13 @@ public class CommonPanacheQueryImpl<Entity> {
         for (Entry<String, Map<String, Object>> entry : filters.entrySet()) {
             Filter filter = session.enableFilter(entry.getKey());
             for (Entry<String, Object> paramEntry : entry.getValue().entrySet()) {
-                filter.setParameter(paramEntry.getKey(), paramEntry.getValue());
+                if (paramEntry.getValue() instanceof Collection<?>) {
+                    filter.setParameterList(paramEntry.getKey(), (Collection<?>) paramEntry.getValue());
+                } else if (paramEntry.getValue() instanceof Object[]) {
+                    filter.setParameterList(paramEntry.getKey(), (Object[]) paramEntry.getValue());
+                } else {
+                    filter.setParameter(paramEntry.getKey(), paramEntry.getValue());
+                }
             }
             filter.validate();
         }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
@@ -32,8 +32,11 @@ import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 @NamedQuery(name = "Person.getByName", query = "from Person2 where name = :name")
 @FilterDef(name = "Person.hasName", defaultCondition = "name = :name", parameters = @ParamDef(name = "name", type = "string"))
 @FilterDef(name = "Person.isAlive", defaultCondition = "status = 'LIVING'")
+@FilterDef(name = "Person.name.in", defaultCondition = "name in (:names)", parameters = {
+        @ParamDef(name = "names", type = "string") })
 @Filter(name = "Person.isAlive")
 @Filter(name = "Person.hasName")
+@Filter(name = "Person.name.in")
 public class Person extends PanacheEntity {
 
     public String name;

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -81,6 +81,11 @@ public class PanacheFunctionalityTest {
     }
 
     @Test
+    public void testFilterWithCollections() {
+        RestAssured.when().get("/test/testFilterWithCollections").then().body(is("OK"));
+    }
+
+    @Test
     public void testJaxbAnnotationTransfer() {
         RestAssured.when()
                 .get("/test/testJaxbAnnotationTransfer")


### PR DESCRIPTION
This PR allows to filter by collections using Panache:

```java
@FilterDef(name = "nameFilter", parameters = {@ParamDef(name = "names", type = "string")})
@Filter(name = "nameFilter", condition = "name in (:names)")
public class Person extends PanacheEntity {
// ...
}
```

Fix https://github.com/quarkusio/quarkus/issues/13832