### PR TITLE
Update OIDC 'Running behind a reverse proxy' docs

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -509,14 +509,6 @@ Future<void> callQuarkusService() async {
   }
 ----
 
-== Running behind a reverse proxy
-
-OIDC authentication mechanism can be affected if your Quarkus application is running behind a reverse proxy/gateway/firewall when HTTP `Host` header may be reset to the internal IP address, HTTPS connection may be terminated, etc. For example, an authorization code flow `redirect_uri` parameter may be set to the internal host instead of the expected external one.
-
-In such cases configuring Quarkus to recognize the original headers forwarded by the proxy will be required, see link:vertx#reverse-proxy[Running behind a reverse proxy] Vert.x documentation section for more information.
-
-`quarkus.oidc.authentication.force-redirect-https-scheme` property may also be used when the Quarkus application is running behind a SSL terminating reverse proxy.
-
 == Cloud Services
 
 === Google Cloud
@@ -750,6 +742,26 @@ Please enable `io.quarkus.oidc.runtime.OidcProvider` `TRACE` level logging to se
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 ----
+
+== Running behind a reverse proxy
+
+OIDC authentication mechanism can be affected if your Quarkus application is running behind a reverse proxy/gateway/firewall when HTTP `Host` header may be reset to the internal IP address, HTTPS connection may be terminated, etc. For example, an authorization code flow `redirect_uri` parameter may be set to the internal host instead of the expected external one.
+
+In such cases configuring Quarkus to recognize the original headers forwarded by the proxy will be required, see link:vertx#reverse-proxy[Running behind a reverse proxy] Vert.x documentation section for more information.
+
+For example, if your Quarkus endpoint runs in a cluster behind Kubernetes Ingress then a redirect from the OpenId Connect Provider back to this endpoint may not work since the calcuated `redirect_uri` parameter may point to the internal endpoint address. This problem can be resolved with the following configuration:
+
+[source,properties]
+----
+quarkus.http.proxy.proxy-address-forwarding=true
+quarkus.http.proxy.allow-forwarded=false
+quarkus.http.proxy.enable-forwarded-host=true
+quarkus.http.proxy.forwarded-host-header=X-ORIGINAL-HOST
+----
+
+where `X-ORIGINAL-HOST` is set by Kubernetes Ingress to represent the external endpoint address.
+
+`quarkus.oidc.authentication.force-redirect-https-scheme` property may also be used when the Quarkus application is running behind a SSL terminating reverse proxy.
 
 == External and Internal Access to OpenId Connect Provider
 


### PR DESCRIPTION
Fixes #17563.

I've moved 'Running behind a reverse proxy' section closer to the one where `KEYCLOAK_FRONTEND_URL` is referenced and updated it with how to configure Quarkus when it runs behind Ingress as shown [here](https://github.com/quarkusio/quarkus/issues/17563#issuecomment-856499124)