### PR TITLE
Handle singular in Continuous Testing log lines

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -279,7 +279,8 @@ public class TestConsoleHandler implements TestListener {
                         }
                     }
                     log.error(
-                            statusFooter(RED + results.getCurrentFailedCount() + " TESTS FAILED"));
+                            statusFooter(RED + results.getCurrentFailedCount() + " "
+                                    + pluralize("TEST", "TESTS", results.getCurrentFailedCount()) + " FAILED"));
                     lastResults = String.format(
                             RED + "%d " + pluralize("test", "tests", results.getCurrentFailedCount()) + " failed"
                                     + RESET + " (" + GREEN + "%d passing" + RESET + ", " + BLUE + "%d skipped"


### PR DESCRIPTION
I missed one in the other PR, noticed while watching a video about continuous testing.