### PR TITLE
Scala 2.12 does not support a JDK 11 target

### DIFF
--- a/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
+++ b/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
@@ -102,7 +102,7 @@
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-explaintypes</arg>
-                        <arg>-target:jvm-11</arg>
+                        <arg>-target:jvm-1.8</arg>
                         <arg>-Ypartial-unification</arg>
                     </args>
                 </configuration>


### PR DESCRIPTION
And in any case, it will need to be -target:11 when we switch to 2.13.