### PR TITLE
Make minor improvements to various RESTEasy Reactive classes that iterate through maps

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
-import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
+import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 
 public abstract class AbstractResponseBuilder extends Response.ResponseBuilder {
 
@@ -70,7 +70,7 @@ public abstract class AbstractResponseBuilder extends Response.ResponseBuilder {
     protected int status = -1;
     protected String reasonPhrase;
     protected Object entity;
-    protected MultivaluedMap<String, Object> metadata = new CaseInsensitiveMap<>();
+    protected MultivaluedTreeMap<String, Object> metadata = new CaseInsensitiveMap<>();
     protected Annotation[] entityAnnotations;
 
     public static SimpleDateFormat getDateFormatRFC822() {
@@ -185,7 +185,7 @@ public abstract class AbstractResponseBuilder extends Response.ResponseBuilder {
         responseBuilder.status = status;
         responseBuilder.reasonPhrase = reasonPhrase;
         responseBuilder.entity = entity;
-        responseBuilder.metadata = new QuarkusMultivaluedHashMap<>();
+        responseBuilder.metadata = new CaseInsensitiveMap<>();
         responseBuilder.metadata.putAll(metadata);
         return responseBuilder;
     }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.EntityTag;
@@ -29,6 +28,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.headers.LinkHeaders;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 
 /**
  * This is the Response class for user-created responses. The client response
@@ -40,7 +40,7 @@ public class ResponseImpl extends Response {
     int status;
     String reasonPhrase;
     protected Object entity;
-    MultivaluedMap<String, Object> headers;
+    MultivaluedTreeMap<String, Object> headers;
     InputStream entityStream;
     private StatusTypeImpl statusType;
     private MultivaluedMap<String, String> stringHeaders;
@@ -283,20 +283,20 @@ public class ResponseImpl extends Response {
 
     @Override
     public MultivaluedMap<String, String> getStringHeaders() {
-        // FIXME: is this mutable?
         if (stringHeaders == null) {
             // let's keep this map case-insensitive
             stringHeaders = new CaseInsensitiveMap<>();
-            for (Entry<String, List<Object>> entry : headers.entrySet()) {
-                List<String> stringValues = new ArrayList<>(entry.getValue().size());
-                for (Object value : entry.getValue()) {
-                    stringValues.add(HeaderUtil.headerToString(value));
-                }
-                stringHeaders.put(entry.getKey(), stringValues);
-            }
+            headers.forEach(this::populateStringHeaders);
         }
-
         return stringHeaders;
+    }
+
+    public void populateStringHeaders(String headerName, List<Object> values) {
+        List<String> stringValues = new ArrayList<>(values.size());
+        for (int i = 0; i < values.size(); i++) {
+            stringValues.add(HeaderUtil.headerToString(values.get(i)));
+        }
+        stringHeaders.put(headerName, stringValues);
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MultivaluedTreeMap.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MultivaluedTreeMap.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
@@ -19,7 +20,7 @@ public class MultivaluedTreeMap<K, V> implements QuarkusMultivaluedMap<K, V>, Se
     private final Map<K, List<V>> map;
 
     public MultivaluedTreeMap() {
-        map = new TreeMap<K, List<V>>();
+        map = new TreeMap<>();
     }
 
     /**
@@ -242,5 +243,10 @@ public class MultivaluedTreeMap<K, V> implements QuarkusMultivaluedMap<K, V>, Se
             }
         }
         return true;
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super List<V>> action) {
+        map.forEach(action);
     }
 }


### PR DESCRIPTION
We remove the use of `entrySet()` where it makes sense and replace it with `forEach()`
which faster and doesn't allocate additional objects