### PR TITLE
Wait until the OIDC endpoint is actually available

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -1,7 +1,6 @@
 package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +25,6 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.ext.web.client.WebClient;
@@ -191,25 +189,9 @@ public class OidcClientRecorder {
     }
 
     private static Uni<String> discoverTokenRequestUri(WebClient client, String authServerUrl, OidcClientConfig oidcConfig) {
-        final String discoveryUrl = authServerUrl + "/.well-known/openid-configuration";
-        final long connectionRetryCount = OidcCommonUtils.getConnectionRetryCount(oidcConfig);
-        final long expireInDelay = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
-        if (connectionRetryCount > 1) {
-            LOG.infof("Connecting to IDP for up to %d times every 2 seconds", connectionRetryCount);
-        }
-        return client.getAbs(discoveryUrl).send().onItem().transform(resp -> {
-            if (resp.statusCode() == 200) {
-                JsonObject json = resp.bodyAsJsonObject();
-                return json.getString("token_endpoint");
-            } else {
-                LOG.tracef("Discovery has failed, status code: %d", resp.statusCode());
-                return null;
-            }
-        }).onFailure(ConnectException.class)
-                .retry()
-                .withBackOff(CONNECTION_BACKOFF_DURATION, CONNECTION_BACKOFF_DURATION)
-                .expireIn(expireInDelay)
-                .onFailure().transform(t -> t.getCause());
+        final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
+        return OidcCommonUtils.discoverMetadata(client, authServerUrl, connectionDelayInMillisecs)
+                .onItem().transform(json -> json.getString("token_endpoint"));
     }
 
     protected static OidcClientException toOidcClientException(String authServerUrlString, Throwable cause) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -1,19 +1,24 @@
 package io.quarkus.oidc.common.runtime;
 
 import java.io.InputStream;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.credentials.runtime.CredentialsProviderFinder;
