### PR TITLE
Update tests  for Hibernate Reactive

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiMutinySessionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -22,20 +23,19 @@ public class SinglePersistenceUnitCdiMutinySessionTest {
                     .addAsResource("application.properties"));
 
     @Inject
-    Mutiny.Session session;
+    Mutiny.SessionFactory sessionFactory;
 
     @Test
     @ActivateRequestContext
     public void test() {
         DefaultEntity entity = new DefaultEntity("default");
 
-        DefaultEntity retrievedEntity = session.withTransaction(tx -> session.persist(entity))
-                .chain(() -> session.withTransaction(tx -> session.clear().find(DefaultEntity.class, entity.getId())))
+        DefaultEntity retrievedEntity = sessionFactory.withTransaction((session, tx) -> session.persist(entity))
+                .chain(() -> sessionFactory.withSession(session -> session.find(DefaultEntity.class, entity.getId())))
                 .await().indefinitely();
 
         assertThat(retrievedEntity)
                 .isNotSameAs(entity)
                 .returns(entity.getName(), DefaultEntity::getName);
     }
-
 }

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitCdiStageSessionTest.java
@@ -25,6 +25,23 @@ public class SinglePersistenceUnitCdiStageSessionTest {
     @Inject
     Stage.Session session;
 
+    @Inject
+    Stage.SessionFactory sessionFactory;
+
+    @Test
+    @ActivateRequestContext
+    public void testWithFactory() {
+        DefaultEntity entity = new DefaultEntity("default");
+
+        DefaultEntity retrievedEntity = sessionFactory.withTransaction((session, tx) -> session.persist(entity))
+                .thenCompose(v -> sessionFactory.withSession(session -> session.find(DefaultEntity.class, entity.getId())))
+                .toCompletableFuture().join();
+
+        assertThat(retrievedEntity)
+                .isNotSameAs(entity)
+                .returns(entity.getName(), DefaultEntity::getName);
+    }
+
     @Test
     @Disabled("#14812: We're getting a ContextNotActiveException for some (unknown) reason")
     @ActivateRequestContext


### PR DESCRIPTION
Injecting the session instead of the session factory is discouraged and it doesn't work in the IDE.
I've update them so that they use the session factory instead.