### PR TITLE
Recalculate compressed size in filterZipFile()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1224,6 +1224,7 @@ public class JarResultBuildStep {
                     while (entries.hasMoreElements()) {
                         ZipEntry entry = entries.nextElement();
                         if (!transformedFromThisArchive.contains(entry.getName())) {
+                            entry.setCompressedSize(-1);
                             out.putNextEntry(entry);
                             try (InputStream inStream = in.getInputStream(entry)) {
                                 int r = 0;


### PR DESCRIPTION
If the machine that produced the original JAR and the machine where
buildRunnerJar is running have different zlib versions, a

java.util.zip.ZipException: invalid entry compressed size (expected 1172 but got 1162 bytes)

may occur. Fix by forcing recalculation of compressed data size when
reusing a ZipEntry.