### PR TITLE
Avoid creating both default client if not needed

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
@@ -26,9 +26,24 @@ public class MongoClientBuildTimeConfig {
 
     /**
      * If set to true, the default clients will always be created even if there are no injection points that use them
+     * 
+     * @deprecated use forceDefaultSyncClient and/or forceDefaultReactiveClient instead
      */
     @ConfigItem(name = "force-default-clients")
+    @Deprecated
     public boolean forceDefaultClients;
+
+    /**
+     * If set to true, the default sync client will always be created even if there are no injection points that use it
+     */
+    @ConfigItem
+    public boolean forceDefaultSyncClient;
+
+    /**
+     * If set to true, the default reactive client will always be created even if there are no injection points that use it
+     */
+    @ConfigItem
+    public boolean forceDefaultReactiveClient;
 
     /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start MongoDB in dev and test mode.

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableClientsBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableClientsBuildItem.java
@@ -4,7 +4,10 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * If generated, all the Mongo clients need to be unremovable
+ *
+ * @deprecated use MongoUnremovableSyncClientsBuildItem and/or MongoUnremovableReactiveClientsBuildItem instead.
  */
+@Deprecated
 public final class MongoUnremovableClientsBuildItem extends MultiBuildItem {
 
 }

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableReactiveClientsBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableReactiveClientsBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.mongodb.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * If generated, all the Mongo reactive clients need to be unremovable
+ */
+public final class MongoUnremovableReactiveClientsBuildItem extends MultiBuildItem {
+
+}

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableSyncClientsBuildItem.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoUnremovableSyncClientsBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.mongodb.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * If generated, all the Mongo sync clients need to be unremovable
+ */
+public final class MongoUnremovableSyncClientsBuildItem extends MultiBuildItem {
+
+}

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultReactiveMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultReactiveMongoClientConfigTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.function.BiConsumer;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mongodb.health.MongoHealthCheck;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultReactiveMongoClientConfigTest extends MongoWithReplicasTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MongoTestBase.class))
+            .withConfigurationResource("default-mongoclient.properties");
+
+    @Inject
+    ReactiveMongoClient reactiveClient;
+
+    @Inject
+    @Any
+    MongoHealthCheck health;
+
+    @AfterEach
+    void cleanup() {
+        if (reactiveClient != null) {
+            reactiveClient.close();
+        }
+    }
+
+    @Test
+    public void testClientInjection() {
+        assertThat(reactiveClient.listDatabases().collect().first().await().indefinitely()).isNotEmpty();
+
+        HealthCheckResponse response = health.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(1).contains(entry("<default-reactive>", "OK"));
+
+        // Stop the database and recheck the health
+        stopMongoDatabase();
+
+        response = health.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(1)
+                .allSatisfy(new BiConsumer<String, Object>() {
+                    @Override
+                    public void accept(String s, Object o) {
+                        assertThat(o.toString()).startsWith("KO, reason:");
+                    }
+                });
+    }
+}

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultSyncAndReactiveMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultSyncAndReactiveMongoClientConfigTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.function.BiConsumer;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.mongodb.health.MongoHealthCheck;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultSyncAndReactiveMongoClientConfigTest extends MongoWithReplicasTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MongoTestBase.class))
+            .withConfigurationResource("default-mongoclient.properties");
+
+    @Inject
+    MongoClient client;
+
+    @Inject
+    ReactiveMongoClient reactiveClient;
+
+    @Inject
+    @Any
+    MongoHealthCheck health;
+
+    @AfterEach
+    void cleanup() {
+        if (reactiveClient != null) {
+            reactiveClient.close();
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void testClientInjection() {
+        assertThat(client.listDatabaseNames().first()).isNotEmpty();
+        assertThat(reactiveClient.listDatabases().collect().first().await().indefinitely()).isNotEmpty();
+
+        org.eclipse.microprofile.health.HealthCheckResponse response = health.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2).contains(entry("<default-reactive>", "OK"),
+                entry("<default>", "OK"));
+
+        // Stop the database and recheck the health
+        stopMongoDatabase();
+
+        response = health.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData().get()).hasSize(2)
+                .allSatisfy(new BiConsumer<String, Object>() {
+                    @Override
+                    public void accept(String s, Object o) {
+                        assertThat(o.toString()).startsWith("KO, reason:");
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Draft PR to avoid defining both sync and reactive MongoDB client in case only one of them is used.
As both client will be CDI beans and will open connections to the DB, only producing the used one is important.

All tests are green but I wonder what is the purpose of https://github.com/quarkusio/quarkus/blob/main/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java#L365 ? @geoand it appears you created this methods, what does it do ?