### PR TITLE
Devtools: support pulling in the complete platform catalog from a single member bom

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -182,8 +182,8 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
     @SuppressWarnings("unchecked")
     private List<ExtensionCatalog> getExtensionOrigins(ExtensionCatalog extensionCatalog, List<Extension> extensionsToAdd)
             throws QuarkusCommandException {
-        final ElementCatalog<ExtensionCatalog> ec = (ElementCatalog<ExtensionCatalog>) extensionCatalog.getMetadata()
-                .get("element-catalog");
+        final ElementCatalog<ExtensionCatalog> ec = ElementCatalogBuilder.getElementCatalog(extensionCatalog,
+                ExtensionCatalog.class);
         if (ec == null) {
             return Collections.emptyList();
         }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformStackIndex.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformStackIndex.java
@@ -2,9 +2,9 @@ package io.quarkus.registry;
 
 import io.quarkus.registry.union.UnionVersion;
 
-class PlatformStackIndex implements UnionVersion {
+public class PlatformStackIndex implements UnionVersion {
 
-    static PlatformStackIndex initial() {
+    public static PlatformStackIndex initial() {
         return new PlatformStackIndex(0, 0, 0);
     }
 

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/union/ElementCatalogBuilder.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/union/ElementCatalogBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.registry.union;
 
+import io.quarkus.registry.catalog.ExtensionCatalog;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -367,4 +368,21 @@ public class ElementCatalogBuilder<M> {
         return Collections.emptyList();
     }
 
+    public static void addUnionMember(final UnionBuilder<ExtensionCatalog> union, final ExtensionCatalog ec) {
+        final MemberBuilder<ExtensionCatalog> builder = union.getOrCreateMember(
+                ec.getId(), ec.getBom().getVersion(), ec);
+        ec.getExtensions()
+                .forEach(e -> builder
+                        .addElement(e.getArtifact().getGroupId() + ":" + e.getArtifact().getArtifactId()));
+    }
+
+    public static void setElementCatalog(ExtensionCatalog extCatalog, ElementCatalog<?> elemCatalog) {
+        if (!elemCatalog.isEmpty()) {
+            extCatalog.getMetadata().put("element-catalog", elemCatalog);
+        }
+    }
+
+    public static <T> ElementCatalog<T> getElementCatalog(ExtensionCatalog extCatalog, Class<T> t) {
+        return (ElementCatalog<T>) extCatalog.getMetadata().get("element-catalog");
+    }
 }


### PR DESCRIPTION
This change allows to specify e.g. a single member bom with `-p` like

`quarkus create -p io.quarkus.platform:quarkus-bom:999-SNAPSHOT hibernate-orm qpid`

and install extensions from other member BOMs that belong to the same release. I.e.

````
    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
  </properties>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>quarkus-qpid-jms-bom</artifactId>
        <version>${quarkus.platform.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>${quarkus.platform.artifact-id}</artifactId>
        <version>${quarkus.platform.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>io.quarkus</groupId>
      <artifactId>quarkus-hibernate-orm</artifactId>
    </dependency>
    <dependency>
      <groupId>org.amqphub.quarkus</groupId>
      <artifactId>quarkus-qpid-jms</artifactId>
    </dependency>
````