### PR TITLE
Update 'quarkus-oidc' and 'quarkus-oidc-client' to get secrets from CredentialsProvider

### DIFF
--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -32,6 +32,8 @@ by the following credentials consumer extensions:
 * `reactive-db2-client`
 * `reactive-mysql-client`
 * `reactive-pg-client`
+* `oidc`
+* `oidc-client`
 
 All extensions that rely on username/password authentication also allow setting configuration
 properties in the `application.properties` as an alternative. But the `Credentials Provider` is the only option

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -360,6 +360,28 @@ quarkus.oidc-client.client-id=quarkus-app
 quarkus.oidc-client.credentials.secret=mysecret
 ----
 
+or
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.client-secret.value=mysecret
+----
+
+or with the secret retrieved from a link:credentials-provider[CredentialsProvider]:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+
+# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
+quarkus.oidc-client.credentials.client-secret.provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc-client.credentials.client-secret.provider.name=oidc-credentials-provider
+----
+
 `client_secret_post`:
 
 [source,properties]
@@ -374,30 +396,54 @@ quarkus.oidc-client.credentials.client-secret.method=post
 
 [source,properties]
 ----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it,
+quarkus.oidc.credentials.jwt.token-key-id=mykey
+----
+
+or with the secret retrieved from a link:credentials-provider[CredentialsProvider]:
+
+[source,properties]
+----
 quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
 quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
+# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
+quarkus.oidc-client.credentials.jwt.secret-provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc-client.credentials.jwt.secret-provider.name=oidc-credentials-provider
 ----
 
 `private_key_jwt` with the PEM key file:
 
 [source,properties]
 ----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.key-file=privateKey.pem
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.key-file=privateKey.pem
+
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it
+quarkus.oidc.credentials.jwt.token-key-id=mykey
 ----
 
 `private_key_jwt` with the key store file:
 
 [source,properties]
 ----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.key-store-file=keystore.jks
-quarkus.oidc-client.credentials.jwt.key-store-password=mypassword
-quarkus.oidc-client.credentials.jwt.key-password=mykeypassword
-quarkus.oidc-client.credentials.jwt.key-id=mykey
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.key-store-file=keystore.jks
+quarkus.oidc.credentials.jwt.key-store-password=mypassword
+quarkus.oidc.credentials.jwt.key-password=mykeypassword
+# Private key alias inside the keystore
+quarkus.oidc.credentials.jwt.key-id=mykey
+
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it,
+# Note it can be different to the `quarkus.oidc.credentials.jwt.key-id` value
+quarkus.oidc.credentials.jwt.token-key-id=mykey
 ----
 
 Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that no client secret goes over the wire.
@@ -523,6 +569,14 @@ Please enable `io.quarkus.oidc.client.runtime.OidcClientImpl` `TRACE` level logg
 ----
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
+----
+
+Please enable `io.quarkus.oidc.client.runtime.OidcClientRecorder` `TRACE` level logging to see more details about the OidcClient initialization errors:
+
+[source, properties]
+----
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".level=TRACE
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-level=TRACE
 ----
 
 == Token endpoint configuration

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -581,6 +581,107 @@ It applies to ID tokens but also to access tokens in a JWT format if the `web-ap
 == Token Propagation
 Please see link:security-openid-connect-client#token-propagation[Token Propagation] section about the Authorization Code Flow access token propagation to the downstream services.
 
+[[oidc-provider-client-authentication]]
+=== Oidc Provider Client Authentication
+
+`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenId Connect Provider has to be done. It has to authenticate to the OpenId Connect Provider when the authorization code has to be exchanged for the ID, access and refresh tokens, when the ID and access tokens have to be refreshed or introspected.
+
+All the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[OIDC Client Authentication] options are supported, for example:
+
+`client_secret_basic`:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=mysecret
+----
+
+or
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.client-secret.value=mysecret
+----
+
+or with the secret retrieved from a link:credentials-provider[CredentialsProvider]:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+
+# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
+quarkus.oidc.credentials.client-secret.provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc.credentials.client-secret.provider.name=oidc-credentials-provider
+----
+
+`client_secret_post`:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.client-secret.value=mysecret
+quarkus.oidc.credentials.client-secret.method=post
+----
+
+`client_secret_jwt`:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it,
+quarkus.oidc.credentials.jwt.token-key-id=mykey
+----
+
+or with the secret retrieved from a link:credentials-provider[CredentialsProvider]:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+
+# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
+quarkus.oidc.credentials.jwt.secret-provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc.credentials.jwt.secret-provider.name=oidc-credentials-provider
+----
+
+`private_key_jwt` with the PEM key file:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.key-file=privateKey.pem
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it
+quarkus.oidc.credentials.jwt.token-key-id=mykey
+----
+
+`private_key_jwt` with the key store file:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.jwt.key-store-file=keystore.jks
+quarkus.oidc.credentials.jwt.key-store-password=mypassword
+quarkus.oidc.credentials.jwt.key-password=mykeypassword
+# Private key alias inside the keystore
+quarkus.oidc.credentials.jwt.key-id=mykey
+# This is a token key identifier 'kid' header - set it if your OpenId Connect provider requires it,
+# Note it can be different to the `quarkus.oidc.credentials.jwt.key-id` value
+quarkus.oidc.credentials.jwt.token-key-id=mykey
+----
+
+Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that no client secret goes over the wire.
+
 [[integration-testing]]
 == Testing
 
