### PR TITLE
Update to Keycloak 14.0.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -186,7 +186,7 @@
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.8</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>12.0.4</keycloak.version>
+        <keycloak.version>14.0.0</keycloak.version>
         <logstash-gelf.version>1.14.1</logstash-gelf.version>
         <jsch.version>0.1.55</jsch.version>
         <jzlib.version>1.1.3</jzlib.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml to match the version -->
-        <keycloak.docker.image>quay.io/keycloak/keycloak:12.0.3</keycloak.docker.image>
+        <keycloak.docker.image>quay.io/keycloak/keycloak:14.0.0</keycloak.docker.image>
 
         <unboundid-ldap.version>4.0.13</unboundid-ldap.version>
 


### PR DESCRIPTION
I've confirmed that the `security-keycloak-authorization` quickstart does not need a `quarkus.keycloak.policy-enforcer.lazy-load-paths=false` workaround with `14.0.0`.

(We had a `13.0.1` dependency at some point in 2.0.0.x but had to revert back to `12.0.4` due to a few side-effects with `keycloak-authorization`)