### PR TITLE
Expose collected platform info through the AppModel

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImports.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImports.java
@@ -1,12 +1,43 @@
 package io.quarkus.bootstrap.model;
 
+import java.util.Collection;
 import java.util.Map;
 
 public interface PlatformImports {
 
+    /**
+     * Quarkus platform properties aggregated from all the platform an application is based on.
+     *
+     * @return aggregated platform properties
+     */
     public Map<String, String> getPlatformProperties();
 
+    /**
+     * Quarkus platform release information.
+     *
+     * @return platform release information
+     */
+    Collection<PlatformReleaseInfo> getPlatformReleaseInfo();
+
+    /**
+     * All the Quarkus platform BOMs imported by an application.
+     *
+     * @return all the Quarkus platform BOMs imported by an application
+     */
+    Collection<AppArtifactCoords> getImportedPlatformBoms();
+
+    /**
+     * In case Quarkus platform member BOM imports were misaligned this method
+     * will return a detailed information about what was found to be in conflict.
+     *
+     * @return platform member BOM misalignment report or null, in case no conflict was detected
+     */
     public String getMisalignmentReport();
 
+    /**
+     * Checks whether the platform member BOM imports belong to the same platform release.
+     *
+     * @return true if imported platform member BOMs belong to the same platform release, otherwise - false
+     */
     public boolean isAligned();
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
@@ -43,8 +43,18 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
     private final Map<AppArtifactCoords, PlatformImport> platformImports = new HashMap<>();
 
     final Map<String, String> collectedProps = new HashMap<String, String>();
+    private final Collection<AppArtifactCoords> platformBoms = new ArrayList<>();
+    private final Collection<PlatformReleaseInfo> platformReleaseInfo = new ArrayList<>();
 
     public PlatformImportsImpl() {
+    }
+
+    public Collection<PlatformReleaseInfo> getPlatformReleaseInfo() {
+        return platformReleaseInfo;
+    }
+
+    public Collection<AppArtifactCoords> getImportedPlatformBoms() {
+        return platformBoms;
     }
 
     void addPlatformRelease(String propertyName, String propertyValue) {
@@ -56,7 +66,11 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
         final String version = propertyName.substring(streamVersionSep + 1);
         allPlatformInfo.computeIfAbsent(platformKey, k -> new PlatformInfo(k)).getOrCreateStream(streamId).addIfNotPresent(
                 version,
-                () -> new PlatformReleaseInfo(platformKey, streamId, version, propertyValue));
+                () -> {
+                    final PlatformReleaseInfo ri = new PlatformReleaseInfo(platformKey, streamId, version, propertyValue);
+                    platformReleaseInfo.add(ri);
+                    return ri;
+                });
     }
 
     public void addPlatformDescriptor(String groupId, String artifactId, String classifier, String type, String version) {
@@ -66,6 +80,7 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
                 null, "pom",
                 version);
         platformImports.computeIfAbsent(bomCoords, c -> new PlatformImport()).descriptorFound = true;
+        platformBoms.add(bomCoords);
     }
 
     public void addPlatformProperties(String groupId, String artifactId, String classifier, String type, String version,


### PR DESCRIPTION
This change allows build steps to consult the collected info about the Quarkus platforms detected in an app using `CurateOutcomeBuildItem.getEffectiveAppModel().getPlatforms()`.