### PR TITLE
Fix issue with custom test annotation and @QuarkusTestResource.List

### DIFF
--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/CustomResourceWithList.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/CustomResourceWithList.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@QuarkusTestResource.List({
+        @QuarkusTestResource(LifecycleManager.class)
+})
+@Stereotype
+public @interface CustomResourceWithList {
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/EndTestWithList.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/EndTestWithList.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.extension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResourceWithList
+@QuarkusTest
+public class EndTestWithList {
+
+    @Test
+    public void test1() {
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/StartTestWithList.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/StartTestWithList.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.extension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResourceWithList
+@QuarkusTest
+public class StartTestWithList {
+
+    @Test
+    public void test1() {
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+}


### PR DESCRIPTION
The repeated annotation was not being properly handled
(as was the case of `@QuarkusTestResource`).
This PR handles it in the same way.

Fixes: #17930