### PR TITLE
Add RestResponse<T> type to RESTEasy Reactive

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -224,28 +224,28 @@ The following HTTP request elements may be obtained by your endpoint method:
 |HTTP element|Annotation|Usage 
 
 |[[path-parameter]]Path parameter
-|`@RestPath` (or nothing)
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestPath.html[`@RestPath`] (or nothing)
 |URI template parameter (simplified version of the https://tools.ietf.org/html/rfc6570[URI Template specification]), 
 see <<uri-parameters,URI parameters>> for more information.
 
 |Query parameter
-|`@RestQuery`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestQuery.html[`@RestQuery`]
 |The value of an https://tools.ietf.org/html/rfc3986#section-3.4[URI query parameter]
 
 |Header
-|`@RestHeader`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestHeader.html[`@RestHeader`]
 |The value of an https://tools.ietf.org/html/rfc7230#section-3.2[HTTP header]
 
 |Cookie
-|`@RestCookie`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestCookie.html[`@RestCookie`]
 |The value of an https://tools.ietf.org/html/rfc6265#section-4.2[HTTP cookie]
 
 |Form parameter
-|`@RestForm`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestForm.html[`@RestForm`]
 |The value of an https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST[HTTP URL-encoded FORM]
 
 |Matrix parameter
-|`@RestMatrix`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestMatrix.html[`@RestMatrix`]
 |The value of an https://tools.ietf.org/html/rfc3986#section-3.3[URI path segment parameter]
 
 |===
@@ -297,8 +297,9 @@ public class Endpoint {
 }
 ----
 
-NOTE: the `@RestPath` annotation is optional: any parameter whose name matches an existing URI
-template variable will be automatically assumed to have `@RestPath`.
+NOTE: the link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestPath.html[`@RestPath`]
+annotation is optional: any parameter whose name matches an existing URI
+template variable will be automatically assumed to have link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestPath.html[`@RestPath`].
 
 You can also use any of the JAX-RS annotations link:{jaxrsapi}/javax/ws/rs/PathParam.html[`@PathParam`],
 link:{jaxrsapi}/javax/ws/rs/QueryParam.html[`@QueryParam`],
@@ -396,7 +397,8 @@ NOTE: You can add support for more <<readers-writers,body parameter types>>.
 
 === Handling Multipart Form data
 
-To handle HTTP requests that have `multipart/form-data` as their content type, RESTEasy Reactive introduces the `@org.jboss.resteasy.reactive.MultipartForm` annotation.
+To handle HTTP requests that have `multipart/form-data` as their content type, RESTEasy Reactive introduces the 
+link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/MultipartForm.html[`@MultipartForm`] annotation.
 Let us look at an example of its use.
 
 Assuming an HTTP request containing a file upload and a form value containing a string description need to be handled, we could write a POJO
@@ -423,15 +425,18 @@ public class FormData {
 }
 ----
 
-The `name` field will contain the data contained in the part of HTTP request called `description` (because `@RestForm` does not define a value, the field name is used),
+The `name` field will contain the data contained in the part of HTTP request called `description` (because 
+link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestForm.html[`@RestForm`] does not define a value, the field name is used),
 while the `file` field will contain data about the uploaded file in the `image` part of HTTP request.
 
-NOTE: `FileUpload` provides access to various metadata of the uploaded file. If however all you need is a handle to the uploaded file, `java.nio.file.Path` or `java.io.File` could be used.
+NOTE: link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/multipart/FileUpload.html[`FileUpload`]
+provides access to various metadata of the uploaded file. If however all you need is a handle to the uploaded file, `java.nio.file.Path` or `java.io.File` could be used.
 
-NOTE: When access to all uploaded files without specifying the form names is needed, RESTEasy Reactive allows the use of `@RestForm List<FileUpload>`, where it is important to **not** set a name for the `@RestForm` annotation.
+NOTE: When access to all uploaded files without specifying the form names is needed, RESTEasy Reactive allows the use of `@RestForm List<FileUpload>`, where it is important to **not** set a name for the link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestForm.html[`@RestForm`] annotation.
 
-NOTE: `@PartType` is used to aid in deserialization of the corresponding part of the request into the desired Java type. It is very useful when for example the corresponding body part is JSON
-and needs to be converted to a POJO.
+NOTE: link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/PartType.html[`@PartType`] is used to aid
+in deserialization of the corresponding part of the request into the desired Java type. It is very useful when
+for example the corresponding body part is JSON and needs to be converted to a POJO.
 
 This POJO could be used in a Resource method like so:
 
@@ -458,7 +463,8 @@ public class Endpoint {
 }
 ----
 
-The use of `@MultipartForm` as method parameter makes RESTEasy Reactive handle the request as a multipart form request.
+The use of link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/MultipartForm.html[`@MultipartForm`] as
+method parameter makes RESTEasy Reactive handle the request as a multipart form request.
 
 WARNING: When handling file uploads, it is very important to move the file to permanent storage (like a database, a dedicated file system or a cloud storage) in your code that handles the POJO.
 Otherwise, the file will no longer be accessible when the request terminates.
@@ -485,13 +491,13 @@ In addition, the following return types are also supported:
 |link:{jdkapi}/java/nio/file/Path.html[`Path`]
 |The contents of the file specified by the given path
 
-|`PathPart`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/PathPart.html[`PathPart`]
 |The partial contents of the file specified by the given path
 
-|`FilePart`
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/FilePart.html[`FilePart`]
 |The partial contents of a file
 
-|link:{vertxapi}io/vertx/core/file/AsyncFile.html[`AsyncFile`]
+|link:{vertxapi}/io/vertx/core/file/AsyncFile.html[`AsyncFile`]
 |Vert.x AsyncFile, which can be in full, or partial
 
 |===
@@ -665,12 +671,16 @@ public class Endpoint {
 
 === Controlling HTTP Caching features
 
-RESTEasy Reactive provides the `@org.jboss.resteasy.reactive.Cache` and `@org.jboss.resteasy.reactive.NoCache` annotations to facilitate handling HTTP caching semantics, i.e. setting the 'Cache-Control' HTTP header.
+RESTEasy Reactive provides the link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/Cache.html[`@Cache`]
+and link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/NoCache.html[`@NoCache`] annotations to facilitate
+handling HTTP caching semantics, i.e. setting the 'Cache-Control' HTTP header.
 
 These annotations can be placed either on a Resource Method or a Resource Class (in which case it applies to all Resource Methods of the class that do *not* contain the same annotation) and allow users
 to return domain objects and not have to deal with building up the `Cache-Control` HTTP header explicitly.
 
-While `@Cache` builds a complex `Cache-Control` header, `@NoCache` is a simplified notation to say that you don't want anything cached; i.e. `Cache-Control: nocache`.
+While link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/Cache.html[`@Cache`]
+builds a complex `Cache-Control` header, link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/NoCache.html[`@NoCache`]
+is a simplified notation to say that you don't want anything cached; i.e. `Cache-Control: nocache`.
 
 NOTE: More information on the `Cache-Control` header and be found in link:https://datatracker.ietf.org/doc/html/rfc7234[RFC 7234]
 
@@ -694,7 +704,7 @@ method takes parameters of the following type:
 |link:{jaxrsapi}/javax/ws/rs/core/SecurityContext.html[`SecurityContext`]
 |Access to the current user and roles
 
-|`SimpleResourceInfo`
+|link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/SimpleResourceInfo.html[`SimpleResourceInfo`]
 |Information about the current endpoint method and class (no reflection required)
 
 |link:{jaxrsapi}/javax/ws/rs/core/UriInfo.html[`UriInfo`]
@@ -715,7 +725,7 @@ method takes parameters of the following type:
 |link:{jaxrsapi}/javax/ws/rs/core/ResourceContext.html[`ResourceContext`]
 |Advanced: access to instances of endpoints
 
-|`ServerRequestContext`
+|link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/spi/ServerRequestContext.html[`ServerRequestContext`]
 |Advanced: RESTEasy Reactive access to the current request/response
 
 |link:{jaxrsapi}/javax/ws/rs/sse/Sse.html[`Sse`]
@@ -1040,8 +1050,9 @@ public class Endpoint {
 
 If your endpoint method is delegating calls to another service layer which
 does not know of JAX-RS, you need a way to turn service exceptions to an
-HTTP response, and you can do that using the `@ServerExceptionMapper` annotation
-on a method, with one parameter of the exception type you want to handle, and turning
+HTTP response, and you can do that using the 
+link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerExceptionMapper.html[`@ServerExceptionMapper`]
+annotation on a method, with one parameter of the exception type you want to handle, and turning
 that exception into a link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`] (or a 
 link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<RestResponse<?>>`]):
 
@@ -1168,7 +1179,9 @@ These filters allow you to do various things such as examine the request URI,
 HTTP method, influence routing, look or change request headers, abort the request,
 or modify the response.
 
-Request filters can be declared with the `@ServerRequestFilter` annotation:
+Request filters can be declared with the 
+link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerRequestFilter.html[`@ServerRequestFilter`]
+annotation:
 
 [source,java]
 ----
@@ -1208,7 +1221,9 @@ run on a worker thread, then `@ServerRequestFilter(nonBlocking=true)` can be use
 Note however, that these filters need to be run before **any** filter that does not use that setting and would run on a worker thread.
 ====
 
-Similarly, response filters can be declared with the `@ServerResponseFilter` annotation:
+Similarly, response filters can be declared with the 
+link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerResponseFilter.html[`@ServerResponseFilter`]
+annotation:
 
 [source,java]
 ----
@@ -1377,8 +1392,9 @@ public class FroMageBodyHandler implements MessageBodyReader<FroMage>,
 }
 ----
 
-If you want to get the most performance our of your writer, you can extend `ServerMessageBodyWriter` instead
-of link:{jaxrsapi}/javax/ws/rs/ext/MessageBodyWriter.html[`MessageBodyWriter`]
+If you want to get the most performance our of your writer, you can extend the 
+link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.html[`ServerMessageBodyWriter`]
+instead of link:{jaxrsapi}/javax/ws/rs/ext/MessageBodyWriter.html[`MessageBodyWriter`]
 where you will be able to use less reflection and bypass the blocking IO layer:
 
 [source,java]

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -12,7 +12,9 @@ include::./attributes.adoc[]
 :mutinyapi: https://smallrye.io/smallrye-mutiny/apidocs
 :httpspec: https://tools.ietf.org/html/rfc7231
 :jsonpapi: https://javadoc.io/doc/javax.json/javax.json-api/1.1.4
-:vertxapi: https://javadoc.io/static/io.vertx/vertx-core/3.9.4
+:vertxapi: https://javadoc.io/static/io.vertx/vertx-core/4.1.0
+:resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/2.0.0.Final
+:resteasy-reactive-common-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive-common/2.0.0.Final
 
 This guide explains how to write REST Services with RESTEasy Reactive in Quarkus.
 
@@ -502,7 +504,7 @@ that resolve to one of the mentioned return types.
 === Setting other response properties
 
 If you need to set more properties on the HTTP response than just the body, such as the status code
-or headers, you can make your method return the link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`]
+or headers, you can make your method return the link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`]
 type:
 
 [source,java]
@@ -517,15 +519,17 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 
 @Path("")
 public class Endpoint {
 
     @GET
-    public Response hello() {
+    public RestResponse<String> hello() {
         // HTTP OK status with text/plain content type
-        return Response.ok("Hello, World!", MediaType.TEXT_PLAIN_TYPE)
+        return ResponseBuilder.ok("Hello, World!", MediaType.TEXT_PLAIN_TYPE)
          // set a response header
          .header("X-FroMage", "Camembert")
          // set the Expires response header to two days from now
@@ -537,6 +541,9 @@ public class Endpoint {
     }
 }
 ----
+
+NOTE: You can also use the JAX-RS type link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`] but it is
+not strongly typed to your entity.
 
 === Async/reactive support
 
@@ -1035,8 +1042,8 @@ If your endpoint method is delegating calls to another service layer which
 does not know of JAX-RS, you need a way to turn service exceptions to an
 HTTP response, and you can do that using the `@ServerExceptionMapper` annotation
 on a method, with one parameter of the exception type you want to handle, and turning
-that exception into a link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`] (or a 
-link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<Response>`]):
+that exception into a link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`] (or a 
+link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<RestResponse<?>>`]):
 
 [source,java]
 ----
@@ -1052,6 +1059,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.RestResponse;
 
 class UnknownCheeseException extends RuntimeException {
     public final String name;
@@ -1082,10 +1090,8 @@ public class Endpoint {
     CheeseService cheeses;
     
     @ServerExceptionMapper
-    public Response mapException(UnknownCheeseException x) {
-        return Response.status(Response.Status.NOT_FOUND)
-                       .entity("Unknown cheese: " + x.name)
-                       .build();
+    public RestResponse<String> mapException(UnknownCheeseException x) {
+        return RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name);
     }
     
     @GET
@@ -1106,16 +1112,13 @@ simply define them outside a REST endpoint class:
 ----
 package org.acme.rest;
 
-import javax.ws.rs.core.Response;
-
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.RestResponse;
 
 class ExceptionMappers {
     @ServerExceptionMapper
-    public Response mapException(UnknownCheeseException x) {
-        return Response.status(Response.Status.NOT_FOUND)
-                       .entity("Unknown cheese: " + x.name)
-                       .build();
+    public RestResponse<String> mapException(UnknownCheeseException x) {
+        return RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name);
     }
 }
 ----
@@ -1145,10 +1148,10 @@ It may declare any of the following return types:
 |===
 |Type|Usage
 
-|link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`]
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`] or link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`]
 |The response to send to the client when the exception occurs
 
-|link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<Response>`]
+|link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<RestResponse>`] or link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<Response>`]
 |An asynchronous response to send to the client when the exception occurs
 
 |===
@@ -1182,10 +1185,10 @@ class Filters {
     }
     
     @ServerRequestFilter
-    public Optional<Response> getFilter(ContainerRequestContext ctx) {
+    public Optional<RestResponse<Void>> getFilter(ContainerRequestContext ctx) {
         // only allow GET methods for now
         if(ctx.getMethod().equals(HttpMethod.GET)) {
-            return Optional.of(Response.status(Response.Status.METHOD_NOT_ALLOWED).build());
+            return Optional.of(RestResponse.status(Response.Status.METHOD_NOT_ALLOWED));
         }
         return Optional.empty();
     }
@@ -1249,13 +1252,13 @@ It may declare any of the following return types:
 |===
 |Type|Usage
 
-|link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`]
+|link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse<?>`] or link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`]
 |The response to send to the client instead of continuing the filter chain, or `null` if the filter chain should proceed
 
-|link:{jdkapi}/java/util/Optional.html[`Optional<Response>`]
+|link:{jdkapi}/java/util/Optional.html[`Optional<RestResponse<?>>`] or link:{jdkapi}/java/util/Optional.html[`Optional<Response>`]
 |An optional response to send to the client instead of continuing the filter chain, or an empty value if the filter chain should proceed
 
