### PR TITLE
Fix Gradle repository URL

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -79,7 +79,7 @@
         <repository>
             <id>gradle-dependencies</id>
             <name>Gradle releases repository</name>
-            <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <url>https://repo.gradle.org/artifactory/libs-releases</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
The URL we are using is not working anymore, we have 404s all over the place.