### PR TITLE
Add the missing quickstarts in the guides

### DIFF
--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -9,6 +9,15 @@ include::./attributes.adoc[]
 
 This reference covers how to write applications that run and then exit.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `getting-started-command-mode` {quickstarts-tree-url}/getting-started-command-mode[directory].
+
 == Writing Command Mode Applications
 
 There are two different approaches that can be used to implement applications

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -23,6 +23,15 @@ link:https://github.com/eclipse/microprofile-context-propagation[MicroProfile Co
 make those Quarkus extensions work properly in reactive/async settings. It works by capturing those contextual
 values that used to be in thread-locals, and restoring them when your code is called.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `context-propagation-quickstart` {quickstarts-tree-url}/context-propagation-quickstart[directory].
+
 == Setting it up
 
 If you are using link:http://smallrye.io/smallrye-mutiny[Mutiny] (the `quarkus-mutiny` extension), you just need to add the

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -13,6 +13,15 @@ While this page describes how to configure it with Maven, it is also possible to
 Let's imagine you have a regular Quarkus project, generated from the https://code.quarkus.io[Quarkus project generator].
 The default configuration is enough, but you can also select some extensions if you want.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `grpc-plain-text-quickstart` {quickstarts-tree-url}/grpc-plain-text-quickstart[directory].
+
 == Configuring your project
 
 Edit the `pom.xml` file to add the Quarkus gRPC extension dependency (just under `<dependencies>`):

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -11,6 +11,15 @@ include::./attributes.adoc[]
 Hibernate ORM is the de facto standard JPA implementation and offers you the full breadth of an Object Relational Mapper.
 It works beautifully in Quarkus.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `hibernate-orm-quickstart` {quickstarts-tree-url}/hibernate-orm-quickstart[directory].
+
 == Setting up and configuring Hibernate ORM
 
 When using Hibernate ORM in Quarkus, you don't need to have a `persistence.xml` resource to configure it.
@@ -772,7 +781,9 @@ Jump over to link:datasource[Quarkus - Datasources] for all details.
 
 "The term multitenancy, in general, is applied to software development to indicate an architecture in which a single running instance of an application simultaneously serves multiple clients (tenants). This is highly common in SaaS solutions. Isolating information (data, customizations, etc.) pertaining to the various tenants is a particular challenge in these systems. This includes the data owned by each tenant stored in the database" (link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy[Hibernate User Guide]).
 
-Quarkus currently supports the link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy-separate-database[separate database] and the link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy-separate-schema[separate schema] approach. 
+Quarkus currently supports the link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy-separate-database[separate database] and the link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#multitenacy-separate-schema[separate schema] approach.
+
+To see multitenancy in action, you can check out the {quickstarts-tree-url}/hibernate-orm-multi-tenancy-quickstart[hibernate-orm-multi-tenancy-quickstart] quickstart.
 
 === Writing the application
 

--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -13,6 +13,15 @@ provides functionality to allow the client that can connect to said server when 
 Check out the https://infinispan.org/documentation[Infinispan documentation] to find out more about the Infinispan project,
 in particular the https://infinispan.org/docs/stable/titles/hotrod_java/hotrod_java.html[Hot Rod Java client guide].
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `infinispan-client-quickstart` {quickstarts-tree-url}/infinispan-client-quickstart[directory].
+
 == Configuration
 
 Once you have your Quarkus project configured you can add the `infinispan-client` extension

--- a/docs/src/main/asciidoc/liquibase.adoc
+++ b/docs/src/main/asciidoc/liquibase.adoc
@@ -13,6 +13,15 @@ https://www.liquibase.org/[Liquibase] is an open source tool for database schema
 
 Quarkus provides first class support for using Liquibase as will be explained in this guide.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `liquibase-quickstart` {quickstarts-tree-url}/liquibase-quickstart[directory].
+
 == Setting up support for Liquibase
 
 To start using Liquibase with your project, you just need to:

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -25,6 +25,15 @@ To complete this guide, you need:
 In this guide, we are going to see how you can send emails from a Quarkus application.
 It covers simple emails, attachments, inlined attachments, the reactive and imperative APIs...
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `mailer-quickstart` {quickstarts-tree-url}/mailer-quickstart[directory].
+
 == Creating the Maven Project
 
 Create a new project with the following command:

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -14,6 +14,15 @@ In the development mode, all files located in `src/main/resources/templates` are
 Furthermore, we try to detect most of the template problems at build time.
 In this guide, you will learn how to easily render templates in your application.
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `qute-quickstart` {quickstarts-tree-url}/qute-quickstart[directory].
+
 == Hello World with JAX-RS
 
 If you want to use Qute in your JAX-RS application, you need to add the `quarkus-resteasy-qute` extension first.

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -16,6 +16,14 @@ While lots of reactive features from Quarkus don't _show_ Vert.x, it's used unde
 Quarkus also integrates smoothly with the Vert.x event bus (to enable asynchronous messaging passing between application components) and some reactive clients.
 You can also use various Vert.x APIs in your Quarkus application, such as deploying _verticles_, instantiating clients...
 
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `vertx-quickstart` {quickstarts-tree-url}/vertx-quickstart[directory].
 
 == Installing
 


### PR DESCRIPTION
Fixes #12521 as some other work had already been done around guide introduction so I think we'll be good now.

I made a pass on the existing quickstarts and found that some guides missing the reference to their related quickstart.
I add it in the standard 'solution' section.

Some quickstarts doesn't seems to have a guide, I didn't try too long to find guides couterpart so there is still some orphans quickstarts.