### PR TITLE
Continuous testing fixes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/console/AeshConsole.java
@@ -19,8 +19,7 @@ public class AeshConsole extends QuarkusConsole {
     private Size size;
     private Attributes attributes;
 
-    private String statusMessage;
-    private String promptMessage;
+    private String[] messages = new String[0];
     private int totalStatusLines = 0;
     private int lastWriteCursorX;
     /**
@@ -60,27 +59,6 @@ public class AeshConsole extends QuarkusConsole {
         }, "Console Shutdown Hoot"));
     }
 
-    private AeshConsole setStatusMessage(String statusMessage) {
-        synchronized (this) {
-            StringBuilder buffer = new StringBuilder();
-            clearStatusMessages(buffer);
-            int newLines = countLines(statusMessage) + countLines(promptMessage);
-            if (statusMessage == null) {
-                if (promptMessage != null) {
-                    newLines += 2;
-                }
-            } else if (promptMessage == null) {
-                newLines += 2;
-            } else {
-                newLines += 3;
-            }
-            this.statusMessage = statusMessage;
-            updatePromptOnChange(buffer, newLines);
-        }
-        deadlockSafeWrite();
-        return this;
-    }
-
     private void updatePromptOnChange(StringBuilder buffer, int newLines) {
         if (newLines > totalStatusLines) {
             StringBuilder nb = new StringBuilder();
@@ -106,27 +84,39 @@ public class AeshConsole extends QuarkusConsole {
     }
 
     private AeshConsole setPromptMessage(String promptMessage) {
+        if (!inputSupport) {
+            return this;
+        }
+        setMessage(0, promptMessage);
+        return this;
+    }
+
+    private AeshConsole setMessage(int position, String message) {
         synchronized (this) {
-            if (!inputSupport) {
-                return this;
+            if (messages.length <= position) {
+                String[] old = messages;
+                messages = new String[position + 1];
+                System.arraycopy(old, 0, this.messages, 0, old.length);
             }
+            messages[position] = message;
+            int newLines = countTotalStatusLines();
             StringBuilder buffer = new StringBuilder();
             clearStatusMessages(buffer);
-            int newLines = countLines(statusMessage) + countLines(promptMessage);
-            if (statusMessage == null) {
-                if (promptMessage != null) {
-                    newLines += 2;
-                }
-            } else if (promptMessage == null) {
-                newLines += 2;
-            } else {
-                newLines += 3;
-            }
-            this.promptMessage = promptMessage;
             updatePromptOnChange(buffer, newLines);
         }
         deadlockSafeWrite();
         return this;
+    }
+
+    private int countTotalStatusLines() {
+        int total = 0;
+        for (String i : messages) {
+            if (i != null) {
+                total++;
+                total += countLines(i);
+            }
+        }
+        return total == 0 ? total : total + 1;
     }
 
     private void end(Connection conn) {
@@ -227,14 +217,20 @@ public class AeshConsole extends QuarkusConsole {
             bottomBlankSpace = 0;
         }
         buffer.append("\n--\n");
-        if (statusMessage != null) {
-            buffer.append(statusMessage);
-            if (promptMessage != null) {
-                buffer.append("\n");
+        for (int i = messages.length - 1; i >= 0; --i) {
+            String msg = messages[i];
+            if (msg != null) {
+                buffer.append(msg);
+                if (i > 0) {
+                    //if there is any more messages to print we add a newline
+                    for (int j = 0; j < i; ++j) {
+                        if (messages[j] != null) {
+                            buffer.append("\n");
+                            break;
+                        }
+                    }
+                }
             }
-        }
-        if (promptMessage != null) {
-            buffer.append(promptMessage);
         }
     }
 
@@ -352,13 +348,27 @@ public class AeshConsole extends QuarkusConsole {
 
         @Override
         protected void setPromptMessage(String prompt) {
-            AeshConsole.this.setPromptMessage(prompt);
+            if (!inputSupport) {
+                return;
+            }
+            setMessage(0, prompt);
+        }
+
+        @Override
+        protected void setResultsMessage(String results) {
+            setMessage(1, results);
+        }
+
+        @Override
+        protected void setCompileErrorMessage(String results) {
+            setMessage(3, results);
         }
 
         @Override
         protected void setStatusMessage(String status) {
-            AeshConsole.this.setStatusMessage(status);
+            setMessage(2, status);
 
         }
+
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -1,9 +1,9 @@
 package io.quarkus.deployment.dev.testing;
 
+import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.BLUE;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.GREEN;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.RED;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.RESET;
-import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.YELLOW;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.helpOption;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.statusFooter;
 import static io.quarkus.deployment.dev.testing.TestConsoleHandler.MessageFormat.statusHeader;
@@ -34,10 +34,12 @@ public class TestConsoleHandler implements TestListener {
 
     private static final Logger log = Logger.getLogger("io.quarkus.test");
 
-    public static final String PAUSED_PROMPT = YELLOW + "Tests paused, press [r] to resume, [h] for more options>" + RESET;
-    public static final String FIRST_RUN_PROMPT = YELLOW + "Running Tests for the first time" + RESET;
-    public static final String RUNNING_PROMPT = "Press [r] to re-run, [v] to view full results, [p] to pause, [h] for more options>";
-    public static final String ABORTED_PROMPT = "Test run aborted.";
+    public static final String PAUSED_PROMPT = "Tests paused, press [" + BLUE + "r" + RESET + "] to resume, [" + BLUE + "h"
+            + RESET + "] for more options>" + RESET;
+    public static final String FIRST_RUN_PROMPT = BLUE + "Running Tests for the first time" + RESET;
+    public static final String RUNNING_PROMPT = "Press [" + BLUE + "r" + RESET + "] to re-run, [" + BLUE
+            + "v" + RESET + "] to view full results, [" + BLUE + "p" + RESET + "] to pause, [" + BLUE
+            + "h" + RESET + "] for more options>";
 
     final DevModeType devModeType;
 
@@ -46,7 +48,7 @@ public class TestConsoleHandler implements TestListener {
     boolean currentlyFailing = false;
     volatile InputHandler.ConsoleStatus promptHandler;
     volatile TestController testController;
-    private String lastStatus;
+    private String lastResults;
 
     public TestConsoleHandler(DevModeType devModeType) {
         this.devModeType = devModeType;
@@ -93,7 +95,7 @@ public class TestConsoleHandler implements TestListener {
                 } else {
                     if (disabled) {
                         if (k == 'r') {
-                            promptHandler.setStatus(YELLOW + "Starting tests" + RESET);
+                            promptHandler.setStatus(BLUE + "Starting tests" + RESET);
                             TestSupport.instance().get().start();
                         }
                     } else if (!firstRun) {
@@ -158,10 +160,12 @@ public class TestConsoleHandler implements TestListener {
         disabled = false;
         if (firstRun) {
             promptHandler.setStatus(null);
+            promptHandler.setResults(null);
             promptHandler.setPrompt(FIRST_RUN_PROMPT);
         } else {
             promptHandler.setPrompt(RUNNING_PROMPT);
-            promptHandler.setStatus(lastStatus);
+            promptHandler.setResults(lastResults);
+            promptHandler.setStatus(null);
         }
     }
 
@@ -170,11 +174,17 @@ public class TestConsoleHandler implements TestListener {
         disabled = true;
         promptHandler.setPrompt(PAUSED_PROMPT);
         promptHandler.setStatus(null);
+        promptHandler.setResults(null);
     }
 
     @Override
     public void testCompileFailed(String message) {
-        promptHandler.setStatus(message);
+        promptHandler.setCompileError(message);
+    }
+
+    @Override
+    public void testCompileSucceeded() {
+        promptHandler.setCompileError(null);
     }
 
     @Override
@@ -226,15 +236,15 @@ public class TestConsoleHandler implements TestListener {
                     end = end + ".";
                 }
                 if (results.getTotalCount() == 0) {
-                    lastStatus = YELLOW + "No tests found" + RESET;
+                    lastResults = BLUE + "No tests found" + RESET;
                 } else if (results.getFailedCount() == 0 && results.getPassedCount() == 0) {
-                    lastStatus = String.format(YELLOW + "All %d tests were skipped" + RESET, results.getSkippedCount());
+                    lastResults = String.format(BLUE + "All %d tests were skipped" + RESET, results.getSkippedCount());
                 } else if (results.getCurrentFailing().isEmpty()) {
                     if (currentlyFailing) {
                         log.info(GREEN + "All tests are now passing" + RESET);
                     }
                     currentlyFailing = false;
-                    lastStatus = String.format(
+                    lastResults = String.format(
                             GREEN + "All %d tests are passing (%d skipped), %d tests were run in %dms." + end + RESET,
                             results.getPassedCount(),
                             results.getSkippedCount(),
@@ -252,15 +262,18 @@ public class TestConsoleHandler implements TestListener {
                     }
                     log.error(
                             statusFooter(RED + results.getCurrentFailedCount() + " TESTS FAILED"));
-                    lastStatus = String.format(
-                            RED + "%d tests failed" + RESET + " (" + GREEN + "%d passing" + RESET + ", " + YELLOW + "%d skipped"
-                                    + RESET + "), %d tests were run in %dms." + end + RESET,
+                    lastResults = String.format(
+                            RED + "%d tests failed" + RESET + " (" + GREEN + "%d passing" + RESET + ", " + BLUE + "%d skipped"
+                                    + RESET + ")" + RED + ", %d tests were run in %dms." + end + RESET,
                             results.getCurrentFailedCount(), results.getPassedCount(), results.getSkippedCount(),
                             results.getCurrentTotalCount(), results.getTotalTime());
                 }
                 //this will re-print when using the basic console
-                promptHandler.setPrompt(RUNNING_PROMPT);
-                promptHandler.setStatus(lastStatus);
+                if (!disabled) {
+                    promptHandler.setPrompt(RUNNING_PROMPT);
+                    promptHandler.setResults(lastResults);
+                    promptHandler.setStatus(null);
+                }
             }
 
             @Override
@@ -270,8 +283,6 @@ public class TestConsoleHandler implements TestListener {
 
             @Override
             public void runAborted() {
-                promptHandler.setStatus(ABORTED_PROMPT);
-                promptHandler.setPrompt(RUNNING_PROMPT);
                 firstRun = false;
             }
 
@@ -296,7 +307,7 @@ public class TestConsoleHandler implements TestListener {
 
         public static final String RED = "\u001B[91m";
         public static final String GREEN = "\u001b[32m";
-        public static final String YELLOW = "\u001b[33m";
+        public static final String BLUE = "\u001b[34m";
         public static final String RESET = "\u001b[0m";
 
         private MessageFormat() {
@@ -315,7 +326,7 @@ public class TestConsoleHandler implements TestListener {
         }
 
         public static String helpOption(String key, String description) {
-            return "[" + GREEN + key + RESET + "] - " + description;
+            return "[" + BLUE + key + RESET + "] - " + description;
         }
 
         public static String helpOption(String key, String description, boolean enabled) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestListener.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestListener.java
@@ -34,4 +34,8 @@ public interface TestListener {
     default void testCompileFailed(String message) {
 
     }
+
+    default void testCompileSucceeded() {
+
+    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
@@ -20,7 +20,6 @@ import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.PostDiscoveryFilter;
-import org.opentest4j.TestAbortedException;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.deployment.dev.ClassScanResult;
@@ -348,9 +347,6 @@ public class TestRunner {
                     throw new RuntimeException(e);
                 }
             }
-            if (disabled) {
-                throw new TestAbortedException("Tests are disabled");
-            }
         }
     }
 
@@ -366,6 +362,9 @@ public class TestRunner {
 
     public synchronized void testCompileSucceeded() {
         compileProblem = null;
+        for (TestListener i : testSupport.testListeners) {
+            i.testCompileSucceeded();
+        }
     }
 
     public boolean isRunning() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -98,10 +98,10 @@ public class TestSupport implements TestController {
                         if (context.getApplicationRoot().getTest().isPresent()) {
                             started = true;
                             init();
+                            testRunner.enable();
                             for (TestListener i : testListeners) {
                                 i.testsEnabled();
                             }
-                            testRunner.enable();
                         }
                     } catch (Exception e) {
                         log.error("Failed to create compiler, runtime compilation will be unavailable", e);

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
@@ -72,6 +72,26 @@ public class BasicConsole extends QuarkusConsole {
             }
 
             @Override
+            protected void setResultsMessage(String results) {
+                DISABLE_FILTER.set(true);
+                try {
+                    statusLogger.info(results);
+                } finally {
+                    DISABLE_FILTER.set(false);
+                }
+            }
+
+            @Override
+            protected void setCompileErrorMessage(String results) {
+                DISABLE_FILTER.set(true);
+                try {
+                    statusLogger.info(results);
+                } finally {
+                    DISABLE_FILTER.set(false);
+                }
+            }
+
+            @Override
             protected void setStatusMessage(String status) {
                 if (status == null) {
                     return;

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/InputHandler.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/InputHandler.java
@@ -10,5 +10,9 @@ public interface InputHandler {
         void setPrompt(String prompt);
 
         void setStatus(String status);
+
+        void setResults(String results);
+
+        void setCompileError(String compileError);
     }
 }

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -119,6 +119,8 @@ public abstract class QuarkusConsole {
         volatile boolean enabled;
         String prompt;
         String status;
+        String results;
+        String compileError;
 
         protected InputHolder(InputHandler handler) {
             this.handler = handler;
@@ -129,6 +131,8 @@ public abstract class QuarkusConsole {
             if (enabled) {
                 setStatus(status);
                 setPrompt(prompt);
+                setResults(results);
+                setCompileError(compileError);
             }
             return this;
         }
@@ -141,8 +145,6 @@ public abstract class QuarkusConsole {
             }
         }
 
-        protected abstract void setPromptMessage(String prompt);
-
         @Override
         public void setStatus(String status) {
             this.status = status;
@@ -151,6 +153,28 @@ public abstract class QuarkusConsole {
             }
         }
 
+        @Override
+        public void setResults(String results) {
+            this.results = results;
+            if (enabled) {
+                setResultsMessage(results);
+            }
+        }
+
+        @Override
+        public void setCompileError(String compileError) {
+            this.compileError = compileError;
+            if (enabled) {
+                setCompileErrorMessage(compileError);
+            }
+        }
+
         protected abstract void setStatusMessage(String status);
+
+        protected abstract void setPromptMessage(String prompt);
+
+        protected abstract void setResultsMessage(String results);
+
+        protected abstract void setCompileErrorMessage(String results);
     }
 }


### PR DESCRIPTION
- Add extra 'compile error' display, so test compile errors don't
  overwrite results.
- Add extra 'test results' display, so current results are always
  visible.
- Fix multiple bugs with pausing/resuming tests
- Change yellow to blue, as ANSI yellow is very close to ANSI green in
  some terminals.