### PR TITLE
Add JavaUtilLoggerProducer to allow injection of java.util.logging.Logger instances

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -56,8 +56,9 @@ import io.quarkus.arc.processor.StereotypeInfo;
 import io.quarkus.arc.runtime.AdditionalBean;
 import io.quarkus.arc.runtime.ArcRecorder;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.arc.runtime.JBossLoggerProducer;
+import io.quarkus.arc.runtime.JavaUtilLoggerProducer;
 import io.quarkus.arc.runtime.LaunchModeProducer;
-import io.quarkus.arc.runtime.LoggerProducer;
 import io.quarkus.arc.runtime.test.PreloadedTestApplicationClassPredicate;
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.deployment.Capabilities;
@@ -540,7 +541,7 @@ public class ArcProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem loggerProducer() {
-        return new AdditionalBeanBuildItem(LoggerProducer.class);
+        return new AdditionalBeanBuildItem(JBossLoggerProducer.class, JavaUtilLoggerProducer.class);
     }
 
     @BuildStep

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/JBossLoggerProducer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/JBossLoggerProducer.java
@@ -15,7 +15,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.log.LoggerName;
 
 @Singleton
-public class LoggerProducer {
+public class JBossLoggerProducer {
 
     private final ConcurrentMap<String, Logger> loggers = new ConcurrentHashMap<>();
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/JavaUtilLoggerProducer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/JavaUtilLoggerProducer.java
@@ -1,0 +1,48 @@
+package io.quarkus.arc.runtime;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Logger;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Singleton;
+
+import io.quarkus.arc.log.LoggerName;
+
+@Singleton
+public class JavaUtilLoggerProducer {
+
+    private final ConcurrentMap<String, Logger> loggers = new ConcurrentHashMap<>();
+
+    @Dependent
+    @Produces
+    Logger getSimpleLogger(InjectionPoint injectionPoint) {
+        return loggers.computeIfAbsent(injectionPoint.getMember().getDeclaringClass().getName(), Logger::getLogger);
+    }
+
+    @LoggerName("")
+    @Dependent
+    @Produces
+    Logger getLoggerWithCustomName(InjectionPoint injectionPoint) {
+        String name = null;
+        for (Annotation qualifier : injectionPoint.getQualifiers()) {
+            if (qualifier.annotationType().equals(LoggerName.class)) {
+                name = ((LoggerName) qualifier).value();
+            }
+        }
+        if (name == null || name.isEmpty()) {
+            throw new IllegalStateException("Unable to derive the logger name at " + injectionPoint);
+        }
+        return loggers.computeIfAbsent(name, Logger::getLogger);
+    }
+
+    @PreDestroy
+    void destroy() {
+        loggers.clear();
+    }
+
+}


### PR DESCRIPTION
Currently, Quarkus supports injection of instances of `org.jboss.logging.Logger` but not of the `java.util.logging.Logger`. This PR adds a `JavaUtilLoggerProducer` similar to the `LoggerProducer` for the jboss Logger. 

The benefit of the java util Logger is that it allows passing lambdas and therefore allows a nice way to produce complex log messages that have no performance impact when that log level isn't active.


**Two questions for the maintainers:**

* Currently the code for the JavaUtilLoggerProducer is practically a copy of the jboss Logger but with the different type in the import. Should I try to extract the common code or do you prefer the simpler solution that duplicates a bit of code. What do you think?
* Should we rename the `LoggerProducer` to `JBossLoggerProducer` since it only produces the JBoss Logger?

