### PR TITLE
Add option to run OpenAPI filter on every request

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-config.version>2.3.0</smallrye-config.version>
         <smallrye-health.version>3.1.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.6</smallrye-open-api.version>
+        <smallrye-open-api.version>2.1.7</smallrye-open-api.version>
         <smallrye-graphql.version>1.2.5</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -22,6 +22,12 @@ public final class SmallRyeOpenApiConfig {
     public Optional<Path> storeSchemaDirectory;
 
     /**
+     * Do not run the filter only at startup, but every time the document is requested (dynamic).
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean alwaysRunFilter;
+
+    /**
      * Add a certain SecurityScheme with config
      */
     public Optional<SecurityScheme> securityScheme;

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyDynamicOASFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyDynamicOASFilter.java
@@ -1,0 +1,19 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+/**
+ * Filter that count version
+ */
+public class MyDynamicOASFilter implements OASFilter {
+
+    private static int counter = 0;
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        String version = "3.0." + counter++;
+        openAPI.setOpenapi(version);
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDynamicFilterTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDynamicFilterTestCase.java
@@ -1,0 +1,50 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiDynamicFilterTestCase {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class, MyDynamicOASFilter.class)
+                    .addAsResource(
+                            new StringAsset("mp.openapi.filter=io.quarkus.smallrye.openapi.test.jaxrs.MyDynamicOASFilter\n"
+                                    + "quarkus.smallrye-openapi.always-run-filter=true"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiFilterResource() {
+
+        // First time should be 3.0.0
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0.0"));
+
+        // Second time should be 3.0.1
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0.1"));
+
+        // Third time should be 3.0.2
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0.2"));
+
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentHolder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentHolder.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.openapi.runtime;
+
+import io.smallrye.openapi.runtime.io.Format;
+
+/**
+ * Holds instances of the OpenAPI Document
+ */
+public interface OpenApiDocumentHolder {
+
+    public byte[] getJsonDocument();
+
+    public byte[] getYamlDocument();
+
+    default byte[] getDocument(Format format) {
+        if (format.equals(Format.JSON)) {
+            return getJsonDocument();
+        }
+        return getYamlDocument();
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -9,6 +9,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -22,54 +24,138 @@ import io.smallrye.openapi.runtime.io.OpenApiSerializer;
  * Loads the document and make it available
  */
 @ApplicationScoped
-public class OpenApiDocumentService {
+public class OpenApiDocumentService implements OpenApiDocumentHolder {
 
-    private byte[] jsonDocument;
-    private byte[] yamlDocument;
+    private boolean alwaysRunFilter;
+
+    private OpenApiDocumentHolder documentHolder;
 
     @PostConstruct
     void create() throws IOException {
 
-        ClassLoader cl = OpenApiConstants.classLoader == null ? Thread.currentThread().getContextClassLoader()
-                : OpenApiConstants.classLoader;
-        try (InputStream is = cl.getResourceAsStream(OpenApiConstants.BASE_NAME + Format.JSON)) {
-            if (is != null) {
-                try (OpenApiStaticFile staticFile = new OpenApiStaticFile(is, Format.JSON)) {
-                    Config config = ConfigProvider.getConfig();
-                    OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
-
-                    OpenApiDocument document = OpenApiDocument.INSTANCE;
-                    document.reset();
-                    document.config(openApiConfig);
-                    document.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
-                    document.filter(OpenApiProcessor.getFilter(openApiConfig, cl));
-                    document.initialize();
-
-                    this.jsonDocument = OpenApiSerializer.serialize(document.get(), Format.JSON)
-                            .getBytes(StandardCharsets.UTF_8);
-                    this.yamlDocument = OpenApiSerializer.serialize(document.get(), Format.YAML)
-                            .getBytes(StandardCharsets.UTF_8);
-                    document.reset();
-                    document = null;
-                }
-            } else {
-                throw new IOException("Could not find [" + OpenApiConstants.BASE_NAME + Format.JSON + "]");
-            }
+        Config config = ConfigProvider.getConfig();
+        this.alwaysRunFilter = config.getOptionalValue("quarkus.smallrye-openapi.always-run-filter", Boolean.class)
+                .orElse(Boolean.FALSE);
+        if (alwaysRunFilter) {
+            this.documentHolder = new DynamicDocument(config);
+        } else {
+            this.documentHolder = new StaticDocument(config);
         }
     }
 
     public byte[] getJsonDocument() {
-        return jsonDocument;
+        return this.documentHolder.getJsonDocument();
     }
 
     public byte[] getYamlDocument() {
-        return yamlDocument;
+        return this.documentHolder.getYamlDocument();
     }
 
-    public byte[] getDocument(Format format) {
-        if (format.equals(Format.JSON)) {
-            return getJsonDocument();
+    /**
+     * Generate the document once on creation.
+     */
+    class StaticDocument implements OpenApiDocumentHolder {
+
+        private byte[] jsonDocument;
+        private byte[] yamlDocument;
+
+        StaticDocument(Config config) {
+            ClassLoader cl = OpenApiConstants.classLoader == null ? Thread.currentThread().getContextClassLoader()
+                    : OpenApiConstants.classLoader;
+            try (InputStream is = cl.getResourceAsStream(OpenApiConstants.BASE_NAME + Format.JSON)) {
+                if (is != null) {
+                    try (OpenApiStaticFile staticFile = new OpenApiStaticFile(is, Format.JSON)) {
+
+                        OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
+
+                        OpenApiDocument document = OpenApiDocument.INSTANCE;
+                        document.reset();
+                        document.config(openApiConfig);
+                        document.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
+                        document.filter(OpenApiProcessor.getFilter(openApiConfig, cl));
+                        document.initialize();
+
+                        this.jsonDocument = OpenApiSerializer.serialize(document.get(), Format.JSON)
+                                .getBytes(StandardCharsets.UTF_8);
+                        this.yamlDocument = OpenApiSerializer.serialize(document.get(), Format.YAML)
+                                .getBytes(StandardCharsets.UTF_8);
+                        document.reset();
+                        document = null;
+                    }
+                }
+            } catch (IOException ex) {
+                throw new RuntimeException("Could not find [" + OpenApiConstants.BASE_NAME + Format.JSON + "]");
+            }
         }
-        return getYamlDocument();
+
+        public byte[] getJsonDocument() {
+            return this.jsonDocument;
+        }
+
+        public byte[] getYamlDocument() {
+            return this.yamlDocument;
+        }
+    }
+
+    /**
+     * Generate the document on every request.
+     */
+    class DynamicDocument implements OpenApiDocumentHolder {
+
+        private OpenAPI generatedOnBuild;
+        private OpenApiConfig openApiConfig;
+        private OASFilter filter;
+
+        DynamicDocument(Config config) {
+            ClassLoader cl = OpenApiConstants.classLoader == null ? Thread.currentThread().getContextClassLoader()
+                    : OpenApiConstants.classLoader;
+            try (InputStream is = cl.getResourceAsStream(OpenApiConstants.BASE_NAME + Format.JSON)) {
+                if (is != null) {
+                    try (OpenApiStaticFile staticFile = new OpenApiStaticFile(is, Format.JSON)) {
+                        this.generatedOnBuild = OpenApiProcessor.modelFromStaticFile(staticFile);
+                        this.openApiConfig = new OpenApiConfigImpl(config);
+                        this.filter = OpenApiProcessor.getFilter(openApiConfig, cl);
+                    }
+                }
+            } catch (IOException ex) {
+                throw new RuntimeException("Could not find [" + OpenApiConstants.BASE_NAME + Format.JSON + "]");
+            }
+        }
+
+        public byte[] getJsonDocument() {
+            try {
+                OpenApiDocument document = getOpenApiDocument();
+                byte[] jsonDocument = OpenApiSerializer.serialize(document.get(), Format.JSON)
+                        .getBytes(StandardCharsets.UTF_8);
+                document.reset();
+                document = null;
+                return jsonDocument;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        public byte[] getYamlDocument() {
+            try {
+                OpenApiDocument document = getOpenApiDocument();
+                byte[] yamlDocument = OpenApiSerializer.serialize(document.get(), Format.YAML)
+                        .getBytes(StandardCharsets.UTF_8);
+                document.reset();
+                document = null;
+                return yamlDocument;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        private OpenApiDocument getOpenApiDocument() {
+            OpenApiDocument document = OpenApiDocument.INSTANCE;
+            document.reset();
+            document.config(this.openApiConfig);
+            document.modelFromStaticFile(this.generatedOnBuild);
+            document.filter(this.filter);
+            document.initialize();
+            return document;
+        }
     }
 }


### PR DESCRIPTION
This PR Update the SmallRye OpenAPI version to 2.1.7 
(see https://github.com/smallrye/smallrye-open-api/releases/tag/2.1.7)

This also adds a configuration (`quarkus.smallrye-openapi.always-run-filter`) that if set to true (default false) will run the filter
on every OpenAPI Document request (rather just on startup). This allows for Dynamic schema generation.
(see https://github.com/smallrye/smallrye-open-api/issues/837)

This is needed by the code.quarkus.io REST Api, that use a Filter to populate the available platform versions in the schema document. This will allow the document to update when a new version is released.
(see https://github.com/quarkusio/code.quarkus.io/pull/477)
