### PR TITLE
Ensure YAML configuration is taken into account for DynamicFeatures

### DIFF
--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -7,6 +7,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalBootstrapConfigSourceProviderBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.StaticInitConfigSourceProviderBuildItem;
 
 public final class ConfigYamlProcessor {
 
@@ -17,10 +18,15 @@ public final class ConfigYamlProcessor {
 
     @BuildStep
     public void bootstrap(
-            BuildProducer<AdditionalBootstrapConfigSourceProviderBuildItem> additionalBootstrapConfigSourceProvider) {
+            BuildProducer<AdditionalBootstrapConfigSourceProviderBuildItem> additionalBootstrapConfigSourceProvider,
+            BuildProducer<StaticInitConfigSourceProviderBuildItem> staticInitConfigSourceProvider) {
         additionalBootstrapConfigSourceProvider.produce(new AdditionalBootstrapConfigSourceProviderBuildItem(
                 ApplicationYamlConfigSourceLoader.InFileSystem.class.getName()));
         additionalBootstrapConfigSourceProvider.produce(new AdditionalBootstrapConfigSourceProviderBuildItem(
+                ApplicationYamlConfigSourceLoader.InClassPath.class.getName()));
+        staticInitConfigSourceProvider.produce(new StaticInitConfigSourceProviderBuildItem(
+                ApplicationYamlConfigSourceLoader.InFileSystem.class.getName()));
+        staticInitConfigSourceProvider.produce(new StaticInitConfigSourceProviderBuildItem(
                 ApplicationYamlConfigSourceLoader.InClassPath.class.getName()));
     }
 

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerDynamicFeature.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerDynamicFeature.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.smallrye.config;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Provider
+public class ServerDynamicFeature implements DynamicFeature {
+
+    @Inject
+    @ConfigProperty(name = "server.info.version")
+    Instance<String> version;
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {
+        if (ServerResource.class.equals(resourceInfo.getResourceClass())
+                && resourceInfo.getResourceMethod().getName().equals("info")) {
+            featureContext.register(new ServerFilter(version.get()));
+        }
+    }
+}

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerFilter.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerFilter.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.smallrye.config;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+@Priority(1001)
+public class ServerFilter implements ContainerResponseFilter {
+    private final String version;
+
+    public ServerFilter(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
+        containerResponseContext.getHeaders().add("X-VERSION", version);
+    }
+}

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerResource.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/ServerResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.smallrye.config;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -10,6 +11,7 @@ import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.smallrye.config.ConfigValidationException;
 import io.smallrye.config.SmallRyeConfig;
@@ -23,6 +25,9 @@ public class ServerResource {
     @Inject
     @ConfigProperties
     ServerProperties serverProperties;
+    @Inject
+    @ConfigProperty(name = "server.info.message")
+    Instance<String> message;
 
     @GET
     public Response getServer() {
@@ -53,5 +58,11 @@ public class ServerResource {
         }
 
         return Response.serverError().build();
+    }
+
+    @GET
+    @Path("/info")
+    public String info() {
+        return message.get();
     }
 }

--- a/integration-tests/smallrye-config/src/main/resources/application.yaml
+++ b/integration-tests/smallrye-config/src/main/resources/application.yaml
@@ -75,3 +75,8 @@ cloud:
 profile:
   main:
     yaml: main
+
+server:
+  info:
+    message: My application info
+    version: 1.2.3.4

--- a/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/ServerResourceTest.java
+++ b/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/ServerResourceTest.java
@@ -5,6 +5,7 @@ import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -65,6 +66,16 @@ class ServerResourceTest {
                 .statusCode(OK.getStatusCode())
                 .body("host", equalTo("localhost"))
                 .body("port", equalTo(8080));
+    }
+
+    @Test
+    void info() {
+        given()
+                .get("/server/info")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .header("X-VERSION", "1.2.3.4")
+                .body(containsString("My application info"));
     }
 
     @Test


### PR DESCRIPTION
fixes #18237 

## Motivation

Value of properties defined into a YAML file cannot be used anymore since Quarkus 2.0 in case of JAX-RS `DynamicFeature`s

## Modifications:

* Adds a test case showing the problem
* Proposes a potential fix to define the `ConfigPropertyProvider` of the yaml extension as `StaticInitConfigSourceProviderBuildItem ` 