### PR TITLE
Exclude JUnit 4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -371,6 +371,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit4-mock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-class-change-agent</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -494,11 +494,13 @@
                                             <exclude>io.quarkus:quarkus-test-*</exclude>
                                             <exclude>io.rest-assured:*</exclude>
                                             <exclude>org.assertj:*</exclude>
+                                            <exclude>junit:junit</exclude>
                                         </excludes>
                                         <includes>
                                             <include>io.quarkus:quarkus-test-*:*:*:test</include>
                                             <include>io.rest-assured:*:*:*:test</include>
                                             <include>org.assertj:*:*:*:test</include>
+                                            <include>junit:junit:*:*:test</include>
                                         </includes>
                                         <message>Found test dependencies with wrong scope:</message>
                                     </bannedDependencies>

--- a/core/junit4-mock/pom.xml
+++ b/core/junit4-mock/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-core-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-junit4-mock</artifactId>
+    <name>Quarkus - JUnit 4 Mock</name>
+    <description>Module with some empty JUnit4 classes to allow Testcontainers
+    to run without needing to include JUnit4 on the class path</description>
+
+
+</project>

--- a/core/junit4-mock/src/main/java/org/junit/rules/ExternalResource.java
+++ b/core/junit4-mock/src/main/java/org/junit/rules/ExternalResource.java
@@ -1,0 +1,7 @@
+package org.junit.rules;
+
+public class ExternalResource {
+    protected void after() {
+
+    }
+}

--- a/core/junit4-mock/src/main/java/org/junit/rules/TestRule.java
+++ b/core/junit4-mock/src/main/java/org/junit/rules/TestRule.java
@@ -1,0 +1,8 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public interface TestRule {
+    Statement apply(Statement var1, Description var2);
+}

--- a/core/junit4-mock/src/main/java/org/junit/runner/Description.java
+++ b/core/junit4-mock/src/main/java/org/junit/runner/Description.java
@@ -1,0 +1,4 @@
+package org.junit.runner;
+
+public class Description {
+}

--- a/core/junit4-mock/src/main/java/org/junit/runners/model/Statement.java
+++ b/core/junit4-mock/src/main/java/org/junit/runners/model/Statement.java
@@ -1,0 +1,8 @@
+package org.junit.runners.model;
+
+public abstract class Statement {
+    public Statement() {
+    }
+
+    public abstract void evaluate() throws Throwable;
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,5 +22,6 @@
         <module>devmode-spi</module>
         <module>launcher</module>
         <module>class-change-agent</module>
+        <module>junit4-mock</module>
     </modules>
 </project>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -122,6 +122,9 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                 <configuration>
+                    <lesserPriorityArtifacts>
+                        <artifact>io.quarkus:quarkus-junit4-mock</artifact>
+                    </lesserPriorityArtifacts>
                     <parentFirstArtifacts>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-runner</parentFirstArtifact>
                         <parentFirstArtifact>io.smallrye.common:smallrye-common-io</parentFirstArtifact>

--- a/extensions/apicurio-registry-avro/deployment/pom.xml
+++ b/extensions/apicurio-registry-avro/deployment/pom.xml
@@ -35,6 +35,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/devservices/db2/pom.xml
+++ b/extensions/devservices/db2/pom.xml
@@ -19,6 +19,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>db2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>com.ibm.db2</groupId>

--- a/extensions/devservices/mariadb/pom.xml
+++ b/extensions/devservices/mariadb/pom.xml
@@ -19,6 +19,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>

--- a/extensions/devservices/mssql/pom.xml
+++ b/extensions/devservices/mssql/pom.xml
@@ -19,6 +19,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/extensions/devservices/mysql/pom.xml
+++ b/extensions/devservices/mysql/pom.xml
@@ -19,6 +19,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/devservices/postgresql/pom.xml
+++ b/extensions/devservices/postgresql/pom.xml
@@ -19,6 +19,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>

--- a/extensions/kafka-client/deployment/pom.xml
+++ b/extensions/kafka-client/deployment/pom.xml
@@ -42,6 +42,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/redis-client/deployment/pom.xml
+++ b/extensions/redis-client/deployment/pom.xml
@@ -30,6 +30,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
@@ -61,6 +61,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/extensions/vault/deployment/pom.xml
+++ b/extensions/vault/deployment/pom.xml
@@ -53,7 +53,15 @@
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This adds a junit4-mock artifact which contains the one interface
testcontainers depends on.