-|link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<Response>`]
+|link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<RestResponse<?>>`] or link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<Response>`]
 |An asynchronous response to send to the client instead of continuing the filter chain, or `null` if the filter chain should proceed
 
 |===
@@ -1267,7 +1270,8 @@ NOTE: You can restrict the Resource methods for which a filter runs, by using li
 [[readers-writers]]
 
 Whenever your endpoint methods return a object (of when they return a 
-link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`] with
+link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse<?>`]
+or link:{jaxrsapi}/javax/ws/rs/core/Response.html[`Response`] with
 an entity), RESTEasy Reactive will look for a way to map that into an HTTP response body.
 
 Similarly, whenever your endpoint method takes an object as parameter, we will look for

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ClientResponseBuilderFactory.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ClientResponseBuilderFactory.java
@@ -2,7 +2,9 @@ package io.quarkus.jaxrs.client.reactive.runtime;
 
 import javax.ws.rs.core.Response;
 
+import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 import org.jboss.resteasy.reactive.client.impl.ClientResponseBuilderImpl;
+import org.jboss.resteasy.reactive.client.impl.ClientRestResponseBuilderImpl;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
 
 /**
@@ -17,5 +19,10 @@ public class ClientResponseBuilderFactory implements ResponseBuilderFactory {
     @Override
     public int priority() {
         return 10; // lower than the server one
+    }
+
+    @Override
+    public <T> ResponseBuilder<T> createRestResponse() {
+        return new ClientRestResponseBuilderImpl<>();
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/JsonSomething.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/JsonSomething.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.response;
+
+public class JsonSomething {
+    public String firstName;
+    public String lastName;
+
+    public JsonSomething(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/RestResponseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/RestResponseResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.response;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestResponse;
+
+@Path("")
+public class RestResponseResource {
+
+    @GET
+    @Path("json")
+    public JsonSomething getJson() {
+        return new JsonSomething("Stef", "Epardaud");
+    }
+
+    @GET
+    @Path("rest-response-json")
+    public RestResponse<JsonSomething> getRestResponseJson() {
+        return RestResponse.ok(new JsonSomething("Stef", "Epardaud"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/RestResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/RestResponseTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.response;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class RestResponseTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(RestResponseResource.class, JsonSomething.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.get("/json")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("{\"firstName\":\"Stef\",\"lastName\":\"Epardaud\"}"))
+                .and().contentType("application/json");
+        RestAssured.get("/rest-response-json")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("{\"firstName\":\"Stef\",\"lastName\":\"Epardaud\"}"))
+                .and().contentType("application/json");
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomFilterGenerator.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomFilterGenerator.java
@@ -16,6 +16,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REQUEST;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.RESOURCE_INFO;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.RESPONSE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_RESPONSE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.THROWABLE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.URI_INFO;
@@ -36,6 +37,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 import org.jboss.resteasy.reactive.server.ServerResponseFilter;
 import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
@@ -128,8 +130,11 @@ final class CustomFilterGenerator {
             ctor.writeInstanceField(delegateField, self, config);
             ctor.returnValue(null);
 
-            if ((returnType == ReturnType.VOID) || (returnType == ReturnType.OPTIONAL_RESPONSE)
-                    || (returnType == ReturnType.RESPONSE)) {
+            if (returnType == ReturnType.VOID
+                    || returnType == ReturnType.OPTIONAL_RESPONSE
+                    || returnType == ReturnType.OPTIONAL_REST_RESPONSE
+                    || returnType == ReturnType.RESPONSE
+                    || returnType == ReturnType.REST_RESPONSE) {
                 // generate the implementation of the filter method
                 MethodCreator filterMethod = cc.getMethodCreator("filter", void.class, ContainerRequestContext.class);
                 ResultHandle rrContainerReqCtxHandle = getRRContainerReqCtxHandle(filterMethod, 0);
@@ -143,13 +148,24 @@ final class CustomFilterGenerator {
                     filterMethod.invokeStaticMethod(ofMethod(FilterUtil.class, "handleOptional", void.class,
                             Optional.class, ResteasyReactiveContainerRequestContext.class), resultHandle,
                             rrContainerReqCtxHandle);
+                } else if (returnType == ReturnType.OPTIONAL_REST_RESPONSE) {
+                    // invoke utility class that deals with Optional
+                    filterMethod.invokeStaticMethod(ofMethod(FilterUtil.class, "handleOptionalRestResponse", void.class,
+                            Optional.class, ResteasyReactiveContainerRequestContext.class), resultHandle,
+                            rrContainerReqCtxHandle);
                 } else if (returnType == ReturnType.RESPONSE) {
                     filterMethod.invokeStaticMethod(ofMethod(FilterUtil.class, "handleResponse", void.class,
                             Response.class, ResteasyReactiveContainerRequestContext.class), resultHandle,
                             rrContainerReqCtxHandle);
+                } else if (returnType == ReturnType.REST_RESPONSE) {
+                    filterMethod.invokeStaticMethod(ofMethod(FilterUtil.class, "handleRestResponse", void.class,
+                            RestResponse.class, ResteasyReactiveContainerRequestContext.class), resultHandle,
+                            rrContainerReqCtxHandle);
                 }
                 filterMethod.returnValue(null);
-            } else if ((returnType == ReturnType.UNI_VOID) || (returnType == ReturnType.UNI_RESPONSE)) {
+            } else if (returnType == ReturnType.UNI_VOID
+                    || returnType == ReturnType.UNI_RESPONSE
+                    || returnType == ReturnType.UNI_REST_RESPONSE) {
                 // generate the implementation of the filter method
                 MethodCreator filterMethod = cc.getMethodCreator("filter", void.class,
                         ResteasyReactiveContainerRequestContext.class);
@@ -159,18 +175,33 @@ final class CustomFilterGenerator {
                         filterMethod.readInstanceField(delegateField, filterMethod.getThis()),
                         getRequestFilterResultHandles(targetMethod, declaringClassName, filterMethod,
                                 getRRReqCtxHandle(filterMethod, rrContainerReqCtxHandle)));
+                String methodName;
+                switch (returnType) {
+                    case UNI_VOID:
+                        methodName = "handleUniVoid";
+                        break;
+                    case UNI_RESPONSE:
+                        methodName = "handleUniResponse";
+                        break;
+                    case UNI_REST_RESPONSE:
+                        methodName = "handleUniRestResponse";
+                        break;
+                    default:
+                        throw new IllegalStateException("ReturnType: '" + returnType + "' is not supported, in method "
+                                + targetMethod.declaringClass() + "." + targetMethod.name());
+                }
                 // invoke utility class that deals with suspend / resume
                 filterMethod
                         .invokeStaticMethod(
                                 ofMethod(FilterUtil.class,
-                                        returnType == ReturnType.UNI_VOID ? "handleUniVoid"
-                                                : "handleUniResponse",
+                                        methodName,
                                         void.class,
                                         Uni.class, ResteasyReactiveContainerRequestContext.class),
                                 uniHandle, rrContainerReqCtxHandle);
                 filterMethod.returnValue(null);
             } else {
-                throw new IllegalStateException("ReturnType: '" + returnType + "' is not supported");
+                throw new IllegalStateException("ReturnType: '" + returnType + "' is not supported, in method "
+                        + targetMethod.declaringClass() + "." + targetMethod.name());
             }
         }
         return generatedClassName;
@@ -428,17 +459,23 @@ final class CustomFilterGenerator {
                     return ReturnType.UNI_VOID;
                 } else if (parameterizedType.arguments().get(0).name().equals(RESPONSE)) {
                     return ReturnType.UNI_RESPONSE;
+                } else if (parameterizedType.arguments().get(0).name().equals(REST_RESPONSE)) {
+                    return ReturnType.UNI_REST_RESPONSE;
                 }
             } else if (parameterizedType.name().equals(OPTIONAL) && (parameterizedType.arguments().size() == 1)) {
                 if (parameterizedType.arguments().get(0).name().equals(RESPONSE)) {
                     return ReturnType.OPTIONAL_RESPONSE;
+                } else if (parameterizedType.arguments().get(0).name().equals(REST_RESPONSE)) {
+                    return ReturnType.OPTIONAL_REST_RESPONSE;
                 }
+            } else if (parameterizedType.name().equals(REST_RESPONSE)) {
+                return ReturnType.REST_RESPONSE;
             }
         } else if (targetMethod.returnType().name().equals(RESPONSE)) {
             return ReturnType.RESPONSE;
         }
         throw new RuntimeException("Method '" + targetMethod.name() + " of class '" + targetMethod.declaringClass().name()
-                + "' cannot be used as a request filter as it does not declare 'void', Optional<Response>, 'Uni<Void>' or 'Uni<Response>' as its return type");
+                + "' cannot be used as a request filter as it does not declare 'void', Response, RestResponse, Optional<Response>, Optional<RestResponse>, 'Uni<Void>', 'Uni<RestResponse>' or 'Uni<Response>' as its return type");
     }
 
     private static ReturnType determineResponseFilterReturnType(MethodInfo targetMethod) {
@@ -457,13 +494,20 @@ final class CustomFilterGenerator {
     }
 
     private static Class<?> determineRequestInterfaceType(ReturnType returnType) {
-        if ((returnType == ReturnType.VOID) || (returnType == ReturnType.OPTIONAL_RESPONSE)
-                || (returnType == ReturnType.RESPONSE)) {
-            return ContainerRequestFilter.class;
-        } else if ((returnType == ReturnType.UNI_VOID) || (returnType == ReturnType.UNI_RESPONSE)) {
-            return ResteasyReactiveContainerRequestFilter.class;
+        switch (returnType) {
+            case VOID:
+            case OPTIONAL_RESPONSE:
+            case OPTIONAL_REST_RESPONSE:
+            case RESPONSE:
+            case REST_RESPONSE:
+                return ContainerRequestFilter.class;
+            case UNI_RESPONSE:
+            case UNI_REST_RESPONSE:
+            case UNI_VOID:
+                return ResteasyReactiveContainerRequestFilter.class;
+            default:
+                throw new IllegalStateException("ReturnType: '" + returnType + "' is not supported");
         }
-        throw new IllegalStateException("ReturnType: '" + returnType + "' is not supported");
     }
 
     private static Class<?> determineResponseInterfaceType(ReturnType returnType) {
@@ -478,8 +522,11 @@ final class CustomFilterGenerator {
     private enum ReturnType {
         VOID,
         RESPONSE,
+        REST_RESPONSE,
         OPTIONAL_RESPONSE,
+        OPTIONAL_REST_RESPONSE,
         UNI_VOID,
-        UNI_RESPONSE
+        UNI_RESPONSE,
+        UNI_REST_RESPONSE
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
@@ -1,0 +1,63 @@
+package io.quarkus.resteasy.reactive.server.test.response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
+
+import org.jboss.resteasy.reactive.RestResponse;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("")
+public class RestResponseResource {
+    @GET
+    @Path("rest-response")
+    public RestResponse<String> getString() {
+        return RestResponse.ok("Hello");
+    }
+
+    @GET
+    @Path("rest-response-full")
+    public RestResponse<String> getResponse() throws URISyntaxException {
+        CacheControl cc = new CacheControl();
+        cc.setMaxAge(42);
+        cc.setPrivate(true);
+        return RestResponse.ResponseBuilder.ok("Hello")
+                .allow("FOO", "BAR")
+                .cacheControl(cc)
+                .contentLocation(new URI("http://example.com/content"))
+                .cookie(new NewCookie("Flavour", "Praliné"))
+                .encoding("Stef-Encoding")
+                .expires(Date.from(Instant.parse("2021-01-01T00:00:00Z")))
+                .header("X-Stef", "FroMage")
+                .language(Locale.FRENCH)
+                .lastModified(Date.from(Instant.parse("2021-01-02T00:00:00Z")))
+                .link("http://example.com/link", "stef")
+                .location(new URI("http://example.com/location"))
+                .tag("yourit")
+                .type("text/stef")
+                .variants(Variant.languages(Locale.ENGLISH, Locale.GERMAN).build())
+                .build();
+    }
+
+    @GET
+    @Path("response-uni")
+    public Response getResponseUniString() {
+        return Response.ok(Uni.createFrom().item("Hello")).build();
+    }
+
+    @GET
+    @Path("rest-response-uni")
+    public RestResponse<Uni<String>> getUniString() {
+        return RestResponse.ok(Uni.createFrom().item("Hello"));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 
 import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
 import io.smallrye.mutiny.Uni;
 
@@ -59,5 +60,27 @@ public class RestResponseResource {
     @Path("rest-response-uni")
     public RestResponse<Uni<String>> getUniString() {
         return RestResponse.ok(Uni.createFrom().item("Hello"));
+    }
+
+    @GET
+    @Path("rest-response-exception")
+    public String getRestResponseException() {
+        throw new UnknownCheeseException1("Cheddar");
+    }
+
+    @GET
+    @Path("uni-rest-response-exception")
+    public String getUniRestResponseException() {
+        throw new UnknownCheeseException2("Cheddar");
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<String> mapException(UnknownCheeseException1 x) {
+        return RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name);
+    }
+
+    @ServerExceptionMapper
+    public Uni<RestResponse<String>> mapExceptionAsync(UnknownCheeseException2 x) {
+        return Uni.createFrom().item(RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name));
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseResource.java
@@ -5,9 +5,11 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
@@ -15,6 +17,7 @@ import javax.ws.rs.core.Variant;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
 import io.smallrye.mutiny.Uni;
 
@@ -82,5 +85,29 @@ public class RestResponseResource {
     @ServerExceptionMapper
     public Uni<RestResponse<String>> mapExceptionAsync(UnknownCheeseException2 x) {
         return Uni.createFrom().item(RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name));
+    }
+
+    @ServerRequestFilter(preMatching = true)
+    public RestResponse<String> restResponseRequestFilter(ContainerRequestContext ctx) {
+        if (ctx.getUriInfo().getPath().equals("/rest-response-request-filter")) {
+            return RestResponse.ok("RestResponse request filter");
+        }
+        return null;
+    }
+
+    @ServerRequestFilter(preMatching = true)
+    public Optional<RestResponse<String>> optionalRestResponseRequestFilter(ContainerRequestContext ctx) {
+        if (ctx.getUriInfo().getPath().equals("/optional-rest-response-request-filter")) {
+            return Optional.of(RestResponse.ok("Optional<RestResponse> request filter"));
+        }
+        return Optional.empty();
+    }
+
+    @ServerRequestFilter(preMatching = true)
+    public Uni<RestResponse<String>> uniRestResponseRequestFilter(ContainerRequestContext ctx) {
+        if (ctx.getUriInfo().getPath().equals("/uni-rest-response-request-filter")) {
+            return Uni.createFrom().item(RestResponse.ok("Uni<RestResponse> request filter"));
+        }
+        return null;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
@@ -83,5 +83,17 @@ public class RestResponseTest {
                 .then().statusCode(404)
                 .and().body(Matchers.equalTo("Unknown cheese: Cheddar"))
                 .and().contentType("text/plain");
+        RestAssured.get("/rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("RestResponse request filter"))
+                .and().contentType("text/plain");
+        RestAssured.get("/optional-rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("Optional<RestResponse> request filter"))
+                .and().contentType("text/plain");
+        RestAssured.get("/uni-rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("Uni<RestResponse> request filter"))
+                .and().contentType("text/plain");
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.resteasy.reactive.server.test.response;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class RestResponseTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(RestResponseResource.class, UnknownCheeseException1.class,
+                                    UnknownCheeseException2.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.get("/rest-response")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("Hello"))
+                .and().contentType("text/plain");
+        RestAssured.get("/rest-response-full")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("Hello"))
+                .contentType("text/stef")
+                .header("Allow", "BAR, FOO")
+                .header("Cache-Control", "no-transform, max-age=42, private")
+                .header("Content-Location", "http://example.com/content")
+                .cookies("Flavour", "Praliné")
+                .header("Content-Encoding", "Stef-Encoding")
+                .header("Expires", "Fri, 01 Jan 2021 00:00:00 GMT")
+                .header("X-Stef", "FroMage")
+                .header("Content-Language", "fr")
+                .header("Last-Modified", "Sat, 02 Jan 2021 00:00:00 GMT")
+                .header("Link", "<http://example.com/link>; rel=\"stef\"")
+                .header("Location", "http://example.com/location")
+                .header("ETag", "\"yourit\"")
+                .header("Vary", "Accept-Language");
+        //        RestAssured.get("/response-uni")
+        //        .then().statusCode(200)
+        //        .and().body(Matchers.equalTo("Hello"))
+        //        .and().contentType("text/plain");
+        //        RestAssured.get("/rest-response-uni")
+        //        .then().statusCode(200)
+        //        .and().body(Matchers.equalTo("Hello"))
+        //        .and().contentType("text/plain");
+        RestAssured.get("/rest-response-exception")
+                .then().statusCode(404)
+                .and().body(Matchers.equalTo("Unknown cheese: Cheddar"))
+                .and().contentType("text/plain");
+        RestAssured.get("/uni-rest-response-exception")
+                .then().statusCode(404)
+                .and().body(Matchers.equalTo("Unknown cheese: Cheddar"))
+                .and().contentType("text/plain");
+        RestAssured.get("/rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("RestResponse request filter"))
+                .and().contentType("text/plain");
+        RestAssured.get("/optional-rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("Optional<RestResponse> request filter"))
+                .and().contentType("text/plain");
+        RestAssured.get("/uni-rest-response-request-filter")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("Uni<RestResponse> request filter"))
+                .and().contentType("text/plain");
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/RestResponseTest.java
@@ -75,5 +75,13 @@ public class RestResponseTest {
                 .then().statusCode(200)
                 .and().body(Matchers.equalTo("Uni<RestResponse> request filter"))
                 .and().contentType("text/plain");
+        RestAssured.get("/rest-response-exception")
+                .then().statusCode(404)
+                .and().body(Matchers.equalTo("Unknown cheese: Cheddar"))
+                .and().contentType("text/plain");
+        RestAssured.get("/uni-rest-response-exception")
+                .then().statusCode(404)
+                .and().body(Matchers.equalTo("Unknown cheese: Cheddar"))
+                .and().contentType("text/plain");
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/UnknownCheeseException1.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/UnknownCheeseException1.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.server.test.response;
+
+@SuppressWarnings("serial")
+public class UnknownCheeseException1 extends RuntimeException {
+
+    public String name;
+
+    public UnknownCheeseException1(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/UnknownCheeseException2.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/UnknownCheeseException2.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.server.test.response;
+
+@SuppressWarnings("serial")
+public class UnknownCheeseException2 extends RuntimeException {
+
+    public String name;
+
+    public UnknownCheeseException2(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AsyncExceptionMappingUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AsyncExceptionMappingUtil.java
@@ -1,10 +1,12 @@
 package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import org.jboss.resteasy.reactive.server.spi.AsyncExceptionMapperContext;
 
@@ -49,5 +51,15 @@ public final class AsyncExceptionMappingUtil {
                 context.resume();
             }
         });
+    }
+
+    public static void handleUniRestResponse(Uni<? extends RestResponse<?>> asyncResponse,
+            AsyncExceptionMapperContext context) {
+        handleUniResponse(asyncResponse.map(new Function<RestResponse<?>, Response>() {
+            @Override
+            public Response apply(RestResponse<?> t) {
+                return t != null ? t.toResponse() : null;
+            }
+        }), context);
     }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseBuilderImpl.java
@@ -1,0 +1,49 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import java.io.InputStream;
+import java.net.URI;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.common.NotImplementedYet;
+import org.jboss.resteasy.reactive.common.jaxrs.AbstractRestResponseBuilder;
+import org.jboss.resteasy.reactive.common.jaxrs.RestResponseImpl;
+
+public class ClientRestResponseBuilderImpl<T> extends AbstractRestResponseBuilder<T> { //TODO: should not extend the server version
+
+    InputStream entityStream;
+    RestClientRequestContext restClientRequestContext;
+
+    public ClientRestResponseBuilderImpl<T> invocationState(RestClientRequestContext restClientRequestContext) {
+        this.restClientRequestContext = restClientRequestContext;
+        return this;
+    }
+
+    public ClientRestResponseBuilderImpl<T> entityStream(InputStream entityStream) {
+        this.entityStream = entityStream;
+        return this;
+    }
+
+    @Override
+    protected AbstractRestResponseBuilder<T> doClone() {
+        return new ClientRestResponseBuilderImpl<>();
+    }
+
+    @Override
+    public RestResponseImpl<T> build() {
+        ClientRestResponseImpl<T> response = new ClientRestResponseImpl<>();
+        populateResponse(response);
+        response.restClientRequestContext = restClientRequestContext;
+        response.setEntityStream(entityStream);
+        return response;
+    }
+
+    @Override
+    public RestResponse.ResponseBuilder<T> contentLocation(URI location) {
+        //TODO: needs some thinking
+        throw new NotImplementedYet();
+    }
+
+    @Override
+    public RestResponse.ResponseBuilder<T> location(URI location) {
+        throw new NotImplementedYet();
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
@@ -1,0 +1,68 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.common.jaxrs.RestResponseImpl;
+import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
+
+/**
+ * This is the RestResponse class client response
+ * object with more deserialising powers than user-created responses @{link {@link RestResponseImpl}.
+ */
+public class ClientRestResponseImpl<T> extends RestResponseImpl<T> {
+
+    RestClientRequestContext restClientRequestContext;
+
+    @SuppressWarnings({ "unchecked" })
+    protected <OtherT> OtherT readEntity(Class<OtherT> entityType, Type genericType, Annotation[] annotations) {
+        // TODO: we probably need better state handling
+        if (entity != null && entityType.isInstance(entity)) {
+            // Note that this works if entityType is InputStream where we return it without closing it, as per spec
+            return (OtherT) entity;
+        }
+
+        checkClosed();
+
+        // apparently we're trying to re-read it here, even if we already have an entity, as long as it's not the right
+        // type
+        // Note that this will get us the entity if it's an InputStream because setEntity checks that
+        InputStream entityStream = getEntityStream();
+        if (entityStream == null) {
+            entityStream = new EmptyInputStream();
+        }
+
+        // it's possible we already read it for a different type, so try to reset it
+        try {
+            if (buffered) {
+                entityStream.reset();
+            } else if (consumed) {
+                throw new IllegalStateException(
+                        "Entity stream has already been read and is not buffered: call Reponse.bufferEntity()");
+            }
+        } catch (IOException e) {
+            throw new ProcessingException(e);
+        }
+
+        // Spec says to return the input stream as-is, without closing it, if that's what we want
+        if (InputStream.class.isAssignableFrom(entityType)) {
+            return (OtherT) entityStream;
+        }
+
+        MediaType mediaType = getMediaType();
+        try {
+            entity = (T) ClientSerialisers.invokeClientReader(annotations, entityType, genericType, mediaType,
+                    restClientRequestContext.properties, getStringHeaders(),
+                    restClientRequestContext.getRestClient().getClientContext().getSerialisers(),
+                    entityStream, restClientRequestContext.getReaderInterceptors(), restClientRequestContext.configuration);
+            consumed = true;
+            close();
+            return (OtherT) entity;
+        } catch (IOException e) {
+            throw new ProcessingException(e);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -42,6 +42,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_MATRIX_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_PATH_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_QUERY_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_RESPONSE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_SSE_ELEMENT_TYPE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SET;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SORTED_SET;
@@ -623,11 +624,12 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             case VOID:
                 return returnType;
             case PARAMETERIZED_TYPE:
-                // NOTE: same code in QuarkusRestRecorder.getNonAsyncReturnType
+                // NOTE: same code in RuntimeResourceDeployment.getNonAsyncReturnType
                 ParameterizedType parameterizedType = returnType.asParameterizedType();
                 if (COMPLETION_STAGE.equals(parameterizedType.name())
                         || UNI.equals(parameterizedType.name())
-                        || MULTI.equals(parameterizedType.name())) {
+                        || MULTI.equals(parameterizedType.name())
+                        || REST_RESPONSE.equals(parameterizedType.name())) {
                     return parameterizedType.arguments().get(0);
                 }
                 return returnType;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -82,6 +82,7 @@ import org.jboss.resteasy.reactive.RestHeader;
 import org.jboss.resteasy.reactive.RestMatrix;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestSseElementType;
 
 public final class ResteasyReactiveDotNames {
@@ -174,6 +175,7 @@ public final class ResteasyReactiveDotNames {
     public static final DotName UNI = DotName.createSimple(Uni.class.getName());
     public static final DotName MULTI = DotName.createSimple(Multi.class.getName());
     public static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    public static final DotName REST_RESPONSE = DotName.createSimple(RestResponse.class.getName());
 
     public static final DotName INTEGER = DotName.createSimple(Integer.class.getName());
     public static final DotName LONG = DotName.createSimple(Long.class.getName());

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestResponse.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestResponse.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.NoContentException;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.Response.StatusType;
 import javax.ws.rs.core.UriBuilder;
@@ -31,9 +32,9 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * Defines the contract between a returned instance and the runtime when
  * an application needs to provide meta-data to the runtime.
  * <p>
- * An application class should not extend this class directly. {@code Response} class is
+ * An application class should not extend this class directly. {@code RestResponse} class is
  * reserved for an extension by API implementation providers. An application should use one
- * of the static methods to create a {@code Response} instance using a ResponseBuilder.
+ * of the static methods to create a {@code RestResponse} instance using a RestResponseBuilder.
  * </p>
  * <p>
  * Several methods have parameters of type URI, {@link UriBuilder} provides
@@ -41,7 +42,6 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * </p>
  *
  * @see RestResponse.ResponseBuilder
- * @since 1.0
  */
 public abstract class RestResponse<T> implements AutoCloseable {
 
@@ -491,6 +491,13 @@ public abstract class RestResponse<T> implements AutoCloseable {
      * @see #getStringHeaders()
      */
     public abstract String getHeaderString(String name);
+
+    /**
+     * Turns this <code>RestResponse</code> into a JAX-RS {@link Response}.
+     * 
+     * @return a JAX-RS {@link Response} representing this response.
+     */
+    public abstract Response toResponse();
 
     /**
      * Create a new ResponseBuilder by performing a shallow copy of an

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestResponse.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestResponse.java
@@ -1,0 +1,2001 @@
+package org.jboss.resteasy.reactive;
+
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.GenericEntity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.NoContentException;
+import javax.ws.rs.core.Response.Status.Family;
+import javax.ws.rs.core.Response.StatusType;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Variant;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * Defines the contract between a returned instance and the runtime when
+ * an application needs to provide meta-data to the runtime.
+ * <p>
+ * An application class should not extend this class directly. {@code Response} class is
+ * reserved for an extension by API implementation providers. An application should use one
+ * of the static methods to create a {@code Response} instance using a ResponseBuilder.
+ * </p>
+ * <p>
+ * Several methods have parameters of type URI, {@link UriBuilder} provides
+ * convenient methods to create such values as does {@link URI#create(java.lang.String)}.
+ * </p>
+ *
+ * @see RestResponse.ResponseBuilder
+ * @since 1.0
+ */
+public abstract class RestResponse<T> implements AutoCloseable {
+
+    /**
+     * Protected constructor, use one of the static methods to obtain a
+     * {@link ResponseBuilder} instance and obtain a RestResponse from that.
+     */
+    protected RestResponse() {
+    }
+
+    /**
+     * Get the status code associated with the response.
+     *
+     * @return the response status code.
+     */
+    public abstract int getStatus();
+
+    /**
+     * Get the complete status information associated with the response.
+     *
+     * @return the response status information. The returned value is never
+     *         {@code null}.
+     */
+    public abstract StatusType getStatusInfo();
+
+    /**
+     * Get the message entity Java instance. Returns {@code null} if the message
+     * does not contain an entity body.
+     * <p>
+     * If the entity is represented by an un-consumed {@link InputStream input stream}
+     * the method will return the input stream.
+     * </p>
+     *
+     * @return the message entity or {@code null} if message does not contain an
+     *         entity body (i.e. when {@link #hasEntity()} returns {@code false}).
+     * @throws IllegalStateException if the entity was previously fully consumed
+     *         as an {@link InputStream input stream}, or
+     *         if the response has been {@link #close() closed}.
+     */
+    public abstract T getEntity();
+
+    /**
+     * Read the message entity input stream as an instance of specified Java type
+     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
+     * message entity stream onto the requested type.
+     * <p>
+     * Method throws an {@link ProcessingException} if the content of the
+     * message cannot be mapped to an entity of the requested type and
+     * {@link IllegalStateException} in case the entity is not backed by an input
+     * stream or if the original entity input stream has already been consumed
+     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * </p>
+     * <p>
+     * A message instance returned from this method will be cached for
+     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
+     * type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream
+     * if open. In case the entity data has been buffered, the buffer will be reset
+     * prior consuming the buffered data to enable subsequent invocations of
+     * {@code readEntity(...)} methods on this response.
+     * </p>
+     *
+     * @param <OtherT> entity instance Java type.
+     * @param entityType the type of entity.
+     * @return the message entity; for a zero-length response entities returns a corresponding
+     *         Java object that represents zero-length data. In case no zero-length representation
+     *         is defined for the Java type, a {@link ProcessingException} wrapping the
+     *         underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be
+     *         mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream,
+     *         the response has been {@link #close() closed} already,
+     *         or if the entity input stream has been fully consumed already and has
+     *         not been buffered prior consuming.
+     * @see javax.ws.rs.ext.MessageBodyReader
+     */
+    public abstract <OtherT> OtherT readEntity(Class<OtherT> entityType);
+
+    /**
+     * Read the message entity input stream as an instance of specified Java type
+     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
+     * message entity stream onto the requested type.
+     * <p>
+     * Method throws an {@link ProcessingException} if the content of the
+     * message cannot be mapped to an entity of the requested type and
+     * {@link IllegalStateException} in case the entity is not backed by an input
+     * stream or if the original entity input stream has already been consumed
+     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * </p>
+     * <p>
+     * A message instance returned from this method will be cached for
+     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
+     * type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream
+     * if open. In case the entity data has been buffered, the buffer will be reset
+     * prior consuming the buffered data to enable subsequent invocations of
+     * {@code readEntity(...)} methods on this response.
+     * </p>
+     *
+     * @param <OtherT> entity instance Java type.
+     * @param entityType the type of entity; may be generic.
+     * @return the message entity; for a zero-length response entities returns a corresponding
+     *         Java object that represents zero-length data. In case no zero-length representation
+     *         is defined for the Java type, a {@link ProcessingException} wrapping the
+     *         underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be
+     *         mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream,
+     *         the response has been {@link #close() closed} already,
+     *         or if the entity input stream has been fully consumed already and has
+     *         not been buffered prior consuming.
+     * @see javax.ws.rs.ext.MessageBodyReader
+     */
+    public abstract <OtherT> OtherT readEntity(GenericType<OtherT> entityType);
+
+    /**
+     * Read the message entity input stream as an instance of specified Java type
+     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
+     * message entity stream onto the requested type.
+     * <p>
+     * Method throws an {@link ProcessingException} if the content of the
+     * message cannot be mapped to an entity of the requested type and
+     * {@link IllegalStateException} in case the entity is not backed by an input
+     * stream or if the original entity input stream has already been consumed
+     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * </p>
+     * <p>
+     * A message instance returned from this method will be cached for
+     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
+     * type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream
+     * if open. In case the entity data has been buffered, the buffer will be reset
+     * prior consuming the buffered data to enable subsequent invocations of
+     * {@code readEntity(...)} methods on this response.
+     * </p>
+     *
+     * @param <OtherT> entity instance Java type.
+     * @param entityType the type of entity.
+     * @param annotations annotations that will be passed to the {@link MessageBodyReader}.
+     * @return the message entity; for a zero-length response entities returns a corresponding
+     *         Java object that represents zero-length data. In case no zero-length representation
+     *         is defined for the Java type, a {@link ProcessingException} wrapping the
+     *         underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be
+     *         mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream,
+     *         the response has been {@link #close() closed} already,
+     *         or if the entity input stream has been fully consumed already and has
+     *         not been buffered prior consuming.
+     * @see javax.ws.rs.ext.MessageBodyReader
+     */
+    public abstract <OtherT> OtherT readEntity(Class<OtherT> entityType, Annotation[] annotations);
+
+    /**
+     * Read the message entity input stream as an instance of specified Java type
+     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
+     * message entity stream onto the requested type.
+     * <p>
+     * Method throws an {@link ProcessingException} if the content of the
+     * message cannot be mapped to an entity of the requested type and
+     * {@link IllegalStateException} in case the entity is not backed by an input
+     * stream or if the original entity input stream has already been consumed
+     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * </p>
+     * <p>
+     * A message instance returned from this method will be cached for
+     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
+     * type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream
+     * if open. In case the entity data has been buffered, the buffer will be reset
+     * prior consuming the buffered data to enable subsequent invocations of
+     * {@code readEntity(...)} methods on this response.
+     * </p>
+     *
+     * @param <OtherT> entity instance Java type.
+     * @param entityType the type of entity; may be generic.
+     * @param annotations annotations that will be passed to the {@link MessageBodyReader}.
+     * @return the message entity; for a zero-length response entities returns a corresponding
+     *         Java object that represents zero-length data. In case no zero-length representation
+     *         is defined for the Java type, a {@link ProcessingException} wrapping the
+     *         underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be
+     *         mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream,
+     *         the response has been {@link #close() closed} already,
+     *         or if the entity input stream has been fully consumed already and has
+     *         not been buffered prior consuming.
+     * @see javax.ws.rs.ext.MessageBodyReader
+     */
+    public abstract <OtherT> OtherT readEntity(GenericType<OtherT> entityType, Annotation[] annotations);
+
+    /**
+     * Check if there is an entity available in the response. The method returns
+     * {@code true} if the entity is present, returns {@code false} otherwise.
+     * <p>
+     * Note that the method may return {@code true} also for response messages with
+     * a zero-length content, in case the <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</code> and
+     * <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</code> headers are specified in the message.
+     * In such case, an attempt to read the entity using one of the {@code readEntity(...)}
+     * methods will return a corresponding instance representing a zero-length entity for a
+     * given Java type or produce a {@link ProcessingException} in case no such instance
+     * is available for the Java type.
+     * </p>
+     *
+     * @return {@code true} if there is an entity present in the message,
+     *         {@code false} otherwise.
+     * @throws IllegalStateException in case the response has been {@link #close() closed}.
+     */
+    public abstract boolean hasEntity();
+
+    /**
+     * Buffer the message entity data.
+     * <p>
+     * In case the message entity is backed by an unconsumed entity input stream,
+     * all the bytes of the original entity input stream are read and stored in a
+     * local buffer. The original entity input stream is consumed and automatically
+     * closed as part of the operation and the method returns {@code true}.
+     * </p>
+     * <p>
+     * In case the response entity instance is not backed by an unconsumed input stream
+     * an invocation of {@code bufferEntity} method is ignored and the method returns
+     * {@code false}.
+     * </p>
+     * <p>
+     * This operation is idempotent, i.e. it can be invoked multiple times with
+     * the same effect which also means that calling the {@code bufferEntity()}
+     * method on an already buffered (and thus closed) message instance is legal
+     * and has no further effect. Also, the result returned by the {@code bufferEntity()}
+     * method is consistent across all invocations of the method on the same
+     * {@code RestResponse} instance.
+     * </p>
+     * <p>
+     * Buffering the message entity data allows for multiple invocations of
+     * {@code readEntity(...)} methods on the response instance. Note however, that
+     * once the response instance itself is {@link #close() closed}, the implementations
+     * are expected to release the buffered message entity data too. Therefore any subsequent
+     * attempts to read a message entity stream on such closed response will result in an
+     * {@link IllegalStateException} being thrown.
+     * </p>
+     *
+     * @return {@code true} if the message entity input stream was available and
+     *         was buffered successfully, returns {@code false} if the entity stream
+     *         was not available.
+     * @throws ProcessingException if there was an error while buffering the entity
+     *         input stream.
+     * @throws IllegalStateException in case the response has been {@link #close() closed}.
+     */
+    public abstract boolean bufferEntity();
+
+    /**
+     * Close the underlying message entity input stream (if available and open)
+     * as well as releases any other resources associated with the response
+     * (e.g. {@link #bufferEntity() buffered message entity data}).
+     * <p>
+     * This operation is idempotent, i.e. it can be invoked multiple times with the
+     * same effect which also means that calling the {@code close()} method on an
+     * already closed message instance is legal and has no further effect.
+     * </p>
+     * <p>
+     * The {@code close()} method should be invoked on all instances that
+     * contain an un-consumed entity input stream to ensure the resources associated
+     * with the instance are properly cleaned-up and prevent potential memory leaks.
+     * This is typical for client-side scenarios where application layer code
+     * processes only the response headers and ignores the response entity.
+     * </p>
+     * <p>
+     * Any attempts to manipulate (read, get, buffer) a message entity on a closed response
+     * will result in an {@link IllegalStateException} being thrown.
+     * </p>
+     *
+     * @throws ProcessingException if there is an error closing the response.
+     */
+    @Override
+    public abstract void close();
+
+    /**
+     * Get the media type of the message entity.
+     *
+     * @return the media type or {@code null} if there is no response entity.
+     */
+    public abstract MediaType getMediaType();
+
+    /**
+     * Get the language of the message entity.
+     *
+     * @return the language of the entity or null if not specified.
+     */
+    public abstract Locale getLanguage();
+
+    /**
+     * Get Content-Length value.
+     *
+     * @return Content-Length as integer if present and valid number. In other
+     *         cases returns {@code -1}.
+     */
+    public abstract int getLength();
+
+    /**
+     * Get the allowed HTTP methods from the Allow HTTP header.
+     *
+     * @return the allowed HTTP methods, all methods will returned as upper case
+     *         strings.
+     */
+    public abstract Set<String> getAllowedMethods();
+
+    /**
+     * Get any new cookies set on the response message.
+     *
+     * @return a read-only map of cookie name (String) to Cookie.
+     */
+    public abstract Map<String, NewCookie> getCookies();
+
+    /**
+     * Get the entity tag.
+     *
+     * @return the entity tag, otherwise {@code null} if not present.
+     */
+    public abstract EntityTag getEntityTag();
+
+    /**
+     * Get message date.
+     *
+     * @return the message date, otherwise {@code null} if not present.
+     */
+    public abstract Date getDate();
+
+    /**
+     * Get the last modified date.
+     *
+     * @return the last modified date, otherwise {@code null} if not present.
+     */
+    public abstract Date getLastModified();
+
+    /**
+     * Get the location.
+     *
+     * @return the location URI, otherwise {@code null} if not present.
+     */
+    public abstract URI getLocation();
+
+    /**
+     * Get the links attached to the message as headers. Any links in the message
+     * that are relative must be resolved with respect to the actual request URI
+     * that produced this response. Note that request URIs may be updated by
+     * filters, so the actual request URI may differ from that in the original
+     * invocation.
+     *
+     * @return links, may return empty {@link Set} if no links are present. Does
+     *         not return {@code null}.
+     */
+    public abstract Set<Link> getLinks();
+
+    /**
+     * Check if link for relation exists.
+     *
+     * @param relation link relation.
+     * @return {@code true} if the link for the relation is present in the
+     *         {@link #getHeaders() message headers}, {@code false} otherwise.
+     */
+    public abstract boolean hasLink(String relation);
+
+    /**
+     * Get the link for the relation. A relative link is resolved with respect
+     * to the actual request URI that produced this response. Note that request
+     * URIs may be updated by filters, so the actual request URI may differ from
+     * that in the original invocation.
+     *
+     * @param relation link relation.
+     * @return the link for the relation, otherwise {@code null} if not present.
+     */
+    public abstract Link getLink(String relation);
+
+    /**
+     * Convenience method that returns a {@link Link.Builder} for the relation.
+     * See {@link #getLink} for more information.
+     *
+     * @param relation link relation.
+     * @return the link builder for the relation, otherwise {@code null} if not
+     *         present.
+     */
+    public abstract Link.Builder getLinkBuilder(String relation);
+
+    /**
+     * See {@link #getHeaders()}.
+     *
+     * This method is considered deprecated. Users are encouraged to switch their
+     * code to use the {@code getHeaders()} method instead. The method may be annotated
+     * as {@link Deprecated &#64;Deprecated} in a future release of the API.
+     *
+     * @return response headers as a multivalued map.
+     */
+    public abstract MultivaluedMap<String, Object> getMetadata();
+
+    /**
+     * Get view of the response headers and their object values.
+     *
+     * The underlying header data may be subsequently modified by the runtime on the
+     * server side. Changes in the underlying header data are reflected in this view.
+     * <p>
+     * On the server-side, when the message is sent, the non-string values will be serialized
+     * using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
+     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the
+     * class of the value or using the values {@code toString} method if a header delegate is
+     * not available.
+     * </p>
+     * <p>
+     * On the client side, the returned map is identical to the one returned by
+     * {@link #getStringHeaders()}.
+     * </p>
+     *
+     * @return response headers as an object view of header values.
+     * @see #getStringHeaders()
+     * @see #getHeaderString
+     */
+    public MultivaluedMap<String, Object> getHeaders() {
+        return getMetadata();
+    }
+
+    /**
+     * Get view of the response headers and their string values.
+     *
+     * The underlying header data may be subsequently modified by the runtime on
+     * the server side. Changes in the underlying header data are reflected in this view.
+     *
+     * @return response headers as a string view of header values.
+     * @see #getHeaders()
+     * @see #getHeaderString
+     */
+    public abstract MultivaluedMap<String, String> getStringHeaders();
+
+    /**
+     * Get a message header as a single string value.
+     *
+     * Each single header value is converted to String using a
+     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
+     * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
+     * for the header value class or using its {@code toString} method if a header
+     * delegate is not available.
+     *
+     * @param name the message header.
+     * @return the message header value. If the message header is not present then
+     *         {@code null} is returned. If the message header is present but has no
+     *         value then the empty string is returned. If the message header is present
+     *         more than once then the values of joined together and separated by a ','
+     *         character.
+     * @see #getHeaders()
+     * @see #getStringHeaders()
+     */
+    public abstract String getHeaderString(String name);
+
+    /**
+     * Create a new ResponseBuilder by performing a shallow copy of an
+     * existing RestResponse.
+     * <p>
+     * The returned builder has its own {@link #getHeaders() response headers}
+     * but the header values are shared with the original {@code RestResponse} instance.
+     * The original response entity instance reference is set in the new response
+     * builder.
+     * </p>
+     * <p>
+     * Note that if the entity is backed by an un-consumed input stream, the
+     * reference to the stream is copied. In such case make sure to
+     * {@link #bufferEntity() buffer} the entity stream of the original response
+     * instance before passing it to this method.
+     * </p>
+     *
+     * @param response a RestResponse from which the status code, entity and
+     *        {@link #getHeaders() response headers} will be copied.
+     * @return a new response builder.
+     */
+    public static <T> RestResponse<T> fromResponse(RestResponse<T> response) {
+        @SuppressWarnings("unchecked")
+        ResponseBuilder<T> b = (ResponseBuilder<T>) ResponseBuilder.create(response.getStatus());
+        if (response.hasEntity()) {
+            b.entity(response.getEntity());
+        }
+        for (String headerName : response.getHeaders().keySet()) {
+            List<Object> headerValues = response.getHeaders().get(headerName);
+            for (Object headerValue : headerValues) {
+                b.header(headerName, headerValue);
+            }
+        }
+        return b.build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status.
+     *
+     * @param status the response status.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is {@code null}.
+     */
+    public static RestResponse<Void> status(StatusType status) {
+        return ResponseBuilder.create(status).build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status.
+     *
+     * @param status the response status.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is {@code null}.
+     */
+    public static <T> RestResponse<T> status(StatusType status, T entity) {
+        return ResponseBuilder.create(status, entity).build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status.
+     *
+     * @param status the response status.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is {@code null}.
+     */
+    public static RestResponse<Void> status(Status status) {
+        return ResponseBuilder.create(status).build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status.
+     *
+     * @param status the response status.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is {@code null}.
+     */
+    public static <T> RestResponse<T> status(Status status, T entity) {
+        return ResponseBuilder.create(status, entity).build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status.
+     *
+     * @param status the response status.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is less than {@code 100} or greater
+     *         than {@code 599}.
+     */
+    public static RestResponse<Void> status(int status) {
+        return ResponseBuilder.create(status).build();
+    }
+
+    /**
+     * Create a new RestResponse with the supplied status and reason phrase.
+     *
+     * @param status the response status.
+     * @param reasonPhrase the reason phrase.
+     * @return a new response.
+     * @throws IllegalArgumentException if status is less than {@code 100} or greater
+     *         than {@code 599}.
+     */
+    public static RestResponse<Void> status(int status, String reasonPhrase) {
+        return ResponseBuilder.create(status, reasonPhrase).build();
+    }
+
+    /**
+     * Create a new RestResponse with an OK status.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> ok() {
+        return ResponseBuilder.ok().build();
+    }
+
+    /**
+     * Create a new RestResponse that contains a representation. It is the
+     * callers responsibility to wrap the actual entity with
+     * {@link GenericEntity} if preservation of its generic type is required.
+     *
+     * @param entity the representation entity data.
+     * @return a new response.
+     */
+    public static <T> RestResponse<T> ok(T entity) {
+        return ResponseBuilder.ok(entity).build();
+    }
+
+    /**
+     * Create a new RestResponse that contains a representation. It is the
+     * callers responsibility to wrap the actual entity with
+     * {@link GenericEntity} if preservation of its generic type is required.
+     *
+     * @param entity the representation entity data.
+     * @param type the media type of the entity.
+     * @return a new response.
+     */
+    public static <T> RestResponse<T> ok(T entity, MediaType type) {
+        return ResponseBuilder.ok(entity, type).build();
+    }
+
+    /**
+     * Create a new RestResponse that contains a representation. It is the
+     * callers responsibility to wrap the actual entity with
+     * {@link GenericEntity} if preservation of its generic type is required.
+     *
+     * @param entity the representation entity data.
+     * @param type the media type of the entity.
+     * @return a new response.
+     */
+    public static <T> RestResponse<T> ok(T entity, String type) {
+        return ResponseBuilder.ok(entity, type).build();
+    }
+
+    /**
+     * Create a new RestResponse that contains a representation. It is the
+     * callers responsibility to wrap the actual entity with
+     * {@link GenericEntity} if preservation of its generic type is required.
+     *
+     * @param entity the representation entity data.
+     * @param variant representation metadata.
+     * @return a new response.
+     */
+    public static <T> RestResponse<T> ok(T entity, Variant variant) {
+        return ResponseBuilder.ok(entity, variant).build();
+    }
+
+    /**
+     * Create a new RestResponse with an server error status.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> serverError() {
+        return ResponseBuilder.serverError().build();
+    }
+
+    /**
+     * Create a new RestResponse for a created resource, set the location
+     * header using the supplied value.
+     *
+     * @param location the URI of the new resource. If a relative URI is
+     *        supplied it will be converted into an absolute URI by resolving it
+     *        relative to the request URI (see {@link UriInfo#getRequestUri}).
+     * @return a new response.
+     * @throws java.lang.IllegalArgumentException
+     *         if location is {@code null}.
+     */
+    public static RestResponse<Void> created(URI location) {
+        return ResponseBuilder.created(location).build();
+    }
+
+    /**
+     * Create a new RestResponse with an ACCEPTED status.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> accepted() {
+        return ResponseBuilder.accepted().build();
+    }
+
+    /**
+     * Create a new RestResponse with an ACCEPTED status that contains
+     * a representation. It is the callers responsibility to wrap the actual entity with
+     * {@link GenericEntity} if preservation of its generic type is required.
+     *
+     * @param entity the representation entity data.
+     * @return a new response.
+     */
+    public static <T> RestResponse<T> accepted(T entity) {
+        return ResponseBuilder.accepted(entity).build();
+    }
+
+    /**
+     * Create a new RestResponse for an empty response.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> noContent() {
+        return ResponseBuilder.noContent().build();
+    }
+
+    /**
+     * Create a new RestResponse with a not-modified status.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> notModified() {
+        return ResponseBuilder.notModified().build();
+    }
+
+    /**
+     * Create a new RestResponse with a not-modified status.
+     *
+     * @param tag a tag for the unmodified entity.
+     * @return a new response.
+     * @throws java.lang.IllegalArgumentException
+     *         if tag is {@code null}.
+     */
+    public static RestResponse<Void> notModified(EntityTag tag) {
+        return ResponseBuilder.notModified(tag).build();
+    }
+
+    /**
+     * Create a new RestResponse with a not-modified status
+     * and a strong entity tag. This is a shortcut
+     * for <code>notModified(new EntityTag(<i>value</i>))</code>.
+     *
+     * @param tag the string content of a strong entity tag. The
+     *        runtime will quote the supplied value when creating the
+     *        header.
+     * @return a new response.
+     * @throws IllegalArgumentException if tag is {@code null}.
+     */
+    public static RestResponse<Void> notModified(String tag) {
+        return ResponseBuilder.notModified(tag).build();
+    }
+
+    /**
+     * Create a new RestResponse for a redirection. Used in the
+     * redirect-after-POST (aka POST/redirect/GET) pattern.
+     *
+     * @param location the redirection URI. If a relative URI is
+     *        supplied it will be converted into an absolute URI by resolving it
+     *        relative to the base URI of the application (see
+     *        {@link UriInfo#getBaseUri}).
+     * @return a new response.
+     * @throws java.lang.IllegalArgumentException
+     *         if location is {@code null}.
+     */
+    public static RestResponse<Void> seeOther(URI location) {
+        return ResponseBuilder.seeOther(location).build();
+    }
+
+    /**
+     * Create a new RestResponse for a temporary redirection.
+     *
+     * @param location the redirection URI. If a relative URI is
+     *        supplied it will be converted into an absolute URI by resolving it
+     *        relative to the base URI of the application (see
+     *        {@link UriInfo#getBaseUri}).
+     * @return a new response.
+     * @throws java.lang.IllegalArgumentException
+     *         if location is {@code null}.
+     */
+    public static RestResponse<Void> temporaryRedirect(URI location) {
+        return ResponseBuilder.temporaryRedirect(location).build();
+    }
+
+    /**
+     * Create a new RestResponse for a not acceptable response.
+     *
+     * @param variants list of variants that were available, a null value is
+     *        equivalent to an empty list.
+     * @return a new response.
+     */
+    public static RestResponse<Void> notAcceptable(List<Variant> variants) {
+        return ResponseBuilder.notAcceptable(variants).build();
+    }
+
+    /**
+     * Create a new RestResponse for a not found response.
+     *
+     * @return a new response.
+     */
+    public static RestResponse<Void> notFound() {
+        return ResponseBuilder.notFound().build();
+    }
+
+    /**
+     * A class used to build RestResponse instances that contain metadata instead
+     * of or in addition to an entity. An initial instance may be obtained via
+     * static methods of the RestResponse.ResponseBuilder class, instance methods provide the
+     * ability to set metadata. E.g. to create a response that indicates the
+     * creation of a new resource:
+     * 
+     * <pre>
+     * &#64;POST
+     * RestResponse&lt;Void&gt; addWidget(...) {
+     *   Widget w = ...
+     *   URI widgetId = UriBuilder.fromResource(Widget.class)...
+     *   return RestResponse.ResponseBuilder.created(widgetId).build();
+     * }
+     * </pre>
+     *
+     * <p>
+     * Several methods have parameters of type URI, {@link UriBuilder} provides
+     * convenient methods to create such values as does {@code URI.create()}.
+     * </p>
+     *
+     * <p>
+     * Where multiple variants of the same method are provided, the type of
+     * the supplied parameter is retained in the metadata of the built
+     * {@code RestResponse}.
+     * </p>
+     */
+    public static abstract class ResponseBuilder<T> {
+
+        /**
+         * Protected constructor, use one of the static methods of
+         * {@code RestResponse} to obtain an instance.
+         */
+        protected ResponseBuilder() {
+        }
+
+        /**
+         * Create a new builder instance.
+         *
+         * @return a new response builder.
+         */
+        protected static <T> ResponseBuilder<T> newInstance() {
+            return ((org.jboss.resteasy.reactive.common.jaxrs.RuntimeDelegateImpl) RuntimeDelegate.getInstance())
+                    .createRestResponseBuilder();
+        }
+
+        /**
+         * Create a RestResponse instance from the current ResponseBuilder. The builder
+         * is reset to a blank state equivalent to calling the ok method.
+         *
+         * @return a RestResponse instance.
+         */
+        public abstract RestResponse<T> build();
+
+        /**
+         * {@inheritDoc}
+         * <p>
+         * Create a copy of the ResponseBuilder preserving its state.
+         * </p>
+         *
+         * @return a copy of the ResponseBuilder.
+         */
+        @Override
+        public abstract ResponseBuilder<T> clone();
+
+        /**
+         * Set the status on the ResponseBuilder.
+         *
+         * @param status the response status.
+         * @return the updated response builder.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater
+         *         than {@code 599}.
+         */
+        public abstract <Ret extends T> ResponseBuilder<Ret> status(int status);
+
+        /**
+         * Set the status on the ResponseBuilder.
+         *
+         * @param status the response status.
+         * @param reasonPhrase the reason phrase.
+         * @return the updated response builder.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater
+         *         than {@code 599}.
+         */
+        public abstract <Ret extends T> ResponseBuilder<Ret> status(int status, String reasonPhrase);
+
+        /**
+         * Set the status on the ResponseBuilder.
+         *
+         * @param status the response status.
+         * @return the updated response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public <Ret extends T> ResponseBuilder<Ret> status(StatusType status) {
+            if (status == null) {
+                throw new IllegalArgumentException();
+            }
+            return status(status.getStatusCode(), status.getReasonPhrase());
+        }
+
+        /**
+         * Set the status on the ResponseBuilder.
+         *
+         * @param status the response status.
+         * @return the updated response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public ResponseBuilder<T> status(Status status) {
+            return status((StatusType) status);
+        }
+
+        /**
+         * Set the response entity in the builder.
+         * <p />
+         * Any Java type instance for a response entity, that is supported by the
+         * runtime can be passed. It is the callers responsibility to wrap the
+         * actual entity with {@link GenericEntity} if preservation of its generic
+         * type is required. Note that the entity can be also set as an
+         * {@link java.io.InputStream input stream}.
+         * <p />
+         * A specific entity media type can be set using one of the {@code type(...)}
+         * methods.
+         *
+         * @param entity the request entity.
+         * @return updated response builder instance.
+         * @see #entity(java.lang.Object, java.lang.annotation.Annotation[])
+         * @see #type(javax.ws.rs.core.MediaType)
+         * @see #type(java.lang.String)
+         */
+        public abstract ResponseBuilder<T> entity(T entity);
+
+        /**
+         * Set the response entity in the builder.
+         * <p />
+         * Any Java type instance for a response entity, that is supported by the
+         * runtime can be passed. It is the callers responsibility to wrap the
+         * actual entity with {@link GenericEntity} if preservation of its generic
+         * type is required. Note that the entity can be also set as an
+         * {@link java.io.InputStream input stream}.
+         * <p />
+         * A specific entity media type can be set using one of the {@code type(...)}
+         * methods.
+         *
+         * @param entity the request entity.
+         * @param annotations annotations that will be passed to the {@link MessageBodyWriter},
+         *        (in addition to any annotations declared directly on a resource
+         *        method that returns the built response).
+         * @return updated response builder instance.
+         * @see #entity(java.lang.Object)
+         * @see #type(javax.ws.rs.core.MediaType)
+         * @see #type(java.lang.String)
+         */
+        public abstract ResponseBuilder<T> entity(T entity, Annotation[] annotations);
+
+        /**
+         * Set the list of allowed methods for the resource. Any duplicate method
+         * names will be truncated to a single entry.
+         *
+         * @param methods the methods to be listed as allowed for the resource,
+         *        if {@code null} any existing allowed method list will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> allow(String... methods);
+
+        /**
+         * Set the list of allowed methods for the resource.
+         *
+         * @param methods the methods to be listed as allowed for the resource,
+         *        if {@code null} any existing allowed method list will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> allow(Set<String> methods);
+
+        /**
+         * Set the cache control data of the message.
+         *
+         * @param cacheControl the cache control directives, if {@code null}
+         *        any existing cache control directives will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> cacheControl(CacheControl cacheControl);
+
+        /**
+         * Set the message entity content encoding.
+         *
+         * @param encoding the content encoding of the message entity,
+         *        if {@code null} any existing value for content encoding will be
+         *        removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> encoding(String encoding);
+
+        /**
+         * Add an arbitrary header.
+         *
+         * @param name the name of the header
+         * @param value the value of the header, the header will be serialized
+         *        using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if
+         *        one is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
+         *        for the class of {@code value} or using its {@code toString} method
+         *        if a header delegate is not available. If {@code value} is {@code null}
+         *        then all current headers of the same name will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> header(String name, Object value);
+
+        /**
+         * Replaces all existing headers with the newly supplied headers.
+         *
+         * @param headers new headers to be set, if {@code null} all existing
+         *        headers will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> replaceAll(MultivaluedMap<String, Object> headers);
+
+        /**
+         * Set the message entity language.
+         *
+         * @param language the language of the message entity, if {@code null} any
+         *        existing value for language will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> language(String language);
+
+        /**
+         * Set the message entity language.
+         *
+         * @param language the language of the message entity, if {@code null} any
+         *        existing value for type will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> language(Locale language);
+
+        /**
+         * Set the message entity media type.
+         *
+         * @param type the media type of the message entity. If {@code null}, any
+         *        existing value for type will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> type(MediaType type);
+
+        /**
+         * Set the message entity media type.
+         *
+         * @param type the media type of the message entity. If {@code null}, any
+         *        existing value for type will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> type(String type);
+
+        /**
+         * Set message entity representation metadata.
+         * <p/>
+         * Equivalent to setting the values of content type, content language,
+         * and content encoding separately using the values of the variant properties.
+         *
+         * @param variant metadata of the message entity, a {@code null} value is
+         *        equivalent to a variant with all {@code null} properties.
+         * @return the updated response builder.
+         * @see #encoding(java.lang.String)
+         * @see #language(java.util.Locale)
+         * @see #type(javax.ws.rs.core.MediaType)
+         */
+        public abstract ResponseBuilder<T> variant(Variant variant);
+
+        /**
+         * Set the content location.
+         *
+         * @param location the content location. Relative or absolute URIs
+         *        may be used for the value of content location. If {@code null} any
+         *        existing value for content location will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> contentLocation(URI location);
+
+        /**
+         * Add cookies to the response message.
+         *
+         * @param cookies new cookies that will accompany the response. A {@code null}
+         *        value will remove all cookies, including those added via the
+         *        {@link #header(java.lang.String, java.lang.Object)} method.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> cookie(NewCookie... cookies);
+
+        /**
+         * Set the response expiration date.
+         *
+         * @param expires the expiration date, if {@code null} removes any existing
+         *        expires value.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> expires(Date expires);
+
+        /**
+         * Set the response entity last modification date.
+         *
+         * @param lastModified the last modified date, if {@code null} any existing
+         *        last modified value will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> lastModified(Date lastModified);
+
+        /**
+         * Set the location.
+         *
+         * @param location the location. If a relative URI is supplied it will be
+         *        converted into an absolute URI by resolving it relative to the
+         *        base URI of the application (see {@link UriInfo#getBaseUri}).
+         *        If {@code null} any existing value for location will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> location(URI location);
+
+        /**
+         * Set a response entity tag.
+         *
+         * @param tag the entity tag, if {@code null} any existing entity tag
+         *        value will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> tag(EntityTag tag);
+
+        /**
+         * Set a strong response entity tag.
+         * <p/>
+         * This is a shortcut for <code>tag(new EntityTag(<i>value</i>))</code>.
+         *
+         * @param tag the string content of a strong entity tag. The
+         *        runtime will quote the supplied value when creating the header.
+         *        If {@code null} any existing entity tag value will be removed.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> tag(String tag);
+
+        /**
+         * Add a Vary header that lists the available variants.
+         *
+         * @param variants a list of available representation variants, a {@code null}
+         *        value will remove an existing value for Vary header.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> variants(Variant... variants);
+
+        /**
+         * Add a Vary header that lists the available variants.
+         *
+         * @param variants a list of available representation variants, a {@code null}
+         *        value will remove an existing value for Vary header.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> variants(List<Variant> variants);
+
+        /**
+         * Add one or more link headers.
+         *
+         * @param links links to be added to the message as headers, a {@code null}
+         *        value will remove any existing Link headers.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> links(Link... links);
+
+        /**
+         * Add a link header.
+         *
+         * @param uri underlying URI for link header.
+         * @param rel value of "rel" parameter.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> link(URI uri, String rel);
+
+        /**
+         * Add a link header.
+         *
+         * @param uri underlying URI for link header.
+         * @param rel value of "rel" parameter.
+         * @return the updated response builder.
+         */
+        public abstract ResponseBuilder<T> link(String uri, String rel);
+
+        /**
+         * Create a new ResponseBuilder by performing a shallow copy of an
+         * existing Response.
+         * <p>
+         * The returned builder has its own {@link #getHeaders() response headers}
+         * but the header values are shared with the original {@code RestResponse} instance.
+         * The original response entity instance reference is set in the new response
+         * builder.
+         * </p>
+         * <p>
+         * Note that if the entity is backed by an un-consumed input stream, the
+         * reference to the stream is copied. In such case make sure to
+         * {@link #bufferEntity() buffer} the entity stream of the original response
+         * instance before passing it to this method.
+         * </p>
+         *
+         * @param response a Response from which the status code, entity and
+         *        {@link #getHeaders() response headers} will be copied.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> fromResponse(RestResponse<T> response) {
+            @SuppressWarnings("unchecked")
+            ResponseBuilder<T> b = (ResponseBuilder<T>) create(response.getStatus());
+            if (response.hasEntity()) {
+                b.entity(response.getEntity());
+            }
+            for (String headerName : response.getHeaders().keySet()) {
+                List<Object> headerValues = response.getHeaders().get(headerName);
+                for (Object headerValue : headerValues) {
+                    b.header(headerName, headerValue);
+                }
+            }
+            return b;
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status.
+         *
+         * @param status the response status.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public static ResponseBuilder<Void> create(StatusType status) {
+            return ResponseBuilder.newInstance().status(status);
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status.
+         *
+         * @param status the response status.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public static <T> ResponseBuilder<T> create(StatusType status, T entity) {
+            return ResponseBuilder.<T> newInstance().status(status).entity(entity);
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status.
+         *
+         * @param status the response status.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public static ResponseBuilder<Void> create(Status status) {
+            return create((StatusType) status);
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status.
+         *
+         * @param status the response status.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if status is {@code null}.
+         */
+        public static <T> ResponseBuilder<T> create(Status status, T entity) {
+            return create((StatusType) status, entity);
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status.
+         *
+         * @param status the response status.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater
+         *         than {@code 599}.
+         */
+        public static ResponseBuilder<Void> create(int status) {
+            return ResponseBuilder.<Void> newInstance().status(status);
+        }
+
+        /**
+         * Create a new ResponseBuilder with the supplied status and reason phrase.
+         *
+         * @param status the response status.
+         * @param reasonPhrase the reason phrase.
+         * @return the updated response builder.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater
+         *         than {@code 599}.
+         */
+        public static ResponseBuilder<Void> create(int status, String reasonPhrase) {
+            return ResponseBuilder.newInstance().status(status, reasonPhrase);
+        }
+
+        /**
+         * Create a new ResponseBuilder with an OK status.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> ok() {
+            return create(Status.OK);
+        }
+
+        /**
+         * Create a new ResponseBuilder that contains a representation. It is the
+         * callers responsibility to wrap the actual entity with
+         * {@link GenericEntity} if preservation of its generic type is required.
+         *
+         * @param entity the representation entity data.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> ok(T entity) {
+            return create(Status.OK, entity);
+        }
+
+        /**
+         * Create a new ResponseBuilder that contains a representation. It is the
+         * callers responsibility to wrap the actual entity with
+         * {@link GenericEntity} if preservation of its generic type is required.
+         *
+         * @param entity the representation entity data.
+         * @param type the media type of the entity.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> ok(T entity, MediaType type) {
+            return ok(entity).type(type);
+        }
+
+        /**
+         * Create a new ResponseBuilder that contains a representation. It is the
+         * callers responsibility to wrap the actual entity with
+         * {@link GenericEntity} if preservation of its generic type is required.
+         *
+         * @param entity the representation entity data.
+         * @param type the media type of the entity.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> ok(T entity, String type) {
+            return ok(entity).type(type);
+        }
+
+        /**
+         * Create a new ResponseBuilder that contains a representation. It is the
+         * callers responsibility to wrap the actual entity with
+         * {@link GenericEntity} if preservation of its generic type is required.
+         *
+         * @param entity the representation entity data.
+         * @param variant representation metadata.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> ok(T entity, Variant variant) {
+            return ok(entity).variant(variant);
+        }
+
+        /**
+         * Create a new ResponseBuilder with an server error status.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> serverError() {
+            return create(Status.INTERNAL_SERVER_ERROR);
+        }
+
+        /**
+         * Create a new ResponseBuilder for a created resource, set the location
+         * header using the supplied value.
+         *
+         * @param location the URI of the new resource. If a relative URI is
+         *        supplied it will be converted into an absolute URI by resolving it
+         *        relative to the request URI (see {@link UriInfo#getRequestUri}).
+         * @return a new response builder.
+         * @throws java.lang.IllegalArgumentException
+         *         if location is {@code null}.
+         */
+        public static ResponseBuilder<Void> created(URI location) {
+            return create(Status.CREATED).location(location);
+        }
+
+        /**
+         * Create a new ResponseBuilder with an ACCEPTED status.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> accepted() {
+            return create(Status.ACCEPTED);
+        }
+
+        /**
+         * Create a new ResponseBuilder with an ACCEPTED status that contains
+         * a representation. It is the callers responsibility to wrap the actual entity with
+         * {@link GenericEntity} if preservation of its generic type is required.
+         *
+         * @param entity the representation entity data.
+         * @return a new response builder.
+         */
+        public static <T> ResponseBuilder<T> accepted(T entity) {
+            return create(Status.ACCEPTED, entity);
+        }
+
+        /**
+         * Create a new ResponseBuilder for an empty response.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> noContent() {
+            return create(Status.NO_CONTENT);
+        }
+
+        /**
+         * Create a new ResponseBuilder with a not-modified status.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> notModified() {
+            return create(Status.NOT_MODIFIED);
+        }
+
+        /**
+         * Create a new ResponseBuilder with a not-modified status.
+         *
+         * @param tag a tag for the unmodified entity.
+         * @return a new response builder.
+         * @throws java.lang.IllegalArgumentException
+         *         if tag is {@code null}.
+         */
+        public static ResponseBuilder<Void> notModified(EntityTag tag) {
+            return notModified().tag(tag);
+        }
+
+        /**
+         * Create a new ResponseBuilder with a not-modified status
+         * and a strong entity tag. This is a shortcut
+         * for <code>notModified(new EntityTag(<i>value</i>))</code>.
+         *
+         * @param tag the string content of a strong entity tag. The
+         *        runtime will quote the supplied value when creating the
+         *        header.
+         * @return a new response builder.
+         * @throws IllegalArgumentException if tag is {@code null}.
+         */
+        public static ResponseBuilder<Void> notModified(String tag) {
+            return notModified().tag(tag);
+        }
+
+        /**
+         * Create a new ResponseBuilder for a redirection. Used in the
+         * redirect-after-POST (aka POST/redirect/GET) pattern.
+         *
+         * @param location the redirection URI. If a relative URI is
+         *        supplied it will be converted into an absolute URI by resolving it
+         *        relative to the base URI of the application (see
+         *        {@link UriInfo#getBaseUri}).
+         * @return a new response builder.
+         * @throws java.lang.IllegalArgumentException
+         *         if location is {@code null}.
+         */
+        public static ResponseBuilder<Void> seeOther(URI location) {
+            return create(Status.SEE_OTHER).location(location);
+        }
+
+        /**
+         * Create a new ResponseBuilder for a temporary redirection.
+         *
+         * @param location the redirection URI. If a relative URI is
+         *        supplied it will be converted into an absolute URI by resolving it
+         *        relative to the base URI of the application (see
+         *        {@link UriInfo#getBaseUri}).
+         * @return a new response builder.
+         * @throws java.lang.IllegalArgumentException
+         *         if location is {@code null}.
+         */
+        public static ResponseBuilder<Void> temporaryRedirect(URI location) {
+            return create(Status.TEMPORARY_REDIRECT).location(location);
+        }
+
+        /**
+         * Create a new ResponseBuilder for a not acceptable response.
+         *
+         * @param variants list of variants that were available, a null value is
+         *        equivalent to an empty list.
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> notAcceptable(List<Variant> variants) {
+            return create(Status.NOT_ACCEPTABLE).variants(variants);
+        }
+
+        /**
+         * Create a new ResponseBuilder for a not found response.
+         *
+         * @return a new response builder.
+         */
+        public static ResponseBuilder<Void> notFound() {
+            return create(Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Commonly used status codes defined by HTTP, see
+     * {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10">HTTP/1.1 documentation</a>}
+     * for the complete list. Additional status codes can be added by applications
+     * by creating an implementation of {@link StatusType}.
+     */
+    public enum Status implements StatusType {
+
+        /**
+         * 100 Continue, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1 documentation</a>}.
+         */
+        CONTINUE(StatusCode.CONTINUE, "Continue"),
+
+        /**
+         * 101 Switching Protocols, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        SWITCHING_PROTOCOLS(StatusCode.SWITCHING_PROTOCOLS, "Switching Protocols"),
+
+        /**
+         * 200 OK, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1 documentation</a>}.
+         */
+        OK(StatusCode.OK, "OK"),
+        /**
+         * 201 Created, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1 documentation</a>}.
+         */
+        CREATED(StatusCode.CREATED, "Created"),
+        /**
+         * 202 Accepted, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1 documentation</a>}.
+         */
+        ACCEPTED(StatusCode.ACCEPTED, "Accepted"),
+        /**
+         * 203 Non-Authoritative Information, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        NON_AUTHORITATIVE_INFORMATION(StatusCode.NON_AUTHORITATIVE_INFORMATION, "Non-Authoritative Information"),
+        /**
+         * 204 No Content, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1 documentation</a>}.
+         */
+        NO_CONTENT(StatusCode.NO_CONTENT, "No Content"),
+        /**
+         * 205 Reset Content, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        RESET_CONTENT(StatusCode.RESET_CONTENT, "Reset Content"),
+        /**
+         * 206 Reset Content, see {@link <a href="https://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1 documentation</a>}.
+         */
+        PARTIAL_CONTENT(StatusCode.PARTIAL_CONTENT, "Partial Content"),
+        /**
+         * 300 Multiple Choices, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1
+         * documentation</a>}.
+         */
+        MULTIPLE_CHOICES(StatusCode.MULTIPLE_CHOICES, "Multiple Choices"),
+        /**
+         * 301 Moved Permanently, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        MOVED_PERMANENTLY(StatusCode.MOVED_PERMANENTLY, "Moved Permanently"),
+        /**
+         * 302 Found, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1 documentation</a>}.
+         */
+        FOUND(StatusCode.FOUND, "Found"),
+        /**
+         * 303 See Other, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1 documentation</a>}.
+         */
+        SEE_OTHER(StatusCode.SEE_OTHER, "See Other"),
+        /**
+         * 304 Not Modified, see {@link <a href="https://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1 documentation</a>}.
+         */
+        NOT_MODIFIED(StatusCode.NOT_MODIFIED, "Not Modified"),
+        /**
+         * 305 Use Proxy, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1 documentation</a>}.
+         */
+        USE_PROXY(StatusCode.USE_PROXY, "Use Proxy"),
+        /**
+         * 307 Temporary Redirect, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1
+         * documentation</a>}.
+         */
+        TEMPORARY_REDIRECT(StatusCode.TEMPORARY_REDIRECT, "Temporary Redirect"),
+        /**
+         * 308 Permanent Redirect, see {@link <a href="https://tools.ietf.org/html/rfc7238#section-3">HTTP/1.1
+         * documentation</a>}.
+         */
+        PERMANENT_REDIRECT(StatusCode.PERMANENT_REDIRECT, "Permanent Redirect"),
+        /**
+         * 400 Bad Request, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1 documentation</a>}.
+         */
+        BAD_REQUEST(StatusCode.BAD_REQUEST, "Bad Request"),
+        /**
+         * 401 Unauthorized, see {@link <a href="https://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1 documentation</a>}.
+         */
+        UNAUTHORIZED(StatusCode.UNAUTHORIZED, "Unauthorized"),
+        /**
+         * 402 Payment Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        PAYMENT_REQUIRED(StatusCode.PAYMENT_REQUIRED, "Payment Required"),
+        /**
+         * 403 Forbidden, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1 documentation</a>}.
+         */
+        FORBIDDEN(StatusCode.FORBIDDEN, "Forbidden"),
+        /**
+         * 404 Not Found, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1 documentation</a>}.
+         */
+        NOT_FOUND(StatusCode.NOT_FOUND, "Not Found"),
+        /**
+         * 405 Method Not Allowed, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        METHOD_NOT_ALLOWED(StatusCode.METHOD_NOT_ALLOWED, "Method Not Allowed"),
+        /**
+         * 406 Not Acceptable, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1
+         * documentation</a>}.
+         */
+        NOT_ACCEPTABLE(StatusCode.NOT_ACCEPTABLE, "Not Acceptable"),
+        /**
+         * 407 Proxy Authentication Required, see {@link <a href="https://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        PROXY_AUTHENTICATION_REQUIRED(StatusCode.PROXY_AUTHENTICATION_REQUIRED, "Proxy Authentication Required"),
+        /**
+         * 408 Request Timeout, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1
+         * documentation</a>}.
+         */
+        REQUEST_TIMEOUT(StatusCode.REQUEST_TIMEOUT, "Request Timeout"),
+        /**
+         * 409 Conflict, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1 documentation</a>}.
+         */
+        CONFLICT(StatusCode.CONFLICT, "Conflict"),
+        /**
+         * 410 Gone, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1 documentation</a>}.
+         */
+        GONE(StatusCode.GONE, "Gone"),
+        /**
+         * 411 Length Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1
+         * documentation</a>}.
+         */
+        LENGTH_REQUIRED(StatusCode.LENGTH_REQUIRED, "Length Required"),
+        /**
+         * 412 Precondition Failed, see {@link <a href="https://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        PRECONDITION_FAILED(StatusCode.PRECONDITION_FAILED, "Precondition Failed"),
+        /**
+         * 413 Payload Too Large, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1
+         * documentation</a>}.
+         */
+        PAYLOAD_TOO_LARGE(StatusCode.PAYLOAD_TOO_LARGE, "Payload Too Large"),
+        /**
+         * 414 URI Too Long, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1
+         * documentation</a>}.
+         */
+        URI_TOO_LONG(StatusCode.URI_TOO_LONG, "URI Too Long"),
+        /**
+         * 415 Unsupported Media Type, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1
+         * documentation</a>}.
+         */
+        UNSUPPORTED_MEDIA_TYPE(StatusCode.UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type"),
+        /**
+         * 416 Requested Range Not Satisfiable, see {@link <a href="https://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        REQUESTED_RANGE_NOT_SATISFIABLE(StatusCode.REQUESTED_RANGE_NOT_SATISFIABLE, "Requested Range Not Satisfiable"),
+        /**
+         * 417 Expectation Failed, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1
+         * documentation</a>}.
+         */
+        EXPECTATION_FAILED(StatusCode.EXPECTATION_FAILED, "Expectation Failed"),
+        /**
+         * 426 Upgrade Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.15">HTTP/1.1
+         * documentation</a>}.
+         */
+        UPGRADE_REQUIRED(StatusCode.UPGRADE_REQUIRED, "Upgrade Required"),
+        /**
+         * 428 Precondition required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional
+         * HTTP Status Codes</a>}.
+         */
+        PRECONDITION_REQUIRED(StatusCode.PRECONDITION_REQUIRED, "Precondition Required"),
+        /**
+         * 429 Too Many Requests, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP
+         * Status Codes</a>}.
+         */
+        TOO_MANY_REQUESTS(StatusCode.TOO_MANY_REQUESTS, "Too Many Requests"),
+        /**
+         * 431 Request Header Fields Too Large, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585:
+         * Additional HTTP Status Codes</a>}.
+         */
+        REQUEST_HEADER_FIELDS_TOO_LARGE(StatusCode.REQUEST_HEADER_FIELDS_TOO_LARGE, "Request Header Fields Too Large"),
+        /**
+         * 500 Internal Server Error, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1
+         * documentation</a>}.
+         */
+        INTERNAL_SERVER_ERROR(StatusCode.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+        /**
+         * 501 Not Implemented, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        NOT_IMPLEMENTED(StatusCode.NOT_IMPLEMENTED, "Not Implemented"),
+        /**
+         * 502 Bad Gateway, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1 documentation</a>}.
+         */
+        BAD_GATEWAY(StatusCode.BAD_GATEWAY, "Bad Gateway"),
+        /**
+         * 503 Service Unavailable, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        SERVICE_UNAVAILABLE(StatusCode.SERVICE_UNAVAILABLE, "Service Unavailable"),
+        /**
+         * 504 Gateway Timeout, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        GATEWAY_TIMEOUT(StatusCode.GATEWAY_TIMEOUT, "Gateway Timeout"),
+        /**
+         * 505 HTTP Version Not Supported, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1
+         * documentation</a>}.
+         */
+        HTTP_VERSION_NOT_SUPPORTED(StatusCode.HTTP_VERSION_NOT_SUPPORTED, "Http Version Not Supported"),
+        /**
+         * 511 Network Authentication Required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585:
+         * Additional HTTP Status Codes</a>}.
+         */
+        NETWORK_AUTHENTICATION_REQUIRED(StatusCode.NETWORK_AUTHENTICATION_REQUIRED, "Network Authentication Required"),
+        ;
+
+        private final int code;
+        private final String reason;
+        private final Family family;
+
+        Status(final int statusCode, final String reasonPhrase) {
+            this.code = statusCode;
+            this.reason = reasonPhrase;
+            this.family = Family.familyOf(statusCode);
+        }
+
+        /**
+         * Get the class of status code.
+         *
+         * @return the class of status code.
+         */
+        @Override
+        public Family getFamily() {
+            return family;
+        }
+
+        /**
+         * Get the associated status code.
+         *
+         * @return the status code.
+         */
+        @Override
+        public int getStatusCode() {
+            return code;
+        }
+
+        /**
+         * Get the reason phrase.
+         *
+         * @return the reason phrase.
+         */
+        @Override
+        public String getReasonPhrase() {
+            return toString();
+        }
+
+        /**
+         * Get the reason phrase.
+         *
+         * @return the reason phrase.
+         */
+        @Override
+        public String toString() {
+            return reason;
+        }
+
+        /**
+         * Convert a numerical status code into the corresponding Status.
+         *
+         * @param statusCode the numerical status code.
+         * @return the matching Status or null is no matching Status is defined.
+         */
+        public static Status fromStatusCode(final int statusCode) {
+            for (Status s : Status.values()) {
+                if (s.code == statusCode) {
+                    return s;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Commonly used status codes defined by HTTP, see
+     * {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.2">HTTP/1.1 documentation</a>}
+     * for the complete list.
+     */
+    public static class StatusCode {
+
+        /**
+         * 100 Continue, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int CONTINUE = 100;
+
+        /**
+         * 101 Switching Protocols, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int SWITCHING_PROTOCOLS = 101;
+
+        /**
+         * 200 OK, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int OK = 200;
+        /**
+         * 201 Created, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1 documentation</a>}.
+         */
+        public final static int CREATED = 201;
+        /**
+         * 202 Accepted, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1 documentation</a>}.
+         */
+        public final static int ACCEPTED = 202;
+        /**
+         * 203 Non-Authoritative Information, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int NON_AUTHORITATIVE_INFORMATION = 203;
+        /**
+         * 204 No Content, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1 documentation</a>}.
+         */
+        public final static int NO_CONTENT = 204;
+        /**
+         * 205 Reset Content, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int RESET_CONTENT = 205;
+        /**
+         * 206 Reset Content, see {@link <a href="https://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int PARTIAL_CONTENT = 206;
+        /**
+         * 300 Multiple Choices, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int MULTIPLE_CHOICES = 300;
+        /**
+         * 301 Moved Permanently, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int MOVED_PERMANENTLY = 301;
+        /**
+         * 302 Found, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1 documentation</a>}.
+         */
+        public final static int FOUND = 302;
+        /**
+         * 303 See Other, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1 documentation</a>}.
+         */
+        public final static int SEE_OTHER = 303;
+        /**
+         * 304 Not Modified, see {@link <a href="https://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int NOT_MODIFIED = 304;
+        /**
+         * 305 Use Proxy, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1 documentation</a>}.
+         */
+        public final static int USE_PROXY = 305;
+        /**
+         * 307 Temporary Redirect, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int TEMPORARY_REDIRECT = 307;
+        /**
+         * 308 Permanent Redirect, see {@link <a href="https://tools.ietf.org/html/rfc7238#section-3">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int PERMANENT_REDIRECT = 308;
+        /**
+         * 400 Bad Request, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int BAD_REQUEST = 400;
+        /**
+         * 401 Unauthorized, see {@link <a href="https://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1 documentation</a>}.
+         */
+        public final static int UNAUTHORIZED = 401;
+        /**
+         * 402 Payment Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int PAYMENT_REQUIRED = 402;
+        /**
+         * 403 Forbidden, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1 documentation</a>}.
+         */
+        public final static int FORBIDDEN = 403;
+        /**
+         * 404 Not Found, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1 documentation</a>}.
+         */
+        public final static int NOT_FOUND = 404;
+        /**
+         * 405 Method Not Allowed, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int METHOD_NOT_ALLOWED = 405;
+        /**
+         * 406 Not Acceptable, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int NOT_ACCEPTABLE = 406;
+        /**
+         * 407 Proxy Authentication Required, see {@link <a href="https://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int PROXY_AUTHENTICATION_REQUIRED = 407;
+        /**
+         * 408 Request Timeout, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int REQUEST_TIMEOUT = 408;
+        /**
+         * 409 Conflict, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1 documentation</a>}.
+         */
+        public final static int CONFLICT = 409;
+        /**
+         * 410 Gone, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1 documentation</a>}.
+         */
+        public final static int GONE = 410;
+        /**
+         * 411 Length Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int LENGTH_REQUIRED = 411;
+        /**
+         * 412 Precondition Failed, see {@link <a href="https://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int PRECONDITION_FAILED = 412;
+        /**
+         * 413 Payload Too Large, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int PAYLOAD_TOO_LARGE = 413;
+        /**
+         * 414 URI Too Long, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int URI_TOO_LONG = 414;
+        /**
+         * 415 Unsupported Media Type, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int UNSUPPORTED_MEDIA_TYPE = 415;
+        /**
+         * 416 Requested Range Not Satisfiable, see {@link <a href="https://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+        /**
+         * 417 Expectation Failed, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int EXPECTATION_FAILED = 417;
+        /**
+         * 426 Upgrade Required, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.5.15">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int UPGRADE_REQUIRED = 426;
+        /**
+         * 428 Precondition required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional
+         * HTTP Status Codes</a>}.
+         */
+        public final static int PRECONDITION_REQUIRED = 428;
+        /**
+         * 429 Too Many Requests, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP
+         * Status Codes</a>}.
+         */
+        public final static int TOO_MANY_REQUESTS = 429;
+        /**
+         * 431 Request Header Fields Too Large, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585:
+         * Additional HTTP Status Codes</a>}.
+         */
+        public final static int REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+        /**
+         * 500 Internal Server Error, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int INTERNAL_SERVER_ERROR = 500;
+        /**
+         * 501 Not Implemented, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int NOT_IMPLEMENTED = 501;
+        /**
+         * 502 Bad Gateway, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1 documentation</a>}.
+         */
+        public final static int BAD_GATEWAY = 502;
+        /**
+         * 503 Service Unavailable, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int SERVICE_UNAVAILABLE = 503;
+        /**
+         * 504 Gateway Timeout, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int GATEWAY_TIMEOUT = 504;
+        /**
+         * 505 HTTP Version Not Supported, see {@link <a href="https://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1
+         * documentation</a>}.
+         */
+        public final static int HTTP_VERSION_NOT_SUPPORTED = 505;
+        /**
+         * 511 Network Authentication Required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585:
+         * Additional HTTP Status Codes</a>}.
+         */
+        public final static int NETWORK_AUTHENTICATION_REQUIRED = 511;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/ResponseBuilderFactory.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/ResponseBuilderFactory.java
@@ -1,11 +1,14 @@
 package org.jboss.resteasy.reactive.common.core;
 
 import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 
 public interface ResponseBuilderFactory {
 
     Response.ResponseBuilder create();
 
     int priority();
+
+    <T> RestResponse.ResponseBuilder<T> createRestResponse();
 
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
@@ -42,8 +42,8 @@ public class ResponseImpl extends Response {
     protected Object entity;
     MultivaluedTreeMap<String, Object> headers;
     InputStream entityStream;
-    private StatusTypeImpl statusType;
-    private MultivaluedMap<String, String> stringHeaders;
+    StatusTypeImpl statusType;
+    MultivaluedMap<String, String> stringHeaders;
     Annotation[] entityAnnotations;
     protected boolean consumed;
     protected boolean closed;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
@@ -1,0 +1,312 @@
+package org.jboss.resteasy.reactive.common.jaxrs;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.GenericEntity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Link.Builder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
+import org.jboss.resteasy.reactive.common.headers.LinkHeaders;
+import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
+
+/**
+ * This is the Response class for user-created responses. The client response
+ * object has more deserialising powers in @{link {@link io.quarkus.rest.server.runtime.client.QuarkusRestClientResponse}.
+ */
+@SuppressWarnings("JavadocReference")
+public class RestResponseImpl<T> extends RestResponse<T> {
+
+    int status;
+    String reasonPhrase;
+    protected T entity;
+    MultivaluedTreeMap<String, Object> headers;
+    InputStream entityStream;
+    private StatusTypeImpl statusType;
+    private MultivaluedMap<String, String> stringHeaders;
+    Annotation[] entityAnnotations;
+    protected boolean consumed;
+    protected boolean closed;
+    protected boolean buffered;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    /**
+     * Internal: this is just cheaper than duplicating the response just to change the status
+     */
+    public void setStatus(int status) {
+        this.status = status;
+        statusType = null;
+    }
+
+    @Override
+    public Response.StatusType getStatusInfo() {
+        if (statusType == null) {
+            statusType = new StatusTypeImpl(status, reasonPhrase);
+        }
+        return statusType;
+    }
+
+    /**
+     * Internal: this is just cheaper than duplicating the response just to change the status
+     */
+    public void setStatusInfo(Response.StatusType statusType) {
+        this.statusType = StatusTypeImpl.valueOf(statusType);
+        status = statusType.getStatusCode();
+    }
+
+    @Override
+    public T getEntity() {
+        // The spec says that getEntity() can be called after readEntity() to obtain the same entity,
+        // but it also sort-of implies that readEntity() calls Response.close(), and the TCK does check
+        // that we throw if closed and non-buffered
+        checkClosed();
+        // this check seems very ugly, but it seems to be needed by the TCK
+        // this will likely require a better solution
+        if (entity instanceof GenericEntity) {
+            GenericEntity<?> genericEntity = (GenericEntity<?>) entity;
+            if (genericEntity.getRawType().equals(genericEntity.getType())) {
+                return (T) ((GenericEntity<?>) entity).getEntity();
+            }
+        }
+        return entity;
+    }
+
+    protected void setEntity(T entity) {
+        this.entity = entity;
+        if (entity instanceof InputStream) {
+            this.entityStream = (InputStream) entity;
+        }
+    }
+
+    public InputStream getEntityStream() {
+        return entityStream;
+    }
+
+    public void setEntityStream(InputStream entityStream) {
+        this.entityStream = entityStream;
+    }
+
+    protected <T> T readEntity(Class<T> entityType, Type genericType, Annotation[] annotations) {
+        // TODO: we probably need better state handling
+        if (entity != null && entityType.isInstance(entity)) {
+            // Note that this works if entityType is InputStream where we return it without closing it, as per spec
+            return (T) entity;
+        }
+        checkClosed();
+        // Spec says to throw this
+        throw new ProcessingException(
+                "Request could not be mapped to type " + (genericType != null ? genericType : entityType));
+    }
+
+    @Override
+    public <OtherT> OtherT readEntity(Class<OtherT> entityType) {
+        return readEntity(entityType, entityType, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <OtherT> OtherT readEntity(GenericType<OtherT> entityType) {
+        return (OtherT) readEntity(entityType.getRawType(), entityType.getType(), null);
+    }
+
+    @Override
+    public <OtherT> OtherT readEntity(Class<OtherT> entityType, Annotation[] annotations) {
+        return readEntity(entityType, entityType, annotations);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <OtherT> OtherT readEntity(GenericType<OtherT> entityType, Annotation[] annotations) {
+        return (OtherT) readEntity(entityType.getRawType(), entityType.getType(), annotations);
+    }
+
+    @Override
+    public boolean hasEntity() {
+        // The TCK checks that
+        checkClosed();
+        // we have an entity already read, or still to be read
+        return entity != null || entityStream != null;
+    }
+
+    @Override
+    public boolean bufferEntity() {
+        checkClosed();
+        // must be idempotent
+        if (buffered) {
+            return true;
+        }
+        if (entityStream != null && !consumed) {
+            // let's not try this again, even if it fails
+            consumed = true;
+            // we're supposed to read the entire stream, but if we can rewind it there's no point so let's keep it
+            if (!entityStream.markSupported()) {
+                ByteArrayOutputStream os = new ByteArrayOutputStream();
+                byte[] buffer = new byte[4096];
+                int read;
+                try {
+                    while ((read = entityStream.read(buffer)) != -1) {
+                        os.write(buffer, 0, read);
+                    }
+                    entityStream.close();
+                } catch (IOException x) {
+                    throw new UncheckedIOException(x);
+                }
+                entityStream = new ByteArrayInputStream(os.toByteArray());
+            }
+            buffered = true;
+            return true;
+        }
+        return false;
+    }
+
+    protected void checkClosed() {
+        // apparently the TCK says that buffered responses don't care about being closed
+        if (closed && !buffered)
+            throw new IllegalStateException("Response has been closed");
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            if (entityStream != null) {
+                try {
+                    entityStream.close();
+                } catch (IOException e) {
+                    throw new ProcessingException(e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return HeaderUtil.getMediaType(headers);
+    }
+
+    @Override
+    public Locale getLanguage() {
+        return HeaderUtil.getLanguage(headers);
+    }
+
+    @Override
+    public int getLength() {
+        return HeaderUtil.getLength(headers);
+    }
+
+    @Override
+    public Set<String> getAllowedMethods() {
+        return HeaderUtil.getAllowedMethods(headers);
+    }
+
+    @Override
+    public Map<String, NewCookie> getCookies() {
+        return HeaderUtil.getNewCookies(headers);
+    }
+
+    @Override
+    public EntityTag getEntityTag() {
+        return HeaderUtil.getEntityTag(headers);
+    }
+
+    @Override
+    public Date getDate() {
+        return HeaderUtil.getDate(headers);
+    }
+
+    @Override
+    public Date getLastModified() {
+        return HeaderUtil.getLastModified(headers);
+    }
+
+    @Override
+    public URI getLocation() {
+        return HeaderUtil.getLocation(headers);
+    }
+
+    private LinkHeaders getLinkHeaders() {
+        return new LinkHeaders(headers);
+    }
+
+    @Override
+    public Set<Link> getLinks() {
+        return new HashSet<>(getLinkHeaders().getLinks());
+    }
+
+    @Override
+    public boolean hasLink(String relation) {
+        return getLinkHeaders().getLinkByRelationship(relation) != null;
+    }
+
+    @Override
+    public Link getLink(String relation) {
+        return getLinkHeaders().getLinkByRelationship(relation);
+    }
+
+    @Override
+    public Builder getLinkBuilder(String relation) {
+        Link link = getLinkHeaders().getLinkByRelationship(relation);
+        if (link == null) {
+            return null;
+        }
+        return Link.fromLink(link);
+    }
+
+    @Override
+    public MultivaluedMap<String, Object> getMetadata() {
+        return headers;
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getStringHeaders() {
+        if (stringHeaders == null) {
+            // let's keep this map case-insensitive
+            stringHeaders = new CaseInsensitiveMap<>();
+            headers.forEach(this::populateStringHeaders);
+        }
+        return stringHeaders;
+    }
+
+    public void populateStringHeaders(String headerName, List<Object> values) {
+        List<String> stringValues = new ArrayList<>(values.size());
+        for (int i = 0; i < values.size(); i++) {
+            stringValues.add(HeaderUtil.headerToString(values.get(i)));
+        }
+        stringHeaders.put(headerName, stringValues);
+    }
+
+    @Override
+    public String getHeaderString(String name) {
+        return HeaderUtil.getHeaderString(getStringHeaders(), name);
+    }
+
+    public Annotation[] getEntityAnnotations() {
+        return entityAnnotations;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RestResponseImpl.java
@@ -51,6 +51,23 @@ public class RestResponseImpl<T> extends RestResponse<T> {
     protected boolean buffered;
 
     @Override
+    public Response toResponse() {
+        ResponseImpl ret = new ResponseImpl();
+        ret.status = status;
+        ret.reasonPhrase = reasonPhrase;
+        ret.entity = entity;
+        ret.headers = headers;
+        ret.entityStream = entityStream;
+        ret.statusType = statusType;
+        ret.stringHeaders = stringHeaders;
+        ret.entityAnnotations = entityAnnotations;
+        ret.consumed = consumed;
+        ret.closed = closed;
+        ret.buffered = buffered;
+        return ret;
+    }
+
+    @Override
     public int getStatus() {
         return status;
     }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RuntimeDelegateImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/RuntimeDelegateImpl.java
@@ -14,6 +14,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.Variant;
 import javax.ws.rs.ext.RuntimeDelegate;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
 import org.jboss.resteasy.reactive.common.headers.CacheControlDelegate;
 import org.jboss.resteasy.reactive.common.headers.CookieHeaderDelegate;
@@ -40,6 +42,11 @@ public class RuntimeDelegateImpl extends RuntimeDelegate {
             public int priority() {
                 return 0;
             }
+
+            @Override
+            public <T> ResponseBuilder<T> createRestResponse() {
+                throw new RuntimeException("Resteasy Reactive server side components are not installed.");
+            }
         };
         ServiceLoader<ResponseBuilderFactory> sl = ServiceLoader.load(ResponseBuilderFactory.class,
                 RuntimeDelegateImpl.class.getClassLoader());
@@ -59,6 +66,10 @@ public class RuntimeDelegateImpl extends RuntimeDelegate {
     @Override
     public Response.ResponseBuilder createResponseBuilder() {
         return factory.create();
+    }
+
+    public <T> RestResponse.ResponseBuilder<T> createRestResponseBuilder() {
+        return factory.createRestResponse();
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
@@ -39,7 +39,8 @@ import javax.ws.rs.core.UriInfo;
  * When {@code value} is not set, then the handled Exception type is deduced by the Exception type used in the method parameters
  * (there must be exactly one Exception type in this case).
  *
- * The return type of the method must be either be of type {@code Response} or {@code Uni<Response>}.
+ * The return type of the method must be either be of type {@code Response}, {@code Uni<Response>}, {@code RestResponse} or
+ * {@code Uni<RestResponse>}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerRequestFilter.java
@@ -50,21 +50,25 @@ import javax.ws.rs.core.UriInfo;
  * <li>{@link SimpleResourceInfo}
  * </ul>
  *
- * The return type of the method must be either be of type {@code void}, {@code Response}, {@code Optional<Response>},
- * {@code Uni<Void>} or
- * {@code Uni<Response>}.
+ * The return type of the method must be either be of type {@code void}, {@code Response}, {@code RestResponse},
+ * {@code Optional<Response>}, {@code Optional<RestResponse>},
+ * {@code Uni<Void>}, {@code Uni<Response>} or
+ * {@code Uni<RestResponse>}.
  * <ul>
  * <li>{@code void} should be used when filtering does not need to perform any blocking operations and the filter cannot abort
  * processing.
- * <li>{@code Response} should be used when filtering does not need to perform any blocking operations and the filter cannot
+ * <li>{@code Response} or {@code RestResponse} should be used when filtering does not need to perform any blocking operations
+ * and the filter cannot
  * abort
  * processing - in this case the processing will be aborted if the response is not {@code null}.
- * <li>{@code Optional<Response>} should be used when filtering does not need to perform any blocking operations but the filter
+ * <li>{@code Optional<Response>} or {@code Optional<RestResponse>} should be used when filtering does not need to perform any
+ * blocking operations but the filter
  * might abort processing - in this case processing is aborted when the {@code Optional} contains a {@code Response} payload.
  * <li>{@code Uni<Void>} should be used when filtering needs to perform a blocking operations but the filter cannot abort
  * processing.
  * Note that {@code Uni<Void>} can easily be produced using: {@code Uni.createFrom().nullItem()}
- * <li>{@code Uni<Response>} should be used when filtering needs to perform a blocking operations and the filter
+ * <li>{@code Uni<Response>} or {@code Uni<RestResponse>} should be used when filtering needs to perform a blocking operations
+ * and the filter
  * might abort processing - in this case processing is aborted when the {@code Uni} contains a {@code Response} payload.
  * </ul>
  *

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerResponseBuilderFactory.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerResponseBuilderFactory.java
@@ -1,8 +1,10 @@
 package org.jboss.resteasy.reactive.server.core;
 
 import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.core.ResponseBuilderFactory;
 import org.jboss.resteasy.reactive.server.jaxrs.ResponseBuilderImpl;
+import org.jboss.resteasy.reactive.server.jaxrs.RestResponseBuilderImpl;
 
 public class ServerResponseBuilderFactory implements ResponseBuilderFactory {
     @Override
@@ -13,5 +15,10 @@ public class ServerResponseBuilderFactory implements ResponseBuilderFactory {
     @Override
     public int priority() {
         return 100;
+    }
+
+    @Override
+    public <T> RestResponse.ResponseBuilder<T> createRestResponse() {
+        return new RestResponseBuilderImpl();
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyWriter;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
 import org.jboss.resteasy.reactive.common.model.MethodParameter;
 import org.jboss.resteasy.reactive.common.model.ParameterType;
@@ -548,6 +549,9 @@ public class RuntimeResourceDeployment {
                 return type.getActualTypeArguments()[0];
             }
             if (type.getRawType() == Multi.class) {
+                return type.getActualTypeArguments()[0];
+            }
+            if (type.getRawType() == RestResponse.class) {
                 return type.getActualTypeArguments()[0];
             }
             return returnType;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
@@ -5,7 +5,9 @@ import java.util.List;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.RestResponseImpl;
 import org.jboss.resteasy.reactive.server.core.EncodedMediaType;
 import org.jboss.resteasy.reactive.server.core.LazyResponse;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -36,10 +38,59 @@ public class ResponseHandler implements ServerRestHandler {
                 if (existing.hasEntity() && (existing.getEntity() != null))
                     requestContext.setGenericReturnType(existing.getEntity().getClass());
                 //TODO: super inefficient
-                responseBuilder = fromResponse((Response) result);
+                responseBuilder = fromResponse(existing);
                 if ((result instanceof ResponseImpl)) {
                     // needed in order to preserve entity annotations
                     ResponseImpl responseImpl = (ResponseImpl) result;
+                    if (responseImpl.getEntityAnnotations() != null) {
+                        requestContext.setAdditionalAnnotations(responseImpl.getEntityAnnotations());
+                    }
+
+                    // this is a weird case where the response comes from the the rest-client
+                    if (responseBuilder.getEntity() == null) {
+                        if (responseImpl.getEntityStream() instanceof ByteArrayInputStream) {
+                            ByteArrayInputStream byteArrayInputStream = (ByteArrayInputStream) responseImpl.getEntityStream();
+                            responseBuilder.entity(byteArrayInputStream.readAllBytes());
+                        }
+                    }
+                }
+            }
+            if (existing.getMediaType() != null) {
+                requestContext.setResponseContentType(existing.getMediaType());
+                mediaTypeAlreadyExists = true;
+            }
+            EncodedMediaType produces = requestContext.getResponseContentType();
+            if (!mediaTypeAlreadyExists && produces != null) {
+                responseBuilder.header(HttpHeaders.CONTENT_TYPE, produces.toString());
+            }
+            if ((responseBuilder instanceof ResponseBuilderImpl)) {
+                // avoid unnecessary copying of HTTP headers from the Builder to the Response
+                requestContext
+                        .setResponse(
+                                new LazyResponse.Existing(((ResponseBuilderImpl) responseBuilder).build(false)));
+            } else {
+                requestContext.setResponse(new LazyResponse.Existing(responseBuilder.build()));
+            }
+        } else if (result instanceof RestResponse) {
+            boolean mediaTypeAlreadyExists = false;
+            //we already have a response
+            //set it explicitly
+            ResponseBuilderImpl responseBuilder;
+            RestResponse<?> existing = (RestResponse<?>) result;
+            if (existing.getEntity() instanceof GenericEntity) {
+                GenericEntity<?> genericEntity = (GenericEntity<?>) existing.getEntity();
+                requestContext.setGenericReturnType(genericEntity.getType());
+                responseBuilder = fromResponse(existing);
+                responseBuilder.entity(genericEntity.getEntity());
+            } else {
+                // TCK says to use the entity type as generic type if we return a response
+                if (existing.hasEntity() && (existing.getEntity() != null))
+                    requestContext.setGenericReturnType(existing.getEntity().getClass());
+                //TODO: super inefficient
+                responseBuilder = fromResponse(existing);
+                if ((result instanceof RestResponseImpl)) {
+                    // needed in order to preserve entity annotations
+                    RestResponseImpl<?> responseImpl = (RestResponseImpl<?>) result;
                     if (responseImpl.getEntityAnnotations() != null) {
                         requestContext.setAdditionalAnnotations(responseImpl.getEntityAnnotations());
                     }
@@ -114,6 +165,21 @@ public class ResponseHandler implements ServerRestHandler {
 
     // avoid the runtime overhead of looking up the provider
     private ResponseBuilderImpl fromResponse(Response response) {
+        Response.ResponseBuilder b = new ResponseBuilderImpl().status(response.getStatus());
+        if (response.hasEntity()) {
+            b.entity(response.getEntity());
+        }
+        for (String headerName : response.getHeaders().keySet()) {
+            List<Object> headerValues = response.getHeaders().get(headerName);
+            for (Object headerValue : headerValues) {
+                b.header(headerName, headerValue);
+            }
+        }
+        return (ResponseBuilderImpl) b;
+    }
+
+    // avoid the runtime overhead of looking up the provider
+    private ResponseBuilderImpl fromResponse(RestResponse<?> response) {
         Response.ResponseBuilder b = new ResponseBuilderImpl().status(response.getStatus());
         if (response.hasEntity()) {
             b.entity(response.getEntity());

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/RestResponseBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/RestResponseBuilderImpl.java
@@ -1,0 +1,89 @@
+package org.jboss.resteasy.reactive.server.jaxrs;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.ws.rs.core.HttpHeaders;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.common.jaxrs.AbstractRestResponseBuilder;
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.resteasy.reactive.server.core.Deployment;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
+
+public class RestResponseBuilderImpl<T> extends AbstractRestResponseBuilder<T> {
+
+    @Override
+    public RestResponse.ResponseBuilder<T> location(URI location) {
+        if (location == null) {
+            metadata.remove(HttpHeaders.LOCATION);
+            return this;
+        }
+        if (!location.isAbsolute()) {
+            // FIXME: this leaks server stuff onto the client
+            ResteasyReactiveRequestContext request = CurrentRequestManager.get();
+            if (request != null) {
+                ServerHttpRequest req = request.serverRequest();
+                try {
+                    String host = req.getRequestHost();
+                    int port = -1;
+                    int index = host.indexOf(":");
+                    if (index > -1) {
+                        port = Integer.parseInt(host.substring(index + 1));
+                        host = host.substring(0, index);
+                    }
+                    String prefix = "";
+                    Deployment deployment = request.getDeployment();
+                    if (deployment != null) {
+                        // prefix is already sanitised
+                        prefix = deployment.getPrefix();
+                    }
+                    // Spec says relative to request, but TCK tests relative to Base URI, so we do that
+                    location = new URI(req.getRequestScheme(), null, host, port,
+                            prefix +
+                                    (location.getPath().startsWith("/") ? location.getPath() : "/" + location.getPath()),
+                            location.getQuery(), null);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        metadata.putSingle(HttpHeaders.LOCATION, location);
+        return this;
+    }
+
+    @Override
+    public RestResponse.ResponseBuilder<T> contentLocation(URI location) {
+        if (location == null) {
+            metadata.remove(HttpHeaders.CONTENT_LOCATION);
+            return this;
+        }
+        if (!location.isAbsolute()) {
+            ResteasyReactiveRequestContext request = CurrentRequestManager.get();
+            if (request != null) {
+                // FIXME: this leaks server stuff onto the client
+                ServerHttpRequest req = request.serverRequest();
+                try {
+                    String host = req.getRequestHost();
+                    int port = -1;
+                    int index = host.indexOf(":");
+                    if (index > -1) {
+                        port = Integer.parseInt(host.substring(index + 1));
+                        host = host.substring(0, index);
+                    }
+                    location = new URI(req.getRequestScheme(), null, host, port,
+                            location.getPath().startsWith("/") ? location.getPath() : "/" + location.getPath(),
+                            location.getQuery(), null);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        metadata.putSingle(HttpHeaders.CONTENT_LOCATION, location);
+        return this;
+    }
+
+    @Override
+    protected AbstractRestResponseBuilder<T> doClone() {
+        return new RestResponseBuilderImpl<>();
+    }
+}


### PR DESCRIPTION
Fixes #16718.

- Adds the `RestResponse` type, which is generic with the entity type
- It's a copy of the JAX-RS `Response` type with generics added and a few modifications
- All static methods on `RestResponse` return a fully-built `RestResponse` instead of a `ResponseBuilder` (shortcuts)
- All previous static methods which returned a builder were moved to `RestResponse.ResponseBuilder` allowing more complex use-cases
- Added updated `RestResponse.Status` and `RestResponse.StatusCode` to list new HTTP statuses and have them as `int` variants (yay).
- Added `Response RestResponse.toResponse()` to convert to a JAX-RS `Response`
- Supported in endpoint return types, as well as exception mappers and request filters (everywhere `Response` was supported)

Questions/remaining:

- ATM it's implemented by being a copy of the `Response` and impls, but perhaps it could just wrap one instead?
- The existing plumbing still relies on `Response`, not sure if we should turn it around or not. Not sure it's worth it.
- The existing JAX-RS `Request` (for preconditions) returns `Response` types, so I haven't updated the docs example to use `RestResponse`. We could extend it to offer variants that deal with `RestResponse` but given that the return type would likely be `RestResponse<Void>` since those status codes don't have any entity, it would likely be awkward and the endpoints using them would have to return `RestResponse<?>` in order to allow both variants…
- I didn't look at the client support, I'm still wondering if it's worth it. I guess.
- Missing support from `smallrye-openapi`.