### PR TITLE
Console live reload fixes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -102,6 +102,7 @@ public interface Capability {
 
     String VERTX = QUARKUS_PREFIX + "vertx";
     String VERTX_CORE = VERTX + ".core";
+    String VERTX_HTTP = VERTX + ".http";
 
     String APICURIO_REGISTRY = QUARKUS_PREFIX + "apicurio.registry";
     String APICURIO_REGISTRY_AVRO = APICURIO_REGISTRY + ".avro";

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -352,8 +352,8 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         return doScan(userInitiated, false);
     }
 
-    public boolean doScan(boolean userInitiated, boolean force) throws IOException {
-        if (!liveReloadEnabled && !force) {
+    public boolean doScan(boolean userInitiated, boolean forceRestart) throws IOException {
+        if (!liveReloadEnabled && !forceRestart) {
             return false;
         }
         scanLock.lock();
@@ -374,7 +374,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     main);
             Set<String> filesChanged = checkForFileChange(DevModeContext.ModuleInfo::getMain, main);
 
-            boolean configFileRestartNeeded = filesChanged.stream().map(main.watchedFilePaths::get)
+            boolean configFileRestartNeeded = forceRestart || filesChanged.stream().map(main.watchedFilePaths::get)
                     .anyMatch(Boolean.TRUE::equals);
             boolean instrumentationChange = false;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -36,9 +36,16 @@ public class TestConsoleHandler implements TestListener {
 
     public static final String PAUSED_PROMPT = "Tests paused, press [" + BLUE + "r" + RESET + "] to resume, [" + BLUE + "h"
             + RESET + "] for more options>" + RESET;
+    public static final String PAUSED_PROMPT_NO_HTTP = "Tests paused, press [" + BLUE + "r" + RESET + "] to resume, [" + BLUE
+            + "s" + RESET + "] to restart with changes, [" + BLUE + "h"
+            + RESET + "] for more options>" + RESET;
     public static final String FIRST_RUN_PROMPT = BLUE + "Running Tests for the first time" + RESET;
     public static final String RUNNING_PROMPT = "Press [" + BLUE + "r" + RESET + "] to re-run, [" + BLUE
             + "v" + RESET + "] to view full results, [" + BLUE + "p" + RESET + "] to pause, [" + BLUE
+            + "h" + RESET + "] for more options>";
+    public static final String RUNNING_PROMPT_NO_HTTP = "Press [" + BLUE + "r" + RESET + "] to re-run, [" + BLUE
+            + "v" + RESET + "] to view full results, [" + BLUE + "p" + RESET + "] to pause, [" + BLUE + "s" + RESET
+            + "] to restart with changes, [" + BLUE
             + "h" + RESET + "] for more options>";
 
     final DevModeType devModeType;
@@ -50,8 +57,15 @@ public class TestConsoleHandler implements TestListener {
     volatile TestController testController;
     private String lastResults;
 
-    public TestConsoleHandler(DevModeType devModeType) {
+    /**
+     * If HTTP is not present we add the 'press s to reload' option to the prompt
+     * to make it clear to users they can restart their apps.
+     */
+    private final boolean hasHttp;
+
+    public TestConsoleHandler(DevModeType devModeType, boolean hasHttp) {
         this.devModeType = devModeType;
+        this.hasHttp = hasHttp;
     }
 
     public void install() {
@@ -127,7 +141,8 @@ public class TestConsoleHandler implements TestListener {
     @Override
     public void listenerRegistered(TestController testController) {
         this.testController = testController;
-        promptHandler.setPrompt(PAUSED_PROMPT);
+        promptHandler.setPrompt(hasHttp ? PAUSED_PROMPT : PAUSED_PROMPT_NO_HTTP);
+
     }
 
     public void printUsage() {
@@ -149,7 +164,7 @@ public class TestConsoleHandler implements TestListener {
             System.out
                     .println(helpOption("i", "Toggle instrumentation based reload", testController.isInstrumentationEnabled()));
             System.out.println(helpOption("l", "Toggle live reload", testController.isLiveReloadEnabled()));
-            System.out.println(helpOption("s", "Force live reload scan"));
+            System.out.println(helpOption("s", "Force restart with any changes"));
         }
         System.out.println(helpOption("h", "Display this help"));
         System.out.println(helpOption("q", "Quit"));
@@ -163,7 +178,7 @@ public class TestConsoleHandler implements TestListener {
             promptHandler.setResults(null);
             promptHandler.setPrompt(FIRST_RUN_PROMPT);
         } else {
-            promptHandler.setPrompt(RUNNING_PROMPT);
+            promptHandler.setPrompt(hasHttp ? RUNNING_PROMPT : RUNNING_PROMPT_NO_HTTP);
             promptHandler.setResults(lastResults);
             promptHandler.setStatus(null);
         }
@@ -172,7 +187,7 @@ public class TestConsoleHandler implements TestListener {
     @Override
     public void testsDisabled() {
         disabled = true;
-        promptHandler.setPrompt(PAUSED_PROMPT);
+        promptHandler.setPrompt(hasHttp ? PAUSED_PROMPT : PAUSED_PROMPT_NO_HTTP);
         promptHandler.setStatus(null);
         promptHandler.setResults(null);
     }
@@ -270,7 +285,7 @@ public class TestConsoleHandler implements TestListener {
                 }
                 //this will re-print when using the basic console
                 if (!disabled) {
-                    promptHandler.setPrompt(RUNNING_PROMPT);
+                    promptHandler.setPrompt(hasHttp ? RUNNING_PROMPT : RUNNING_PROMPT_NO_HTTP);
                     promptHandler.setResults(lastResults);
                     promptHandler.setStatus(null);
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -11,6 +11,8 @@ import org.objectweb.asm.Opcodes;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.IsTest;
@@ -46,7 +48,7 @@ public class TestTracingProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     @Produce(TestSetupBuildItem.class)
     void setupConsole(TestConfig config, BuildProducer<TestListenerBuildItem> testListenerBuildItemBuildProducer,
-            LaunchModeBuildItem launchModeBuildItem) {
+            LaunchModeBuildItem launchModeBuildItem, Capabilities capabilities) {
         if (!TestSupport.instance().isPresent() || config.continuousTesting == TestConfig.Mode.DISABLED
                 || config.flatClassPath) {
             return;
@@ -57,7 +59,8 @@ public class TestTracingProcessor {
         consoleInstalled = true;
         if (config.console) {
             ConsoleHelper.installConsole(config);
-            TestConsoleHandler consoleHandler = new TestConsoleHandler(launchModeBuildItem.getDevModeType().get());
+            TestConsoleHandler consoleHandler = new TestConsoleHandler(launchModeBuildItem.getDevModeType().get(),
+                    capabilities.isPresent(Capability.VERTX_HTTP));
             consoleHandler.install();
             testListenerBuildItemBuildProducer.produce(new TestListenerBuildItem(consoleHandler));
         }

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -76,6 +76,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.vertx.http</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
- Pressing s will now always restart, even if no changes
- If there is no HTTP installed 'press [s] to restart' is now in the
  default prompt