@@ -749,6 +850,14 @@ Please enable `io.quarkus.oidc.runtime.OidcProvider` `TRACE` level logging to se
 ----
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
+----
+
+Please enable `io.quarkus.oidc.runtime.OidcRecorder` `TRACE` level logging to see more details about the OidcProvider client initialization errors:
+
+[source, properties]
+----
+quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".min-level=TRACE
 ----
 
 == Running behind a reverse proxy

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -507,6 +507,11 @@ Note it is also recommended to use `quarkus.oidc.token.audience` property to ver
 
 Please see link:security-openid-connect-client#token-propagation[Token Propagation] section about the Bearer access token propagation to the downstream services.
 
+[[oidc-provider-authentication]]
+=== Oidc Provider Client Authentication
+
+`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenId Connect Provider has to be done. If the bearer token has to be introspected then `OidcProviderClient` has to authenticate to the OpenId Connect Provider. Please see link:security-openid-connect-web-authentication#oidc-provider-client-authentication[OidcProviderClient Authentication] for more information about all the supported authentication options.
+
 [[integration-testing]]
 == Testing
 
@@ -865,6 +870,14 @@ Please enable `io.quarkus.oidc.runtime.OidcProvider` `TRACE` level logging to se
 ----
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
+----
+
+Please enable `io.quarkus.oidc.runtime.OidcRecorder` `TRACE` level logging to see more details about the OidcProvider client initialization errors:
+
+[source, properties]
+----
+quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".min-level=TRACE
 ----
 
 == External and Internal Access to OpenId Connect Provider

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
@@ -18,7 +18,8 @@ public class OidcClientCredentialsJwtSecretTestCase {
 
     private static Class<?>[] testClasses = {
             OidcClientsResource.class,
-            ProtectedResource.class
+            ProtectedResource.class,
+            SecretProvider.class
     };
 
     @RegisterExtension

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
@@ -18,7 +18,8 @@ public class OidcClientCredentialsTestCase {
 
     private static Class<?>[] testClasses = {
             OidcClientsResource.class,
-            ProtectedResource.class
+            ProtectedResource.class,
+            SecretProvider.class
     };
 
     @RegisterExtension

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/SecretProvider.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/SecretProvider.java
@@ -1,0 +1,26 @@
+package io.quarkus.oidc.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Unremovable
+@Named("vault-secret-provider")
+public class SecretProvider implements CredentialsProvider {
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        Map<String, String> creds = new HashMap<>();
+        creds.put("secret-from-vault", "secret");
+        creds.put("secret-from-vault-for-jwt",
+                "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
+        return creds;
+    }
+
+}

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
@@ -3,4 +3,4 @@ quarkus.oidc.client-id=quarkus-app
 quarkus.oidc-client.client-enabled=false
 quarkus.oidc-client.jwt.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt.client-id=${quarkus.oidc.client-id}
-quarkus.oidc-client.jwt.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc-client.jwt.credentials.jwt.secret-provider.key=secret-from-vault-for-jwt

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
@@ -4,4 +4,5 @@ quarkus.oidc.credentials.secret=secret
 
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
-quarkus.oidc-client.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.credentials.client-secret.provider.name=vault-secret-provider
+quarkus.oidc-client.credentials.client-secret.provider.key=secret-from-vault

--- a/extensions/oidc-common/deployment/pom.xml
+++ b/extensions/oidc-common/deployment/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/oidc-common/runtime/pom.xml
+++ b/extensions/oidc-common/runtime/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials</artifactId>
+        </dependency>
+        <dependency>
           <groupId>io.smallrye.reactive</groupId>
           <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
         </dependency>

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -135,6 +135,14 @@ public class OidcCommonConfig {
             this.clientSecret = clientSecret;
         }
 
+        public Jwt getJwt() {
+            return jwt;
+        }
+
+        public void setJwt(Jwt jwt) {
+            this.jwt = jwt;
+        }
+
         /**
          * Supports the client authentication methods which involve sending a client secret.
          *
@@ -158,10 +166,16 @@ public class OidcCommonConfig {
             }
 
             /**
-             * The client secret
+             * The client secret value - it will be ignored if 'secret.key' is set
              */
             @ConfigItem
             public Optional<String> value = Optional.empty();
+
+            /**
+             * The Secret CredentialsProvider
+             */
+            @ConfigItem
+            public Provider provider = new Provider();
 
             /**
              * Authentication method.
@@ -184,6 +198,14 @@ public class OidcCommonConfig {
             public void setMethod(Method method) {
                 this.method = Optional.of(method);
             }
+
+            public Provider getSecretProvider() {
+                return provider;
+            }
+
+            public void setSecretProvider(Provider secretProvider) {
+                this.provider = secretProvider;
+            }
         }
 
         /**
@@ -201,6 +223,12 @@ public class OidcCommonConfig {
              */
             @ConfigItem
             public Optional<String> secret = Optional.empty();
+
+            /**
+             * If provided, indicates that JWT is signed using a secret key provided by Secret CredentialsProvider
+             */
+            @ConfigItem
+            public Provider secretProvider = new Provider();
 
             /**
              * If provided, indicates that JWT is signed using a private key in PEM or JWK format
@@ -258,6 +286,58 @@ public class OidcCommonConfig {
 
             public void setLifespan(int lifespan) {
                 this.lifespan = lifespan;
+            }
+
+            public Optional<String> getTokenKeyId() {
+                return tokenKeyId;
+            }
+
+            public void setTokenKeyId(String tokenKeyId) {
+                this.tokenKeyId = Optional.of(tokenKeyId);
+            }
+
+            public Provider getSecretProvider() {
+                return secretProvider;
+            }
+
+            public void setSecretProvider(Provider secretProvider) {
+                this.secretProvider = secretProvider;
+            }
+
+        }
+
+        /**
+         * CredentialsProvider which provides a client secret
+         */
+        @ConfigGroup
+        public static class Provider {
+
+            /**
+             * The CredentialsProvider name which should only be set if more than one CredentialsProvider is registered
+             */
+            @ConfigItem
+            public Optional<String> name = Optional.empty();
+
+            /**
+             * The CredentialsProvider client secret key
+             */
+            @ConfigItem
+            public Optional<String> key = Optional.empty();
+
+            public Optional<String> getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = Optional.of(name);
+            }
+
+            public Optional<String> getKey() {
+                return key;
+            }
+
+            public void setKey(String key) {
+                this.key = Optional.of(key);
             }
         }
     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -28,7 +28,8 @@ public class CodeFlowDevModeTestCase {
             ProtectedResource.class,
             UnprotectedResource.class,
             CustomTenantConfigResolver.class,
-            CustomTokenStateManager.class
+            CustomTokenStateManager.class,
+            SecretProvider.class
     };
 
     @RegisterExtension

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecretProvider.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecretProvider.java
@@ -1,0 +1,22 @@
+package io.quarkus.oidc.test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Unremovable
+@Named("vault-secret-provider")
+public class SecretProvider implements CredentialsProvider {
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        return Collections.singletonMap("secret-from-vault", "secret");
+    }
+
+}

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -2,7 +2,8 @@ quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-enabled=false
 # This is a wrong client-id, will be updated to 'quarkus-web-app' in the dev mode test
 quarkus.oidc.client-id=client-dev
-quarkus.oidc.credentials.secret=secret
+quarkus.oidc.credentials.client-secret.provider.name=vault-secret-provider
+quarkus.oidc.credentials.client-secret.provider.key=secret-from-vault
 quarkus.oidc.application-type=web-app
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL


### PR DESCRIPTION
Fixes #15125.

This PR has the following updates:
- introduces `Credentials.Provider` configuration group
- Both `Credentials.Secret` and `Credentials.Jwt` groups can use a client secret; so `Credentials.Secret` now has a `provider` property to specify a secret key (`quarkus.oidc.credentials.client-secret.provider.key`) that should be used to retrieve a secret, similarly for `Jwt` - but since `Jwt` can have not only a client secret but also a private key configured, the property is called `secret-provider` which one can use as `quarkus.oidc.credentials.jwt.secret-provider.key`
- Updated some of the existing `quarkus-oidc`/`quarkus-oidc-client` tests to use a test `CredentialsProvider`
- Updated `OidcClient Authentication` docs to refer to the new options and also added a similar section to the OIDC `web-app` docs since the config root is different
- Few other minor doc and code updates 
