### PR TITLE
Downgrade Opentracing contrib JDBC to a version that didn't use a proxy

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -24,7 +24,7 @@
         <opentracing-web-servlet-filter.version>0.4.0</opentracing-web-servlet-filter.version>
         <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.4.0</opentracing-concurrent.version>
-        <opentracing-jdbc.version>0.2.12</opentracing-jdbc.version>
+        <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.3.0</opentelemetry.version>


### PR DESCRIPTION
/cc @kenfinnigan 

@gsmet as it's too late for Quarkus 2.0, I'll add a note about it in the migration guide, people using the Opentracing JDBC driver would need to manually downgrade the version inside there pom.xml. Maybe it's also worth a note in the annoucement blog post.

I'll try to add an integration test for it tomorrow and open an issue upstream as discussed in #18033