### PR TITLE
Prefer workspace POMs for quarkus:dependency-tree goal

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -80,6 +80,7 @@ public class DependencyTreeMojo extends AbstractMojo {
                         .setRemoteRepositoryManager(bootstrapProvider.remoteRepositoryManager())
                         //.setRepositorySystemSession(repoSession) the session should be initialized with the loaded workspace
                         .setRemoteRepositories(repos)
+                        .setPreferPomsFromWorkspace(true)
                         .build()
                 : resolver;
     }


### PR DESCRIPTION
This adds support for executing `mvn quarkus:dependency-tree` for a project that hasn't been built yet.