### PR TITLE
Fix RR kotline deployment dependencies

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-common-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -800,7 +800,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private org.eclipse.aether.artifact.Artifact getDeploymentArtifact(org.eclipse.aether.artifact.Artifact a)
             throws MojoExecutionException {
-        final Properties props = getExtensionDescriptor(a, true);
+        final Properties props = getExtensionDescriptor(a, false);
         if (props == null) {
             return null;
         }
@@ -822,7 +822,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             return null;
         }
         // if it hasn't been packaged yet, we skip it, we are not packaging yet
-        if (packaged && !isJarFile(f)) {
+        if (!a.getExtension().equals("jar") || packaged && !isJarFile(f)) {
             return null;
         }
         try {


### PR DESCRIPTION
With the changes to the `extension-descriptor` goal I get the following error
````
[INFO] --- quarkus-bootstrap-maven-plugin:999-SNAPSHOT:extension-descriptor (generate-extension-descriptor) @ quarkus-resteasy-reactive-kotlin ---
[ERROR] Quarkus Extension Dependency Verification Error
[ERROR] Deployment artifact io.quarkus:quarkus-resteasy-reactive-kotlin-deployment::jar:999-SNAPSHOT was found to be missing dependencies on the Quarkus extension artifacts marked with '-' below:
[ERROR] +     io.quarkus:quarkus-resteasy-reactive-kotlin::jar
[ERROR] -     io.quarkus:quarkus-resteasy-reactive-common-deployment::jar
[ERROR] -         io.quarkus:quarkus-mutiny-deployment::jar
[ERROR] +             io.quarkus:quarkus-core-deployment::jar
[ERROR] -             io.quarkus:quarkus-smallrye-context-propagation-deployment::jar
[ERROR] -         io.quarkus:quarkus-vertx-core-deployment::jar
[ERROR] +             io.quarkus:quarkus-arc-deployment::jar
[ERROR] -             io.quarkus:quarkus-netty-deployment::jar
[ERROR] -         io.quarkus:quarkus-jsonp-deployment::jar
````

Which is fixed in the deployment pom.xml.