### PR TITLE
Go back to Liquibase 4.3.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -158,7 +158,7 @@
         <jgit.version>5.12.0.202106070339-r</jgit.version>
         <flyway.version>7.10.0</flyway.version>
         <yasson.version>1.0.9</yasson.version>
-        <liquibase.version>4.4.0</liquibase.version>
+        <liquibase.version>4.3.5</liquibase.version>
         <snakeyaml.version>1.29</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <neo4j-java-driver.version>4.3.2</neo4j-java-driver.version>

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -46,7 +45,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.util.ServiceUtil;
@@ -106,7 +104,6 @@ class LiquibaseProcessor {
             BuildProducer<NativeImageResourceBuildItem> resource,
             BuildProducer<ServiceProviderBuildItem> services,
             BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitialized,
-            BuildProducer<RuntimeReinitializedClassBuildItem> runtimeReInitialized,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
 
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(liquibase.diff.compare.CompareControl.class.getName()));
@@ -115,8 +112,7 @@ class LiquibaseProcessor {
                 liquibase.change.AbstractSQLChange.class.getName(),
                 liquibase.database.jvm.JdbcConnection.class.getName()));
 
-        reflective.produce(new ReflectiveClassBuildItem(true, false, false, "liquibase.command.LiquibaseCommandFactory",
-                liquibase.command.CommandFactory.class.getName()));
+        reflective.produce(new ReflectiveClassBuildItem(true, false, false, "liquibase.command.LiquibaseCommandFactory"));
 
         reflective.produce(new ReflectiveClassBuildItem(true, true, true,
                 liquibase.parser.ChangeLogParserCofiguration.class.getName(),
@@ -184,26 +180,10 @@ class LiquibaseProcessor {
                 liquibase.sqlgenerator.SqlGenerator.class,
                 liquibase.structure.DatabaseObject.class,
                 liquibase.hub.HubService.class)
-                .forEach(t -> consumeService(t, (serviceClass, implementations) -> {
-                    services.produce(
-                            new ServiceProviderBuildItem(serviceClass.getName(), implementations.toArray(new String[0])));
-                    reflective.produce(new ReflectiveClassBuildItem(true, true, false, implementations.toArray(new String[0])));
-                }));
+                .forEach(t -> addService(services, reflective, t, false));
 
         // Register Precondition services, and the implementation class for reflection while also registering fields for reflection
-        consumeService(liquibase.precondition.Precondition.class, (serviceClass, implementations) -> {
-            services.produce(new ServiceProviderBuildItem(serviceClass.getName(), implementations.toArray(new String[0])));
-            reflective.produce(new ReflectiveClassBuildItem(true, true, true, implementations.toArray(new String[0])));
-        });
-
-        // CommandStep implementations are needed
-        consumeService(liquibase.command.CommandStep.class, (serviceClass, implementations) -> {
-            services.produce(new ServiceProviderBuildItem(serviceClass.getName(), implementations.toArray(new String[0])));
-            reflective.produce(new ReflectiveClassBuildItem(true, false, false, implementations.toArray(new String[0])));
-            for (String implementation : implementations) {
-                runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(implementation));
-            }
-        });
+        addService(services, reflective, liquibase.precondition.Precondition.class, true);
 
         // liquibase XSD
         resource.produce(new NativeImageResourceBuildItem(
@@ -227,12 +207,17 @@ class LiquibaseProcessor {
         resourceBundle.produce(new NativeImageResourceBundleBuildItem("liquibase/i18n/liquibase-core"));
     }
 
-    private void consumeService(Class<?> serviceClass, BiConsumer<Class<?>, Collection<String>> consumer) {
+    private void addService(BuildProducer<ServiceProviderBuildItem> services,
+            BuildProducer<ReflectiveClassBuildItem> reflective, Class<?> serviceClass,
+            boolean shouldRegisterFieldForReflection) {
         try {
             String service = "META-INF/services/" + serviceClass.getName();
             Set<String> implementations = ServiceUtil.classNamesNamedIn(Thread.currentThread().getContextClassLoader(),
                     service);
-            consumer.accept(serviceClass, implementations);
+            services.produce(new ServiceProviderBuildItem(serviceClass.getName(), implementations.toArray(new String[0])));
+
+            reflective.produce(new ReflectiveClassBuildItem(true, true, shouldRegisterFieldForReflection,
+                    implementations.toArray(new String[0])));
         } catch (IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -112,8 +112,6 @@ class LiquibaseProcessor {
                 liquibase.change.AbstractSQLChange.class.getName(),
                 liquibase.database.jvm.JdbcConnection.class.getName()));
 
-        reflective.produce(new ReflectiveClassBuildItem(true, false, false, "liquibase.command.LiquibaseCommandFactory"));
-
         reflective.produce(new ReflectiveClassBuildItem(true, true, true,
                 liquibase.parser.ChangeLogParserCofiguration.class.getName(),
                 liquibase.hub.HubServiceFactory.class.getName(),


### PR DESCRIPTION
Since the upgrade to Liquibase 4.4, we have some errors with their license stuff. Given we don't have the sources and things are obfuscated, it's not exactly easy to know what's going on so for now, let's go back to 4.3.5.

For the record:
```
Caused by: java.lang.NullPointerException
	at liquibase.license.pro.DaticalTrueLicenseService.licenseIsInstalled(Unknown Source)
	at liquibase.license.pro.DaticalTrueLicenseService.licenseIsValid(Unknown Source)
	at liquibase.configuration.pro.EnvironmentValueProvider.getProvidedValue(Unknown Source)
	at liquibase.configuration.LiquibaseConfiguration.getCurrentConfiguredValue(LiquibaseConfiguration.java:123)
	at liquibase.configuration.ConfigurationDefinition.getCurrentConfiguredValue(ConfigurationDefinition.java:93)
	at liquibase.configuration.ConfigurationDefinition.getCurrentValue(ConfigurationDefinition.java:61)
	at liquibase.logging.core.DefaultLogMessageFilter.filterMessage(DefaultLogMessageFilter.java:12)
	at liquibase.logging.core.AbstractLogger.filterMessage(AbstractLogger.java:92)
	at liquibase.logging.core.JavaLogger.log(JavaLogger.java:26)
	at liquibase.logging.core.AbstractLogger.info(AbstractLogger.java:50)
	at liquibase.logging.core.AbstractLogger.info(AbstractLogger.java:45)
	at liquibase.servicelocator.StandardServiceLocator.findInstances(StandardServiceLocator.java:28)
	at liquibase.plugin.AbstractPluginFactory.findAllInstances(AbstractPluginFactory.java:92)
	at liquibase.plugin.AbstractPluginFactory.getPlugin(AbstractPluginFactory.java:62)
	at liquibase.logging.core.LogServiceFactory.getDefaultLogService(LogServiceFactory.java:22)
	at liquibase.Scope.getCurrentScope(Scope.java:79)
	at liquibase.configuration.ConfigurationDefinition$Building.build(ConfigurationDefinition.java:323)
	at com.datical.liquibase.ext.config.LiquibaseProConfiguration.<clinit>(Unknown Source)
```

Note that GraalVM recommends to make `com.datical.liquibase.ext.config.LiquibaseProConfiguration` runtime initialized but it's not as easy as it seems as this class is used in a ton of clinits across the codebase.

And for now, I must admit I don't want to waste my time on this given I have absolutely no idea what's going wrong. I'll open an issue in the Liquibase tracker to see if they are willing to help.