### PR TITLE
Revert opentracing-tracerresolver to v0.1.5 (in Quarkus branch 1.13)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -22,7 +22,7 @@
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>
-        <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
+        <opentracing-tracerresolver.version>0.1.5</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>


### PR DESCRIPTION
Otherwise it introduces `opentracing-api` v0.33.0 into dependency tree which affects Gradle dependency resolution negatively.

v0.1.8 has no substantial changes comparing to v0.1.5, only `opentracing-api` update and relevant mock update due to breaking changes in opentracing API.

Resolves #17960