### PR TITLE
Qute - introduce strict rendering

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
@@ -31,7 +31,7 @@ public class PropertyNotFoundDevModeTest {
         assertEquals("Property \"foo\" not found in expression {foo.surname} in template foo on line 1",
                 RestAssured.get("test-foo").then().statusCode(200).extract().body().asString());
         assertEquals(
-                "Property \"name\" not found on base object \"java.lang.String\" in expression {bar.name} in template bar on line 1",
+                "Property \"name\" not found on the base object \"java.lang.String\" in expression {bar.name} in template bar on line 1",
                 RestAssured.get("test-bar").then().statusCode(200).extract().body().asString());
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/ReflectionResolverTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/ReflectionResolverTest.java
@@ -19,7 +19,9 @@ public class ReflectionResolverTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HelloReflect.class)
-                    .addAsResource(new StringAsset("{age}:{ping}:{noMatch}:{active}:{isActive}:{hasItem}:{item}:{age2}"),
+                    .addAsResource(
+                            new StringAsset(
+                                    "{age}:{ping}:{noMatch ?: 'NOT_FOUND'}:{active}:{isActive}:{hasItem}:{item}:{age2}"),
                             "templates/reflect.txt"));
 
     @Inject

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/CollectionTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/CollectionTemplateExtensionsTest.java
@@ -28,7 +28,7 @@ public class CollectionTemplateExtensionsTest {
     @Test
     public void testListGetByIndex() {
         assertEquals("true=true=NOT_FOUND",
-                engine.parse("{@java.util.List<Boolean> list}{list.0.booleanValue}={list[0]}={list[100]}")
+                engine.parse("{@java.util.List<Boolean> list}{list.0.booleanValue}={list[0]}={list[100] ?: 'NOT_FOUND'}")
                         .data("list", Collections.singletonList(true)).render());
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ConfigTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ConfigTemplateExtensionsTest.java
@@ -19,7 +19,7 @@ public class ConfigTemplateExtensionsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset(
-                            "{config:foo}={config:property('foo')} {config:nonExistent}={config:property('nonExistent')} {config:['foo.bar.baz']}={config:property('foo.bar.baz')} {config:['quarkus.qute.remove-standalone-lines']}={config:property('quarkus.qute.remove-standalone-lines')} {config:property(name)}"),
+                            "{config:foo}={config:property('foo')} {config:nonExistent ?: 'NOT_FOUND'}={config:property('nonExistent') ?: 'NOT_FOUND'} {config:['foo.bar.baz']}={config:property('foo.bar.baz')} {config:['quarkus.qute.remove-standalone-lines']}={config:property('quarkus.qute.remove-standalone-lines')} {config:property(name)}"),
                             "templates/foo.html")
                     .addAsResource(new StringAsset("foo=false\nfoo.bar.baz=11"), "application.properties"));
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/TemplateExtensionMethodsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/TemplateExtensionMethodsTest.java
@@ -28,7 +28,8 @@ public class TemplateExtensionMethodsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Foo.class, Extensions.class, PrioritizedExtensions.class)
-                    .addAsResource(new StringAsset("{foo.name.toLower} {foo.name.ignored} {foo.callMe(1)} {foo.baz}"),
+                    .addAsResource(
+                            new StringAsset("{foo.name.toLower} {foo.name.ignored ?: 'NOT_FOUND'} {foo.callMe(1)} {foo.baz}"),
                             "templates/foo.txt")
                     .addAsResource(new StringAsset("{baz.setScale(baz.defaultScale,roundingMode)}"),
                             "templates/baz.txt")
@@ -80,7 +81,7 @@ public class TemplateExtensionMethodsTest {
         map.put("charlie", "3");
         assertEquals("3:1:NOT_FOUND:1:false:true",
                 engine.parse(
-                        "{myMap.size}:{myMap.alpha}:{myMap.missing}:{myMap.get(key)}:{myMap.empty}:{myMap.containsKey('charlie')}")
+                        "{myMap.size}:{myMap.alpha}:{myMap.missing ?: 'NOT_FOUND'}:{myMap.get(key)}:{myMap.empty}:{myMap.containsKey('charlie')}")
                         .data("myMap", map).data("key", "alpha").render());
 
     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundNoopTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundNoopTest.java
@@ -19,7 +19,9 @@ public class PropertyNotFoundNoopTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset("foos:{foos}"), "templates/test.html")
-                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=noop"), "application.properties"));
+                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=noop"
+                            + "\nquarkus.qute.strict-rendering=false"),
+                            "application.properties"));
 
     @Inject
     Template test;

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundOutputOriginalTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundOutputOriginalTest.java
@@ -19,7 +19,8 @@ public class PropertyNotFoundOutputOriginalTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset("foos:{foos}"), "templates/test.html")
-                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=output-original"),
+                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=output-original"
+                            + "\nquarkus.qute.strict-rendering=false"),
                             "application.properties"));
 
     @Inject

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundThrowExceptionTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundThrowExceptionTest.java
@@ -23,7 +23,8 @@ public class PropertyNotFoundThrowExceptionTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset("foos:{foos}"), "templates/test.html")
-                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=throw-exception"),
+                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=throw-exception"
+                            + "\nquarkus.qute.strict-rendering=false"),
                             "application.properties"));
 
     @Inject

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/TypeCheckExcludesTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/TypeCheckExcludesTest.java
@@ -23,7 +23,8 @@ public class TypeCheckExcludesTest {
                             + "{@io.quarkus.qute.deployment.typesafe.Machine machine}"
                             + "{movie.name}::{movie.superior}::{machine.ping}::{machine.neverEver}"), "templates/movie.html")
                     .addAsResource(new StringAsset(
-                            "quarkus.qute.type-check-excludes=io.quarkus.qute.deployment.typesafe.Movie.superior,io.quarkus.qute.deployment.typesafe.Machine.*"),
+                            "quarkus.qute.type-check-excludes=io.quarkus.qute.deployment.typesafe.Movie.superior,io.quarkus.qute.deployment.typesafe.Machine.*"
+                                    + "\nquarkus.qute.strict-rendering=false"),
                             "application.properties"));
 
     @Inject

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -82,26 +82,32 @@ public class EngineProducer {
         // Note that arrays are handled specifically during validation
         builder.addValueResolver(ValueResolvers.arrayResolver());
 
-        // If needed use a specific result mapper for the selected strategy  
-        if (runtimeConfig.propertyNotFoundStrategy.isPresent()) {
-            switch (runtimeConfig.propertyNotFoundStrategy.get()) {
-                case THROW_EXCEPTION:
-                    builder.addResultMapper(new PropertyNotFoundThrowException());
-                    break;
-                case NOOP:
-                    builder.addResultMapper(new PropertyNotFoundNoop());
-                    break;
-                case OUTPUT_ORIGINAL:
-                    builder.addResultMapper(new PropertyNotFoundOutputOriginal());
-                    break;
-                default:
-                    // Use the default strategy
-                    break;
-            }
+        // Enable/disable strict rendering
+        if (runtimeConfig.strictRendering) {
+            builder.strictRendering(true);
         } else {
-            // Throw an expection in the development mode
-            if (launchMode == LaunchMode.DEVELOPMENT) {
-                builder.addResultMapper(new PropertyNotFoundThrowException());
+            builder.strictRendering(false);
+            // If needed use a specific result mapper for the selected strategy  
+            if (runtimeConfig.propertyNotFoundStrategy.isPresent()) {
+                switch (runtimeConfig.propertyNotFoundStrategy.get()) {
+                    case THROW_EXCEPTION:
+                        builder.addResultMapper(new PropertyNotFoundThrowException());
+                        break;
+                    case NOOP:
+                        builder.addResultMapper(new PropertyNotFoundNoop());
+                        break;
+                    case OUTPUT_ORIGINAL:
+                        builder.addResultMapper(new PropertyNotFoundOutputOriginal());
+                        break;
+                    default:
+                        // Use the default strategy
+                        break;
+                }
+            } else {
+                // Throw an expection in the development mode
+                if (launchMode == LaunchMode.DEVELOPMENT) {
+                    builder.addResultMapper(new PropertyNotFoundThrowException());
+                }
             }
         }
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.qute.runtime;
 
 import java.util.Optional;
 
+import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateException;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -11,10 +12,11 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class QuteRuntimeConfig {
 
     /**
-     * The strategy used if a property is not found when evaluating a standalone expression at runtime.
+     * The strategy used when a standalone expression evaluates to a "not found" value at runtime and
+     * the {@code io.quarkus.qute.strict-rendering} config property is set to {@code false}
      * <p>
-     * This strategy is not used when evaluating an expression that is used in a section parameter, e.g.
-     * <code>{#if foo.name}</code>. In such case, it's the responsibility of the section to handle this situation appropriately.
+     * This strategy is never used when evaluating section parameters, e.g. <code>{#if foo.name}</code>. In such case, it's the
+     * responsibility of the section to handle this situation appropriately.
      * <p>
      * By default, the {@code NOT_FOUND} constant is written to the output. However, in the development mode the
      * {@link PropertyNotFoundStrategy#THROW_EXCEPTION} is used by default, i.e. when the strategy is not specified.
@@ -27,6 +29,16 @@ public class QuteRuntimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean removeStandaloneLines;
+
+    /**
+     * If set to {@code true} then any expression that is evaluated to a {@link Results.NotFound} value will always result in a
+     * {@link TemplateException} and the rendering is aborted.
+     * <p>
+     * Note that the {@code quarkus.qute.property-not-found-strategy} config property is completely ignored if strict rendering
+     * is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean strictRendering;
 
     public enum PropertyNotFoundStrategy {
         /**

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletedStage.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletedStage.java
@@ -39,6 +39,10 @@ public final class CompletedStage<T> implements CompletionStage<T>, Supplier<T> 
     }
 
     public T get() {
+        if (exception != null) {
+            // Throw an exception if completed exceptionally
+            throw new TemplateException(exception);
+        }
         return result;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -62,6 +62,16 @@ public interface Engine {
     public List<ResultMapper> getResultMappers();
 
     /**
+     * Maps the given result to a string value. If no result mappers are available the {@link Object#toString()} value is used.
+     * 
+     * @param result Must not be null
+     * @param expression Must not be null
+     * @return the string value
+     * @see Engine#getResultMappers()
+     */
+    public String mapResult(Object result, Expression expression);
+
+    /**
      *
      * @param id
      * @param template

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -21,6 +21,7 @@ public final class EngineBuilder {
     Function<String, SectionHelperFactory<?>> sectionHelperFunc;
     final List<ParserHook> parserHooks;
     boolean removeStandaloneLines;
+    boolean strictRendering;
 
     EngineBuilder() {
         this.sectionHelperFactories = new HashMap<>();
@@ -29,6 +30,7 @@ public final class EngineBuilder {
         this.locators = new ArrayList<>();
         this.resultMappers = new ArrayList<>();
         this.parserHooks = new ArrayList<>();
+        this.strictRendering = true;
     }
 
     public EngineBuilder addSectionHelper(SectionHelperFactory<?> factory) {
@@ -148,6 +150,20 @@ public final class EngineBuilder {
      */
     public EngineBuilder removeStandaloneLines(boolean value) {
         this.removeStandaloneLines = value;
+        return this;
+    }
+
+    /**
+     * If set to {@code true} then any expression that is evaluated to a {@link Results.NotFound} will always result in a
+     * {@link TemplateException} and the rendering is aborted.
+     * <p>
+     * Strict rendering is enabled by default.
+     * 
+     * @param value
+     * @return self
+     */
+    public EngineBuilder strictRendering(boolean value) {
+        this.strictRendering = value;
         return this;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
@@ -19,9 +19,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import org.jboss.logging.Logger;
 
-/**
- * 
- */
 class EngineImpl implements Engine {
 
     private static final Logger LOGGER = Logger.getLogger(EngineImpl.class);
@@ -43,7 +40,7 @@ class EngineImpl implements Engine {
         this.valueResolvers = sort(builder.valueResolvers);
         this.namespaceResolvers = ImmutableList.<NamespaceResolver> builder()
                 .addAll(builder.namespaceResolvers).add(new TemplateImpl.DataNamespaceResolver()).build();
-        this.evaluator = new EvaluatorImpl(this.valueResolvers, this.namespaceResolvers);
+        this.evaluator = new EvaluatorImpl(this.valueResolvers, this.namespaceResolvers, builder.strictRendering);
         this.templates = new ConcurrentHashMap<>();
         this.locators = sort(builder.locators);
         this.resultMappers = sort(builder.resultMappers);
@@ -94,6 +91,21 @@ class EngineImpl implements Engine {
 
     public List<ResultMapper> getResultMappers() {
         return resultMappers;
+    }
+
+    @Override
+    public String mapResult(Object result, Expression expression) {
+        String val = null;
+        for (ResultMapper mapper : resultMappers) {
+            if (mapper.appliesTo(expression.getOrigin(), result)) {
+                val = mapper.map(result, expression);
+                break;
+            }
+        }
+        if (val == null) {
+            val = result.toString();
+        }
+        return val;
     }
 
     public Template putTemplate(String id, Template template) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.qute;
 
 import io.quarkus.qute.Expression.Part;
 import io.quarkus.qute.ExpressionImpl.PartImpl;
+import io.quarkus.qute.Results.NotFound;
 import io.smallrye.mutiny.Uni;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,17 +15,15 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletionStage;
 import org.jboss.logging.Logger;
 
-/**
- * 
- */
 class EvaluatorImpl implements Evaluator {
 
     private static final Logger LOGGER = Logger.getLogger(EvaluatorImpl.class);
 
     private final List<ValueResolver> resolvers;
     private final Map<String, List<NamespaceResolver>> namespaceResolvers;
+    private final boolean strictRendering;
 
-    EvaluatorImpl(List<ValueResolver> valueResolvers, List<NamespaceResolver> namespaceResolvers) {
+    EvaluatorImpl(List<ValueResolver> valueResolvers, List<NamespaceResolver> namespaceResolvers, boolean strictRendering) {
         this.resolvers = valueResolvers;
         Map<String, List<NamespaceResolver>> namespaceResolversMap = new HashMap<>();
         for (NamespaceResolver namespaceResolver : namespaceResolvers) {
@@ -45,6 +44,7 @@ class EvaluatorImpl implements Evaluator {
             }
         }
         this.namespaceResolvers = namespaceResolversMap;
+        this.strictRendering = strictRendering;
     }
 
     @Override
@@ -63,37 +63,40 @@ class EvaluatorImpl implements Evaluator {
                 // Very often a single matching resolver will be found
                 return matching.get(0).resolve(context).thenCompose(r -> {
                     if (parts.hasNext()) {
-                        return resolveReference(false, r, parts, resolutionContext);
+                        return resolveReference(false, r, parts, resolutionContext, expression);
                     } else {
                         return toCompletionStage(r);
                     }
                 });
             } else {
                 // Multiple namespace resolvers match
-                return resolveNamespace(context, resolutionContext, parts, matching.iterator());
+                return resolveNamespace(context, resolutionContext, parts, matching.iterator(), expression);
             }
         } else {
             if (expression.isLiteral()) {
                 return expression.asLiteral();
             } else {
                 parts = expression.getParts().iterator();
-                return resolveReference(true, resolutionContext.getData(), parts, resolutionContext);
+                return resolveReference(true, resolutionContext.getData(), parts, resolutionContext, expression);
             }
         }
     }
 
     private CompletionStage<Object> resolveNamespace(EvalContext context, ResolutionContext resolutionContext,
-            Iterator<Part> parts, Iterator<NamespaceResolver> resolvers) {
+            Iterator<Part> parts, Iterator<NamespaceResolver> resolvers, Expression expression) {
         NamespaceResolver resolver = resolvers.next();
         return resolver.resolve(context).thenCompose(r -> {
             if (Results.isNotFound(r)) {
                 if (resolvers.hasNext()) {
-                    return resolveNamespace(context, resolutionContext, parts, resolvers);
+                    return resolveNamespace(context, resolutionContext, parts, resolvers, expression);
                 } else {
+                    if (strictRendering && !parts.hasNext()) {
+                        throw propertyNotFound(r, expression);
+                    }
                     return Results.notFound(context);
                 }
             } else if (parts.hasNext()) {
-                return resolveReference(false, r, parts, resolutionContext);
+                return resolveReference(false, r, parts, resolutionContext, expression);
             } else {
                 return toCompletionStage(r);
             }
@@ -101,21 +104,21 @@ class EvaluatorImpl implements Evaluator {
     }
 
     private CompletionStage<Object> resolveReference(boolean tryParent, Object ref, Iterator<Part> parts,
-            ResolutionContext resolutionContext) {
+            ResolutionContext resolutionContext, final Expression expression) {
         Part part = parts.next();
         EvalContextImpl evalContext = new EvalContextImpl(tryParent, ref, part, resolutionContext);
         if (!parts.hasNext()) {
             // The last part - no need to compose
-            return resolve(evalContext, null, true);
+            return resolve(evalContext, null, true, expression, true);
         } else {
             // Next part - no need to try the parent context/outer scope
-            return resolve(evalContext, null, true)
-                    .thenCompose(r -> resolveReference(false, r, parts, resolutionContext));
+            return resolve(evalContext, null, true, expression, false)
+                    .thenCompose(r -> resolveReference(false, r, parts, resolutionContext, expression));
         }
     }
 
     private CompletionStage<Object> resolve(EvalContextImpl evalContext, Iterator<ValueResolver> resolvers,
-            boolean tryCachedResolver) {
+            boolean tryCachedResolver, final Expression expression, boolean isLastPart) {
 
         if (tryCachedResolver) {
             // Try the cached resolver first
@@ -123,7 +126,7 @@ class EvaluatorImpl implements Evaluator {
             if (cachedResolver != null && cachedResolver.appliesTo(evalContext)) {
                 return cachedResolver.resolve(evalContext).thenCompose(r -> {
                     if (Results.isNotFound(r)) {
-                        return resolve(evalContext, null, false);
+                        return resolve(evalContext, null, false, expression, isLastPart);
                     } else {
                         return toCompletionStage(r);
                     }
@@ -150,14 +153,21 @@ class EvaluatorImpl implements Evaluator {
                 return resolve(
                         new EvalContextImpl(true, parent.getData(), parent,
                                 evalContext.part),
-                        null, false);
+                        null, false, expression, isLastPart);
             }
             LOGGER.tracef("Unable to resolve %s", evalContext);
+            Object notFound;
             if (Results.isNotFound(evalContext.getBase())) {
                 // If the base is "not found" then just return it
-                return CompletedStage.of(evalContext.getBase());
+                notFound = evalContext.getBase();
+            } else {
+                notFound = Results.NotFound.from(evalContext);
             }
-            return Results.notFound(evalContext);
+            // If in strict mode then just throw an exception
+            if (strictRendering && isLastPart) {
+                throw propertyNotFound(notFound, expression);
+            }
+            return CompletedStage.of(notFound);
         }
 
         final Iterator<ValueResolver> remainingResolvers = resolvers;
@@ -165,7 +175,7 @@ class EvaluatorImpl implements Evaluator {
         return applicableResolver.resolve(evalContext).thenCompose(r -> {
             if (Results.isNotFound(r)) {
                 // Result not found - try the next resolver
-                return resolve(evalContext, remainingResolvers, false);
+                return resolve(evalContext, remainingResolvers, false, expression, isLastPart);
             } else {
                 // Cache the first resolver where a result is found
                 evalContext.setCachedResolver(foundResolver);
@@ -184,6 +194,18 @@ class EvaluatorImpl implements Evaluator {
             return ((Uni<Object>) result).subscribeAsCompletionStage();
         }
         return CompletedStage.of(result);
+    }
+
+    private static TemplateException propertyNotFound(Object result, Expression expression) {
+        String propertyMessage;
+        if (result instanceof NotFound) {
+            propertyMessage = ((NotFound) result).asMessage();
+        } else {
+            propertyMessage = "Property not found";
+        }
+        return new TemplateException(
+                String.format("%s in expression {%s} in template %s on line %s", propertyMessage, expression.toOriginalString(),
+                        expression.getOrigin().getTemplateId(), expression.getOrigin().getLine()));
     }
 
     static class EvalContextImpl implements EvalContext {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletionStage;
 
 final class ExpressionImpl implements Expression {
 
-    static final ExpressionImpl EMPTY = new ExpressionImpl(0, null, Collections.emptyList(), null, null);
+    static final ExpressionImpl EMPTY = new ExpressionImpl(0, null, Collections.emptyList(), Results.NotFound.EMPTY, null);
 
     /**
      * 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
@@ -78,7 +78,7 @@ public final class Expressions {
             if (splitConfig.isSeparator(c)) {
                 // Adjacent separators may be ignored
                 if (separator == 0 || separator != c) {
-                    if (!literal && brackets == 0) {
+                    if (!literal && brackets == 0 && infix == 0) {
                         if (splitConfig.shouldPrependSeparator(c)) {
                             buffer.append(c);
                         }
@@ -99,20 +99,27 @@ public final class Expressions {
                 }
                 // Non-separator char
                 if (!literal) {
-                    if (brackets == 0 && buffer.length() > 0 && c == ' ') {
+                    if (splitConfig.isInfixNotationSupported() && brackets == 0 && c == ' ') {
+                        // Not inside a virtual method
                         if (infix == 1) {
                             // The second space after the infix method
+                            // foo or bar
+                            // ------^
                             buffer.append(LEFT_BRACKET);
                             infix++;
                         } else if (infix == 2) {
                             // Next infix method
+                            // foo or bar or baz
+                            // ----------^
                             infix = 1;
                             buffer.append(RIGHT_BRACKET);
                             if (addPart(buffer, parts)) {
                                 buffer = new StringBuilder();
                             }
                         } else {
-                            // First space - start infix method
+                            // First space - start a new infix method
+                            // foo or bar
+                            // ---^
                             infix++;
                             if (addPart(buffer, parts)) {
                                 buffer = new StringBuilder();
@@ -120,8 +127,10 @@ public final class Expressions {
                         }
                     } else {
                         if (Parser.isLeftBracket(c)) {
+                            // Start of a virtual method
                             brackets++;
                         } else if (Parser.isRightBracket(c)) {
+                            // End of a virtual method
                             brackets--;
                         }
                         buffer.append(c);
@@ -170,6 +179,10 @@ public final class Expressions {
             return ',' == candidate;
         }
 
+        public boolean isInfixNotationSupported() {
+            return false;
+        }
+
     };
 
     private static final SplitConfig TYPE_INFO_SPLIT_CONFIG = new DefaultSplitConfig() {
@@ -213,6 +226,10 @@ public final class Expressions {
 
         default boolean shouldAppendSeparator(char candidate) {
             return false;
+        }
+
+        default boolean isInfixNotationSupported() {
+            return true;
         }
 
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Futures.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Futures.java
@@ -20,7 +20,7 @@ public final class Futures {
                 try {
                     return fu.get();
                 } catch (InterruptedException | ExecutionException e) {
-                    throw new IllegalStateException(e);
+                    throw new TemplateException(e);
                 }
             }
         };

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
@@ -49,7 +49,7 @@ final class MethodsCandidate implements AccessorCandidate {
                             }
                         }
                         // No method matches the parameter types
-                        result.complete(Results.notFound(context));
+                        result.complete(Results.NotFound.from(context));
                     }
                 });
                 return result;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultMapper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultMapper.java
@@ -3,8 +3,12 @@ package io.quarkus.qute;
 import io.quarkus.qute.TemplateNode.Origin;
 
 /**
- * The first result mapper that applies to the result object is used to map the result to the string value. The mapper with
- * higher priority wins.
+ * This component can be used to map a result of an evaluated value expression to a string value.
+ * <p>
+ * The first result mapper that applies to the result object is used. The mapper with higher priority wins.
+ * 
+ * @see Engine#getResultMappers()
+ * @see Engine#mapResult(Object, Expression)
  */
 @FunctionalInterface
 public interface ResultMapper extends WithPriority {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -177,7 +177,8 @@ public final class Results {
                 if (!(base instanceof Map)
                         // Just ignore the data map
                         || !((Map<?, ?>) base).containsKey(TemplateInstanceBase.DATA_MAP_KEY)) {
-                    builder.append(" on base object \"").append(base == null ? "null" : base.getClass().getName()).append("\"");
+                    builder.append(" on the base object \"").append(base == null ? "null" : base.getClass().getName())
+                            .append("\"");
                 }
                 return builder.toString();
             } else {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
@@ -20,14 +20,8 @@ public class SingleResultNode implements ResultNode {
         if (value != null) {
             String result = null;
             if (expressionNode != null) {
-                for (ResultMapper mapper : expressionNode.getEngine().getResultMappers()) {
-                    if (mapper.appliesTo(expressionNode.expression.getOrigin(), value)) {
-                        result = mapper.map(value, expressionNode.expression);
-                        break;
-                    }
-                }
-            }
-            if (result == null) {
+                result = expressionNode.getEngine().mapResult(value, expressionNode.expression);
+            } else {
                 result = value.toString();
             }
             consumer.accept(result);

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
@@ -79,13 +79,16 @@ public class UserTagSectionHelper implements SectionHelper {
 
         @Override
         public ParametersInfo getParameters() {
-            return ParametersInfo.builder().addParameter(new Parameter(IT, "it", false)).build();
+            return ParametersInfo.builder().addParameter(new Parameter(IT, IT, false)).build();
         }
 
         @Override
         public UserTagSectionHelper initialize(SectionInitContext context) {
             Map<String, Expression> params = new HashMap<>();
             for (Entry<String, String> entry : context.getParameters().entrySet()) {
+                if (entry.getKey().equals(IT) && entry.getValue().equals(IT)) {
+                    continue;
+                }
                 params.put(entry.getKey(), context.parseValue(entry.getValue()));
             }
             boolean isEmpty = context.getBlocks().size() == 1 && context.getBlocks().get(0).isEmpty();

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ArrayResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ArrayResolverTest.java
@@ -17,7 +17,13 @@ public class ArrayResolverTest {
         assertEquals("3", engine.parse("{array.length}").data("array", int1).render());
         assertEquals("2", engine.parse("{array.1}").data("array", int1).render());
         assertEquals("3", engine.parse("{array.get(2)}").data("array", int1).render());
-        assertEquals("NOT_FOUND", engine.parse("{array.get('foo')}").data("array", int1).render());
+        try {
+            fail(engine.parse("{array.get('foo')}").data("array", int1).render());
+        } catch (TemplateException expected) {
+            assertEquals(
+                    "Method \"get('foo')\" not found on the base object \"[I\" in expression {array.get('foo')} in template 4 on line 1",
+                    expected.getMessage());
+        }
         assertEquals("3", engine.parse("{array.get(last)}").data("array", int1, "last", 2).render());
         assertEquals("1", engine.parse("{array[0]}").data("array", int1).render());
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/EngineTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/EngineTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.qute.TemplateNode.Origin;
+import org.junit.jupiter.api.Test;
+
+public class EngineTest {
+
+    @Test
+    public void testMapResut() {
+        Engine engine = Engine.builder().addResultMapper((res, expr) -> "FOO").addResultMapper(new ResultMapper() {
+
+            @Override
+            public int getPriority() {
+                // Is executed before the FOO mapper
+                return 10;
+            }
+
+            @Override
+            public boolean appliesTo(Origin origin, Object result) {
+                return result instanceof Integer;
+            }
+
+            @Override
+            public String map(Object result, Expression expression) {
+                return "" + ((Integer) result) * 10;
+            }
+        }).build();
+        Template test = engine.parse("{foo}");
+        assertEquals("50",
+                engine.mapResult(5, test.getExpressions().iterator().next()));
+        assertEquals("FOO",
+                engine.mapResult("bar", test.getExpressions().iterator().next()));
+    }
+
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
@@ -58,8 +58,16 @@ public class ExpressionTest {
         } catch (TemplateException expected) {
             assertTrue(expected.getMessage().contains("Non-literal value"));
         }
-        //verify("name[1l]['foo']", null, null, name("name"), name("1"), name("foo"));
+        verify("name[1l]['foo']", null, null, name("name"), name("1"), name("foo"));
         verify("foo[\"name.dot\"].value", null, null, name("foo"), name("name.dot"), name("value"));
+        verify("list[100] or 'NOT_FOUND'", null, null, name("list"), name("100"),
+                virtualMethod("or", ExpressionImpl.literalFrom(-1, "'NOT_FOUND'")));
+        verify("hero.name.isBlank ? hulk.name : hero.name", null, null, name("hero"), name("name"), name("isBlank"),
+                virtualMethod("?", ExpressionImpl.from("hulk.name")),
+                virtualMethod(":", ExpressionImpl.from("hero.name")));
+        verify("hero.name.isBlank ? 'Hulk' : hero.name", null, null, name("hero"), name("name"), name("isBlank"),
+                virtualMethod("?", ExpressionImpl.literalFrom(-1, "'Hulk'")),
+                virtualMethod(":", ExpressionImpl.from("hero.name")));
     }
 
     @Test

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IfSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IfSectionTest.java
@@ -73,9 +73,9 @@ public class IfSectionTest {
     public void testCompositeParameters() {
         Engine engine = Engine.builder().addDefaults().build();
         assertEquals("OK", engine.parse("{#if (true || false) && true}OK{/if}").render());
-        assertEquals("OK", engine.parse("{#if (foo || false || true) && (true)}OK{/if}").render());
-        assertEquals("NOK", engine.parse("{#if foo || false}OK{#else}NOK{/if}").render());
-        assertEquals("OK", engine.parse("{#if false || (foo || (false || true))}OK{#else}NOK{/if}").render());
+        assertEquals("OK", engine.parse("{#if (foo.or(false) || false || true) && (true)}OK{/if}").render());
+        assertEquals("NOK", engine.parse("{#if foo.or(false) || false}OK{#else}NOK{/if}").render());
+        assertEquals("OK", engine.parse("{#if false || (foo.or(false) || (false || true))}OK{#else}NOK{/if}").render());
         assertEquals("NOK", engine.parse("{#if (true && false)}OK{#else}NOK{/if}").render());
         assertEquals("OK", engine.parse("{#if true && true}OK{#else}NOK{/if}").render());
         assertEquals("NOK", engine.parse("{#if true && false}OK{#else}NOK{/if}").render());
@@ -181,8 +181,8 @@ public class IfSectionTest {
         assertEquals("0", engine.parse("{#if arrayEmpty && name}1{#else}0{/if}").render(data));
         assertEquals("1", engine.parse("{#if array && intTwo}1{#else}0{/if}").render(data));
         assertEquals("1", engine.parse("{#if (array && intZero) || true}1{#else}0{/if}").render(data));
-        assertEquals("0", engine.parse("{#if nonExistent}1{#else}0{/if}").render(data));
-        assertEquals("1", engine.parse("{#if !nonExistent}1{#else}0{/if}").render(data));
+        assertEquals("0", engine.parse("{#if nonExistent.or(false)}1{#else}0{/if}").render(data));
+        assertEquals("1", engine.parse("{#if !nonExistent.or(false)}1{#else}0{/if}").render(data));
     }
 
     @Test

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
@@ -22,25 +22,25 @@ public class LoopSectionTest {
         Map<String, String> item = new HashMap<>();
         item.put("name", "Lu");
 
-        List<Map<String, String>> listOfMaps = new ArrayList<>();
-        listOfMaps.add(item);
-        listOfMaps.add(new HashMap<>());
+        List<Map<String, String>> items = new ArrayList<>();
+        items.add(item);
+        items.add(new HashMap<>());
 
         Engine engine = Engine.builder()
                 .addSectionHelper(new IfSectionHelper.Factory())
                 .addSectionHelper(new LoopSectionHelper.Factory()).addDefaultValueResolvers()
                 .build();
 
-        Template template = engine.parse("{#for item in this}{count}.{item.name}{#if hasNext}\n{/if}{/for}");
-        assertEquals("1.Lu\n2.NOT_FOUND", template.render(listOfMaps));
+        Template template = engine.parse("{#for item in this}{count}.{item.name ?: 'NOT_FOUND'}{#if hasNext}\n{/if}{/for}");
+        assertEquals("1.Lu\n2.NOT_FOUND", template.render(items));
 
-        template = engine.parse("{#each this}{count}.{it.name}{#if hasNext}\n{/if}{/each}");
+        template = engine.parse("{#each this}{count}.{it.name ?: 'NOT_FOUND'}{#if hasNext}\n{/if}{/each}");
         assertEquals("1.Lu\n2.NOT_FOUND",
-                template.render(listOfMaps));
+                template.render(items));
 
         template = engine.parse("{#each this}{#if odd}odd{#else}even{/if}{/each}");
         assertEquals("oddeven",
-                template.render(listOfMaps));
+                template.render(items));
     }
 
     @Test
@@ -152,7 +152,7 @@ public class LoopSectionTest {
 
     @Test
     public void testNotFound() {
-        Engine engine = Engine.builder().addDefaults().build();
+        Engine engine = Engine.builder().addDefaults().strictRendering(false).build();
         try {
             engine.parse("{#for i in items}{i}:{/for}").render();
             fail();
@@ -169,7 +169,7 @@ public class LoopSectionTest {
         final HashMap<String, Object> data = new HashMap<>();
         data.put("dependencies", Arrays.asList(dep1, new HashMap<>()));
         data.put("version", "hellllllo");
-        Engine engine = Engine.builder().addDefaults().build();
+        Engine engine = Engine.builder().strictRendering(false).addDefaults().build();
         String result = engine.parse("{#for dep in dependencies}{#if dep.version}<version>{dep.version}</version>{/if}{/for}")
                 .render(data);
         assertFalse(result.contains("hellllllo"), result);

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.quarkus.qute.Results.Result;
 import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +41,7 @@ public class NamespaceResolversTest {
                     return "foo1";
                 }).build()).addNamespaceResolver(NamespaceResolver.builder("foo").priority(50).resolve(e -> {
                     // This one should we used first but returns NOT_FOUND and so the other resolver is used
-                    return Result.NOT_FOUND;
+                    return Results.NotFound.from(e);
                 }).build()).build();
         assertEquals("FOO1", engine.parse("{foo:baz.toUpperCase}").render());
     }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ReflectionResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ReflectionResolverTest.java
@@ -33,7 +33,7 @@ public class ReflectionResolverTest {
     @Test
     public void testMethodWithParameterNotFound() {
         assertEquals("NOT_FOUND", Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build()
-                .parse("{foo.computeLength(true)}").data("foo", new Foo("box")).render());
+                .parse("{foo.computeLength(true) ?: 'NOT_FOUND'}").data("foo", new Foo("box")).render());
     }
 
     @Test

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
@@ -10,14 +10,15 @@ public class SetSectionTest {
     public void testSet() {
         Engine engine = Engine.builder().addDefaults().build();
         assertEquals("NOT_FOUND - true:mix",
-                engine.parse("{foo} - {#set foo=true bar='mix'}{foo}:{bar}{/}").render());
+                engine.parse("{foo ?: 'NOT_FOUND'} - {#set foo=true bar='mix'}{foo}:{bar}{/}").render());
     }
 
     @Test
     public void testLet() {
         Engine engine = Engine.builder().addDefaults().build();
         assertEquals("NOT_FOUND:what?! - true:mix:what?!",
-                engine.parse("{foo}:{baz} - {#let foo=true bar='mix'}{foo}:{bar}:{baz}{/}").data("baz", "what?!").render());
+                engine.parse("{foo ?: 'NOT_FOUND'}:{baz} - {#let foo=true bar='mix'}{foo}:{bar}:{baz}{/}").data("baz", "what?!")
+                        .render());
     }
 
     @Test

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
@@ -145,7 +145,7 @@ public class SimpleTest {
     @Test
     public void testNotFound() {
         assertEquals("Property \"foo\" not found in foo.bar Collection size: 0",
-                Engine.builder().addDefaultValueResolvers()
+                Engine.builder().strictRendering(false).addDefaultValueResolvers()
                         .addResultMapper(new ResultMapper() {
 
                             public int getPriority() {
@@ -193,7 +193,7 @@ public class SimpleTest {
     @Test
     public void testNotFoundThrowException() {
         try {
-            Engine.builder().addDefaults()
+            Engine.builder().strictRendering(false).addDefaults()
                     .addResultMapper(new ResultMapper() {
 
                         public boolean appliesTo(Origin origin, Object val) {

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/StrictRenderingTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/StrictRenderingTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.qute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class StrictRenderingTest {
+
+    @Test
+    public void testStrictRendering() {
+        Engine engine = Engine.builder().strictRendering(true).addDefaults().addValueResolver(new ReflectionValueResolver())
+                .build();
+        Hero hero = new Hero();
+        hero.names = "John,Andy";
+        try {
+            engine.parse("{#if hero.nams}OK{/if}", null, "hero1").data("hero", hero).render();
+            fail();
+        } catch (TemplateException expected) {
+            assertEquals(
+                    "Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams} in template hero1 on line 1",
+                    expected.getMessage());
+        }
+        try {
+            engine.parse("{hero.nams}", null, "hero2").data("hero", hero).render();
+            fail();
+        } catch (TemplateException expected) {
+            assertEquals(
+                    "Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams} in template hero2 on line 1",
+                    expected.getMessage());
+        }
+        assertEquals(
+                "John,Andy",
+                engine.parse("{hero.names}", null, "hero3").data("hero", hero).render());
+    }
+
+    public static class Hero {
+
+        public String names;
+
+    }
+
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
@@ -15,7 +15,7 @@ public class UserTagTest {
                 .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
                 .build();
 
-        Template tag = engine.parse("{#if showImage}{it.name}{#else}nope{/if}");
+        Template tag = engine.parse("{#if showImage.or(false)}{it.name}{#else}nope{/if}");
         engine.putTemplate("my-tag-id", tag);
 
         Map<String, Object> order = new HashMap<>();
@@ -36,7 +36,7 @@ public class UserTagTest {
                 .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
                 .build();
 
-        Template tag = engine.parse("{#if showImage}<b>{nested-content}</b>{#else}nope{/if}");
+        Template tag = engine.parse("{#if showImage.or(false)}<b>{nested-content}</b>{#else}nope{/if}");
         engine.putTemplate("my-tag-id", tag);
 
         Map<String, Object> order = new HashMap<>();

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/WhenSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/WhenSectionTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +56,12 @@ public class WhenSectionTest {
         assertEquals("0", template.data("state", State.OFF).render());
         assertEquals("-1", template.data("state", State.BROKEN).render());
         assertEquals("none", template.data("state", State.UNKNOWN).render());
-        assertEquals("none", template.data("state", null).render());
+        try {
+            fail(template.data("state", null).render());
+        } catch (TemplateException expected) {
+            assertEquals("Property \"ON\" not found in expression {ON} in template <<synthetic>> on line 0",
+                    expected.getMessage());
+        }
     }
 
     @Test
@@ -66,7 +72,12 @@ public class WhenSectionTest {
         assertEquals("valid", template.data("state", State.OFF).render());
         assertEquals("invalid", template.data("state", State.BROKEN).render());
         assertEquals("none", template.data("state", State.UNKNOWN).render());
-        assertEquals("none", template.data("state", null).render());
+        try {
+            fail(template.data("state", null).render());
+        } catch (TemplateException expected) {
+            assertEquals("Property \"ON\" not found in expression {ON} in template <<synthetic>> on line 0",
+                    expected.getMessage());
+        }
     }
 
     @Test
@@ -104,6 +115,22 @@ public class WhenSectionTest {
         assertEquals("Not in!", templateNotIn.data("testVal", "foos").data("itemName", null).render());
         assertEquals("Not in!", templateNotIn.data("testVal", "bazz").data("itemName", "baz").render());
         assertEquals("In!", templateNotIn.data("testVal", "baz").data("itemName", "baz").render());
+    }
+
+    @Test
+    public void testWhenNotFound() {
+        Engine engine = Engine.builder().addDefaults().build();
+        Template template = engine.parse("{#when testMe}"
+                + "{#is not 'foo'}"
+                + "Not a Foo"
+                + "{#else}"
+                + "Foo"
+                + "{/when}");
+        try {
+            fail(template.render());
+        } catch (TemplateException expected) {
+            assertEquals("Property \"testMe\" not found in expression {testMe} in template 1 on line 1", expected.getMessage());
+        }
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/WithSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/WithSectionTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,14 @@ public class WithSectionTest {
         map.put("key", "val");
         data.put("map", map);
         assertEquals("val", template.render(data));
+    }
+
+    @Test
+    public void testWithResultNotFound() {
+        try {
+            fail(Engine.builder().addDefaults().build().parse("{#with something}{key}{/with}").render());
+        } catch (TemplateException expected) {
+        }
     }
 
 }

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
@@ -110,17 +110,19 @@ public class SimpleGeneratorTest {
         assertEquals(" FOO ", engine.parse("{#if !items} {name.toUpperCase} {/if}").render(new MyService()));
         assertEquals("OK", engine.parse("{#if this.getList(5).size == 5}OK{/if}").render(new MyService()));
         assertEquals("2", engine.parse("{this.getListVarargs('foo','bar').size}").render(new MyService()));
-        assertEquals("NOT_FOUND", engine.parse("{this.getAnotherTestName(1)}").render(new MyService()));
+        assertEquals("NOT_FOUND", engine.parse("{this.getAnotherTestName(1).or('NOT_FOUND')}").render(new MyService()));
         assertEquals("Martin NOT_FOUND OK NOT_FOUND",
-                engine.parse("{name} {surname} {isStatic ?: 'OK'} {base}").render(new PublicMyService()));
-        assertEquals("foo NOT_FOUND", engine.parse("{id} {bar}").render(new MyItem()));
+                engine.parse("{name} {surname.or('NOT_FOUND')} {isStatic ?: 'OK'} {base.or('NOT_FOUND')}")
+                        .render(new PublicMyService()));
+        assertEquals("foo NOT_FOUND", engine.parse("{id} {bar.or('NOT_FOUND')}").render(new MyItem()));
         // Param types don't match - NOT_FOUND
-        assertEquals("NOT_FOUND", engine.parse("{this.getList(5,5)}").render(new MyService()));
+        assertEquals("NOT_FOUND", engine.parse("{this.getList(5,5).or('NOT_FOUND')}").render(new MyService()));
         // Test multiple extension methods with the same number of parameters
         assertEquals("1", engine.parse("{service.getDummy(5,2l).size}").data("service", new MyService()).render());
         // No extension method matches the param types
         assertEquals("NOT_FOUND",
-                engine.parse("{service.getDummy(5,resultNotFound)}").data("service", new MyService()).render());
+                engine.parse("{service.getDummy(5,resultNotFound.or(false)).or('NOT_FOUND')}").data("service", new MyService())
+                        .render());
         // Extension method with varargs
         assertEquals("alphabravo",
                 engine.parse("{#each service.getDummyVarargs(5,'alpha','bravo')}{it}{/}").data("service", new MyService())

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
@@ -47,9 +47,14 @@ final class QuteCodestartFileReader implements CodestartFileReader {
     public static String readQuteFile(CodestartResource projectResource, Source source, String languageName,
             Map<String, Object> data) {
         final String content = source.read();
+        final String templateId = source.absolutePath();
         final Engine engine = Engine.builder().addDefaults()
                 .addResultMapper(new MissingValueMapper())
                 .removeStandaloneLines(true)
+                // For now we need to disable strict rendering for codestarts
+                // A param of an {#if} section is not considered falsy if the value represents a "not found" result
+                // https://github.com/quarkusio/quarkus/pull/18227#discussion_r662301281
+                .strictRendering(false)
                 .addLocator(
                         id -> findIncludeTemplate(source.getCodestartResource(), languageName, id)
                                 .map(IncludeTemplateLocation::new))
@@ -59,7 +64,7 @@ final class QuteCodestartFileReader implements CodestartFileReader {
                 .addLocator(id -> Optional.of(new FallbackTemplateLocation()))
                 .build();
         try {
-            return engine.parse(content).render(data);
+            return engine.parse(content, null, templateId).render(data);
         } catch (Exception e) {
             throw new CodestartException("Error while rendering template: " + source.absolutePath(), e);
         }


### PR DESCRIPTION
- i.e. if any expression is evaluated to "not found" value a
TemplateException is thrown and rendering is aborted
- it's enabled by default
- it can be disabled via io.quarkus.qute.strict-rendering=false