### PR TITLE
Implement label-based container discovery for Redis Dev Service

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -620,6 +620,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/redis-dev-services.adoc
+++ b/docs/src/main/asciidoc/redis-dev-services.adoc
@@ -1,0 +1,37 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Dev Services for Redis
+
+:extension-status: preview
+include::./attributes.adoc[]
+
+Quarkus supports a feature called DevServices that allows you to create various datasources without any config.
+What that means practically, is that if you have docker running and have not configured `quarkus.redis.hosts`,
+Quarkus will automatically start a Redis container when running tests or dev-mode, and automatically configure the connection.
+
+Available properties to customize the Redis DevService.
+include::{generated-dir}/config/quarkus-redis-client-config-group-dev-services-config.adoc[opts=optional, leveloffset=+1]
+
+When running the production version of the application, the Redis connection need to be configured as normal,
+so if you want to include a production database config in your `application.properties` and continue to use DevServices
+we recommend that you use the `%prod.` profile to define your Redis settings.
+
+Dev Services for Redis relies on Docker to start the server.
+If your environment does not support Docker, you will need to start the server manually, or connect to an already running server.
+
+== Shared server
+
+Most of the time you need to share the server between applications.
+Dev Services for Redis implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single server.
+
+NOTE: Dev Services for Redis starts the container with the `quarkus-dev-service-redis` label which is used to identify the container.
+
+If you need multiple (shared) servers, you can configure the `quarkus.redis.devservices.service-name` attribute and indicate the server name.
+It looks for a container with the same value, or starts a new one if none can be found.
+The default service name is `redis`.
+
+Sharing is enabled by default in dev mode, but disabled in test mode.
+You can disable the sharing with `quarkus.redis.devservices.shared=false`.

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -89,6 +89,20 @@ docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name red
 If you use <<dev-services,DevServices>>, launching the container manually is not necessary!
 ====
 
+== Shared server
+
+Most of the time you need to share the server between applications.
+Dev Services for Redis implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single server.
+
+NOTE: Dev Services for Redis starts the container with the `quarkus-dev-service-redis` label which is used to identify the container.
+
+If you need multiple (shared) servers, you can configure the `quarkus.redis.devservices.service-name` attribute and indicate the server name.
+It looks for a container with the same value, or starts a new one if none can be found.
+The default service name is `redis`.
+
+Sharing is enabled by default in dev mode, but disabled in test mode.
+You can disable the sharing with `quarkus.redis.devservices.shared=false`.
+
 == Configuring Redis properties
 
 Once we have the Redis server running, we need to configure the Redis connection properties.

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -86,22 +86,8 @@ docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name red
 
 [NOTE]
 ====
-If you use <<dev-services,DevServices>>, launching the container manually is not necessary!
+If you use xref:redis-dev-services.adoc[Dev Services for Redis], launching the container manually is not necessary!
 ====
-
-== Shared server
-
-Most of the time you need to share the server between applications.
-Dev Services for Redis implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single server.
-
-NOTE: Dev Services for Redis starts the container with the `quarkus-dev-service-redis` label which is used to identify the container.
-
-If you need multiple (shared) servers, you can configure the `quarkus.redis.devservices.service-name` attribute and indicate the server name.
-It looks for a container with the same value, or starts a new one if none can be found.
-The default service name is `redis`.
-
-Sharing is enabled by default in dev mode, but disabled in test mode.
-You can disable the sharing with `quarkus.redis.devservices.shared=false`.
 
 == Configuring Redis properties
 
@@ -117,7 +103,7 @@ quarkus.redis.hosts=redis://localhost:6379 <1>
 
 [NOTE]
 ====
-This is needed if you are not using <<dev-services,DevServices>>
+This is needed if you are not using xref:redis-dev-services.adoc[Dev Services for Redis]
 ====
 
 
@@ -628,21 +614,6 @@ ReactiveRedisClient defaultReactiveRedisClient = ReactiveRedisClient.createClien
 // creating a named reactive redis client whose configuration name is "second"
 ReactiveRedisClient namedReactiveRedisClient = ReactiveRedisClient.createClient("second");
 ----
-
-
-[[dev-services]]
-=== DevServices (Configuration Free Redis)
-
-Quarkus supports a feature called DevServices that allows you to create various datasources without any config.
-What that means practically, is that if you have docker running and have not configured `quarkus.redis.hosts`,
-Quarkus will automatically start a Redis container when running tests or dev-mode, and automatically configure the connection.
-
-Available properties to customize the Redis DevService.
-include::{generated-dir}/config/quarkus-redis-client-config-group-dev-services-config.adoc[opts=optional, leveloffset=+1]
-
-When running the production version of the application, the Redis connection need to be configured as normal,
-so if you want to include a production database config in your `application.properties` and continue to use DevServices
-we recommend that you use the `%prod.` profile to define your Redis settings.
 
 [[config-reference]]
 == Configuration Reference

