### PR TITLE
Add test case to make sure DDL scripts are not created in append mode

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/scripts/GenerateScriptNotAppendedTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/scripts/GenerateScriptNotAppendedTestCase.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm.scripts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class GenerateScriptNotAppendedTestCase {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-generate-script.properties", "application.properties")
+                    .addClasses(MyEntity.class));
+
+    @RepeatedTest(2)
+    public void verifyScriptIsOverwritten() throws Exception {
+        String script = Files.readString(Path.of(GenerateScriptNotAppendedTestCase.class.getResource("/create.sql").toURI()));
+        assertEquals(1, Pattern.compile("create table MyEntity").matcher(script).results().count());
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-generate-script.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-generate-script.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-orm.scripts.generation=create
+quarkus.hibernate-orm.scripts.generation.create-target=target/test-classes/create.sql


### PR DESCRIPTION
The test uses `QuarkusDevModeTest` to make sure the DDL generation is executed individually for both test method executions.

Fixes #17924