### PR TITLE
Produce valid JSON for Multi<String> return type in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/StreamingUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/StreamingUtil.java
@@ -58,9 +58,14 @@ public class StreamingUtil {
         for (MessageBodyWriter<Object> writer : writers) {
             // Spec(API) says we should use class/type/mediaType but doesn't talk about annotations 
             if (writer.isWriteable(entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType)) {
-                // FIXME: spec doesn't really say what headers we should use here
-                writer.writeTo(entity, entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType,
-                        Serialisers.EMPTY_MULTI_MAP, baos);
+                // FIXME: Hack to enforce double quotes being written (our JSON writers won't do due to some TCK hack)
+                if (entityClass.equals(String.class) && mediaType.toString().startsWith(MediaType.APPLICATION_JSON)) {
+                    baos.write(("\"" + entity + "\"").getBytes(StandardCharsets.UTF_8));
+                } else {
+                    // FIXME: spec doesn't really say what headers we should use here
+                    writer.writeTo(entity, entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType,
+                            Serialisers.EMPTY_MULTI_MAP, baos);
+                }
                 wrote = true;
                 break;
             }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -154,6 +154,7 @@
         <module>reactive-messaging-kafka</module>
         <module>reactive-messaging-http</module>
         <module>rest-client</module>
+        <module>resteasy-reactive</module>
         <module>resteasy-reactive-kotlin</module>
         <module>resteasy-reactive-rest-client</module>
         <module>resteasy-reactive-rest-client-multipart</module>

--- a/integration-tests/resteasy-reactive/pom.xml
+++ b/integration-tests/resteasy-reactive/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-resteasy-reactive</artifactId>
+
+    <name>Quarkus - Integration Tests - RESTEasy Reactive</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/BigKeysResource.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/BigKeysResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.resteasy.reactive;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("/bigkeys")
+public class BigKeysResource {
+
+    @POST
+    public Payload post(Payload payload) {
+        return payload;
+    }
+
+    public static class Payload {
+
+        private Map<BigDecimal, String> bdMap;
+
+        private Map<BigInteger, String> biMap;
+
+        public Map<BigDecimal, String> getBdMap() {
+            return bdMap;
+        }
+
+        public void setBdMap(Map<BigDecimal, String> bdMap) {
+            this.bdMap = bdMap;
+        }
+
+        public Map<BigInteger, String> getBiMap() {
+            return biMap;
+        }
+
+        public void setBiMap(Map<BigInteger, String> biMap) {
+            this.biMap = biMap;
+        }
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/Greeting.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/Greeting.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.resteasy.reactive;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+public class Greeting {
+
+    private final String message;
+    private final LocalDate date;
+    private final Date sqlDate;
+
+    public Greeting(String message, LocalDate date, Date sqlDate) {
+        this.message = message;
+        this.date = date;
+        this.sqlDate = sqlDate;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public Date getSqlDate() {
+        return sqlDate;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/GreetingResource.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/GreetingResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.resteasy.reactive;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/greeting")
+public class GreetingResource {
+
+    @GET
+    public Greeting hello() {
+        LocalDate localDate = LocalDate.of(2019, 01, 01);
+        return new Greeting("hello", localDate, new Date(localDate.toEpochDay()));
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/MessageResource.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/MessageResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.resteasy.reactive;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/message")
+public class MessageResource {
+
+    @ConfigProperty(name = "message")
+    String message;
+
+    @GET
+    public String message() {
+        return message;
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/MyRestService.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/MyRestService.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.resteasy.reactive;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient(configKey = "my-service")
+@Path("/reactive")
+public interface MyRestService {
+
+    @GET
+    @Path("/hello")
+    @Consumes(MediaType.TEXT_PLAIN)
+    Uni<String> hello();
+
+    @GET
+    @Path("/pet")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Uni<Pet> pet();
+
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/Pet.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/Pet.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.resteasy.reactive;
+
+public class Pet {
+
+    private String name;
+    private String kind;
+
+    public String getName() {
+        return name;
+    }
+
+    public Pet setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public Pet setKind(String kind) {
+        this.kind = kind;
+        return this;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/ReactiveMutinyResource.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/ReactiveMutinyResource.java
@@ -1,0 +1,88 @@
+package io.quarkus.it.resteasy.reactive;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestSseElementType;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@Path("/reactive")
+@Produces(MediaType.APPLICATION_JSON)
+public class ReactiveMutinyResource {
+
+    @Inject
+    io.quarkus.it.resteasy.reactive.SomeService service;
+
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> hello() {
+        return service.greeting();
+    }
+
+    @GET
+    @Path("/fail")
+    public Uni<String> fail() {
+        return Uni.createFrom().failure(new IOException("boom"));
+    }
+
+    @GET
+    @Path("/response")
+    public Uni<Response> response() {
+        return service.greeting()
+                .onItem().transform(v -> Response.accepted().type("text/plain").entity(v).build());
+    }
+
+    @GET
+    @Path("/hello/stream")
+    public Multi<String> helloAsMulti() {
+        return service.greetingAsMulti();
+    }
+
+    @GET
+    @Path("/pet")
+    public Uni<Pet> pet() {
+        return service.getPet();
+    }
+
+    @GET
+    @Path("/pet/stream")
+    public Multi<Pet> pets() {
+        return service.getPets();
+    }
+
+    @GET
+    @Path("/pets")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @RestSseElementType(MediaType.APPLICATION_JSON)
+    public Multi<Pet> sse() {
+        return service.getMorePets();
+    }
+
+    @Inject
+    @RestClient
+    MyRestService client;
+
+    @GET
+    @Path("/client")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> callHello() {
+        return client.hello();
+    }
+
+    @GET
+    @Path("/client/pet")
+    public Uni<Pet> callPet() {
+        return client.pet();
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/SomeService.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/SomeService.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.resteasy.reactive;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class SomeService {
+
+    private ExecutorService executor;
+
+    @PostConstruct
+    public void init() {
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @PreDestroy
+    public void cleanup() {
+        executor.shutdownNow();
+    }
+
+    Uni<String> greeting() {
+        return Uni.createFrom().item("hello")
+                .emitOn(executor);
+    }
+
+    Multi<String> greetingAsMulti() {
+        return Multi.createFrom().items("h", "e", "l", "l", "o")
+                .groupItems().intoMultis().of(2)
+                .onItem().transformToUniAndConcatenate(g -> g.collect().in(StringBuffer::new, StringBuffer::append))
+                .emitOn(executor)
+                .onItem().transform(StringBuffer::toString);
+    }
+
+    Uni<Pet> getPet() {
+        return Uni.createFrom().item(new Pet().setName("neo").setKind("rabbit"))
+                .emitOn(executor);
+    }
+
+    public Multi<Pet> getPets() {
+        return Multi.createFrom().items(
+                new Pet().setName("neo").setKind("rabbit"),
+                new Pet().setName("indy").setKind("dog"))
+                .emitOn(executor);
+    }
+
+    public Multi<Pet> getMorePets() {
+        return Multi.createFrom().items(
+                new Pet().setName("neo").setKind("rabbit"),
+                new Pet().setName("indy").setKind("dog"),
+                new Pet().setName("plume").setKind("dog"),
+                new Pet().setName("titi").setKind("bird"),
+                new Pet().setName("rex").setKind("mouse"))
+                .emitOn(executor);
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/BaseClass.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/BaseClass.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.resteasy.reactive.generics;
+
+public class BaseClass<T> {
+
+    private String baseVariable;
+    private T data;
+
+    public String getBaseVariable() {
+        return this.baseVariable;
+    }
+
+    public void setBaseVariable(String baseVariable) {
+        this.baseVariable = baseVariable;
+    }
+
+    public T getData() {
+        return this.data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/ExtendedClass.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/ExtendedClass.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.resteasy.reactive.generics;
+
+public class ExtendedClass extends BaseClass<MyData> {
+
+    private String extendedVariable;
+
+    public String getExtendedVariable() {
+        return this.extendedVariable;
+    }
+
+    public void setExtendedVariable(String extendedVariable) {
+        this.extendedVariable = extendedVariable;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/GenericsResource.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/GenericsResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.resteasy.reactive.generics;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/generics")
+public class GenericsResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ExtendedClass testExtendedClass() {
+        final ExtendedClass c = new ExtendedClass();
+        c.setBaseVariable("myBaseVariable");
+        c.setExtendedVariable("myExtendedVariable");
+        final MyData d = new MyData();
+        d.setDataVariable("myData");
+        c.setData(d);
+        return c;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/MyData.java
+++ b/integration-tests/resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/generics/MyData.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.resteasy.reactive.generics;
+
+public class MyData {
+
+    private String dataVariable;
+
+    public String getDataVariable() {
+        return this.dataVariable;
+    }
+
+    public void setDataVariable(String dataVariable) {
+        this.dataVariable = dataVariable;
+    }
+}

--- a/integration-tests/resteasy-reactive/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+my-service/mp-rest/url=${test.url}
+message=Production

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ApplicationPropertiesOverrideIT.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ApplicationPropertiesOverrideIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * tests that application.properties is read from src/main/resources when running native image tests
+ * 
+ * This does not necessarily belong here, but main and test-extension have a lot of existing
+ * config that would need to be duplicated, so it is here out of convenience.
+ */
+@QuarkusIntegrationTest
+class ApplicationPropertiesOverrideIT {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/message")
+                .then()
+                .statusCode(200)
+                .body(containsString("Production"));
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ApplicationPropertiesOverrideTest.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ApplicationPropertiesOverrideTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * tests that application.properties is read from src/test/resources
+ * 
+ * This does not necessarily belong here, but main and test-extension have a lot of existing
+ * config that would need to be duplicated, so it is here out of convenience.
+ */
+@QuarkusTest
+class ApplicationPropertiesOverrideTest {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/message")
+                .then()
+                .statusCode(200)
+                .body(containsString("Test"));
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/BigKeysResourceIT.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/BigKeysResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.reactive;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class BigKeysResourceIT extends BigKeysResourceTest {
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/BigKeysResourceTest.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/BigKeysResourceTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class BigKeysResourceTest {
+
+    @Test
+    public void test() throws IOException {
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"bdMap\":{\"1\":\"One\", \"2\":\"Two\"},  \"biMap\":{\"1\":\"One\", \"2\":\"Two\"}}")
+                .when().post("/bigkeys")
+                .then()
+                .statusCode(200)
+                .body("bdMap.1", equalTo("One"))
+                .body("biMap.2", equalTo("Two"));
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GenericsResourceIT.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GenericsResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.reactive;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class GenericsResourceIT extends GenericsResourceTest {
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GenericsResourceTest.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GenericsResourceTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.resteasy.reactive.generics.ExtendedClass;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class GenericsResourceTest {
+
+    @Test
+    public void testExtendedEndpoint() {
+        ExtendedClass response = given()
+                .when().get("/generics")
+                .then()
+                .statusCode(200)
+                .extract().body().as(ExtendedClass.class);
+        assertEquals("myBaseVariable", response.getBaseVariable());
+        assertEquals("myExtendedVariable", response.getExtendedVariable());
+        assertEquals("myData", response.getData().getDataVariable());
+    }
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GreetingResourceTest.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GreetingResourceTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class GreetingResourceTest {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(containsString("hello"))
+                .body(containsString("2019-01-01"));
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GreetingResourceTestIT.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/GreetingResourceTestIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.reactive;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class GreetingResourceTestIT extends GreetingResourceTest {
+}

--- a/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ReactiveMutinyTest.java
+++ b/integration-tests/resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/ReactiveMutinyTest.java
@@ -1,0 +1,134 @@
+package io.quarkus.it.resteasy.reactive;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.SseEventSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+
+@QuarkusTest
+public class ReactiveMutinyTest {
+
+    @Test
+    public void testHello() {
+        get("/reactive/hello")
+                .then()
+                .body(is("hello"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testFail() {
+        get("/reactive/fail")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    public void testResponse() {
+        get("/reactive/response")
+                .then()
+                .body(is("hello"))
+                .statusCode(202);
+    }
+
+    @Test
+    public void testHelloAsMulti() {
+        get("/reactive/hello/stream")
+                .then()
+                .contentType("application/json")
+                .body("[0]", is("he"))
+                .body("[1]", is("ll"))
+                .body("[2]", is("o"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testSerialization() {
+        get("/reactive/pet")
+                .then()
+                .contentType("application/json")
+                .body("name", is("neo"))
+                .body("kind", is("rabbit"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testMultiWithSerialization() {
+        get("/reactive/pet/stream")
+                .then()
+                .contentType("application/json")
+                .body("[0].name", is("neo"))
+                .body("[0].kind", is("rabbit"))
+                .body("[1].name", is("indy"))
+                .body("[1].kind", is("dog"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testSSE() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target("http://localhost:" + RestAssured.port + "/reactive/pets");
+        try (SseEventSource eventSource = SseEventSource.target(target).build()) {
+            Uni<List<Pet>> petList = Uni.createFrom().emitter(new Consumer<UniEmitter<? super List<Pet>>>() {
+                @Override
+                public void accept(UniEmitter<? super List<Pet>> uniEmitter) {
+                    List<Pet> pets = new CopyOnWriteArrayList<>();
+                    eventSource.register(event -> {
+                        Pet pet = event.readData(Pet.class, MediaType.APPLICATION_JSON_TYPE);
+                        pets.add(pet);
+                        if (pets.size() == 5) {
+                            uniEmitter.complete(pets);
+                        }
+                    }, ex -> {
+                        uniEmitter.fail(new IllegalStateException("SSE failure", ex));
+                    });
+                    eventSource.open();
+
+                }
+            });
+            List<Pet> pets = petList.await().atMost(Duration.ofMinutes(1));
+            Assertions.assertEquals(5, pets.size());
+            Assertions.assertEquals("neo", pets.get(0).getName());
+            Assertions.assertEquals("indy", pets.get(1).getName());
+            Assertions.assertEquals("plume", pets.get(2).getName());
+            Assertions.assertEquals("titi", pets.get(3).getName());
+            Assertions.assertEquals("rex", pets.get(4).getName());
+        }
+    }
+
+    @Test
+    public void testClientReturningUni() {
+        get("/reactive/client")
+                .then()
+                .body(is("hello"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testClientReturningUniOfPet() {
+        get("/reactive/client/pet")
+                .then()
+                .contentType("application/json")
+                .body("name", is("neo"))
+                .body("kind", is("rabbit"))
+                .statusCode(200);
+    }
+
+}

--- a/integration-tests/resteasy-reactive/src/test/resources/application.properties
+++ b/integration-tests/resteasy-reactive/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+message=Test


### PR DESCRIPTION
This is primarily meant to provide a fix for #18043. However, there were no `integration-tests/resteasy-reactive` yet, so I added them. I have a few questions with you to discuss:

**Regarding my fix for the issue in `StreamingUtil.java`...**
  - is it safe for integration, regarding the UTF-8 charset and regarding the `MediaType` condition?
  - the fix is a bit hack-ish; I think, if possible, it would be better to change those Jackson/JSONB writers, for example `FullyFeaturedServerJacksonMessageBodyWriter`; however, I wasn't sure how to test that for side-effects; probably running the RESTeasy TCK?

**Regarding the integration tests for RESTeasy reactive**
I added the project right under `integration-tests` and copied (YUK!) some classes from the `resteasy-mutiny` and `resteasy-jackson` integration tests. Would be better to share the classes, using a parent or shared project. However, I was not sure how much restructuring I would be allowed to do in this scope. You might like to have this done under a separate GitHub issue?