### PR TITLE
Show proper error when a `@QuarkusTest` is run from a non-Quarkus project dir

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -314,6 +314,11 @@ public class QuarkusTestExtension
                         .bootstrap();
             }
 
+            if (curatedApplication.getAppModel().getUserDependencies().isEmpty()) {
+                throw new RuntimeException(
+                        "The tests were run against a directory that does not contain a Quarkus project. Please ensure that the test is configured to use the proper working directory.");
+            }
+
             Index testClassesIndex = TestClassIndexer.indexTestClasses(requiredTestClass);
             // we need to write the Index to make it reusable from other parts of the testing infrastructure that run in different ClassLoaders
             TestClassIndexer.writeIndex(testClassesIndex, requiredTestClass);


### PR DESCRIPTION
This change fixes the (not uncommon) case where the IDE picks the wrong
working directory to launch the tests.
Without this PR, Quarkus throws a totally un-actionable message
regarding SmallRye Config's inability to expand the platform
properties

Fixes: #18132