### PR TITLE
Qute - deprecate Results.Result enum and introduce Results.NotFound

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -818,7 +818,7 @@ public class MessageBundleProcessor {
         BytecodeCreator success = throwableIsNull.trueBranch();
 
         // Return if the name is null or NOT_FOUND
-        ResultHandle resultNotFound = success.readStaticField(Descriptors.RESULT_NOT_FOUND);
+        ResultHandle resultNotFound = success.invokeStaticInterfaceMethod(Descriptors.NOT_FOUND_FROM_EC, whenEvalContext);
         BytecodeCreator nameIsNull = success.ifNull(whenComplete.getMethodParam(0)).trueBranch();
         nameIsNull.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet,
                 resultNotFound);
@@ -893,7 +893,7 @@ public class MessageBundleProcessor {
                     MethodDescriptor.ofMethod(defaultBundleImpl, "resolve", CompletionStage.class, EvalContext.class),
                     resolve.getThis(), evalContext));
         } else {
-            resolve.returnValue(resolve.readStaticField(Descriptors.RESULTS_NOT_FOUND));
+            resolve.returnValue(resolve.invokeStaticMethod(Descriptors.RESULTS_NOT_FOUND_EC, evalContext));
         }
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.qute.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.vertx.web.Route;
+import io.restassured.RestAssured;
+
+public class PropertyNotFoundDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest testConfig = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(Routes.class)
+                    .addAsResource(new StringAsset("{foo.surname}"), "templates/foo.html")
+                    .addAsResource(new StringAsset("{bar.name}"), "templates/bar.html"));
+
+    @Test
+    public void testExceptionIsThrown() {
+        assertEquals("Property \"foo\" not found in expression {foo.surname} in template foo on line 1",
+                RestAssured.get("test-foo").then().statusCode(200).extract().body().asString());
+        assertEquals(
+                "Property \"name\" not found on base object \"java.lang.String\" in expression {bar.name} in template bar on line 1",
+                RestAssured.get("test-bar").then().statusCode(200).extract().body().asString());
+    }
+
+    @Singleton
+    public static class Routes {
+
+        @Inject
+        Template foo;
+
+        @Route(produces = "text/plain")
+        String testFoo() {
+            try {
+                return foo.render();
+            } catch (TemplateException e) {
+                return e.getMessage();
+            }
+        }
+
+        @Inject
+        Template bar;
+
+        @Route(produces = "text/plain")
+        String testBar() {
+            try {
+                return bar.data("bar", "alpha").render();
+            } catch (TemplateException e) {
+                return e.getMessage();
+            }
+        }
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundNoop.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundNoop.java
@@ -2,7 +2,7 @@ package io.quarkus.qute.runtime;
 
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.ResultMapper;
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateNode.Origin;
 
 class PropertyNotFoundNoop implements ResultMapper {
@@ -14,7 +14,7 @@ class PropertyNotFoundNoop implements ResultMapper {
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
-        return result.equals(Result.NOT_FOUND);
+        return Results.isNotFound(result);
     }
 
     @Override

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundOutputExpression.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundOutputExpression.java
@@ -2,7 +2,7 @@ package io.quarkus.qute.runtime;
 
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.ResultMapper;
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateNode.Origin;
 
 class PropertyNotFoundOutputOriginal implements ResultMapper {
@@ -14,7 +14,7 @@ class PropertyNotFoundOutputOriginal implements ResultMapper {
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
-        return result.equals(Result.NOT_FOUND);
+        return Results.isNotFound(result);
     }
 
     @Override

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundThrowException.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/PropertyNotFoundThrowException.java
@@ -2,7 +2,8 @@ package io.quarkus.qute.runtime;
 
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.ResultMapper;
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
+import io.quarkus.qute.Results.NotFound;
 import io.quarkus.qute.TemplateException;
 import io.quarkus.qute.TemplateNode.Origin;
 
@@ -15,13 +16,19 @@ class PropertyNotFoundThrowException implements ResultMapper {
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
-        return result.equals(Result.NOT_FOUND);
+        return Results.isNotFound(result);
     }
 
     @Override
     public String map(Object result, Expression expression) {
+        String propertyMessage;
+        if (result instanceof NotFound) {
+            propertyMessage = ((NotFound) result).asMessage();
+        } else {
+            propertyMessage = "Property not found";
+        }
         throw new TemplateException(expression.getOrigin(),
-                String.format("Property not found in expression {%s} in template %s on line %s", expression.toOriginalString(),
+                String.format("%s in expression {%s} in template %s on line %s", propertyMessage, expression.toOriginalString(),
                         expression.getOrigin().getTemplateId(), expression.getOrigin().getLine()));
     }
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.qute.runtime;
 
+import java.util.Optional;
+
 import io.quarkus.qute.TemplateException;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -13,9 +15,12 @@ public class QuteRuntimeConfig {
      * <p>
      * This strategy is not used when evaluating an expression that is used in a section parameter, e.g.
      * <code>{#if foo.name}</code>. In such case, it's the responsibility of the section to handle this situation appropriately.
+     * <p>
+     * By default, the {@code NOT_FOUND} constant is written to the output. However, in the development mode the
+     * {@link PropertyNotFoundStrategy#THROW_EXCEPTION} is used by default, i.e. when the strategy is not specified.
      */
-    @ConfigItem(defaultValue = "default")
-    public PropertyNotFoundStrategy propertyNotFoundStrategy;
+    @ConfigItem
+    public Optional<PropertyNotFoundStrategy> propertyNotFoundStrategy;
     /**
      * Specify whether the parser should remove standalone lines from the output. A standalone line is a line that contains at
      * least one section tag, parameter declaration, or comment but no expression and no non-whitespace character.

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/CollectionTemplateExtensions.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/CollectionTemplateExtensions.java
@@ -6,7 +6,7 @@ import java.util.ListIterator;
 
 import javax.enterprise.inject.Vetoed;
 
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateExtension;
 
 @Vetoed // Make sure no bean is created from this class
@@ -23,7 +23,7 @@ public class CollectionTemplateExtensions {
         int idx = Integer.parseInt(index);
         if (idx >= list.size()) {
             // Be consistent with property resolvers
-            return (T) Result.NOT_FOUND;
+            return (T) Results.NotFound.from(index);
         }
         return list.get(idx);
     }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/ConfigTemplateExtensions.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/ConfigTemplateExtensions.java
@@ -9,7 +9,7 @@ import javax.enterprise.inject.Vetoed;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateExtension;
 
 @Vetoed // Make sure no bean is created from this class
@@ -27,7 +27,7 @@ public class ConfigTemplateExtensions {
     @TemplateExtension(namespace = CONFIG, priority = DEFAULT_PRIORITY + 1)
     static Object property(String propertyName) {
         Optional<String> val = ConfigProvider.getConfig().getOptionalValue(propertyName, String.class);
-        return val.isPresent() ? val.get() : Result.NOT_FOUND;
+        return val.isPresent() ? val.get() : Results.NotFound.from(propertyName);
     }
 
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/MapTemplateExtensions.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/MapTemplateExtensions.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import javax.enterprise.inject.Vetoed;
 
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateExtension;
 
 @Vetoed // Make sure no bean is created from this class
@@ -31,7 +31,7 @@ public class MapTemplateExtensions {
             default:
                 Object val = map.get(name);
                 if (val == null) {
-                    return map.containsKey(name) ? null : Result.NOT_FOUND;
+                    return map.containsKey(name) ? null : Results.NotFound.from(name);
                 }
                 return val;
         }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/JsonObjectValueResolver.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/JsonObjectValueResolver.java
@@ -41,7 +41,7 @@ public class JsonObjectValueResolver implements ValueResolver {
             default:
                 return jsonObject.containsKey(context.getName())
                         ? CompletableFuture.completedFuture(jsonObject.getValue(context.getName()))
-                        : Results.NOT_FOUND;
+                        : Results.notFound(context);
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/MultiMapValueResolver.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/MultiMapValueResolver.java
@@ -46,7 +46,7 @@ public class MultiMapValueResolver implements ValueResolver {
             default:
                 return multiMap.contains(context.getName())
                         ? CompletableFuture.completedFuture(multiMap.get(context.getName()))
-                        : Results.NOT_FOUND;
+                        : Results.notFound(context);
         }
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Booleans.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Booleans.java
@@ -1,6 +1,5 @@
 package io.quarkus.qute;
 
-import io.quarkus.qute.Results.Result;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -14,14 +13,14 @@ public final class Booleans {
     }
 
     /**
-     * A value is considered falsy if it's null, {@link Result#NOT_FOUND}, {code false}, an empty collection, an empty map, an
-     * empty array, an empty string/char sequence or a number equal to zero.
+     * A value is considered falsy if it's null, "not found" as defined by {@link Results#isNotFound(Object)}, {code false}, an
+     * empty collection, an empty map, an empty array, an empty string/char sequence or a number equal to zero.
      * 
      * @param value
      * @return {@code true} if the value is falsy
      */
     public static boolean isFalsy(Object value) {
-        if (value == null || Results.Result.NOT_FOUND.equals(value)) {
+        if (value == null || Results.isNotFound(value)) {
             return true;
         } else if (value instanceof Boolean) {
             return !(Boolean) value;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -1,6 +1,5 @@
 package io.quarkus.qute;
 
-import io.quarkus.qute.Results.Result;
 import io.quarkus.qute.TemplateNode.Origin;
 import java.util.Collections;
 import java.util.Iterator;
@@ -60,7 +59,7 @@ final class ExpressionImpl implements Expression {
         this.id = id;
         this.namespace = namespace;
         this.parts = parts;
-        this.literal = literal != Result.NOT_FOUND ? CompletableFuture.completedFuture(literal) : null;
+        this.literal = literal != Results.NotFound.EMPTY ? CompletableFuture.completedFuture(literal) : null;
         this.origin = origin;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
@@ -2,7 +2,6 @@ package io.quarkus.qute;
 
 import static io.quarkus.qute.Booleans.isFalsy;
 
-import io.quarkus.qute.Results.Result;
 import io.quarkus.qute.SectionHelperFactory.ParserDelegate;
 import io.quarkus.qute.SectionHelperFactory.SectionInitContext;
 import java.math.BigDecimal;
@@ -280,11 +279,11 @@ public class IfSectionHelper implements SectionHelper {
             } else {
                 // Binary operator
                 try {
-                    if (Result.NOT_FOUND.equals(conditionValue)) {
+                    if (Results.isNotFound(conditionValue)) {
                         conditionValue = null;
                     }
                     Object localValue = previousValue;
-                    if (Result.NOT_FOUND.equals(localValue)) {
+                    if (Results.isNotFound(localValue)) {
                         localValue = null;
                     }
                     val = operator.evaluate(localValue, conditionValue);

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
@@ -1,6 +1,5 @@
 package io.quarkus.qute;
 
-import io.quarkus.qute.Results.Result;
 import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 
@@ -16,13 +15,13 @@ class LiteralSupport {
     /**
      * 
      * @param literal
-     * @return {@link Result#NOT_FOUND} if no literal was found, otherwise the literal value
+     * @return {@link Results.NotFound.EMPTY} if no literal was found, otherwise the literal value
      */
     static Object getLiteralValue(String literal) {
+        Object value = Results.NotFound.EMPTY;
         if (literal == null || literal.isEmpty()) {
-            return Result.NOT_FOUND;
+            return value;
         }
-        Object value = Result.NOT_FOUND;
         if (isStringLiteralSeparator(literal.charAt(0))) {
             value = literal.substring(1, literal.length() - 1);
         } else if (literal.equals("true")) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -2,7 +2,6 @@ package io.quarkus.qute;
 
 import static io.quarkus.qute.Parameter.EMPTY;
 
-import io.quarkus.qute.Results.Result;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -106,7 +105,7 @@ public class LoopSectionHelper implements SectionHelper {
             return elements.iterator();
         } else {
             String msg;
-            if (Result.NOT_FOUND.equals(it)) {
+            if (Results.isNotFound(it)) {
                 msg = String.format(
                         "Iteration error in template [%s] on line %s: {%s} not found, use {%<s.orEmpty} to ignore this error",
                         iterable.getOrigin().getTemplateId(), iterable.getOrigin().getLine(), iterable.toOriginalString());
@@ -233,7 +232,7 @@ public class LoopSectionHelper implements SectionHelper {
                 case "even":
                     return (index % 2 != 0) ? Results.TRUE : Results.FALSE;
                 default:
-                    return Results.NOT_FOUND;
+                    return Results.notFound(key);
             }
         }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
@@ -49,7 +49,7 @@ final class MethodsCandidate implements AccessorCandidate {
                             }
                         }
                         // No method matches the parameter types
-                        result.complete(Results.NOT_FOUND);
+                        result.complete(Results.notFound(context));
                     }
                 });
                 return result;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -1,7 +1,6 @@
 package io.quarkus.qute;
 
 import io.quarkus.qute.Expression.Part;
-import io.quarkus.qute.Results.Result;
 import io.quarkus.qute.SectionHelperFactory.ParametersInfo;
 import io.quarkus.qute.TemplateNode.Origin;
 import java.io.IOException;
@@ -714,7 +713,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
             if (strParts.size() == 1) {
                 String literal = strParts.get(0);
                 Object literalValue = LiteralSupport.getLiteralValue(literal);
-                if (!Result.NOT_FOUND.equals(literalValue)) {
+                if (!Results.isNotFound(literalValue)) {
                     return ExpressionImpl.literal(idGenerator.get(), literal, literalValue, origin);
                 }
             }
@@ -738,7 +737,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
             }
             parts.add(part);
         }
-        return new ExpressionImpl(idGenerator.get(), namespace, ImmutableList.copyOf(parts), Result.NOT_FOUND, origin);
+        return new ExpressionImpl(idGenerator.get(), namespace, ImmutableList.copyOf(parts), Results.NotFound.EMPTY, origin);
     }
 
     private static Part createPart(Supplier<Integer> idGenerator, String namespace, Part first,
@@ -760,7 +759,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
         if (Expressions.isBracketNotation(value)) {
             value = Expressions.parseBracketContent(value);
             Object literal = LiteralSupport.getLiteralValue(value);
-            if (literal != null && !Result.NOT_FOUND.equals(literal)) {
+            if (literal != null && !Results.isNotFound(literal)) {
                 value = literal.toString();
             } else {
                 StringBuilder builder = new StringBuilder(literal == null ? "Null" : "Non-literal");

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
@@ -53,11 +53,11 @@ public class ReflectionValueResolver implements ValueResolver {
         // At this point the candidate for the given key should be already computed
         AccessorCandidate candidate = candidates.get(key).orElse(null);
         if (candidate == null) {
-            return Results.NOT_FOUND;
+            return Results.notFound(context);
         }
         ValueAccessor accessor = candidate.getAccessor(context);
         if (accessor == null) {
-            return Results.NOT_FOUND;
+            return Results.notFound(context);
         }
         return accessor.getValue(base);
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -1,13 +1,22 @@
 package io.quarkus.qute;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
-/**
- * Result constants.
- */
 public final class Results {
 
+    /**
+     * This field will be removed at some point post Quarkus 2.1.
+     * 
+     * @deprecated Use {@link #notFound(EvalContext)} or {@link #notFound(String)} instead
+     */
+    @Deprecated
     public static final CompletionStage<Object> NOT_FOUND = CompletableFuture.completedFuture(Result.NOT_FOUND);
     public static final CompletableFuture<Object> FALSE = CompletableFuture.completedFuture(false);
     public static final CompletableFuture<Object> TRUE = CompletableFuture.completedFuture(true);
@@ -16,6 +25,33 @@ public final class Results {
     private Results() {
     }
 
+    /**
+     * 
+     * @param result
+     * @return {@code true} if the value represents a "not found" result
+     */
+    public static boolean isNotFound(Object result) {
+        return Result.NOT_FOUND == result || result instanceof NotFound;
+    }
+
+    public static CompletionStage<Object> notFound(EvalContext evalContext) {
+        return CompletableFuture.completedFuture(NotFound.from(evalContext));
+    }
+
+    public static CompletionStage<Object> notFound(String name) {
+        return CompletableFuture.completedFuture(NotFound.from(name));
+    }
+
+    public static CompletionStage<Object> notFound() {
+        return CompletableFuture.completedFuture(NotFound.EMPTY);
+    }
+
+    /**
+     * This enum will be removed at some point post Quarkus 2.1.
+     * 
+     * @deprecated {@link NotFound} instead.
+     */
+    @Deprecated
     public enum Result {
 
         NOT_FOUND;
@@ -24,6 +60,134 @@ public final class Results {
         public String toString() {
             return "NOT_FOUND";
         }
+    }
+
+    /**
+     * Represents various types of "result not found" values.
+     */
+    public interface NotFound {
+
+        static final NotFound EMPTY = new NotFound() {
+
+            @Override
+            public String toString() {
+                return "NOT_FOUND";
+            }
+
+        };
+
+        public static NotFound from(EvalContext context) {
+            return new EvalContextNotFound(Objects.requireNonNull(context));
+        }
+
+        public static NotFound from(String name) {
+            return new NameOnlyNotFound(Objects.requireNonNull(name));
+        }
+
+        /**
+         * 
+         * @return the base object or empty
+         */
+        default Optional<Object> getBase() {
+            return Optional.empty();
+        }
+
+        /**
+         * 
+         * @return the name of the virtual property/function
+         */
+        default Optional<String> getName() {
+            return Optional.empty();
+        }
+
+        /**
+         * @return the list of parameters, is never {@code null}
+         */
+        default List<Expression> getParams() {
+            return Collections.emptyList();
+        }
+
+        default String asMessage() {
+            String name = getName().orElse(null);
+            if (name != null) {
+                // Property "foo" not found on base object "org.acme.Bar"
+                // Method "getDiscount(value)" not found on base object "org.acme.Item"
+                List<Expression> params = getParams();
+                StringBuilder builder = new StringBuilder();
+                if (params.isEmpty()) {
+                    builder.append("Property ");
+                } else {
+                    builder.append("Method ");
+                }
+                builder.append("\"").append(name);
+                if (!params.isEmpty()) {
+                    builder.append("(");
+                    builder.append(getParams().stream().map(Expression::toOriginalString).collect(Collectors.joining(",")));
+                    builder.append(")");
+                }
+                builder.append("\" not found");
+                Object base = getBase().orElse(null);
+                if (!(base instanceof Map)
+                        // Just ignore the data map
+                        || !((Map<?, ?>) base).containsKey(TemplateInstanceBase.DATA_MAP_KEY)) {
+                    builder.append(" on base object \"").append(base == null ? "null" : base.getClass().getName()).append("\"");
+                }
+                return builder.toString();
+            } else {
+                return "NOT_FOUND";
+            }
+        }
+
+    }
+
+    static final class NameOnlyNotFound implements NotFound {
+
+        private final Optional<String> name;
+
+        NameOnlyNotFound(String name) {
+            this.name = Optional.of(name);
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return "NOT_FOUND";
+        }
+
+    }
+
+    static final class EvalContextNotFound implements NotFound {
+
+        private final EvalContext evalContext;
+
+        EvalContextNotFound(EvalContext evalContext) {
+            this.evalContext = evalContext;
+        }
+
+        @Override
+        public Optional<Object> getBase() {
+            return Optional.ofNullable(evalContext.getBase());
+        }
+
+        @Override
+        public Optional<String> getName() {
+            return Optional.of(evalContext.getName());
+        }
+
+        @Override
+        public List<Expression> getParams() {
+            return evalContext.getParams();
+        }
+
+        @Override
+        public String toString() {
+            return "NOT_FOUND";
+        }
+
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -129,7 +129,7 @@ class TemplateImpl implements Template {
             if (rootContext != null && rootContext instanceof ResolutionContext) {
                 return ((ResolutionContext) rootContext).evaluate(context.getName());
             }
-            return Results.NOT_FOUND;
+            return Results.notFound(context);
         }
 
         @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
@@ -1,9 +1,13 @@
 package io.quarkus.qute;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class TemplateInstanceBase implements TemplateInstance {
+
+    static final String DATA_MAP_KEY = "io.quarkus.qute.dataMap";
+    static final Map<String, Object> EMPTY_DATA_MAP = Collections.singletonMap(DATA_MAP_KEY, true);
 
     protected Object data;
     protected Map<String, Object> dataMap;
@@ -25,6 +29,7 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
         this.data = null;
         if (dataMap == null) {
             dataMap = new HashMap<String, Object>();
+            dataMap.put(DATA_MAP_KEY, true);
         }
         dataMap.put(key, data);
         return this;
@@ -42,7 +47,13 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
     }
 
     protected Object data() {
-        return data != null ? data : dataMap;
+        if (data != null) {
+            return data;
+        }
+        if (dataMap != null) {
+            return dataMap;
+        }
+        return EMPTY_DATA_MAP;
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolver.java
@@ -1,12 +1,10 @@
 package io.quarkus.qute;
 
-import io.quarkus.qute.Results.Result;
-
 /**
  * Value resolvers are used when evaluating expressions.
  * <p>
  * First the resolvers that apply to the given {@link EvalContext} are filtered. Then the resolver with highest priority is used
- * to resolve the data. If {@link Result#NOT_FOUND} is returned the next available resolver is tried.
+ * to resolve the data. If {@link Results#isNotFound(Object)} is returned the next available resolver is tried.
  * 
  * @see EvalContext
  */

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -2,7 +2,6 @@ package io.quarkus.qute;
 
 import static io.quarkus.qute.Booleans.isFalsy;
 
-import io.quarkus.qute.Results.Result;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Collections;
@@ -96,7 +95,7 @@ public final class ValueResolvers {
 
             @Override
             public CompletionStage<Object> resolve(EvalContext context) {
-                if (context.getBase() == null || Results.Result.NOT_FOUND.equals(context.getBase())) {
+                if (context.getBase() == null || Results.isNotFound(context.getBase())) {
                     return context.evaluate(context.getParams().get(0));
                 }
                 return CompletableFuture.completedFuture(context.getBase());
@@ -118,7 +117,7 @@ public final class ValueResolvers {
 
             @Override
             public CompletionStage<Object> resolve(EvalContext context) {
-                if (context.getBase() == null || Results.Result.NOT_FOUND.equals(context.getBase())) {
+                if (context.getBase() == null || Results.isNotFound(context.getBase())) {
                     return empty;
                 }
                 return CompletableFuture.completedFuture(context.getBase());
@@ -147,7 +146,7 @@ public final class ValueResolvers {
             @Override
             public CompletionStage<Object> resolve(EvalContext context) {
                 if (isFalsy(context.getBase())) {
-                    return Results.NOT_FOUND;
+                    return Results.notFound(context);
                 }
                 return context.evaluate(context.getParams().get(0));
             }
@@ -291,7 +290,7 @@ public final class ValueResolvers {
                             if (literalValue instanceof Integer) {
                                 return CompletableFuture.completedFuture(Array.get(context.getBase(), (Integer) literalValue));
                             }
-                            return Results.NOT_FOUND;
+                            return Results.notFound(context);
                         } catch (InterruptedException | ExecutionException e) {
                             throw new RuntimeException(e);
                         }
@@ -300,7 +299,7 @@ public final class ValueResolvers {
                             if (idx instanceof Integer) {
                                 return CompletableFuture.completedFuture(Array.get(context.getBase(), (Integer) idx));
                             }
-                            return Results.NOT_FOUND;
+                            return Results.notFound(context);
                         });
                     }
                 } else {
@@ -309,7 +308,7 @@ public final class ValueResolvers {
                     try {
                         index = Integer.parseInt(name);
                     } catch (NumberFormatException e) {
-                        return Results.NOT_FOUND;
+                        return Results.notFound(context);
                     }
                     return CompletableFuture.completedFuture(Array.get(context.getBase(), index));
                 }
@@ -334,7 +333,7 @@ public final class ValueResolvers {
                     });
                 }
             default:
-                return Results.NOT_FOUND;
+                return Results.notFound(context);
         }
     }
 
@@ -349,16 +348,16 @@ public final class ValueResolvers {
                                     int idx = r instanceof Integer ? (Integer) r : Integer.valueOf(r.toString());
                                     if (idx >= list.size()) {
                                         // Be consistent with property resolvers
-                                        return Result.NOT_FOUND;
+                                        return Results.NotFound.from(context);
                                     }
                                     return list.get(idx);
                                 } catch (NumberFormatException e) {
-                                    return Result.NOT_FOUND;
+                                    return Results.NotFound.from(context);
                                 }
                             });
                 }
             default:
-                return Results.NOT_FOUND;
+                return Results.notFound(context);
         }
     }
 
@@ -371,7 +370,7 @@ public final class ValueResolvers {
             case "getValue":
                 return entry.getValue();
             default:
-                return Result.NOT_FOUND;
+                return Results.NotFound.from(name);
         }
     }
 
@@ -407,7 +406,7 @@ public final class ValueResolvers {
             default:
                 Object val = map.get(name);
                 if (val == null) {
-                    return map.containsKey(name) ? Results.NULL : Results.NOT_FOUND;
+                    return map.containsKey(name) ? Results.NULL : Results.notFound(context);
                 }
                 return CompletableFuture.completedFuture(val);
         }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/GlobalNamespaceResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/GlobalNamespaceResolverTest.java
@@ -16,7 +16,7 @@ public class GlobalNamespaceResolverTest {
                     @Override
                     public CompletionStage<Object> resolve(EvalContext context) {
                         if (!context.getName().equals("foo")) {
-                            return Results.NOT_FOUND;
+                            return Results.notFound(context);
                         }
                         CompletableFuture<Object> ret = new CompletableFuture<>();
                         context.evaluate(context.getParams().get(0)).whenComplete((r, e) -> {

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
@@ -3,7 +3,7 @@ package io.quarkus.qute;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results.NotFound;
 import io.quarkus.qute.TemplateNode.Origin;
 import java.util.Collection;
 import java.util.Collections;
@@ -145,7 +145,7 @@ public class SimpleTest {
 
     @Test
     public void testNotFound() {
-        assertEquals("foo.bar Collection size: 0",
+        assertEquals("Property \"foo\" not found in foo.bar Collection size: 0",
                 Engine.builder().addDefaultValueResolvers()
                         .addResultMapper(new ResultMapper() {
 
@@ -154,17 +154,20 @@ public class SimpleTest {
                             }
 
                             public boolean appliesTo(Origin origin, Object val) {
-                                return val.equals(Result.NOT_FOUND);
+                                return Results.isNotFound(val);
                             }
 
                             @Override
                             public String map(Object result, Expression expression) {
+                                if (result instanceof NotFound) {
+                                    return ((NotFound) result).asMessage() + " in " + expression.toOriginalString();
+                                }
                                 return expression.toOriginalString();
                             }
                         }).addResultMapper(new ResultMapper() {
 
                             public boolean appliesTo(Origin origin, Object val) {
-                                return val.equals(Result.NOT_FOUND);
+                                return Results.isNotFound(val);
                             }
 
                             @Override
@@ -183,8 +186,9 @@ public class SimpleTest {
                                 return "Collection size: " + collection.size();
                             }
                         }).build()
-                        .parse("{foo.bar} {this}")
-                        .render(Collections.emptyList()));
+                        .parse("{foo.bar} {collection}")
+                        .data("collection", Collections.emptyList())
+                        .render());
     }
 
     @Test
@@ -194,7 +198,7 @@ public class SimpleTest {
                     .addResultMapper(new ResultMapper() {
 
                         public boolean appliesTo(Origin origin, Object val) {
-                            return val.equals(Result.NOT_FOUND);
+                            return Results.isNotFound(val);
                         }
 
                         @Override

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
@@ -6,7 +6,7 @@ import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.EvaluatedParams;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.Results;
-import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.Results.NotFound;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -86,11 +86,11 @@ public final class Descriptors {
             CharSequence.class);
     public static final MethodDescriptor MATCHER_MATCHES = MethodDescriptor.ofMethod(Matcher.class, "matches", boolean.class);
     public static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
+    public static final MethodDescriptor RESULTS_NOT_FOUND_EC = MethodDescriptor.ofMethod(Results.class, "notFound",
+            CompletionStage.class, EvalContext.class);
+    public static final MethodDescriptor NOT_FOUND_FROM_EC = MethodDescriptor.ofMethod(NotFound.class, "from",
+            NotFound.class, EvalContext.class);
 
-    public static final FieldDescriptor RESULTS_NOT_FOUND = FieldDescriptor.of(Results.class, "NOT_FOUND",
-            CompletionStage.class);
-    public static final FieldDescriptor RESULT_NOT_FOUND = FieldDescriptor.of(Result.class, "NOT_FOUND",
-            Result.class);
     public static final FieldDescriptor EVALUATED_PARAMS_STAGE = FieldDescriptor.of(EvaluatedParams.class, "stage",
             CompletionStage.class);
 

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -263,11 +263,8 @@ public class ExtensionMethodGenerator {
             whenComplete.assign(whenRet, ret);
             AssignableResultHandle whenEvaluatedParams = whenComplete.createVariable(EvaluatedParams.class);
             whenComplete.assign(whenEvaluatedParams, evaluatedParamsHandle);
-            AssignableResultHandle whenEvalContext = null;
-            if (params.getFirst(ParamKind.ATTR) != null) {
-                whenEvalContext = whenComplete.createVariable(EvalContext.class);
-                whenComplete.assign(whenEvalContext, evalContext);
-            }
+            AssignableResultHandle whenEvalContext = whenComplete.createVariable(EvalContext.class);
+            whenComplete.assign(whenEvalContext, evalContext);
 
             BranchResult throwableIsNull = whenComplete.ifNull(whenComplete.getMethodParam(1));
             BytecodeCreator success = throwableIsNull.trueBranch();
@@ -286,7 +283,7 @@ public class ExtensionMethodGenerator {
                             whenEvaluatedParams, success.load(isVarArgs), paramTypesHandle))
                     .falseBranch();
             typeMatchFailed.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet,
-                    typeMatchFailed.readStaticField(Descriptors.RESULT_NOT_FOUND));
+                    typeMatchFailed.invokeStaticInterfaceMethod(Descriptors.NOT_FOUND_FROM_EC, whenEvalContext));
             typeMatchFailed.returnValue(null);
 
             // try
@@ -513,11 +510,8 @@ public class ExtensionMethodGenerator {
                     whenComplete.assign(whenRet, ret);
                     AssignableResultHandle whenEvaluatedParams = whenComplete.createVariable(EvaluatedParams.class);
                     whenComplete.assign(whenEvaluatedParams, evaluatedParamsHandle);
-                    AssignableResultHandle whenEvalContext = null;
-                    if (params.getFirst(ParamKind.ATTR) != null) {
-                        whenEvalContext = whenComplete.createVariable(EvalContext.class);
-                        whenComplete.assign(whenEvalContext, evalContext);
-                    }
+                    AssignableResultHandle whenEvalContext = whenComplete.createVariable(EvalContext.class);
+                    whenComplete.assign(whenEvalContext, evalContext);
 
                     BranchResult throwableIsNull = whenComplete.ifNull(whenComplete.getMethodParam(1));
                     BytecodeCreator success = throwableIsNull.trueBranch();
@@ -536,7 +530,7 @@ public class ExtensionMethodGenerator {
                                     whenEvaluatedParams, success.load(isVarArgs), paramTypesHandle))
                             .falseBranch();
                     typeMatchFailed.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet,
-                            typeMatchFailed.readStaticField(Descriptors.RESULT_NOT_FOUND));
+                            typeMatchFailed.invokeStaticInterfaceMethod(Descriptors.NOT_FOUND_FROM_EC, whenEvalContext));
                     typeMatchFailed.returnValue(null);
 
                     // try
@@ -590,7 +584,7 @@ public class ExtensionMethodGenerator {
             @Override
             public void close() {
                 constructor.returnValue(null);
-                resolve.returnValue(resolve.readStaticField(Descriptors.RESULTS_NOT_FOUND));
+                resolve.returnValue(resolve.invokeStaticMethod(Descriptors.RESULTS_NOT_FOUND_EC, evalContext));
             }
 
         }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -374,7 +374,7 @@ public class ValueResolverGenerator {
                         paramsCount, evalContext);
             }
         }
-        resolve.returnValue(resolve.readStaticField(Descriptors.RESULTS_NOT_FOUND));
+        resolve.returnValue(resolve.invokeStaticMethod(Descriptors.RESULTS_NOT_FOUND_EC, evalContext));
     }
 
     private void matchMethod(MethodInfo method, ClassInfo clazz, MethodCreator resolve, ResultHandle base, ResultHandle name,
@@ -413,6 +413,8 @@ public class ValueResolverGenerator {
         whenComplete.assign(whenRet, ret);
         AssignableResultHandle whenEvaluatedParams = whenComplete.createVariable(EvaluatedParams.class);
         whenComplete.assign(whenEvaluatedParams, evaluatedParams);
+        AssignableResultHandle whenEvalContext = whenComplete.createVariable(EvalContext.class);
+        whenComplete.assign(whenEvalContext, evalContext);
 
         BranchResult throwableIsNull = whenComplete.ifNull(whenComplete.getMethodParam(1));
 
@@ -432,7 +434,7 @@ public class ValueResolverGenerator {
                         whenEvaluatedParams, success.load(isVarArgs(method)), paramTypesHandle))
                 .falseBranch();
         typeMatchFailed.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet,
-                typeMatchFailed.readStaticField(Descriptors.RESULT_NOT_FOUND));
+                typeMatchFailed.invokeStaticInterfaceMethod(Descriptors.NOT_FOUND_FROM_EC, whenEvalContext));
         typeMatchFailed.returnValue(null);
 
         ResultHandle[] paramsHandle = new ResultHandle[methodParams.size()];
@@ -524,6 +526,8 @@ public class ValueResolverGenerator {
         whenComplete.assign(whenRet, ret);
         AssignableResultHandle whenEvaluatedParams = whenComplete.createVariable(EvaluatedParams.class);
         whenComplete.assign(whenEvaluatedParams, evaluatedParams);
+        AssignableResultHandle whenEvalContext = whenComplete.createVariable(EvalContext.class);
+        whenComplete.assign(whenEvalContext, evalContext);
 
         BranchResult throwableIsNull = whenComplete.ifNull(whenComplete.getMethodParam(1));
         // complete
@@ -631,9 +635,9 @@ public class ValueResolverGenerator {
         failure.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE_EXCEPTIONALLY, whenRet,
                 whenComplete.getMethodParam(1));
 
-        // No method matches - return Result.NOT_FOUND
+        // No method matches - result not found
         whenComplete.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet,
-                whenComplete.readStaticField(Descriptors.RESULT_NOT_FOUND));
+                whenComplete.invokeStaticInterfaceMethod(Descriptors.NOT_FOUND_FROM_EC, whenEvalContext));
         whenComplete.returnValue(null);
 
         matchScope.returnValue(ret);

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
@@ -112,7 +112,7 @@ final class QuteCodestartFileReader implements CodestartFileReader {
     static class MissingValueMapper implements ResultMapper {
 
         public boolean appliesTo(TemplateNode.Origin origin, Object result) {
-            return Results.Result.NOT_FOUND.equals(result);
+            return Results.isNotFound(result);
         }
 
         public String map(Object result, Expression expression) {


### PR DESCRIPTION
- in order to improve the error message when a property/method is not
found
   - E.g. _"Property not found in expression {bar.name} in template bar on line 1"._ becomes _"Property **"name"** not found **on base object \"java.lang.String\"** in expression {bar.name} in template bar on line 1."_
- also use the quarkus.qute.property-not-found-strategy=throw-exception
by default in the development mode
- related to #16076