### PR TITLE
Escape | and ` for default values in config doc generation

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -85,7 +85,9 @@ final class SummaryTableDocFormatter implements DocFormatter {
                 // make sure nobody inserts a table cell separator here
                 doc.replace("|", "\\|"),
                 typeContent, typeDetail,
-                defaultValue.isEmpty() ? required : String.format("`%s`", defaultValue)));
+                defaultValue.isEmpty() ? required
+                        : String.format("`%s`", defaultValue.replace("|", "\\|")
+                                .replace("`", "\\`"))));
     }
 
     @Override


### PR DESCRIPTION
Fixes #18296