### PR TITLE
CLI: set JBANG_REPO during surefire tests

### DIFF
--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -156,6 +156,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <JBANG_REPO>${settings.localRepository}</JBANG_REPO>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Update the JBANG_REPO environment variable correctly for the release build

Resolves #18224 