### PR TITLE
Fix parse error on attribute from @Inheritance superclass in spring-data extension

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Inheritance;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Version;
 
@@ -86,6 +87,7 @@ public final class DotNames {
 
     public static final DotName JPA_ID = DotName.createSimple(Id.class.getName());
     public static final DotName VERSION = DotName.createSimple(Version.class.getName());
+    public static final DotName JPA_INHERITANCE = DotName.createSimple(Inheritance.class.getName());
     public static final DotName JPA_MAPPED_SUPERCLASS = DotName.createSimple(MappedSuperclass.class.getName());
     public static final DotName JPA_ENTITY = DotName.createSimple(Entity.class.getName());;
     public static final DotName VOID = DotName.createSimple(void.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/MethodNameParser.java
@@ -66,7 +66,7 @@ public class MethodNameParser {
     public MethodNameParser(ClassInfo entityClass, IndexView indexView) {
         this.entityClass = entityClass;
         this.indexView = indexView;
-        this.mappedSuperClassInfos = getMappedSuperClassInfos(indexView, entityClass);
+        this.mappedSuperClassInfos = getSuperClassInfos(indexView, entityClass);
     }
 
     public enum QueryType {
@@ -508,13 +508,13 @@ public class MethodNameParser {
     }
 
     private FieldInfo getFieldInfo(String fieldName, ClassInfo entityClass,
-            MutableReference<List<ClassInfo>> mappedSuperClassInfos) {
+            MutableReference<List<ClassInfo>> superClassInfos) {
         FieldInfo fieldInfo = entityClass.field(fieldName);
         if (fieldInfo == null) {
-            if (mappedSuperClassInfos.isEmpty()) {
-                mappedSuperClassInfos.set(getMappedSuperClassInfos(indexView, entityClass));
+            if (superClassInfos.isEmpty()) {
+                superClassInfos.set(getSuperClassInfos(indexView, entityClass));
             }
-            for (ClassInfo superClass : mappedSuperClassInfos.get()) {
+            for (ClassInfo superClass : superClassInfos.get()) {
                 fieldInfo = superClass.field(fieldName);
                 if (fieldInfo != null) {
                     break;
@@ -524,12 +524,14 @@ public class MethodNameParser {
         return fieldInfo;
     }
 
-    private List<ClassInfo> getMappedSuperClassInfos(IndexView indexView, ClassInfo entityClass) {
+    private List<ClassInfo> getSuperClassInfos(IndexView indexView, ClassInfo entityClass) {
         List<ClassInfo> mappedSuperClassInfoElements = new ArrayList<>(3);
         Type superClassType = entityClass.superClassType();
         while (superClassType != null && !superClassType.name().equals(DotNames.OBJECT)) {
             ClassInfo superClass = indexView.getClassByName(superClassType.name());
             if (superClass.classAnnotation(DotNames.JPA_MAPPED_SUPERCLASS) != null) {
+                mappedSuperClassInfoElements.add(superClass);
+            } else if (superClass.classAnnotation(DotNames.JPA_INHERITANCE) != null) {
                 mappedSuperClassInfoElements.add(superClass);
             }
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValue.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValue.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+public class CatalogValue extends AbstractEntity {
+
+    private String key;
+    private String displayName;
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValueRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValueRepository.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CatalogValueRepository extends JpaRepository<CatalogValue, Long> {
+
+    CatalogValue findByKey(String key);
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValueResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/CatalogValueResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@Path("/catalog-value")
+public class CatalogValueResource {
+
+    private final CatalogValueRepository repository;
+
+    private final FederalStateCatalogValueRepository federalStateRepository;
+
+    public CatalogValueResource(CatalogValueRepository repository,
+            FederalStateCatalogValueRepository federalStateRepository) {
+        this.repository = repository;
+        this.federalStateRepository = federalStateRepository;
+    }
+
+    @Path("/super/{key}")
+    @GET
+    @Produces("application/json")
+    public CatalogValue findByKey(@PathParam("key") String key) {
+        return repository.findByKey(key);
+    }
+
+    @Path("/federal-state/{key}")
+    @GET
+    @Produces("application/json")
+    public CatalogValue findFederalStateByKey(@PathParam("key") String key) {
+        return federalStateRepository.findByKey(key);
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/FederalStateCatalogValue.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/FederalStateCatalogValue.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("federalState")
+public class FederalStateCatalogValue extends CatalogValue {
+
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/FederalStateCatalogValueRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/FederalStateCatalogValueRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.spring.data.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FederalStateCatalogValueRepository extends JpaRepository<FederalStateCatalogValue, Long> {
+
+    // note: key is defined in superclass of FederalStateCatalogValue
+    FederalStateCatalogValue findByKey(String key);
+}

--- a/integration-tests/spring-data-jpa/src/main/resources/import.sql
+++ b/integration-tests/spring-data-jpa/src/main/resources/import.sql
@@ -81,3 +81,8 @@ INSERT INTO employee(id, user_id, first_name, last_name, team_id) VALUES (102, '
 INSERT INTO MotorCar(id, brand, model) VALUES (1, 'Monteverdi', 'Hai 450');
 INSERT INTO MotorCar(id, brand, model) VALUES (2, 'Rinspeed', 'iChange');
 INSERT INTO MotorCar(id, brand, model) VALUES (3, 'Rinspeed', 'Oasis');
+
+INSERT INTO CatalogValue(id, key, displayName, type) VALUES (1, 'DE-BY', 'Bavaria', 'federalState');
+INSERT INTO CatalogValue(id, key, displayName, type) VALUES (2, 'DE-SN', 'Saxony', 'federalState');
+INSERT INTO CatalogValue(id, key, displayName, type) VALUES (3, 'DE', 'Germany', 'country');
+INSERT INTO CatalogValue(id, key, displayName, type) VALUES (4, 'FR', 'France', 'country');

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatalogValueResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatalogValueResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class CatalogValueResourceIT extends CatalogValueResourceTest {
+
+}

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatalogValueResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatalogValueResourceTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.spring.data.jpa;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CatalogValueResourceTest {
+
+    @Test
+    void findByKey() {
+        when().get("/catalog-value/super/DE-SN").then()
+                .statusCode(200)
+                .body(containsString("Saxony"))
+                .body(containsString("DE-SN"));
+    }
+
+    @Test
+    void findFederalStateByKey() {
+        when().get("/catalog-value/federal-state/DE-SN").then()
+                .statusCode(200)
+                .body(containsString("Saxony"))
+                .body(containsString("DE-SN"));
+    }
+}


### PR DESCRIPTION
Fixes the following exception when the method name targets an attribute from a SINGLE_TABLE superclass (here: `key`):
```
io.quarkus.spring.data.deployment.UnableToParseMethodException: Entity io.quarkus.it.spring.data.jpa.FederalStateCatalogValue does not contain a field named: key. Offending method is findByKey of Repository io.quarkus.it.spring.data.jpa.FederalStateCatalogValueRepository.
	at io.quarkus.spring.data.deployment.MethodNameParser.resolveNestedField(MethodNameParser.java:372)
	at io.quarkus.spring.data.deployment.MethodNameParser.parse(MethodNameParser.java:202)
	at io.quarkus.spring.data.deployment.generate.DerivedMethodsAdder.add(DerivedMethodsAdder.java:114)
	at io.quarkus.spring.data.deployment.generate.SpringDataRepositoryCreator.implementCrudRepository(SpringDataRepositoryCreator.java:116)
	at io.quarkus.spring.data.deployment.SpringDataJPAProcessor.implementCrudRepositories(SpringDataJPAProcessor.java:273)
	at io.quarkus.spring.data.deployment.SpringDataJPAProcessor.build(SpringDataJPAProcessor.java:107)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:820)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:277)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2442)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1476)
	at java.base/java.lang.Thread.run(Thread.java:834)
	at org.jboss.threads.JBossThread.run(JBossThread.java:501)
```

The test only covers SINGLE_TABLE but we can always iterate later on JOINED and TABLE_PER_CLASS.