### PR TITLE
Minor security doc updates

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -1088,7 +1088,9 @@ SmallRye JWT supports the following properties which can be used to customize th
 |===
 |Property Name|Default|Description
 |smallrye.jwt.sign.key.location|`none`|Location of a private key which will be used to sign the claims when either a no-argument `sign()` or `innerSign()` method is called.
+|smallrye.jwt.sign.key.id|`none`|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.encrypt.key.location|`none`|Location of a public key which will be used to encrypt the claims or inner JWT when a no-argument `encrypt()` method is called.
+|smallrye.jwt.encrypt.key.id|`none`|Encryption key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -42,9 +42,7 @@ Quarkus provides Mutual TLS authentication so that you can authenticate users ba
 
 Please see link:security-built-in-authentication#mutual-tls[Mutual TLS Authentication] for more information.
 
-=== OpenId Connect, JWT, OAuth2
-
-==== OpenId Connect
+=== OpenId Connect
 
 `quarkus-oidc` extension provides a reactive, interoperable, multi-tenant enabled OpenId Connect adapter which supports `Bearer Token` and `Authorization Code Flow` authentication mechanisms.
 
@@ -77,7 +75,7 @@ If you use Keycloak and Bearer tokens then also see the link:security-keycloak-a
 If you need to configure Keycloak programmatically then consider using https://www.keycloak.org/docs/latest/server_development/#admin-rest-api[Keycloak Admin REST API] with the help of the `quarkus-keycloak-admin-client` extension.
 ====
 
-==== OpenId Connect Client and Filters
+=== OpenId Connect Client and Filters
 
 `quarkus-oidc-client` extension provides `OidcClient` for acquiring and refreshing access tokens from OpenId Connect and OAuth2 providers which support `client-credentials`, `password` and `refresh_token` token grants.
 
@@ -88,7 +86,7 @@ If you need to configure Keycloak programmatically then consider using https://w
 See the link:security-openid-connect-client[Using OpenID Connect and OAuth2 Client] guide for more information.
 
 [[smallrye-jwt]]
-==== SmallRye JWT
+=== SmallRye JWT
 
 `quarkus-smallrye-jwt` provides Microprofile JWT 1.1.1 implementation and many more options to verify signed and encrypted `JWT` tokens and represent them as `org.eclipse.microprofile.jwt.JsonWebToken`.
 
@@ -98,13 +96,13 @@ Additionally it provides `JWT Generation API` for creating `signed`, `inner-sign
 
 See the link:security-jwt[Using SmallRye JWT] guide for more information.
 
-==== OAuth2
+=== OAuth2
 
 `quarkus-elytron-security-oauth2` provides an alternative to `quarkus-oidc` Bearer Token Authentication Mechanism. It is based on `Elytron` and is primarily meant for introspecting the opaque tokens remotely.
 
 See the link:security-oauth2[Using OAuth2] guide for more information.
 
-==== Choosing between OpenId Connect, SmallRye JWT and OAuth2 extensions
+=== Choosing between OpenId Connect, SmallRye JWT and OAuth2 extensions
 
 `quarkus-oidc` extension requires an OpenId Connect provider such as Keycloak which can be used to verify the Bearer tokens or authenticate the end users with the Authorization Code flow. In both cases `quarkus-oidc` requires a connection to this OpenId Connect provider.
 


### PR DESCRIPTION
This PR tries to fix security.adoc TOC since right now none of OIDC/JWT/OAuth2 subsections are accessible via TOC.
Also update the list of JWT Build properties