### PR TITLE
Document requirement for elevated shell on build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,7 @@ Do the same with _Names count to use static import with '\*'_.
 * Navigate to the directory: `cd quarkus`
 * Set Maven heap to 4GB `export MAVEN_OPTS="-Xmx4g"`
 * Invoke `./mvnw -Dquickly` from the root directory
+* _Note: On Windows, it may be necessary to run the build from an elevated shell. If you experience a failed build with the error `"A required privilege is not held by the client"`, this should fix it._
 
 ```bash
 git clone https://github.com/quarkusio/quarkus.git


### PR DESCRIPTION
See: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Development.20flow.20for.20updating.20Extension.20for.20JVM.20language.3F/near/244023777

On Windows 10, the build fails unless you run it from an elevated prompt.
I'm unsure if Windows is even regarded as a supported development platform, certainly don't blame you if it isn't.

```ps1
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:48 min
[INFO] Finished at: 2021-06-26T12:59:39-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.1.0:testResources (default-testResources) on project quarkus-kubernetes-service-binding: C:\Users\rayga\Projects\tmp\quarkus\extensions\kubernetes-service-binding\runtime\target\test-classes\k8s\test-k8s\provider: A required privilege is not held by the client.
```