### PR TITLE
Fixes version selection for non-platform extensions when the stream is not specified

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/union/ElementCatalogBuilder.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/union/ElementCatalogBuilder.java
@@ -172,6 +172,10 @@ public class ElementCatalogBuilder<M> {
             this.catalogBuilder = catalogBuilder;
         }
 
+        public UnionVersion version() {
+            return version;
+        }
+
         public MemberBuilder<T> getOrCreateMember(Object memberKey, Object memberVersion) {
             return getOrCreateMember(memberKey, memberVersion, null);
         }
@@ -336,7 +340,6 @@ public class ElementCatalogBuilder<M> {
     }
 
     public static <T> List<T> getMembersForElements(ElementCatalog<T> elementCatalog, Collection<String> elementKeys) {
-
         final Map<UnionVersion, Map<Object, Member<T>>> unionVersions = new TreeMap<>(UnionVersion::compareTo);
         for (Object elementKey : elementKeys) {
             final Element<T> e = elementCatalog.get(elementKey);


### PR DESCRIPTION
I'll need to enhance the testing framework to be able to add proper tests for these use-case. In the meantime though I was using the following commands to test the issues

`quarkus create datadog-opentracing minio kogito-quarkus-rules --registry-client -e` should result in

````
    <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
    <quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
  </properties>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>${quarkus.platform.artifact-id}</artifactId>
        <version>${quarkus.platform.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.kie.kogito</groupId>
      <artifactId>kogito-quarkus-rules</artifactId>
    </dependency>
    <dependency>
      <groupId>io.quarkiverse.minio</groupId>
      <artifactId>quarkus-minio</artifactId>
    </dependency>
    <dependency>
      <groupId>io.quarkiverse.opentracing.datadog</groupId>
      <artifactId>quarkus-datadog-opentracing</artifactId>
      <version>1.0.0</version>
    </dependency>
````

`quarkus create datadog-opentracing minio --registry-client -e` should result in
````
    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
    <quarkus.platform.version>2.0.0.CR3</quarkus.platform.version>
    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
  </properties>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>${quarkus.platform.artifact-id}</artifactId>
        <version>${quarkus.platform.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>io.quarkiverse.minio</groupId>
      <artifactId>quarkus-minio</artifactId>
      <version>2.0.0.CR3</version>
    </dependency>
    <dependency>
      <groupId>io.quarkiverse.opentracing.datadog</groupId>
      <artifactId>quarkus-datadog-opentracing</artifactId>
      <version>2.0.0</version>
    </dependency>
````

NOTE: I did modify the version of `quarkus-datadog-opentracing` in the `.m2/repository/io/quarkus/registry/quarkus-non-platform-extensions/1.0-SNAPSHOT/quarkus-non-platform-extensions-1.0-SNAPSHOT-2.0.0.CR3.json` to `2.0.0` just to have a different version in the 2.0 stream.