### PR TITLE
Fix generated bytecode of Panache repository's getEntityManager(class) method

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
@@ -48,7 +48,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * 
      * @deprecated use {@link Panache#getEntityManager(Class)} instead to access an entity manager for any entity class
      */
-    @GenerateBridge
+    @GenerateBridge(ignoreEntityTypeParam = true)
     @Deprecated
     default EntityManager getEntityManager(Class<?> clazz) {
         throw implementationInjectionMissing();

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/impl/GenerateBridge.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/impl/GenerateBridge.java
@@ -22,4 +22,9 @@ public @interface GenerateBridge {
      * still inject interceptor calls and mock stubs.
      */
     boolean callSuperMethod() default false;
+
+    /**
+     * Set to false when the implemented method should not receive the entity type as one of its parameters
+     */
+    boolean ignoreEntityTypeParam() default false;
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/User.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/User.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    public String id;
+
+    @Column(name = "first_name")
+    public String firstName;
+
+    @Column(name = "last_name")
+    public String lastName;
+
+    public Integer age;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/UserRepository.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/UserRepository.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.panache;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+
+@ApplicationScoped
+@Transactional
+public class UserRepository implements PanacheRepositoryBase<User, String> {
+
+    public Optional<User> find(final String id) {
+        return Optional.ofNullable(findById(id));
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/resources/UserResource.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/resources/UserResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.panache.resources;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.quarkus.it.panache.UserRepository;
+
+@Path("/users")
+@Produces(MediaType.APPLICATION_JSON)
+public class UserResource {
+    @Inject
+    UserRepository userRepository;
+
+    @GET
+    @Path("/{id}")
+    public Response get(@PathParam("id") final String id) {
+        return userRepository.find(id)
+                .map(user -> Response.ok(user).build())
+                .orElse(Response.status(NOT_FOUND).build());
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
@@ -7,3 +7,5 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.metrics.enabled=true
+
+quarkus.package.fernflower.enabled=true

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheRepositoryBaseTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheRepositoryBaseTest.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.panache;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class PanacheRepositoryBaseTest {
+
+    @Test
+    public void test() {
+        RestAssured.when().get("/users/1").then().statusCode(404);
+    }
+}


### PR DESCRIPTION
The problem with the code before this change was that the implementation of the method
would introduce the entity type as the first argument to the call to
`AbstractJpaOperations#getEntityManager` resulting in a call to method
that did not exist

Initially reported at: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Quarkus.202.2E0.2E0.2EFinal.20-.20PanacheRepository.20native.20image