### PR TITLE
Write image ID and digest files when building with Jib

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -139,4 +139,18 @@ public class JibConfig {
      */
     @ConfigItem
     public Optional<Set<String>> platforms;
+
+    /**
+     * The path of a file that will be written containing the digest of the generated image.
+     * If the path is relative, is writen to the output directory of the build tool
+     */
+    @ConfigItem(defaultValue = "jib-image.digest")
+    public String imageDigestFile;
+
+    /**
+     * The path of a file that will be written containing the id of the generated image.
+     * If the path is relative, is writen to the output directory of the build tool
+     */
+    @ConfigItem(defaultValue = "jib-image.id")
+    public String imageIdFile;
 }

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
@@ -1,5 +1,7 @@
 import io.quarkus.deployment.util.ExecUtil
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
 try {
@@ -13,16 +15,29 @@ String group = System.getProperty("user.name")
 assert ExecUtil.exec("docker", "images", group + "/container-build-jib")
 assert ExecUtil.exec("docker", "rmi", group + "/container-build-jib:0.1-SNAPSHOT")
 
-File propertiesFile =
-        System.getProperty("user.dir").endsWith("maven-invoker-way")
-                ? Paths.get("target", "it", "container-build-jib", "target", "quarkus-artifact.properties").toFile()
-                : Paths.get("integration-tests", "container-image", "maven-invoker-way", "target", "it", "container-build-jib", "target", "quarkus-artifact.properties").toFile()
+
+Path pathInIT = Paths.get("target", "it", "container-build-jib", "target")
+Path target;
+String userDir = System.getProperty("user.dir")
+if (userDir.endsWith("maven-invoker-way")) {
+    target = pathInIT
+} else if (userDir.endsWith("integration-tests")) {
+    target = Paths.get("container-image", "maven-invoker-way").resolve(pathInIT)
+} else { // we are in the quarkus root
+    target = Paths.get("integration-tests", "container-image", "maven-invoker-way").resolve(pathInIT)
+}
+
+assert Files.exists(target.toAbsolutePath())
+
+File propertiesFile = target.resolve("quarkus-artifact.properties").toFile()
 Properties properties = new Properties()
 propertiesFile.withInputStream {
     properties.load(it)
 }
 
-
-
 assert properties.type == 'jar-container'
 assert properties."metadata.container-image" == group + "/container-build-jib:0.1-SNAPSHOT"
+
+
+assert Files.exists(target.resolve("jib-image.digest"))
+assert Files.exists(target.resolve("jib-image.id"))


### PR DESCRIPTION
These files are also generated by the jib maven plugin
so users expect it to be found.
The configuration used here uses the same defaults as the
jib maven plugin does.

Resolves: #18233