### PR TITLE
Export JBANG_REPO env variable for release test ci job

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository == 'quarkusio/quarkus'
     env:
       MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m
+      JBANG_REPO: $HOME/release/repository
     steps:
       - uses: actions/checkout@v2
         with:

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -14,7 +14,6 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.RegistryClientMixin;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
-import io.quarkus.registry.config.RegistriesConfigLocator;
 
 public class JBangRunner implements BuildSystemRunner {
     static final String[] windowsWrapper = { "jbang.cmd", "jbang.ps1" };
@@ -72,7 +71,6 @@ public class JBangRunner implements BuildSystemRunner {
             args.add("--native");
         }
         args.add("build");
-        setJbangProperties(args, false);
         args.addAll(params);
         args.add(getMainPath());
         return prependExecutable(args);
@@ -125,11 +123,5 @@ public class JBangRunner implements BuildSystemRunner {
             throw new IllegalStateException("Unable to find a source file for use with JBang");
         }
         return mainPath;
-    }
-
-    void setJbangProperties(ArrayDeque<String> args, boolean batchMode) {
-        ExecuteUtil.propagatePropertyIfSet("maven.repo.local", args);
-        ExecuteUtil.propagatePropertyIfSet(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY, args);
-        ExecuteUtil.propagatePropertyIfSet("io.quarkus.maven.secondary-local-repo", args);
     }
 }


### PR DESCRIPTION
As mentionned in zulip, this export the `JBANG_REPO` that is used to set a custom maven local repo. (https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Quarkus.20CLI.20.2B.20release/near/243016375)