### PR TITLE
Implement shared  broker for the AMQP Dev Service

### DIFF
--- a/docs/src/main/asciidoc/amqp-dev-services.adoc
+++ b/docs/src/main/asciidoc/amqp-dev-services.adoc
@@ -23,6 +23,20 @@ Dev Services for AMQP relies on Docker to start the broker.
 If your environment does not support Docker, you will need to start the broker manually, or connect to an already running broker.
 You can configure the broker access using the `amqp-host`, `amqp-port`, `amqp-user` and `amqp-password` properties.
 
+== Shared broker
+
+Most of the time you need to share the broker between applications.
+Dev Services for AMQP implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single broker.
+
+NOTE: Dev Services for AMQP starts the container with the `quarkus-dev-service-amqp` label which is used to identify the container.
+
+If you need multiple (shared) brokers, you can configure the `quarkus.amqp.devservices.service-name` attribute and indicate the broker name.
+It looks for a container with the same value, or starts a new one if none can be found.
+The default service name is `amqp`.
+
+Sharing is enabled by default in dev mode, but disabled in test mode.
+You can disable the sharing with `quarkus.amqp.devservices.shared=false`.
+
 == Setting the port
 
 By default, Dev Services for AMQP picks a random port and configures the application.

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -40,4 +40,31 @@ public class AmqpDevServicesBuildTimeConfig {
     @ConfigItem(defaultValue = "--no-autotune --mapped --no-fsync")
     public String extraArgs;
 
+    /**
+     * Indicates if the AMQP broker managed by Quarkus Dev Services is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services for AMQP starts a new container.
+     * <p>
+     * The discovery uses the {@code quarkus-dev-service-amqp} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code quarkus-dev-service-aqmp} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services for AMQP looks for a container with the
+     * {@code quarkus-dev-service-amqp} label
+     * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it
+     * starts a new container with the {@code quarkus-dev-service-amqp} label set to the specified value.
+     * <p>
+     * This property is used when you need multiple shared AMQP brokers.
+     */
+    @ConfigItem(defaultValue = "amqp")
+    public String serviceName;
+
 }


### PR DESCRIPTION
Shameless copy of the Kafka broker discovery for dev services, but for AMQP.
As for Kafka, the lookup is based on container labels.