### PR TITLE
UUID Config Source

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
@@ -11,7 +11,8 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * We don't really use this, because these are configurations for the config itself, so it causes a chicken / egg
  * problem, but we have it so the configurations can be properly documented.
  *
- * Relocation of the Config configurations to the Quarkus namespace is done in ConfigUtils#configBuilder.
+ * Relocation of the Config configurations to the Quarkus namespace is done in
+ * {@link io.quarkus.runtime.configuration.ConfigUtils#configBuilder}.
  */
 @ConfigRoot(name = ConfigItem.PARENT, phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class ConfigConfig {
@@ -28,4 +29,13 @@ public class ConfigConfig {
      */
     @ConfigItem(name = "config.profile.parent")
     public Optional<String> profileParent;
+
+    /**
+     * A property that allows accessing a generated UUID.
+     * It generates that UUID at startup time. So it changes between two starts including in dev mode.
+     *
+     * Access this generated UUID using expressions: `${quarkus.uuid}`.
+     */
+    @ConfigItem(name = "uuid")
+    public Optional<String> uuid;
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.IntFunction;
 
@@ -46,6 +47,12 @@ import io.smallrye.config.common.utils.ConfigSourceUtil;
  *
  */
 public final class ConfigUtils {
+
+    /**
+     * The name of the property associated with a random UUID generated at launch time.
+     */
+    static final String UUID_KEY = "quarkus.uuid";
+
     private ConfigUtils() {
     }
 
@@ -97,6 +104,7 @@ public final class ConfigUtils {
         }
         if (runTime) {
             builder.addDefaultSources();
+            builder.withDefaultValue(UUID_KEY, UUID.randomUUID().toString());
             builder.withSources(dotEnvSources(classLoader));
         } else {
             final List<ConfigSource> sources = new ArrayList<>();

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.runtime.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.LaunchMode;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class UUIDPropertyTest {
+
+    static ClassLoader classLoader;
+    static ConfigProviderResolver cpr;
+
+    @BeforeAll
+    public static void initConfig() {
+        classLoader = Thread.currentThread().getContextClassLoader();
+        cpr = ConfigProviderResolver.instance();
+    }
+
+    @AfterEach
+    public void doAfter() {
+        try {
+            cpr.releaseConfig(cpr.getConfig());
+        } catch (IllegalStateException ignored) {
+            // just means no config was installed, which is fine
+        }
+    }
+
+    private SmallRyeConfig buildConfig() {
+        final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+        builder.withDefaultValue(ConfigUtils.UUID_KEY, UUID.randomUUID().toString());
+        final SmallRyeConfig config = builder.build();
+        cpr.registerConfig(config, classLoader);
+        return config;
+    }
+
+    @Test
+    void testConfigSource() {
+        SmallRyeConfig config = buildConfig();
+        assertThat(config.getConfigSources()).isNotEmpty();
+        ConfigValue value = config.getConfigValue(ConfigUtils.UUID_KEY);
+        assertThat(value).isNotNull();
+        assertThat(value.getValue()).isNotNull().isNotBlank();
+    }
+
+    @Test
+    void testBuildTimeWithDevMode() {
+        SmallRyeConfig config = ConfigUtils.configBuilder(false, LaunchMode.DEVELOPMENT).build();
+        assertThat(config.getConfigSources()).isNotEmpty();
+        ConfigValue value = config.getConfigValue(ConfigUtils.UUID_KEY);
+        assertThat(value).isNotNull();
+        assertThat(value.getValue()).isNull();
+    }
+}

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -380,6 +380,21 @@ application.host=${HOST:${remote.host}}
 This will expand the `HOST` environment variable and use the value of the property `remote.host` as the default value
 if `HOST` is not set.
 
+== Accessing a generating UUID
+
+The default config source from Quarkus provides a random UUID value.
+It generates the UUID at startup time.
+So, the value changes between startups, including reloads in dev mode.
+
+You can access the generated value using the `quarkus.uuid` property.
+Use <<property-expressions, expressions>> to access it: `${quarkus.uuid}`.
+For example, it can be useful to configure a Kafka client with a unique consumer group:
+
+[source, properties]
+----
+mp.messaging.incoming.prices.group.id=${quarkus.uuid}
+----
+
 == Clearing properties
 
 Run time properties which are optional, and which have had values set at build time or which have a default value,


### PR DESCRIPTION
Define a new low-priority config source generating a unique UUID at startup.

The use case is mainly Kafka consumers who need to a unique group.id every time (to restart the processing from the first offset).