### PR TITLE
Mutiny Vert.x bindings upgrade to 2.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,7 +52,8 @@
         <smallrye-jwt.version>3.2.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-reactive-utils.version>2.6.0</smallrye-reactive-utils.version>
+        <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
+        <smallrye-reactive-utils.version>2.7.0</smallrye-reactive-utils.version>
         <smallrye-reactive-messaging.version>3.5.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -4851,17 +4852,17 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-converter-api</artifactId>
-                <version>${smallrye-reactive-utils.version}</version>
+                <version>${smallrye-reactive-types-converter.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-converter-mutiny</artifactId>
-                <version>${smallrye-reactive-utils.version}</version>
+                <version>${smallrye-reactive-types-converter.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
-                <version>${smallrye-reactive-utils.version}</version>
+                <version>${smallrye-reactive-types-converter.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Also apply the split of the reactive converter utils that are going on a different release lifecycle.