### PR TITLE
Micrometer: Pause briefly in CI tests to allow request threads to settle

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
@@ -86,8 +86,9 @@ public class UriTagCorsTest {
                 .when().options("/hello/world").then()
                 .statusCode(200);
 
-        // Make sure other threads have time to finish
-        Thread.sleep(3);
+        // Try to let metrics gathering finish.
+        // Looking for 3 timers: uri=/cors-preflight, uri=/vertx/echo/{msg}, uri=/hello/{message}
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 3);
 
         // CORS pre-flight
         Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/cors-preflight").timers().size(),

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpApplicationRootTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpApplicationRootTest.java
@@ -67,6 +67,12 @@ public class UriTagWithHttpApplicationRootTest {
         when().get("/foo/bar/async-ping/two").then().statusCode(200);
         when().get("/foo/bar/async-ping/three").then().statusCode(200);
 
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 5);
+        Util.waitForMeters(registry.find("http.client.requests").timers(), 1);
+
+        System.out.println("Server paths\n" + Util.listMeters(registry, "http.server.requests"));
+        System.out.println("Client paths\n" + Util.listMeters(registry, "http.client.requests"));
+
         // Application Path does not apply to non-rest endpoints: /vertx/item/{id}, /servlet
         Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/vertx/item/{id}").timers().size(),
                 Util.foundServerRequests(registry,

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpRootTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithHttpRootTest.java
@@ -63,6 +63,9 @@ public class UriTagWithHttpRootTest {
         when().get("/foo/async-ping/two").then().statusCode(200);
         when().get("/foo/async-ping/three").then().statusCode(200);
 
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 5);
+        Util.waitForMeters(registry.find("http.client.requests").timers(), 1);
+
         System.out.println("Server paths\n" + Util.listMeters(registry, "http.server.requests"));
         System.out.println("Client paths\n" + Util.listMeters(registry, "http.client.requests"));
 

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/Util.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/Util.java
@@ -1,6 +1,7 @@
 package io.quarkus.micrometer.test;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
@@ -52,5 +53,12 @@ public class Util {
                     return x.getId().getTag(tag);
                 })
                 .collect(Collectors.joining(","));
+    }
+
+    public static <T> void waitForMeters(Collection<T> collection, int count) throws InterruptedException {
+        int i = 0;
+        do {
+            Thread.sleep(3);
+        } while (collection.size() < count && i++ < 10);
     }
 }


### PR DESCRIPTION
Relevant when using in-memory registry.

Manifests as this intermittent failure: 
```
org.opentest4j.AssertionFailedError: 
/hello/{message} for options request
Found:
MeterId{name='http.server.requests', tags=[tag(method=OPTIONS),tag(outcome=SUCCESS),tag(status=200),tag(uri=/cors-preflight)]}
MeterId{name='http.server.requests', tags=[tag(method=OPTIONS),tag(outcome=SUCCESS),tag(status=200),tag(uri=/vertx/echo/{msg})]} ==> expected: <1> but was: <0>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:542)
	at io.quarkus.micrometer.deployment.binder.UriTagCorsTest.testCORSPreflightRequest(UriTagCorsTest.java:102)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
```

https://github.com/quarkusio/quarkus/pull/18211#issuecomment-870239413