### PR TITLE
Enable the generation of documentation for extensions whose package name contains 5 specific components

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -41,7 +41,8 @@ final public class Constants {
     public static final String CONFIG = "config";
 
     public static final Pattern CLASS_NAME_PATTERN = Pattern.compile("^.+[\\.$](\\w+)$");
-    public static final Pattern PKG_PATTERN = Pattern.compile("^io\\.quarkus\\.(\\w+)\\.?(\\w+)?\\.?(\\w+)?\\.?(\\w+)?");
+    public static final Pattern PKG_PATTERN = Pattern
+            .compile("^io\\.quarkus\\.(\\w+)\\.?(\\w+)?\\.?(\\w+)?\\.?(\\w+)?\\.?(\\w+)?");
 
     public static final String INSTANCE_SYM = "__instance";
     public static final String QUARKUS = "quarkus";

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
@@ -335,45 +335,6 @@ public class DocGeneratorUtil {
     }
 
     /**
-     * Guess extension name from given configuration root class name
-     */
-    public static String computeExtensionGeneralConfigDocFileName(String configRoot) {
-        StringBuilder extensionNameBuilder = new StringBuilder();
-        final Matcher matcher = Constants.PKG_PATTERN.matcher(configRoot);
-        if (!matcher.find()) {
-            extensionNameBuilder.append(configRoot);
-        } else {
-            String extensionName = matcher.group(1);
-            final String subgroup = matcher.group(2);
-            extensionNameBuilder.append(Constants.QUARKUS);
-            extensionNameBuilder.append(Constants.DASH);
-
-            if (Constants.DEPLOYMENT.equals(extensionName) || Constants.RUNTIME.equals(extensionName)) {
-                extensionNameBuilder.append(CORE);
-            } else if (subgroup != null && !Constants.DEPLOYMENT.equals(subgroup)
-                    && !Constants.RUNTIME.equals(subgroup) && !Constants.COMMON.equals(subgroup)
-                    && subgroup.matches(Constants.DIGIT_OR_LOWERCASE)) {
-                extensionNameBuilder.append(extensionName);
-                extensionNameBuilder.append(Constants.DASH);
-                extensionNameBuilder.append(subgroup);
-
-                final String qualifier = matcher.group(3);
-                if (qualifier != null && !Constants.DEPLOYMENT.equals(qualifier)
-                        && !Constants.RUNTIME.equals(qualifier) && !Constants.COMMON.equals(qualifier)
-                        && qualifier.matches(Constants.DIGIT_OR_LOWERCASE)) {
-                    extensionNameBuilder.append(Constants.DASH);
-                    extensionNameBuilder.append(qualifier);
-                }
-            } else {
-                extensionNameBuilder.append(extensionName);
-            }
-        }
-
-        extensionNameBuilder.append(Constants.ADOC_EXTENSION);
-        return extensionNameBuilder.toString();
-    }
-
-    /**
      * Guess config group file name from given configuration group class name
      */
     public static String computeConfigGroupDocFileName(String configGroupClassName) {


### PR DESCRIPTION
Because I'm going to introduce an extension named `quarkus-hibernate-search-orm-elasticsearch-aws`. Yes that's a mouthful, but considering it's an integration into the existing `quarkus-hibernate-search-orm-elasticsearch`, there isn't much choice in how to name it...

The change is quite similar to 5be4cffe02fe5d204a39e84302771733accf2f1c, so I expect it should be safe?

Note I also tried the pattern `^io\\.quarkus\\.(\\w+)(?:\\.(\\w+))*` as an alternative, but it doesn't work: it seems capturing groups in non-capturing groups are ignored for some reason.