### PR TITLE
Validate option for hibernate database generation

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -72,7 +72,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          *
          * `drop-and-create` is awesome in development mode.
          *
-         * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`.
+         * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`, `validate`.
          */
         @ConfigItem(name = ConfigItem.PARENT, defaultValue = "none")
         public String generation = "none";
@@ -102,7 +102,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         /**
          * Select whether the database schema DDL files are generated or not.
          *
-         * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`.
+         * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`, `validate`.
          */
         @ConfigItem(name = ConfigItem.PARENT, defaultValue = "none")
         public String generation = "none";


### PR DESCRIPTION
In the [hibernate-orm guide](https://quarkus.io/guides/hibernate-orm#quarkus-hibernate-orm_quarkus.hibernate-orm.database.generation), `validate` is not shown as a valid value for the `quarkus.hibernate-orm.database.generation` property.