### PR TITLE
Extension registry transfer listener

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
@@ -48,7 +48,7 @@ public class MavenRegistryArtifactResolverWithCleanup implements MavenRegistryAr
      */
     protected static ArtifactResult resolveAndCleanupOldTimestampedVersions(MavenArtifactResolver resolver, Artifact artifact,
             boolean cleanupOldTimestampedVersions) throws BootstrapMavenException {
-        if (!cleanupOldTimestampedVersions) {
+        if (!artifact.isSnapshot() || !cleanupOldTimestampedVersions) {
             return resolver.resolve(artifact);
         }
 
@@ -63,7 +63,9 @@ public class MavenRegistryArtifactResolverWithCleanup implements MavenRegistryAr
         if (jsonDirContent != null && jsonDirContent.length > existingFiles.size()) {
             final String fileName = result.getArtifact().getFile().getName();
             for (File c : jsonDirContent) {
-                if (c.getName().length() > fileName.length() && c.getName().startsWith(artifact.getArtifactId())
+                if (c.getName().length() > fileName.length()
+                        && c.getName().startsWith(artifact.getArtifactId())
+                        && c.getName().endsWith(artifact.getClassifier())
                         && existingFiles.contains(c.getName())) {
                     c.deleteOnExit();
                 }


### PR DESCRIPTION
This PR introduces a registry artifact transfer listener. I.e. with this change whenever the client is refreshing the local extension catalog cache, `Refreshing the local extension catalog cache of <registry-id>` is logged, e.g.

````
[aloubyansky@localhost test]$ quarkus create app --registry-client
Refreshing the local extension catalog cache of registry.quarkus.io
-----------

applying codestarts...
📚  java
🔨  maven
📦  quarkus
📝  config-properties
🔧  dockerfiles
🔧  maven-wrapper
🚀  resteasy-codestart

-----------
[SUCCESS] ✅  quarkus project has been successfully generated in:
--> /home/aloubyansky/playground/test/code-with-quarkus
-----------
````

This PR also fixes a bug in cleaning up the local cache of timestamped snapshot artifacts.