--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-devservices-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-devservices-common</artifactId>
+    <name>Quarkus - DevServices - Common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
@@ -1,0 +1,23 @@
+package io.quarkus.devservices.common;
+
+public class ContainerAddress {
+    private final String host;
+    private final int port;
+
+    public ContainerAddress(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUrl() {
+        return String.format("%s:%d", host, port);
+    }
+}

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -1,0 +1,61 @@
+package io.quarkus.devservices.common;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
+
+import io.quarkus.runtime.LaunchMode;
+
+public class ContainerLocator {
+
+    private static final Logger log = Logger.getLogger(ContainerLocator.class);
+    private static final BiPredicate<ContainerPort, Integer> hasMatchingPort = (containerPort,
+            port) -> containerPort.getPrivatePort() != null &&
+                    containerPort.getPublicPort() != null &&
+                    containerPort.getPrivatePort().equals(port);
+
+    private final String devServiceLabel;
+    private final int port;
+
+    public ContainerLocator(String devServiceLabel, int port) {
+        this.devServiceLabel = devServiceLabel;
+        this.port = port;
+    }
+
+    private Optional<Container> lookup(String expectedLabelValue) {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(container -> expectedLabelValue.equals(container.getLabels().get(devServiceLabel)))
+                .findAny();
+    }
+
+    private Optional<ContainerPort> getMappedPort(Container container, int port) {
+        return Arrays.stream(container.getPorts())
+                .filter(containerPort -> hasMatchingPort.test(containerPort, port))
+                .findAny();
+    }
+
+    public Optional<ContainerAddress> locateContainer(String serviceName, boolean shared, LaunchMode launchMode) {
+        if (shared && launchMode == LaunchMode.DEVELOPMENT) {
+            return lookup(serviceName)
+                    .flatMap(container -> getMappedPort(container, port)
+                            .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
+                                    .map(port -> {
+                                        final ContainerAddress containerAddress = new ContainerAddress(containerPort.getIp(),
+                                                containerPort.getPublicPort());
+                                        log.infof("Dev Services container found: %s (%s). Connecting to: %s.",
+                                                container.getId(),
+                                                container.getImage(),
+                                                containerAddress.getUrl());
+                                        return containerAddress;
+                                    })));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/extensions/devservices/pom.xml
+++ b/extensions/devservices/pom.xml
@@ -25,6 +25,7 @@
         <module>derby</module>
         <module>mssql</module>
         <module>db2</module>
+        <module>common</module>
     </modules>
 
 </project>

--- a/extensions/kafka-client/deployment/pom.xml
+++ b/extensions/kafka-client/deployment/pom.xml
@@ -53,6 +53,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/redis-client/deployment/pom.xml
+++ b/extensions/redis-client/deployment/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client</artifactId>
         </dependency>
         <dependency>

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesConfig.java
@@ -34,6 +34,33 @@ public class DevServicesConfig {
     @ConfigItem
     public OptionalInt port;
 
+    /**
+     * Indicates if the Redis server managed by Quarkus Dev Services is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services for Redis starts a new container.
+     * <p>
+     * The discovery uses the {@code quarkus-dev-service-redis} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code quarkus-dev-service-redis} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services for Redis looks for a container with the
+     * {@code quarkus-dev-service-redis} label
+     * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it
+     * starts a new container with the {@code quarkus-dev-service-redis} label set to the specified value.
+     * <p>
+     * This property is used when you need multiple shared Redis servers.
+     */
+    @ConfigItem(defaultValue = "redis")
+    public String serviceName;
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -43,11 +70,13 @@ public class DevServicesConfig {
         DevServicesConfig that = (DevServicesConfig) o;
         return enabled == that.enabled &&
                 Objects.equals(imageName, that.imageName) &&
-                Objects.equals(port, that.port);
+                Objects.equals(port, that.port) &&
+                Objects.equals(shared, that.shared) &&
+                Objects.equals(serviceName, that.serviceName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, imageName, port);
+        return Objects.hash(enabled, imageName, port, shared, serviceName);
     }
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.client.deployment;
 
 import static io.quarkus.redis.client.runtime.RedisClientUtil.isDefault;
+import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -10,7 +11,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.OptionalInt;
 
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
 import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -35,6 +39,13 @@ public class DevServicesProcessor {
     private static final String REDIS_6_ALPINE = "redis:6-alpine";
     private static final int REDIS_EXPOSED_PORT = 6379;
     private static final String REDIS_SCHEME = "redis://";
+
+    /**
+     * Label to add to shared Dev Service for Redis running in containers.
+     * This allows other applications to discover the running service and use it instead of starting a new instance.
+     */
+    private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-redis";
+
     private static final String QUARKUS = "quarkus.";
     private static final String DOT = ".";
     private static volatile List<Closeable> closeables;
@@ -76,7 +87,7 @@ public class DevServicesProcessor {
         List<Closeable> currentCloseables = new ArrayList<>();
         for (Entry<String, DevServiceConfiguration> entry : currentDevServicesConfiguration.entrySet()) {
             String connectionName = entry.getKey();
-            StartResult startResult = startContainer(connectionName, entry.getValue().devservices);
+            StartResult startResult = startContainer(connectionName, entry.getValue().devservices, launchMode.getLaunchMode());
             if (startResult == null) {
                 continue;
             }
@@ -120,7 +131,29 @@ public class DevServicesProcessor {
         }
     }
 
-    private StartResult startContainer(String connectionName, DevServicesConfig devServicesConfig) {
+    private static Container lookup(String expectedLabelValue) {
+        List<Container> containers = DockerClientFactory.lazyClient().listContainersCmd().exec();
+        for (Container container : containers) {
+            String s = container.getLabels().get(DEV_SERVICE_LABEL);
+            if (expectedLabelValue.equalsIgnoreCase(s)) {
+                return container;
+            }
+        }
+        return null;
+    }
+
+    private static ContainerPort getMappedPort(Container container, int port) {
+        for (ContainerPort p : container.getPorts()) {
+            Integer mapped = p.getPrivatePort();
+            Integer publicPort = p.getPublicPort();
+            if (mapped != null && mapped == port && publicPort != null) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private StartResult startContainer(String connectionName, DevServicesConfig devServicesConfig, LaunchMode launchMode) {
         if (!devServicesConfig.enabled) {
             // explicitly disabled
             log.debug("Not starting devservices for " + (isDefault(connectionName) ? "default redis client" : connectionName)
@@ -139,7 +172,23 @@ public class DevServicesProcessor {
 
         DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(REDIS_6_ALPINE))
                 .asCompatibleSubstituteFor(REDIS_6_ALPINE);
-        FixedPortRedisContainer redisContainer = new FixedPortRedisContainer(dockerImageName, devServicesConfig.port);
+
+        if (devServicesConfig.shared && launchMode == DEVELOPMENT) {
+            Container container = lookup(devServicesConfig.serviceName);
+            if (container != null) {
+                ContainerPort port = getMappedPort(container, REDIS_EXPOSED_PORT);
+                if (port != null) {
+                    String url = port.getIp() + ":" + port.getPublicPort();
+                    log.infof("Dev Services for Redis container found: %s (%s). "
+                                    + "Connecting to: %s.",
+                            container.getId(),
+                            container.getImage(), url);
+                    return new StartResult(url, null);
+                }
+            }
+        }
+
+        FixedPortRedisContainer redisContainer = new FixedPortRedisContainer(dockerImageName, devServicesConfig.port, launchMode == DEVELOPMENT ? devServicesConfig.serviceName : null);
         redisContainer.start();
         String redisHost = REDIS_SCHEME + redisContainer.getHost() + ":" + redisContainer.getPort();
         return new StartResult(redisHost,
@@ -169,12 +218,15 @@ public class DevServicesProcessor {
         }
     }
 
-    private static class FixedPortRedisContainer extends GenericContainer {
+    private static class FixedPortRedisContainer extends GenericContainer<FixedPortRedisContainer> {
         OptionalInt fixedExposedPort;
 
-        public FixedPortRedisContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort) {
+        public FixedPortRedisContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, String serviceName) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
+            if (serviceName != null) {
+                withLabel(DEV_SERVICE_LABEL, serviceName);
+            }
         }
 
         @Override

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/pom.xml
@@ -97,6 +97,10 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The PR started as a copy-paste solution for label-based container discovery for Redis dev service -
in order to handle: https://github.com/quarkusio/quarkus/issues/18029.

Based on these two PRs:

- Kafka: https://github.com/quarkusio/quarkus/pull/17837
- AMQP: https://github.com/quarkusio/quarkus/pull/17980

As many of you have noticed this required refactoring - so for that purpose I introduced two new classes:

- [ContainerLocator](https://github.com/quarkusio/quarkus/pull/18181/files#diff-46fcf1e20a4ba63f591741375828efe01cd293e303ff664663f4262476fb5238)
- [ContainerAddess](https://github.com/quarkusio/quarkus/pull/18181/files#diff-efd6f27826c11155e7d487d185a3eed8e0eaa230aa131ba02f87d1937da0ef06)

Both of them are located in a new module called simply: `Quarkus - DevServices - Common`.
The commits were not squashed (yet) for easier review.