### PR TITLE
Prevent possible NPE in QuarkusRestPathTemplateInterceptor

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
@@ -24,7 +24,7 @@ public class QuarkusRestPathTemplateInterceptor {
     @AroundInvoke
     Object restMethodInvoke(InvocationContext context) throws Exception {
         QuarkusRestPathTemplate annotation = getAnnotation(context);
-        if (annotation != null) {
+        if ((annotation != null) && (request.getCurrent() != null)) {
             ((HttpServerRequestInternal) request.getCurrent().request()).context().putLocal("UrlPathTemplate",
                     annotation.value());
         }


### PR DESCRIPTION
This can happen if a JAX-RS Resource is injected into a test
and invoked in it.

Fixes: #18146