### PR TITLE
ArC - ignore decorators during bean discovery

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -116,12 +116,17 @@ public class ArcProcessor {
     }
 
     @BuildStep
-    AdditionalBeanBuildItem quarkusApplication(CombinedIndexBuildItem combinedIndexBuildItem) {
+    AdditionalBeanBuildItem quarkusApplication(CombinedIndexBuildItem combinedIndex) {
+        List<String> quarkusApplications = new ArrayList<>();
+        for (ClassInfo quarkusApplication : combinedIndex.getIndex()
+                .getAllKnownImplementors(DotName.createSimple(QuarkusApplication.class.getName()))) {
+            if (quarkusApplication.classAnnotation(DotNames.DECORATOR) == null) {
+                quarkusApplications.add(quarkusApplication.name().toString());
+            }
+        }
         return AdditionalBeanBuildItem.builder().setUnremovable()
                 .setDefaultScope(DotName.createSimple(ApplicationScoped.class.getName()))
-                .addBeanClasses(combinedIndexBuildItem.getIndex()
-                        .getAllKnownImplementors(DotName.createSimple(QuarkusApplication.class.getName())).stream()
-                        .map(s -> s.name().toString()).toArray(String[]::new))
+                .addBeanClasses(quarkusApplications)
                 .build();
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -773,8 +773,9 @@ public class BeanDeployment {
                 continue;
             }
 
-            if (annotationStore.hasAnnotation(beanClass, DotNames.INTERCEPTOR)) {
-                // Skip interceptors
+            if (annotationStore.hasAnnotation(beanClass, DotNames.INTERCEPTOR)
+                    || annotationStore.hasAnnotation(beanClass, DotNames.DECORATOR)) {
+                // Skip interceptors and decorators
                 continue;
             }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
@@ -49,6 +49,11 @@ final class Decorators {
                 priority = annotation.value().asInt();
                 priorityDeclared = true;
             }
+            ScopeInfo scopeAnnotation = beanDeployment.getScope(annotation.name());
+            if (scopeAnnotation != null && !BuiltinScope.DEPENDENT.is(scopeAnnotation)) {
+                throw new DefinitionException(
+                        "A decorator must be @Dependent but " + decoratorClass + " declares " + scopeAnnotation.getDotName());
+            }
         }
 
         //  The set includes all bean types which are Java interfaces, except for java.io.Serializable

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/SimpleDecoratorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/SimpleDecoratorTest.java
@@ -8,6 +8,7 @@ import javax.annotation.Priority;
 import javax.decorator.Decorator;
 import javax.decorator.Delegate;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -45,6 +46,7 @@ public class SimpleDecoratorTest {
 
     }
 
+    @Dependent
     @Priority(1)
     @Decorator
     static class TrimConverterDecorator implements Converter<String> {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/NonDependentScopeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/NonDependentScopeTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class NonDependentScopeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Converter.class, DecoratorWithWrongScope.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        assertNotNull(container.getFailure());
+        assertTrue(
+                container.getFailure().getMessage()
+                        .contains(
+                                "A decorator must be @Dependent but io.quarkus.arc.test.decorators.validation.NonDependentScopeTest$DecoratorWithWrongScope declares javax.enterprise.context.ApplicationScoped"),
+                container.getFailure().getMessage());
+    }
+
+    interface Converter<T, U> {
+
+        T convert(T value);
+
+    }
+
+    @ApplicationScoped
+    @Priority(1)
+    @Decorator
+    static class DecoratorWithWrongScope implements Converter<String, String> {
+
+        @Inject
+        @Delegate
+        Converter<String, String> delegate;
+
+        @Override
+        public String convert(String value) {
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
- also fail the build if a decorator declares any other scope than
Dependent
- do not register QuarkusApplication decorators as additional beans
- resolves #18200