### PR TITLE
Introduce support for Kotlin Flow as return type in RESTEasy Reactive

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4805,6 +4805,11 @@
                 <artifactId>kotlinx-coroutines-jdk8</artifactId>
                 <version>${kotlin.coroutine.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-reactive</artifactId>
+                <version>${kotlin.coroutine.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.amazonaws</groupId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/pom.xml
@@ -26,6 +26,10 @@
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-jdk8</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-reactive</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/FlowToPublisherHandler.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/FlowToPublisherHandler.kt
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.reactive.server.runtime.kotlin
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asPublisher
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler
+
+class FlowToPublisherHandler : ServerRestHandler {
+
+    override fun handle(requestContext: ResteasyReactiveRequestContext?) {
+        val result = requestContext!!.result
+        if (result is Flow<*>) {
+            requestContext.result = (result as Flow<Any>) // cast needed for extension function
+                                        .asPublisher()
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/FixedHandlersChainCustomizer.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/FixedHandlersChainCustomizer.java
@@ -1,0 +1,45 @@
+package org.jboss.resteasy.reactive.server.model;
+
+import java.util.Collections;
+import java.util.List;
+import org.jboss.resteasy.reactive.common.model.ResourceClass;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public class FixedHandlersChainCustomizer implements HandlerChainCustomizer {
+
+    private List<ServerRestHandler> handlers;
+    private Phase phase;
+
+    public FixedHandlersChainCustomizer(List<ServerRestHandler> handlers, Phase phase) {
+        this.handlers = handlers;
+        this.phase = phase;
+    }
+
+    public FixedHandlersChainCustomizer() {
+    }
+
+    @Override
+    public List<ServerRestHandler> handlers(Phase phase, ResourceClass resourceClass,
+            ServerResourceMethod serverResourceMethod) {
+        if (this.phase == phase) {
+            return handlers;
+        }
+        return Collections.emptyList();
+    }
+
+    public List<ServerRestHandler> getHandlers() {
+        return handlers;
+    }
+
+    public void setHandlers(List<ServerRestHandler> handlers) {
+        this.handlers = handlers;
+    }
+
+    public Phase getPhase() {
+        return phase;
+    }
+
+    public void setPhase(Phase phase) {
+        this.phase = phase;
+    }
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/FlowResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/FlowResource.kt
@@ -1,0 +1,35 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import org.jboss.resteasy.reactive.RestSseElementType
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("flow")
+class FlowResource {
+
+    @GET
+    @Path("str")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    fun sseStrings() = flow {
+        emit("Hello")
+        emit("From")
+        emit("Kotlin")
+        emit("Flow")
+    }
+
+    @GET
+    @Path("json")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @RestSseElementType(MediaType.APPLICATION_JSON)
+    fun sseJson() = flow {
+        emit(Country("Barbados", "Bridgetown"))
+        delay(1000)
+        emit(Country("Mauritius", "Port Louis"))
+        delay(1000)
+        emit(Country("Fiji", "Suva"))
+    }
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.native.enable-https-url-handler=true
+quarkus.kafka.devservices.enabled=false
 countries/mp-rest/url=${test.url}
 
 mp.messaging.outgoing.countries-emitter.connector=smallrye-kafka

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/FlowResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/FlowResourceTest.kt
@@ -1,0 +1,50 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.test.common.http.TestHTTPResource
+import io.quarkus.test.junit.QuarkusTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.sse.SseEventSource
+
+@QuarkusTest
+class FlowResourceTest {
+
+    @TestHTTPResource("/flow")
+    var flowPath: String? = null
+
+    @Test
+    fun testSeeStrings() {
+        testSse("str", 5) {
+            assertThat(it).containsExactly("Hello", "From", "Kotlin", "Flow")
+        }
+    }
+
+    @Test
+    fun testSeeJson() {
+        testSse("json", 10) {
+            assertThat(it).containsExactly(
+                    "{\"name\":\"Barbados\",\"capital\":\"Bridgetown\"}",
+                    "{\"name\":\"Mauritius\",\"capital\":\"Port Louis\"}",
+                    "{\"name\":\"Fiji\",\"capital\":\"Suva\"}")
+        }
+    }
+
+    private fun testSse(path: String, timeout: Long, assertion: (List<String>) -> Unit) {
+        val client = ClientBuilder.newBuilder().build()
+        val target: WebTarget = client.target("$flowPath/$path")
+        SseEventSource.target(target).reconnectingEvery(Int.MAX_VALUE.toLong(), TimeUnit.SECONDS)
+                .build().use { eventSource ->
+                    val res = CompletableFuture<List<String>>()
+                    val collect = Collections.synchronizedList(ArrayList<String>())
+                    eventSource.register({ inboundSseEvent -> collect.add(inboundSseEvent.readData()) }, { throwable -> res.completeExceptionally(throwable) }) { res.complete(collect) }
+                    eventSource.open()
+                    val list = res.get(timeout, TimeUnit.SECONDS)
+                    assertion(list)
+                }
+    }
+}


### PR DESCRIPTION
What I like about this is that is reuses all the internals of RESTEasy Reactive.
A small downside is that users need to include the `kotlinx-coroutines-reactive` dependency (however there a good build time message warning about this).

It's likely a good start, but would need more testing and perhaps adaptation to fit (yet unknown) use cases

Resolves: #18201