@@ -27,15 +32,21 @@ import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.build.JwtSignatureBuilder;
 import io.smallrye.jwt.util.KeyUtils;
 import io.smallrye.jwt.util.ResourceUtils;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcCommonUtils {
+    public static final Duration CONNECTION_BACKOFF_DURATION = Duration.ofSeconds(2);
+
     static final byte AMP = '&';
     static final byte EQ = '=';
+
+    private static final Logger LOG = Logger.getLogger(OidcCommonUtils.class);
 
     private OidcCommonUtils() {
 
@@ -138,11 +149,6 @@ public class OidcCommonUtils {
         }
     }
 
-    public static long getConnectionRetryCount(OidcCommonConfig oidcConfig) {
-        final long connectionDelayInSecs = getConnectionDelay(oidcConfig);
-        return connectionDelayInSecs > 1 ? connectionDelayInSecs / 2 : 1;
-    }
-
     private static long getConnectionDelay(OidcCommonConfig oidcConfig) {
         return oidcConfig.getConnectionDelay().isPresent()
                 ? oidcConfig.getConnectionDelay().get().getSeconds()
@@ -150,7 +156,12 @@ public class OidcCommonUtils {
     }
 
     public static long getConnectionDelayInMillis(OidcCommonConfig oidcConfig) {
-        return getConnectionDelay(oidcConfig) * 1000;
+        final long connectionDelayInSecs = getConnectionDelay(oidcConfig);
+        final long connectionRetryCount = connectionDelayInSecs > 1 ? connectionDelayInSecs / 2 : 1;
+        if (connectionRetryCount > 1) {
+            LOG.infof("Connecting to OpenId Connect Provider for up to %d times every 2 seconds", connectionRetryCount);
+        }
+        return connectionDelayInSecs * 1000;
     }
 
     public static Optional<ProxyOptions> toProxyOptions(OidcCommonConfig.Proxy proxyConfig) {
@@ -286,5 +297,26 @@ public class OidcCommonUtils {
             return clientJwtKey(oidcConfig.credentials);
         }
         return null;
+    }
+
+    public static Predicate<? super Throwable> oidcEndpointNotAvailable() {
+        return t -> (t instanceof ConnectException
+                || (t instanceof OidcEndpointAccessException && ((OidcEndpointAccessException) t).getErrorStatus() == 404));
+    }
+
+    public static Uni<JsonObject> discoverMetadata(WebClient client, String authServerUrl, long connectionDelayInMillisecs) {
+        final String discoveryUrl = authServerUrl + OidcConstants.WELL_KNOWN_CONFIGURATION;
+        return client.getAbs(discoveryUrl).send().onItem().transform(resp -> {
+            if (resp.statusCode() == 200) {
+                return resp.bodyAsJsonObject();
+            } else {
+                LOG.tracef("Discovery has failed, status code: %d", resp.statusCode());
+                throw new OidcEndpointAccessException(resp.statusCode());
+            }
+        }).onFailure(oidcEndpointNotAvailable())
+                .retry()
+                .withBackOff(CONNECTION_BACKOFF_DURATION, CONNECTION_BACKOFF_DURATION)
+                .expireIn(connectionDelayInMillisecs)
+                .onFailure().transform(t -> t.getCause());
     }
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -2,6 +2,8 @@ package io.quarkus.oidc.common.runtime;
 
 public final class OidcConstants {
 
+    public static final String WELL_KNOWN_CONFIGURATION = "/.well-known/openid-configuration";
+
     public static final String CLIENT_ASSERTION = "client_assertion";
     public static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
     public static final String JWT_BEARER_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcEndpointAccessException.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcEndpointAccessException.java
@@ -1,0 +1,16 @@
+package io.quarkus.oidc.common.runtime;
+
+@SuppressWarnings("serial")
+public class OidcEndpointAccessException extends RuntimeException {
+
+    private final int errorStatus;
+
+    public OidcEndpointAccessException(int errorStatus) {
+        this.errorStatus = errorStatus;
+    }
+
+    public int getErrorStatus() {
+        return errorStatus;
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JsonWebKeySet.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JsonWebKeySet.java
@@ -6,25 +6,24 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jose4j.jwk.JsonWebKey;
-import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.lang.JoseException;
 
 import io.quarkus.oidc.OIDCException;
 
-public class JsonWebKeyCache {
+public class JsonWebKeySet {
     private static final String RSA_KEY_TYPE = "RSA";
     private static final String EC_KEY_TYPE = "EC";
     private static final String SIGNATURE_USE = "sig";
 
     private Map<String, Key> keys = new HashMap<>();
 
-    public JsonWebKeyCache(String json) {
+    public JsonWebKeySet(String json) {
         initKeys(json);
     }
 
     private void initKeys(String json) {
         try {
-            JsonWebKeySet jwkSet = new JsonWebKeySet(json);
+            org.jose4j.jwk.JsonWebKeySet jwkSet = new org.jose4j.jwk.JsonWebKeySet(json);
             for (JsonWebKey jwkKey : jwkSet.getJsonWebKeys()) {
                 if ((RSA_KEY_TYPE.equals(jwkKey.getKeyType()) || EC_KEY_TYPE.equals(jwkKey.getKeyType())
                         || jwkKey.getKeyType() == null)

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -50,7 +50,7 @@ public class OidcProvider {
     final String issuer;
     final String[] audience;
 
-    public OidcProvider(OidcProviderClient client, OidcTenantConfig oidcConfig, JsonWebKeyCache jwks) {
+    public OidcProvider(OidcProviderClient client, OidcTenantConfig oidcConfig, JsonWebKeySet jwks) {
         this.client = client;
         this.oidcConfig = oidcConfig;
         this.keyResolver = jwks == null ? null : new JsonWebKeyResolver(jwks, oidcConfig.token.forcedJwkRefreshInterval);
@@ -190,11 +190,11 @@ public class OidcProvider {
     }
 
     private class JsonWebKeyResolver implements RefreshableVerificationKeyResolver {
-        volatile JsonWebKeyCache jwks;
+        volatile JsonWebKeySet jwks;
         volatile long lastForcedRefreshTime;
         volatile long forcedJwksRefreshIntervalMilliSecs;
 
-        JsonWebKeyResolver(JsonWebKeyCache jwks, Duration forcedJwksRefreshInterval) {
+        JsonWebKeyResolver(JsonWebKeySet jwks, Duration forcedJwksRefreshInterval) {
             this.jwks = jwks;
             this.forcedJwksRefreshIntervalMilliSecs = forcedJwksRefreshInterval.toMillis();
         }
@@ -217,10 +217,10 @@ public class OidcProvider {
             final long now = System.currentTimeMillis();
             if (now > lastForcedRefreshTime + forcedJwksRefreshIntervalMilliSecs) {
                 lastForcedRefreshTime = now;
-                return client.getJsonWebKeySet().onItem().transformToUni(new Function<JsonWebKeyCache, Uni<? extends Void>>() {
+                return client.getJsonWebKeySet().onItem().transformToUni(new Function<JsonWebKeySet, Uni<? extends Void>>() {
 
                     @Override
-                    public Uni<? extends Void> apply(JsonWebKeyCache t) {
+                    public Uni<? extends Void> apply(JsonWebKeySet t) {
                         jwks = t;
                         return Uni.createFrom().voidItem();
                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -13,6 +13,7 @@ import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.OidcEndpointAccessException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.http.HttpHeaders;
@@ -48,9 +49,9 @@ public class OidcProviderClient {
         return metadata;
     }
 
-    public Uni<JsonWebKeyCache> getJsonWebKeySet() {
+    public Uni<JsonWebKeySet> getJsonWebKeySet() {
         return client.getAbs(metadata.getJsonWebKeySetUri()).send().onItem()
-                .transform(resp -> getJsonWebKeyCache(resp));
+                .transform(resp -> getJsonWebKeySet(resp));
     }
 
     public Uni<JsonObject> getUserInfo(String token) {
@@ -67,11 +68,11 @@ public class OidcProviderClient {
                 .transform(resp -> getTokenIntrospection(resp));
     }
 
-    private JsonWebKeyCache getJsonWebKeyCache(HttpResponse<Buffer> resp) {
+    private JsonWebKeySet getJsonWebKeySet(HttpResponse<Buffer> resp) {
         if (resp.statusCode() == 200) {
-            return new JsonWebKeyCache(resp.bodyAsString(StandardCharsets.UTF_8.name()));
+            return new JsonWebKeySet(resp.bodyAsString(StandardCharsets.UTF_8.name()));
         } else {
-            throw new OIDCException();
+            throw new OidcEndpointAccessException(resp.statusCode());
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import java.net.ConnectException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +36,6 @@ public class OidcRecorder {
 
     private static final Logger LOG = Logger.getLogger(OidcRecorder.class);
     private static final String DEFAULT_TENANT_ID = "Default";
-    private static final Duration CONNECTION_BACKOFF_DURATION = Duration.ofSeconds(2);
 
     private static final Map<String, TenantConfigContext> dynamicTenantsConfig = new ConcurrentHashMap<>();
 
@@ -230,11 +227,11 @@ public class OidcRecorder {
                     @Override
                     public Uni<OidcProvider> apply(OidcProviderClient client) {
                         if (client.getMetadata().getJsonWebKeySetUri() != null) {
-                            return client.getJsonWebKeySet().onItem()
-                                    .transform(new Function<JsonWebKeyCache, OidcProvider>() {
+                            return getJsonWebSetUni(client, oidcConfig).onItem()
+                                    .transform(new Function<JsonWebKeySet, OidcProvider>() {
 
                                         @Override
-                                        public OidcProvider apply(JsonWebKeyCache jwks) {
+                                        public OidcProvider apply(JsonWebKeySet jwks) {
                                             return new OidcProvider(client, oidcConfig, jwks);
                                         }
 
@@ -244,6 +241,18 @@ public class OidcRecorder {
                         }
                     }
                 });
+    }
+
+    protected static Uni<JsonWebKeySet> getJsonWebSetUni(OidcProviderClient client, OidcTenantConfig oidcConfig) {
+        if (!oidcConfig.isDiscoveryEnabled()) {
+            final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
+            return client.getJsonWebKeySet().onFailure(OidcCommonUtils.oidcEndpointNotAvailable())
+                    .retry()
+                    .withBackOff(OidcCommonUtils.CONNECTION_BACKOFF_DURATION, OidcCommonUtils.CONNECTION_BACKOFF_DURATION)
+                    .expireIn(connectionDelayInMillisecs);
+        } else {
+            return client.getJsonWebKeySet();
+        }
     }
 
     protected static Uni<OidcProviderClient> createOidcClientUni(OidcTenantConfig oidcConfig,
@@ -271,16 +280,9 @@ public class OidcRecorder {
                     introspectionUri, authorizationUri, jwksUri, userInfoUri, endSessionUri,
                     oidcConfig.token.issuer.orElse(null)));
         } else {
-            final long connectionRetryCount = OidcCommonUtils.getConnectionRetryCount(oidcConfig);
-            final long expireInDelay = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
-            if (connectionRetryCount > 1) {
-                LOG.infof("Connecting to IDP for up to %d times every 2 seconds", connectionRetryCount);
-            }
-            metadataUni = discoverMetadata(client, authServerUriString, oidcConfig).onFailure(ConnectException.class)
-                    .retry()
-                    .withBackOff(CONNECTION_BACKOFF_DURATION, CONNECTION_BACKOFF_DURATION)
-                    .expireIn(expireInDelay)
-                    .onFailure().transform(e -> e.getCause());
+            final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
+            metadataUni = OidcCommonUtils.discoverMetadata(client, authServerUriString, connectionDelayInMillisecs)
+                    .onItem().transform(json -> new OidcConfigurationMetadata(json));
         }
         return metadataUni.onItemOrFailure()
                 .transformToUni(new BiFunction<OidcConfigurationMetadata, Throwable, Uni<? extends OidcProviderClient>>() {
@@ -303,18 +305,6 @@ public class OidcRecorder {
                         return Uni.createFrom().item(new OidcProviderClient(client, metadata, oidcConfig));
                     }
                 });
-    }
-
-    private static Uni<OidcConfigurationMetadata> discoverMetadata(WebClient client, String authServerUrl,
-            OidcTenantConfig oidcConfig) {
-        final String discoveryUrl = authServerUrl + "/.well-known/openid-configuration";
-        return client.getAbs(discoveryUrl).send().onItem().transform(resp -> {
-            if (resp.statusCode() == 200) {
-                return new OidcConfigurationMetadata(resp.bodyAsJsonObject());
-            } else {
-                return null;
-            }
-        });
     }
 
     private static boolean isServiceApp(OidcTenantConfig oidcConfig) {


### PR DESCRIPTION
Fixes #18089.

This PR makes sure that the `connection-delay` is used until the OIDC endpoint is actually available:
- condition for the failure has changed - it is either `ConnectException` or a newly introduced `OidcTokenAccessException` with `404` - the actual realm resource must be available
- until now the `connection-delay` was only applicable for the auto-discovery case - but not when discovery was disabled - so I added the same failure handling when an initial JWK set is retrieved and the discovery is not enabled
- The changes apply to both `quarkus-oidc` and `quarkus-oidc-client` - so the other changes are about making some code reusable (to do with the auto-discovery, and connection-delay checks)

CC @famod 
