### PR TITLE
Make processing of Jackson's MismatchedInputException customizable

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderWithCustomMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ExceptionInReaderWithCustomMapperTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ExceptionInReaderWithCustomMapperTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FroMage.class, FroMageEndpoint.class, CustomMismatchedInputExceptionMapper.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.with().contentType("application/json").body("{\"name\": \"brie\"}").put("/fromage")
+                .then().statusCode(406);
+    }
+
+    @Provider
+    public static class CustomMismatchedInputExceptionMapper implements ExceptionMapper<MismatchedInputException> {
+        @Override
+        public Response toResponse(MismatchedInputException exception) {
+            return Response.status(Response.Status.NOT_ACCEPTABLE).build();
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/DefaultMismatchedInputException.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/DefaultMismatchedInputException.java
@@ -1,0 +1,13 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class DefaultMismatchedInputException
+        implements ExceptionMapper<com.fasterxml.jackson.databind.exc.MismatchedInputException> {
+
+    @Override
+    public Response toResponse(com.fasterxml.jackson.databind.exc.MismatchedInputException exception) {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
@@ -49,12 +49,7 @@ public class ServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
     @Override
     public Object readFrom(Class<Object> type, Type genericType, MediaType mediaType, ServerRequestContext context)
             throws WebApplicationException, IOException {
-        try {
-            return doReadFrom(type, genericType, context.getInputStream());
-        } catch (MismatchedInputException e) {
-            context.abortWith(Response.status(Response.Status.BAD_REQUEST).build());
-            return null;
-        }
+        return doReadFrom(type, genericType, context.getInputStream());
     }
 
     private Object doReadFrom(Class<Object> type, Type genericType, InputStream entityStream) throws IOException {


### PR DESCRIPTION
This keeps the default behavior (which `io.quarkus.resteasy.reactive.jackson.deployment.test,ExceptionInReaderTest` verifies), but allows users to now react to the exception in the normal ways

Fixes: #18184