### PR TITLE
Enable SSL and all security services for smallrye-jwt

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.jwt.deployment;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -25,6 +26,8 @@ import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -55,6 +58,16 @@ class SmallRyeJwtProcessor {
     private static final DotName CLAIMS_NAME = DotName.createSimple(Claims.class.getName());
 
     SmallRyeJWTConfig config;
+
+    @BuildStep(onlyIf = IsEnabled.class)
+    ExtensionSslNativeSupportBuildItem enableSslInNative() {
+        return new ExtensionSslNativeSupportBuildItem(Feature.SMALLRYE_JWT);
+    }
+
+    @BuildStep(onlyIf = IsEnabled.class)
+    EnableAllSecurityServicesBuildItem security() {
+        return new EnableAllSecurityServicesBuildItem();
+    }
 
     /**
      * Register the CDI beans that are needed by the MP-JWT extension
@@ -159,5 +172,13 @@ class SmallRyeJwtProcessor {
                         AnnotationValue.createEnumValue("standard", CLAIMS_NAME, "UNKNOWN") }));
         configurator.creator(RawOptionalClaimCreator.class);
         beanConfigurator.produce(new BeanConfiguratorBuildItem(configurator));
+    }
+
+    public static class IsEnabled implements BooleanSupplier {
+        SmallRyeJWTConfig config;
+
+        public boolean getAsBoolean() {
+            return config.enabled;
+        }
     }
 }


### PR DESCRIPTION
It is already done for `quarkus-oidc` but not for `smallrye-jwt`
See https://stackoverflow.com/questions/67977862/quarkus-jwt-authentication-doesnt-work-as-a-native-app