### PR TITLE
Cli cleanup

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Build.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.build.BaseBuildCommand;
 import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
@@ -23,6 +24,9 @@ public class Build extends BaseBuildCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options%n")
     BuildOptions buildOptions = new BuildOptions();
 
+    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = false)
+    PropertiesOptions propertiesOptions = new PropertiesOptions();
+
     @Parameters(description = "Additional parameters passed to the build system")
     List<String> params = new ArrayList<>();
 
@@ -33,7 +37,8 @@ public class Build extends BaseBuildCommand implements Callable<Integer> {
             output.throwIfUnmatchedArguments(spec.commandLine());
 
             BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, propertiesOptions, runMode,
+                    params);
 
             if (runMode.isDryRun()) {
                 dryRunBuild(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs);
@@ -68,7 +73,7 @@ public class Build extends BaseBuildCommand implements Callable<Integer> {
                 + ", buildNative=" + buildOptions.buildNative
                 + ", offline=" + buildOptions.offline
                 + ", runTests=" + buildOptions.runTests
-                + ", properties=" + buildOptions.properties
+                + ", properties=" + propertiesOptions.properties
                 + ", output=" + output
                 + ", params=" + params + "]";
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -3,6 +3,7 @@ package io.quarkus.cli;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.create.BaseCreateCommand;
 import io.quarkus.cli.create.CodeGenerationGroup;
 import io.quarkus.cli.create.CreateProjectMixin;
@@ -41,6 +42,9 @@ public class CreateApp extends BaseCreateCommand {
     @CommandLine.ArgGroup(order = 5, exclusive = false, heading = "%nCode Generation%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
+    @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    PropertiesOptions propertiesOptions = new PropertiesOptions();
+
     @CommandLine.Parameters(arity = "0..1", paramLabel = "EXTENSION", description = "Extension(s) to add to the project.")
     Set<String> extensions = new HashSet<>();
 
@@ -51,6 +55,7 @@ public class CreateApp extends BaseCreateCommand {
             output.throwIfUnmatchedArguments(spec.commandLine());
 
             createProject.setSingleProjectGAV(gav);
+            createProject.setTestOutputDirectory(output.getTestDirectory());
             createProject.projectRoot(); // verify project directories early
 
             BuildTool buildTool = targetBuildTool.getBuildTool(BuildTool.MAVEN);
@@ -58,7 +63,9 @@ public class CreateApp extends BaseCreateCommand {
             createProject.setSourceTypeExtensions(extensions, sourceType);
             createProject.setCodegenOptions(codeGeneration);
 
-            QuarkusCommandInvocation invocation = createProject.build(buildTool, targetQuarkusVersion, output);
+            QuarkusCommandInvocation invocation = createProject.build(buildTool, targetQuarkusVersion,
+                    output, propertiesOptions.properties);
+
             boolean success = true;
 
             if (runMode.isDryRun()) {
@@ -85,6 +92,7 @@ public class CreateApp extends BaseCreateCommand {
                 + ", codeGeneration=" + codeGeneration
                 + ", extensions=" + extensions
                 + ", project=" + createProject
+                + ", properties=" + propertiesOptions.properties
                 + '}';
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -4,13 +4,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 import io.quarkus.cli.common.PropertiesOptions;
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.create.BaseCreateCommand;
 import io.quarkus.cli.create.CodeGenerationGroup;
 import io.quarkus.cli.create.CreateProjectMixin;
 import io.quarkus.cli.create.TargetBuildToolGroup;
 import io.quarkus.cli.create.TargetGAVGroup;
 import io.quarkus.cli.create.TargetLanguageGroup;
-import io.quarkus.cli.create.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.handlers.CreateJBangProjectCommandHandler;
 import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -4,13 +4,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 import io.quarkus.cli.common.PropertiesOptions;
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.create.BaseCreateCommand;
 import io.quarkus.cli.create.CodeGenerationGroup;
 import io.quarkus.cli.create.CreateProjectMixin;
 import io.quarkus.cli.create.TargetBuildToolGroup;
 import io.quarkus.cli.create.TargetGAVGroup;
 import io.quarkus.cli.create.TargetLanguageGroup;
-import io.quarkus.cli.create.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.handlers.CreateJBangProjectCommandHandler;
 import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -3,6 +3,7 @@ package io.quarkus.cli;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.create.BaseCreateCommand;
 import io.quarkus.cli.create.CodeGenerationGroup;
 import io.quarkus.cli.create.CreateProjectMixin;
@@ -41,6 +42,9 @@ public class CreateCli extends BaseCreateCommand {
     @CommandLine.ArgGroup(order = 5, exclusive = false, heading = "%nCode Generation%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
+    @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    PropertiesOptions propertiesOptions = new PropertiesOptions();
+
     @CommandLine.Parameters(arity = "0..1", paramLabel = "EXTENSION", description = "Extensions to add to project.")
     Set<String> extensions = new HashSet<>();
 
@@ -51,6 +55,7 @@ public class CreateCli extends BaseCreateCommand {
             output.throwIfUnmatchedArguments(spec.commandLine());
 
             createProject.setSingleProjectGAV(gav);
+            createProject.setTestOutputDirectory(output.getTestDirectory());
             createProject.projectRoot(); // verify project directories early
 
             BuildTool buildTool = targetBuildTool.getBuildTool(BuildTool.MAVEN);
@@ -58,7 +63,9 @@ public class CreateCli extends BaseCreateCommand {
             createProject.setSourceTypeExtensions(extensions, sourceType);
             createProject.setCodegenOptions(codeGeneration);
 
-            QuarkusCommandInvocation invocation = createProject.build(buildTool, targetQuarkusVersion, output);
+            QuarkusCommandInvocation invocation = createProject.build(buildTool, targetQuarkusVersion,
+                    output, propertiesOptions.properties);
+
             boolean success = true;
 
             // TODO: default extension (picocli)
@@ -88,6 +95,7 @@ public class CreateCli extends BaseCreateCommand {
                 + ", codeGeneration=" + codeGeneration
                 + ", extensions=" + extensions
                 + ", project=" + createProject
+                + ", properties=" + propertiesOptions.properties
                 + '}';
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -1,11 +1,11 @@
 package io.quarkus.cli;
 
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.create.BaseCreateCommand;
 import io.quarkus.cli.create.CreateProjectMixin;
 import io.quarkus.cli.create.ExtensionNameGenerationGroup;
 import io.quarkus.cli.create.ExtensionTargetGVGroup;
 import io.quarkus.cli.create.ExtensionTestGenerationGroup;
-import io.quarkus.cli.create.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;

--- a/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
@@ -10,6 +10,7 @@ import io.quarkus.cli.build.BaseBuildCommand;
 import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
@@ -20,7 +21,10 @@ public class Dev extends BaseBuildCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nDev Mode options%n")
     DevOptions devOptions = new DevOptions();
 
-    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = true, heading = "%nDebug options%n")
+    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = false)
+    PropertiesOptions propertiesOptions = new PropertiesOptions();
+
+    @CommandLine.ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options%n")
     DebugOptions debugOptions = new DebugOptions();
 
     @Parameters(description = "Parameters passed to the application.")
@@ -33,9 +37,10 @@ public class Dev extends BaseBuildCommand implements Callable<Integer> {
             output.throwIfUnmatchedArguments(spec.commandLine());
 
             BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareDevMode(devOptions, debugOptions, params);
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareDevMode(devOptions, propertiesOptions, debugOptions,
+                    params);
 
-            if (devOptions.dryRun) {
+            if (devOptions.isDryRun()) {
                 dryRunDev(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs);
                 return CommandLine.ExitCode.OK;
             }
@@ -66,6 +71,7 @@ public class Dev extends BaseBuildCommand implements Callable<Integer> {
     public String toString() {
         return "Dev [debugOptions=" + debugOptions
                 + ", devOptions=" + devOptions
+                + ", properties=" + propertiesOptions.properties
                 + ", output=" + output
                 + ", params=" + params + "]";
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -8,7 +8,7 @@ import io.quarkus.cli.build.BaseBuildCommand;
 import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.ListFormatOptions;
 import io.quarkus.cli.common.RunModeOption;
-import io.quarkus.cli.create.TargetQuarkusVersionGroup;
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.commands.ListExtensions;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
@@ -27,7 +27,10 @@ public class BaseBuildCommand {
 
     public Path projectRoot() {
         if (projectRoot == null) {
-            projectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+            projectRoot = output.getTestDirectory();
+            if (projectRoot == null) {
+                projectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+            }
         }
         return projectRoot;
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -15,6 +15,7 @@ import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
 import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RegistryClientMixin;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
@@ -88,9 +89,11 @@ public interface BuildSystemRunner {
 
     Integer removeExtension(RunModeOption runMode, Set<String> extensions) throws Exception;
 
-    BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
+    BuildCommandArgs prepareBuild(BuildOptions buildOptions, PropertiesOptions propertiesOptions, RunModeOption runMode,
+            List<String> params);
 
-    BuildCommandArgs prepareDevMode(DevOptions devOptions, DebugOptions debugOptions, List<String> params);
+    BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions, DebugOptions debugOptions,
+            List<String> params);
 
     Path getProjectRoot();
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -11,6 +11,7 @@ import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
 import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.registry.config.RegistriesConfigLocator;
@@ -97,7 +98,8 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, PropertiesOptions propertiesOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setGradleProperties(args, runMode.isBatchMode());
 
@@ -116,7 +118,7 @@ public class GradleRunner implements BuildSystemRunner {
         }
 
         // add any other discovered properties
-        args.addAll(flattenMappedProperties(buildOptions.properties));
+        args.addAll(flattenMappedProperties(propertiesOptions.properties));
         // Add any other unmatched arguments
         args.addAll(params);
 
@@ -124,7 +126,8 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareDevMode(DevOptions devOptions, DebugOptions debugOptions, List<String> params) {
+    public BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+            DebugOptions debugOptions, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setGradleProperties(args, false);
 
@@ -140,7 +143,7 @@ public class GradleRunner implements BuildSystemRunner {
         //TODO: addDebugArguments(args, debugOptions);
 
         // add any other discovered properties
-        args.addAll(flattenMappedProperties(devOptions.properties));
+        args.addAll(flattenMappedProperties(propertiesOptions.properties));
         // Add any other unmatched arguments
         args.addAll(params);
         return prependExecutable(args);

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -11,6 +11,7 @@ import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
 import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RegistryClientMixin;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
@@ -58,7 +59,8 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, PropertiesOptions propertiesOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
 
         if (buildOptions.offline) {
@@ -77,7 +79,8 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareDevMode(DevOptions devOptions, DebugOptions debugOptions, List<String> params) {
+    public BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+            DebugOptions debugOptions, List<String> params) {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -12,6 +12,7 @@ import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.ListFormatOptions;
 import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.commands.AddExtensions;
 import io.quarkus.devtools.commands.ListExtensions;
@@ -97,7 +98,8 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, PropertiesOptions propertiesOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setMavenProperties(args, runMode.isBatchMode());
 
@@ -122,7 +124,7 @@ public class MavenRunner implements BuildSystemRunner {
         }
 
         // add any other discovered properties
-        args.addAll(flattenMappedProperties(buildOptions.properties));
+        args.addAll(flattenMappedProperties(propertiesOptions.properties));
         // Add any other unmatched arguments
         args.addAll(params);
 
@@ -130,7 +132,8 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareDevMode(DevOptions devOptions, DebugOptions debugOptions, List<String> params) {
+    public BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+            DebugOptions debugOptions, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setMavenProperties(args, false);
 
@@ -145,7 +148,7 @@ public class MavenRunner implements BuildSystemRunner {
 
         //TODO: addDebugArguments(args, debugOptions);
 
-        args.addAll(flattenMappedProperties(devOptions.properties));
+        args.addAll(flattenMappedProperties(propertiesOptions.properties));
         // Add any other unmatched arguments
         args.addAll(params);
         return prependExecutable(args);

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/BuildOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/BuildOptions.java
@@ -1,13 +1,8 @@
 package io.quarkus.cli.common;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import picocli.CommandLine;
 
 public class BuildOptions {
-    public Map<String, String> properties = new HashMap<>();
-
     @CommandLine.Option(order = 3, names = {
             "--clean" }, description = "Perform clean as part of build. False by default.", negatable = true)
     public boolean clean = false;
@@ -20,11 +15,6 @@ public class BuildOptions {
 
     @CommandLine.Option(order = 6, names = { "--tests" }, description = "Run tests.", negatable = true)
     public boolean runTests = true;
-
-    @CommandLine.Option(order = 7, names = "-D", mapFallbackValue = "", description = "Additional Java properties.")
-    void setProperty(Map<String, String> props) {
-        this.properties = props;
-    }
 
     public boolean skipTests() {
         return !runTests;

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/DevOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/DevOptions.java
@@ -1,15 +1,14 @@
 package io.quarkus.cli.common;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import picocli.CommandLine;
 
 public class DevOptions {
-    public Map<String, String> properties = new HashMap<>();
+    @CommandLine.Option(order = 2, names = { "--dry-run" }, description = "Show actions that would be taken.")
+    boolean dryRun = false;
 
-    @CommandLine.Option(order = 2, names = { "--dryrun" }, description = "Show actions that would be taken.")
-    public boolean dryRun = false;
+    // Allow the option variant, but don't crowd help
+    @CommandLine.Option(names = { "--dryrun" }, hidden = true)
+    boolean dryRun2 = false;
 
     @CommandLine.Option(order = 3, names = {
             "--clean" }, description = "Perform clean as part of build. False by default.", negatable = true)
@@ -19,18 +18,16 @@ public class DevOptions {
             "--no-tests" }, description = "Toggle continuous testing mode. Enabled by default.", negatable = true, hidden = true)
     public boolean runTests = true; // TODO: does this make sense re: continuous test?
 
-    @CommandLine.Option(order = 5, names = "-D", mapFallbackValue = "", description = "Java properties")
-    void setProperty(Map<String, String> props) {
-        this.properties = props;
-    }
-
     public boolean skipTests() {
         return !runTests;
     }
 
+    public boolean isDryRun() {
+        return dryRun || dryRun2;
+    }
+
     @Override
     public String toString() {
-        return "DevOptions [clean=" + clean + ", properties=" + properties + ", tests=" + runTests
-                + "]";
+        return "DevOptions [clean=" + clean + ", tests=" + runTests + "]";
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
@@ -4,6 +4,8 @@ import static io.quarkus.devtools.messagewriter.MessageIcons.ERROR_ICON;
 import static io.quarkus.devtools.messagewriter.MessageIcons.WARN_ICON;
 
 import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -25,6 +27,14 @@ public class OutputOptionMixin implements MessageWriter {
     @CommandLine.Option(names = {
             "--cli-test" }, hidden = true, description = "Manually set output streams for unit test purposes.")
     boolean cliTestMode;
+
+    Path testProjectRoot;
+
+    @CommandLine.Option(names = { "--cli-test-dir" }, hidden = true)
+    void setTestProjectRoot(String path) {
+        // Allow the starting/project directory to be specified. Used during test.
+        testProjectRoot = Paths.get(path).toAbsolutePath();
+    }
 
     @Spec(Spec.Target.MIXEE)
     CommandSpec mixee;
@@ -89,6 +99,13 @@ public class OutputOptionMixin implements MessageWriter {
         if (isShowErrors()) {
             err().println(colorScheme().stackTraceText(ex));
         }
+    }
+
+    public Path getTestDirectory() {
+        if (isCliTest()) {
+            return testProjectRoot;
+        }
+        return null;
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/PropertiesOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/PropertiesOptions.java
@@ -1,0 +1,20 @@
+package io.quarkus.cli.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import picocli.CommandLine;
+
+public class PropertiesOptions {
+    public Map<String, String> properties = new HashMap<>();
+
+    @CommandLine.Option(order = 5, names = "-D", mapFallbackValue = "", description = "Java properties")
+    void setProperty(Map<String, String> props) {
+        this.properties = props;
+    }
+
+    @Override
+    public String toString() {
+        return properties.toString();
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/RegistryClientMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/RegistryClientMixin.java
@@ -3,7 +3,6 @@ package io.quarkus.cli.common;
 import java.nio.file.Path;
 
 import io.quarkus.cli.Version;
-import io.quarkus.cli.create.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
@@ -31,6 +30,12 @@ public class RegistryClientMixin {
     ExtensionCatalog getExtensionCatalog(TargetQuarkusVersionGroup targetVersion, OutputOptionMixin log) {
         log.debug("Resolving Quarkus extension catalog for " + targetVersion);
         QuarkusProjectHelper.setMessageWriter(log);
+
+        if (targetVersion.isStreamSpecified() && !enableRegistryClient) {
+            throw new UnsupportedOperationException(
+                    "Specifying a stream (--stream) requires the registry client to resolve resources. " +
+                            "Please try again with the registry client enabled (--registry-client)");
+        }
 
         if (targetVersion.isPlatformSpecified()) {
             ArtifactCoords coords = targetVersion.getPlatformBom();

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
@@ -1,4 +1,4 @@
-package io.quarkus.cli.create;
+package io.quarkus.cli.common;
 
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.maven.StreamCoords;
@@ -31,7 +31,7 @@ public class TargetQuarkusVersionGroup {
         }
     }
 
-    @CommandLine.Option(paramLabel = "groupId:artifactId:version", names = { "-p",
+    @CommandLine.Option(paramLabel = "groupId:artifactId:version", names = { "-P",
             "--platform-bom" }, description = "A specific Quarkus platform BOM, for example:%n  io.quarkus:quarkus-bom:1.13.4.Final")
     void setPlatformBom(String bom) {
         bom = bom.trim();

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
@@ -25,7 +25,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
 public class CreateProjectMixin {
-
     Map<String, Object> values = new HashMap<>();
     Path outputPath;
     Path projectRootPath;
@@ -40,6 +39,12 @@ public class CreateProjectMixin {
 
     @Mixin
     RegistryClientMixin registryClient;
+
+    public void setTestOutputDirectory(Path testOutputDirectory) {
+        if (testOutputDirectory != null && targetDirectory == null) {
+            outputPath = testOutputDirectory;
+        }
+    }
 
     public Path outputDirectory() {
         if (outputPath == null) {
@@ -88,7 +93,7 @@ public class CreateProjectMixin {
     }
 
     public QuarkusCommandInvocation build(BuildTool buildTool, TargetQuarkusVersionGroup targetVersion,
-            OutputOptionMixin log)
+            OutputOptionMixin log, Map<String, String> properties)
             throws RegistryResolutionException {
 
         // TODO: Allow this to be configured? infer from active Java version?
@@ -104,6 +109,16 @@ public class CreateProjectMixin {
         }
 
         QuarkusProject qp = registryClient.createQuarkusProject(projectRoot(), targetVersion, buildTool, log);
+
+        properties.entrySet().forEach(x -> {
+            if (x.getValue().length() > 0) {
+                System.setProperty(x.getKey(), x.getValue());
+                log.info("property: %s=%s", x.getKey(), x.getValue());
+            } else {
+                System.setProperty(x.getKey(), "");
+                log.info("property: %s", x.getKey());
+            }
+        });
         return new QuarkusCommandInvocation(qp, values);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.RegistryClientMixin;
+import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.devtools.commands.CreateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.project.BuildTool;

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.cli;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -7,19 +10,23 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import io.quarkus.devtools.messagewriter.MessageIcons;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+
 /**
  * This is ordered to make output easier to view (as it effectively dumps help)
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class CliHelpTest {
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
 
     @Test
     @Order(1)
     public void testCommandHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "--help");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute();
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot);
         Assertions.assertEquals(result.stdout, result2.stdout, "Invoking the base command should show usage help");
         CliDriver.println("-- same as above\n\n");
     }
@@ -27,21 +34,21 @@ public class CliHelpTest {
     @Test
     @Order(20)
     public void testCreateHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(21)
     public void testCreateAppHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "app", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(22)
     public void testCreateCliHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "cli", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "--help");
         result.echoSystemOut();
     }
 
@@ -49,31 +56,31 @@ public class CliHelpTest {
     @Order(23)
     @Disabled
     public void testCreateExtensionHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "extension", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(30)
     public void testBuildHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("build", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "build", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(40)
     public void testDevHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("dev", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "dev", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(50)
     public void testExtHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("ext", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "--help");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute("extension", "--help");
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "extension", "--help");
         Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
     }
@@ -81,17 +88,17 @@ public class CliHelpTest {
     @Test
     @Order(51)
     public void testExtAddHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("ext", "add", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "add", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(52)
     public void testExtListHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("ext", "ls", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "ls", "--help");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute("ext", "list", "--help");
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "ext", "list", "--help");
         Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
     }
@@ -99,10 +106,10 @@ public class CliHelpTest {
     @Test
     @Order(53)
     public void testExtRemoveHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("ext", "rm", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "rm", "--help");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute("ext", "remove", "--help");
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "ext", "remove", "--help");
         Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
     }
@@ -110,14 +117,26 @@ public class CliHelpTest {
     @Order(60)
     @Test
     public void testGenerateCompletionHelp() throws Exception {
-        CliDriver.Result result = CliDriver.execute("generate-completion", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "generate-completion", "--help");
         result.echoSystemOut();
     }
 
     @Test
     @Order(70)
     public void testCommandVersion() throws Exception {
-        CliDriver.Result result = CliDriver.execute("version", "--help");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "version", "--help");
         result.echoSystemOut();
+    }
+
+    @Test
+    @Order(80)
+    public void testMessageFlags() throws Exception {
+        MessageWriter writer = MessageWriter.debug();
+        writer.error("error"); // has emoji
+        writer.warn("warn"); // has emoji
+        writer.info(MessageIcons.NOOP_ICON + " info");
+        writer.info(MessageIcons.OK_ICON + " info");
+        writer.info(MessageIcons.NOK_ICON + " info");
+        writer.debug("debug");
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -44,7 +44,7 @@ public class CliNonProjectTest {
     @Test
     public void testListPlatformExtensions() throws Exception {
         // List extensions of a specified platform version
-        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-p=io.quarkus:quarkus-bom:2.0.0.CR3", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-P=io.quarkus:quarkus-bom:2.0.0.CR3", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,21 +13,18 @@ import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 public class CliNonProjectTest {
-    static String startingDir;
     static Path workspaceRoot;
 
     @BeforeAll
     public static void initial() throws Exception {
-        startingDir = System.getProperty("user.dir");
-        workspaceRoot = Paths.get(startingDir).toAbsolutePath().resolve("target/test-project/CliNonProjectTest");
-        System.setProperty("user.dir", workspaceRoot.toFile().getAbsolutePath());
+        workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+                .resolve("target/test-project/CliNonProjectTest");
         CliDriver.deleteDir(workspaceRoot);
         Files.createDirectories(workspaceRoot);
     }
 
     @AfterEach
     public void verifyEmptyDirectory() throws Exception {
-        System.setProperty("user.dir", workspaceRoot.toFile().getAbsolutePath());
         String[] files = workspaceRoot.toFile().list();
         Assertions.assertNotNull(files,
                 "Directory list operation should succeed");
@@ -36,14 +32,9 @@ public class CliNonProjectTest {
                 "Directory should be empty. Found: " + Arrays.toString(files));
     }
 
-    @AfterAll
-    public static void allDone() {
-        System.setProperty("user.dir", startingDir);
-    }
-
     @Test
     public void testListOutsideOfProject() throws Exception {
-        CliDriver.Result result = CliDriver.execute("ext", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),
@@ -53,7 +44,7 @@ public class CliNonProjectTest {
     @Test
     public void testListPlatformExtensions() throws Exception {
         // List extensions of a specified platform version
-        CliDriver.Result result = CliDriver.execute("ext", "list", "-p=io.quarkus:quarkus-bom:2.0.0.CR3", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-p=io.quarkus:quarkus-bom:2.0.0.CR3", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),
@@ -64,7 +55,7 @@ public class CliNonProjectTest {
 
     @Test
     public void testBuildOutsideOfProject() throws Exception {
-        CliDriver.Result result = CliDriver.execute("build", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "build", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.USAGE, result.exitCode,
                 "'quarkus build' should fail outside of a quarkus project directory:\n" + result);
         System.out.println(result);
@@ -72,7 +63,7 @@ public class CliNonProjectTest {
 
     @Test
     public void testDevOutsideOfProject() throws Exception {
-        CliDriver.Result result = CliDriver.execute("dev", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "dev", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.USAGE, result.exitCode,
                 "'quarkus dev' should fail outside of a quarkus project directory:\n" + result);
         System.out.println(result);
@@ -81,13 +72,13 @@ public class CliNonProjectTest {
     @Test
     public void testCreateAppDryRun() throws Exception {
         // A dry run of create should not create any files or directories
-        CliDriver.Result result = CliDriver.execute("create", "--dry-run", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "--dry-run", "-e");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("project would have been created"),
                 "Should contain 'project would have been created', found: " + result.stdout);
 
-        CliDriver.Result result2 = CliDriver.execute("create", "--dryrun", "-e");
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "create", "--dryrun", "-e");
         Assertions.assertEquals(result.stdout, result2.stdout,
                 "Invoking the command with --dryrun should produce the same result");
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -3,9 +3,7 @@ package io.quarkus.cli;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,31 +11,20 @@ import io.quarkus.devtools.project.codegen.CreateProjectHelper;
 import picocli.CommandLine;
 
 public class CliProjectJBangTest {
-    static String startingDir;
-    static Path workspaceRoot;
-    Path project;
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("target/test-project/CliProjectJBangTest");
 
-    @BeforeAll
-    public static void initial() throws Exception {
-        startingDir = System.getProperty("user.dir");
-        workspaceRoot = Paths.get(startingDir).toAbsolutePath().resolve("target/test-project/CliProjectJBangTest");
-    }
+    Path project;
 
     @BeforeEach
     public void setupTestDirectories() throws Exception {
-        System.setProperty("user.dir", workspaceRoot.toFile().getAbsolutePath());
         CliDriver.deleteDir(workspaceRoot);
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    @AfterAll
-    public static void allDone() {
-        System.setProperty("user.dir", startingDir);
-    }
-
     @Test
     public void testCreateAppDefaults() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "app", "--jbang", "--verbose", "-e", "-B");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang", "--verbose", "-e", "-B");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
@@ -51,11 +38,10 @@ public class CliProjectJBangTest {
 
         Path javaMain = valdiateJBangSourcePackage(project, ""); // no package name
 
-        String source = CliDriver.readFileAsString(javaMain);
+        String source = CliDriver.readFileAsString(project, javaMain);
         Assertions.assertTrue(source.contains("quarkus-resteasy"),
                 "Generated source should reference resteasy. Found:\n" + source);
 
-        System.setProperty("user.dir", project.toFile().getAbsolutePath());
         result = CliDriver.invokeValidateDryRunBuild(project);
 
         CliDriver.invokeValidateBuild(project);
@@ -63,11 +49,12 @@ public class CliProjectJBangTest {
 
     @Test
     public void testCreateAppOverrides() throws Exception {
-        project = workspaceRoot.resolve("nested/my-project");
+        Path nested = workspaceRoot.resolve("cli-nested");
+        project = nested.resolve("my-project");
 
-        CliDriver.Result result = CliDriver.execute("create", "app", "--jbang", "--verbose", "-e", "-B",
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang", "--verbose", "-e", "-B",
                 "--package-name=custom.pkg",
-                "--output-directory=nested",
+                "--output-directory=" + nested,
                 "--group-id=silly", "--artifact-id=my-project", "--version=0.1.0",
                 "vertx-web");
 
@@ -81,11 +68,10 @@ public class CliProjectJBangTest {
         validateBasicIdentifiers(project, "silly", "my-project", "0.1.0");
         Path javaMain = valdiateJBangSourcePackage(project, "");
 
-        String source = CliDriver.readFileAsString(javaMain);
+        String source = CliDriver.readFileAsString(project, javaMain);
         Assertions.assertTrue(source.contains("quarkus-vertx-web"),
                 "Generated source should reference vertx-web. Found:\n" + source);
 
-        System.setProperty("user.dir", project.toFile().getAbsolutePath());
         result = CliDriver.invokeValidateDryRunBuild(project);
 
         CliDriver.invokeValidateBuild(project);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -5,9 +5,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,31 +16,19 @@ import picocli.CommandLine;
  * Similar to CliProjectGradleTest ..
  */
 public class CliProjectMavenTest {
-    static String startingDir;
-    static Path workspaceRoot;
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("target/test-project/CliProjectMavenTest");
     Path project;
-
-    @BeforeAll
-    public static void initial() throws Exception {
-        startingDir = System.getProperty("user.dir");
-        workspaceRoot = Paths.get(startingDir).toAbsolutePath().resolve("target/test-project/CliProjectMavenTest");
-    }
 
     @BeforeEach
     public void setupTestDirectories() throws Exception {
-        System.setProperty("user.dir", workspaceRoot.toFile().getAbsolutePath());
         CliDriver.deleteDir(workspaceRoot);
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    @AfterAll
-    public static void allDone() {
-        System.setProperty("user.dir", startingDir);
-    }
-
     @Test
     public void testCreateAppDefaults() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "app", "-e", "-B", "--verbose");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
@@ -57,7 +43,6 @@ public class CliProjectMavenTest {
 
         CliDriver.valdiateGeneratedSourcePackage(project, "org/acme");
 
-        System.setProperty("user.dir", project.toFile().getAbsolutePath());
         result = CliDriver.invokeValidateDryRunBuild(project);
 
         CliDriver.invokeValidateBuild(project);
@@ -65,14 +50,15 @@ public class CliProjectMavenTest {
 
     @Test
     public void testCreateAppOverrides() throws Exception {
-        project = workspaceRoot.resolve("nested/my-project");
+        Path nested = workspaceRoot.resolve("cli-nested");
+        project = nested.resolve("my-project");
 
         List<String> configs = Arrays.asList("custom.app.config1=val1",
                 "custom.app.config2=val2", "lib.config=val3");
 
-        CliDriver.Result result = CliDriver.execute("create", "app", "--verbose", "-e", "-B",
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--verbose", "-e", "-B",
                 "--no-wrapper", "--package-name=custom.pkg",
-                "--output-directory=nested",
+                "--output-directory=" + nested,
                 "--group-id=silly", "--artifact-id=my-project", "--version=0.1.0",
                 "--app-config=" + String.join(",", configs),
                 "resteasy-reactive");
@@ -90,7 +76,6 @@ public class CliProjectMavenTest {
         CliDriver.valdiateGeneratedSourcePackage(project, "custom/pkg");
         CliDriver.validateApplicationProperties(project, configs);
 
-        System.setProperty("user.dir", project.toFile().getAbsolutePath());
         result = CliDriver.invokeValidateDryRunBuild(project);
         Assertions.assertTrue(result.stdout.contains("-Dproperty=value1 -Dproperty2=value2"),
                 "result should contain '-Dproperty=value1 -Dproperty2=value2':\n" + result.stdout);
@@ -100,38 +85,39 @@ public class CliProjectMavenTest {
 
     @Test
     public void testExtensionList() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create", "app", "-e", "-B", "--verbose");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
-        System.setProperty("user.dir", project.toFile().getAbsolutePath());
-
         Path pom = project.resolve("pom.xml");
-        String pomContent = CliDriver.readFileAsString(pom);
+        String pomContent = CliDriver.readFileAsString(project, pom);
         Assertions.assertFalse(pomContent.contains("quarkus-qute"),
                 "Dependencies should not contain qute extension by default. Found:\n" + pomContent);
 
-        CliDriver.invokeExtensionAddQute(pom);
-        CliDriver.invokeExtensionAddRedundantQute();
-        CliDriver.invokeExtensionListInstallable();
-        CliDriver.invokeExtensionAddMultiple(pom);
-        CliDriver.invokeExtensionRemoveQute(pom);
-        CliDriver.invokeExtensionRemoveMultiple(pom);
+        CliDriver.invokeExtensionAddQute(project, pom);
+        CliDriver.invokeExtensionAddRedundantQute(project);
+        CliDriver.invokeExtensionListInstallable(project);
+        CliDriver.invokeExtensionAddMultiple(project, pom);
+        CliDriver.invokeExtensionRemoveQute(project, pom);
+        CliDriver.invokeExtensionRemoveMultiple(project, pom);
 
-        CliDriver.invokeExtensionListInstallableSearch();
-        CliDriver.invokeExtensionListFormatting();
+        CliDriver.invokeExtensionListInstallableSearch(project);
+        CliDriver.invokeExtensionListFormatting(project);
 
         // TODO: Maven and Gradle give different return codes
-        result = CliDriver.invokeExtensionRemoveNonexistent();
+        result = CliDriver.invokeExtensionRemoveNonexistent(project);
         Assertions.assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode,
                 "Expected error return code. Result:\n" + result);
     }
 
     @Test
     public void testCreateArgPassthrough() throws Exception {
-        CliDriver.Result result = CliDriver.execute("create",
+        Path nested = workspaceRoot.resolve("cli-nested");
+        project = nested.resolve("my-project");
+
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create",
                 "--verbose", "-e", "-B",
                 "--dryrun", "--no-wrapper", "--package-name=custom.pkg",
-                "--output-directory=nested",
+                "--output-directory=" + nested,
                 "--group-id=silly", "--artifact-id=my-project", "--version=0.1.0");
 
         // We don't need to retest this, just need to make sure all of the arguments were passed through
@@ -158,7 +144,7 @@ public class CliProjectMavenTest {
 
         Assertions.assertTrue(pom.toFile().exists(),
                 "pom.xml should exist: " + pom.toAbsolutePath().toString());
-        String pomContent = CliDriver.readFileAsString(pom);
+        String pomContent = CliDriver.readFileAsString(project, pom);
         Assertions.assertTrue(pomContent.contains("<groupId>" + group + "</groupId>"),
                 "pom.xml should contain group id:\n" + pomContent);
         Assertions.assertTrue(pomContent.contains("<artifactId>" + artifact + "</artifactId>"),

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
@@ -1,19 +1,24 @@
 package io.quarkus.cli;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class CliVersionTest {
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
+
     @Test
     public void testCommandVersion() throws Exception {
-        CliDriver.Result result = CliDriver.execute("version");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "version");
         result.echoSystemOut();
 
-        CliDriver.Result result2 = CliDriver.execute("-v");
+        CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "-v");
         Assertions.assertEquals(result.stdout, result2.stdout, "Version output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
 
-        CliDriver.Result result3 = CliDriver.execute("--version");
+        CliDriver.Result result3 = CliDriver.execute(workspaceRoot, "--version");
         Assertions.assertEquals(result.stdout, result3.stdout, "Version output for command aliases should be the same.");
         CliDriver.println("-- same as above\n\n");
     }

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -95,7 +95,7 @@ applying codestarts...
 📝  config-properties
 🔧  dockerfiles
 🔧  maven-wrapper
-📄  resteasy-codestart
+🚀  resteasy-codestart
 
 -----------
 [SUCCESS] ✅ quarkus project has been successfully generated in:
@@ -123,7 +123,7 @@ applying codestarts...
 📝  config-properties
 🔧  dockerfiles
 🔧  maven-wrapper
-📄  resteasy-codestart
+🚀  resteasy-codestart
 
 -----------
 [SUCCESS] ✅ quarkus project has been successfully generated in:
@@ -225,16 +225,16 @@ $ quarkus build
 [INFO] Total time:  8.331 s
 [INFO] Finished at: 2021-05-27T10:13:28-04:00
 [INFO] ------------------------------------------------------------------------
----
+----
 
-Note: Output will vary depending on the build tool your project is using (maven, gradle, or jbang).
+Note: Output will vary depending on the build tool your project is using (`maven`, `gradle`, or `jbang`).
 
 == Development mode
 
 [source,shell]
 ----
 $ quarkus dev --help
----
+----
 
 To start dev mode from the Quarkus CLI do:
 
@@ -261,6 +261,6 @@ __  ____  __  _____   ___  __ ____  ______
 Tests paused, press [r] to resume
 ----
 
-Note: Output will vary depending on the build tool your project is using (maven, gradle, or jbang).
+Note: Output will vary depending on the build tool your project is using (`maven`, `gradle`, or `jbang`).
 
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartType.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartType.java
@@ -1,14 +1,15 @@
 package io.quarkus.devtools.codestarts;
 
+import io.quarkus.devtools.messagewriter.MessageIcons;
 import io.smallrye.common.os.OS;
 
 public enum CodestartType {
-    LANGUAGE(true, 1, toEmoji("U+1F4DA")),
-    BUILDTOOL(true, 2, toEmoji("U+1F528")),
-    PROJECT(true, 3, toEmoji("U+1F4E6")),
-    CONFIG(true, 4, toEmoji("U+1F4DD")),
-    TOOLING(false, 5, toEmoji("U+1F527")),
-    CODE(false, 6, toEmoji("U+1F4C4")),
+    LANGUAGE(true, 1, MessageIcons.toEmoji("U+1F4DA")),
+    BUILDTOOL(true, 2, MessageIcons.toEmoji("U+1F528")),
+    PROJECT(true, 3, MessageIcons.toEmoji("U+1F4E6")),
+    CONFIG(true, 4, MessageIcons.toEmoji("U+1F4DD")),
+    TOOLING(false, 5, MessageIcons.toEmoji("U+1F527")),
+    CODE(false, 6, MessageIcons.toEmoji("U+1F680")),
     ;
 
     private final boolean base;
@@ -33,17 +34,4 @@ public enum CodestartType {
         return processingOrder;
     }
 
-    // Simplify life so we can just understand what emojis we are using
-    static String toEmoji(String text) {
-        String[] codes = text.replace("U+", "0x").split(" ");
-        final StringBuilder stringBuilder = new StringBuilder();
-        for (String code : codes) {
-            final Integer intCode = Integer.decode(code.trim());
-            for (Character character : Character.toChars(intCode)) {
-                stringBuilder.append(character);
-            }
-        }
-        stringBuilder.append(' ');
-        return stringBuilder.toString();
-    }
 }

--- a/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageIcons.java
+++ b/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageIcons.java
@@ -4,11 +4,11 @@ import io.smallrye.common.os.OS;
 
 public enum MessageIcons {
 
-    OK_ICON("\u2705", "[SUCCESS]"),
-    NOK_ICON("\u274c", "[FAILURE]"),
-    NOOP_ICON("\uD83D\uDC4D", ""),
-    WARN_ICON("\uD83D\uDD25", "[WARN]"),
-    ERROR_ICON("\u2757", "[ERROR]");
+    OK_ICON(toEmoji("U+2705"), "[SUCCESS]"),
+    NOK_ICON(toEmoji("U+274C"), "[FAILURE]"),
+    NOOP_ICON(toEmoji("U+1F44D"), ""),
+    WARN_ICON(toEmoji("U+1F525"), "[WARN]"),
+    ERROR_ICON(toEmoji("U+2757"), "[ERROR]");
 
     private String icon;
     private String messageCode;
@@ -16,6 +16,20 @@ public enum MessageIcons {
     MessageIcons(String icon, String messageCode) {
         this.icon = icon;
         this.messageCode = messageCode;
+    }
+
+    // Simplify life so we can just understand what emojis we are using
+    public static String toEmoji(String text) {
+        String[] codes = text.replace("U+", "0x").split(" ");
+        final StringBuilder stringBuilder = new StringBuilder();
+        for (String code : codes) {
+            final Integer intCode = Integer.decode(code.trim());
+            for (Character character : Character.toChars(intCode)) {
+                stringBuilder.append(character);
+            }
+        }
+        stringBuilder.append(' ');
+        return stringBuilder.toString();
     }
 
     @Override


### PR DESCRIPTION
Support providing Java -D options at create time, too (just in case). Handle that better across commands.

Flip `-S` and `-s`, where `-p` and `-s` specify platform/stream, and `-S` is now for searching .. 

Consistent specification of emoji, and use less-boring rocketship. 