### PR TITLE
Improve the Gradle dev experience from the CLI

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.CategoryListFormatOptions;
@@ -97,7 +98,8 @@ public interface BuildSystemRunner {
     BuildCommandArgs prepareBuild(BuildOptions buildOptions, PropertiesOptions propertiesOptions, RunModeOption runMode,
             List<String> params);
 
-    BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions, DebugOptions debugOptions,
+    List<Supplier<BuildCommandArgs>> prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+            DebugOptions debugOptions,
             List<String> params);
 
     Path getProjectRoot();

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.CategoryListFormatOptions;
@@ -86,7 +87,7 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+    public List<Supplier<BuildCommandArgs>> prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
             DebugOptions debugOptions, List<String> params) {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -3,8 +3,10 @@ package io.quarkus.cli.build;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import io.quarkus.cli.Version;
 import io.quarkus.cli.common.BuildOptions;
@@ -149,7 +151,7 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
+    public List<Supplier<BuildCommandArgs>> prepareDevMode(DevOptions devOptions, PropertiesOptions propertiesOptions,
             DebugOptions debugOptions, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setMavenProperties(args, false);
@@ -168,7 +170,13 @@ public class MavenRunner implements BuildSystemRunner {
         args.addAll(flattenMappedProperties(propertiesOptions.properties));
         // Add any other unmatched arguments
         args.addAll(params);
-        return prependExecutable(args);
+        BuildCommandArgs buildCommandArgs = prependExecutable(args);
+        return Collections.singletonList(new Supplier<BuildCommandArgs>() {
+            @Override
+            public BuildCommandArgs get() {
+                return buildCommandArgs;
+            }
+        });
     }
 
     void setSkipTests(ArrayDeque<String> args) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -1,5 +1,6 @@
 package io.quarkus.gradle.tasks;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,6 +56,7 @@ import io.quarkus.runtime.LaunchMode;
 
 public class QuarkusDev extends QuarkusTask {
 
+    public static final String IO_QUARKUS_DEVMODE_ARGS = "io.quarkus.devmode-args";
     private Set<File> filesIncludedInClasspath = new HashSet<>();
 
     private File buildDir;
@@ -186,12 +188,22 @@ public class QuarkusDev extends QuarkusTask {
 
         try {
             QuarkusDevModeLauncher runner = newLauncher();
-            getProject().exec(action -> {
-                action.commandLine(runner.args()).workingDir(getWorkingDir());
-                action.setStandardInput(System.in)
-                        .setErrorOutput(System.out)
-                        .setStandardOutput(System.out);
-            });
+            String outputFile = System.getProperty(IO_QUARKUS_DEVMODE_ARGS);
+            if (outputFile == null) {
+                getProject().exec(action -> {
+                    action.commandLine(runner.args()).workingDir(getWorkingDir());
+                    action.setStandardInput(System.in)
+                            .setErrorOutput(System.out)
+                            .setStandardOutput(System.out);
+                });
+            } else {
+                try (BufferedWriter is = Files.newBufferedWriter(Paths.get(outputFile))) {
+                    for (String i : runner.args()) {
+                        is.write(i);
+                        is.newLine();
+                    }
+                }
+            }
 
         } catch (Exception e) {
             throw new GradleException("Failed to run", e);
@@ -218,9 +230,11 @@ public class QuarkusDev extends QuarkusTask {
                 .outputDir(getBuildDir())
                 .debug(System.getProperty("debug"))
                 .debugHost(System.getProperty("debugHost", "localhost"))
-                .suspend(System.getProperty("suspend"))
-                .jvmArgs("-Dquarkus.test.basic-console=true")
-                .jvmArgs("-Dio.quarkus.launched-from-ide=true");
+                .suspend(System.getProperty("suspend"));
+        if (System.getProperty(IO_QUARKUS_DEVMODE_ARGS) == null) {
+            builder.jvmArgs("-Dquarkus.test.basic-console=true")
+                    .jvmArgs("-Dio.quarkus.launched-from-ide=true");
+        }
 
         if (getJvmArgs() != null) {
             builder.jvmArgs(getJvmArgs());

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -163,13 +163,23 @@ You can install all extensions which match a globbing pattern:
 [[dev-mode]]
 == Development mode
 
-Quarkus comes with a built-in development mode.
+Quarkus comes with a built-in development mode. The best way to run this is via the link:cli-tooling.adoc[Quarkus CLI]
 Run your application with:
 
 [source,bash]
 ----
-./gradlew quarkusDev
+quarkus dev
 ----
+
+If you don't want to install the Quarkus CLI you can run development mode directly from gradle:
+
+[source,bash]
+----
+./gradlew --console=plain quarkusDev
+----
+
+Note that if you run it this way the continuous testing experience will not be as nice, as gradle runs as a daemon
+Quarkus can't draw the 'pretty' test output so falls back to just logging the output.
 
 You can then update the application sources, resources and configurations.
 The changes are automatically reflected in your running application.


### PR DESCRIPTION
This will make the CLI directly launch devmode, so continuous testing
can draw its fancy output in the terminal.