### PR TITLE
Allow URLs to be called with empty path on OpenTelemetry-filtered req…

### DIFF
--- a/extensions/opentelemetry/rest-client/runtime/src/main/java/io/quarkus/opentelemetry/restclient/ClientTracingFilter.java
+++ b/extensions/opentelemetry/rest-client/runtime/src/main/java/io/quarkus/opentelemetry/restclient/ClientTracingFilter.java
@@ -38,7 +38,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         // Create new span
-        SpanBuilder builder = tracer.spanBuilder(requestContext.getUri().getPath().substring(1))
+        SpanBuilder builder = tracer.spanBuilder(requestContext.getUri().getPath())
                 .setSpanKind(SpanKind.CLIENT);
 
         // Add attributes


### PR DESCRIPTION
An empty path currently leads to this:

Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.base/java.lang.String.substring(String.java:1841)
	at io.quarkus.opentelemetry.tracing.client.ClientTracingFilter.filter(ClientTracingFilter.java:41)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.filterRequest(ClientInvocation.java:686)
	... 118 more