### PR TITLE
Register the fields of the ChangeStreamDocument for reflection

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -135,11 +135,13 @@ public class MongoClientProcessor {
         reflectiveClassNames.addAll(propertyCodecProviders.getPropertyCodecProviderClassNames());
         reflectiveClassNames.addAll(bsonDiscriminators.getBsonDiscriminatorClassNames());
         reflectiveClassNames.addAll(commandListeners.getCommandListenerClassNames());
-        reflectiveClassNames.add(ChangeStreamDocument.class.getName());
 
-        return reflectiveClassNames.stream()
+        List<ReflectiveClassBuildItem> reflectiveClass = reflectiveClassNames.stream()
                 .map(s -> new ReflectiveClassBuildItem(true, true, false, s))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(() -> new ArrayList<>()));
+        // ChangeStreamDocument needs to be registered for reflection with its fields.
+        reflectiveClass.add(new ReflectiveClassBuildItem(true, true, true, ChangeStreamDocument.class.getName()));
+        return reflectiveClass;
     }
 
     @BuildStep


### PR DESCRIPTION
Fixes #17878

@geoand I saw you register the ChangeStreamDocument class for reflection, apparently its fields needs to be registered for reflection or they would be null (see #17878).

I choose to only register the fields of the ChangeStreamDocument for reflection and not the other as this didn't seems to be an issue for the other classes.