### PR TITLE
Update to SmallRye Fault Tolerance 5.2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <smallrye-open-api.version>2.1.7</smallrye-open-api.version>
         <smallrye-graphql.version>1.2.8</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.0</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>5.1.0</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>5.2.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.2.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
@@ -2,13 +2,16 @@ package io.quarkus.deployment.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
@@ -300,6 +303,72 @@ public class JandexUtilTest {
     }
 
     public static class ErasedRepo2 extends MultiBoundedRepo {
+    }
+
+    @Test
+    public void testLoadRawType() {
+        Index index = index(TestMethods.class);
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(TestMethods.class.getName()));
+
+        assertEquals(void.class, JandexUtil.loadRawType(clazz.method("aaa").returnType()));
+        assertEquals(int.class, JandexUtil.loadRawType(clazz.method("bbb").returnType()));
+        assertEquals(String.class, JandexUtil.loadRawType(clazz.method("ccc").returnType()));
+        assertEquals(List.class, JandexUtil.loadRawType(clazz.method("ddd").returnType()));
+        assertEquals(String[][].class, JandexUtil.loadRawType(clazz.method("eee").returnType()));
+        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("fff").returnType()));
+        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("ggg").returnType()));
+        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("hhh").returnType()));
+        assertEquals(Comparable.class, JandexUtil.loadRawType(clazz.method("iii").returnType()));
+        assertEquals(Comparable.class, JandexUtil.loadRawType(clazz.method("jjj").returnType()));
+        assertEquals(Serializable.class, JandexUtil.loadRawType(clazz.method("kkk").returnType()));
+        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("lll").returnType()
+                .asParameterizedType().arguments().get(0)));
+        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("mmm").returnType()
+                .asParameterizedType().arguments().get(0)));
+        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("nnn").returnType()
+                .asParameterizedType().arguments().get(0)));
+        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("ooo").returnType()
+                .asParameterizedType().arguments().get(0)));
+        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("ppp").returnType()
+                .asParameterizedType().arguments().get(0)));
+        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("qqq").returnType()
+                .asParameterizedType().arguments().get(0)));
+    }
+
+    public interface TestMethods<X> {
+        void aaa();
+
+        int bbb();
+
+        String ccc();
+
+        List<String> ddd();
+
+        String[][] eee();
+
+        X fff();
+
+        <Y extends Number> Y ggg();
+
+        <Y extends Number & Comparable<Y>> Y hhh();
+
+        <Y extends Comparable<Y>> Y iii();
+
+        <Y extends Comparable<Y> & Serializable> Y jjj();
+
+        <Y extends Serializable & Comparable<Y>> Y kkk();
+
+        List<?> lll();
+
+        List<? extends Number> mmm();
+
+        List<? super String> nnn();
+
+        List<? extends X> ooo();
+
+        <Y extends Number> List<? extends Y> ppp();
+
+        <Y extends Number> List<? super Y> qqq();
     }
 
     private static Index index(Class<?>... classes) {

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -504,13 +504,13 @@ All that is needed to enable the fault tolerance features in Quarkus is:
 == Additional resources
 
 SmallRye Fault Tolerance has more features than shown here.
-Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/5.1.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
+Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/5.2.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
 
 In Quarkus, you can use the SmallRye Fault Tolerance optional features out of the box.
 
-Support for Mutiny is present, so your `@Asynchronous` methods can return `Uni`.
+Support for Mutiny is present, so your asynchronous methods can return `Uni` in addition to `CompletionStage`.
 
-MicroProfile Context Propagation is integrated with Fault Tolerance, so existing contexts are automatically propagated to your `@Asynchronous` methods.
+MicroProfile Context Propagation is integrated with Fault Tolerance, so existing contexts are automatically propagated to your asynchronous methods.
 
 [NOTE]
 ====
@@ -519,4 +519,17 @@ This is contrary to MicroProfile Fault Tolerance specification, which states tha
 
 We believe that in presence of MicroProfile Context Propagation, this requirement should not apply.
 The entire point of context propagation is to make sure the new thread has the same contexts as the original thread.
+====
+
+Non-compatible mode is enabled by default, so methods that return `CompletionStage` (or `Uni`) have asynchronous fault tolerance applied without any `@Asynchronous`, `@Blocking` or `@NonBlocking` annotation.
+
+[NOTE]
+====
+This mode is not compatible with the MicroProfile Fault Tolerance specification, albeit the incompatibility is very small.
+To restore full compatibility, add this configuration property:
+
+[source,properties]
+----
+smallrye.faulttolerance.mp-compatibility=true
+----
 ====

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/DotNames.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/DotNames.java
@@ -1,0 +1,46 @@
+package io.quarkus.smallrye.faulttolerance.deployment;
+
+import java.util.Set;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.jboss.jandex.DotName;
+
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+import io.smallrye.faulttolerance.api.CustomBackoff;
+import io.smallrye.faulttolerance.api.CustomBackoffStrategy;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+
+public final class DotNames {
+    public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
+
+    public static final DotName ASYNCHRONOUS = DotName.createSimple(Asynchronous.class.getName());
+    public static final DotName BULKHEAD = DotName.createSimple(Bulkhead.class.getName());
+    public static final DotName CIRCUIT_BREAKER = DotName.createSimple(CircuitBreaker.class.getName());
+    public static final DotName FALLBACK = DotName.createSimple(Fallback.class.getName());
+    public static final DotName RETRY = DotName.createSimple(Retry.class.getName());
+    public static final DotName TIMEOUT = DotName.createSimple(Timeout.class.getName());
+
+    // SmallRye annotations (@CircuitBreakerName, @[Non]Blocking, @*Backoff) alone do _not_ trigger
+    // the fault tolerance interceptor, only in combination with other fault tolerance annotations
+    public static final Set<DotName> FT_ANNOTATIONS = Set.of(ASYNCHRONOUS, BULKHEAD, CIRCUIT_BREAKER, FALLBACK, RETRY, TIMEOUT);
+
+    public static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
+    public static final DotName NON_BLOCKING = DotName.createSimple(NonBlocking.class.getName());
+
+    public static final DotName CIRCUIT_BREAKER_NAME = DotName.createSimple(CircuitBreakerName.class.getName());
+
+    public static final DotName EXPONENTIAL_BACKOFF = DotName.createSimple(ExponentialBackoff.class.getName());
+    public static final DotName FIBONACCI_BACKOFF = DotName.createSimple(FibonacciBackoff.class.getName());
+    public static final DotName CUSTOM_BACKOFF = DotName.createSimple(CustomBackoff.class.getName());
+    public static final DotName CUSTOM_BACKOFF_STRATEGY = DotName.createSimple(CustomBackoffStrategy.class.getName());
+
+    public static final Set<DotName> BACKOFF_ANNOTATIONS = Set.of(EXPONENTIAL_BACKOFF, FIBONACCI_BACKOFF, CUSTOM_BACKOFF);
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -1,0 +1,181 @@
+package io.quarkus.smallrye.faulttolerance.deployment;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.arc.processor.AnnotationStore;
+import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
+import io.quarkus.deployment.util.JandexUtil;
+import io.quarkus.gizmo.ClassOutput;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+import io.smallrye.faulttolerance.api.CustomBackoff;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+import io.smallrye.faulttolerance.autoconfig.FaultToleranceMethod;
+import io.smallrye.faulttolerance.autoconfig.MethodDescriptor;
+
+final class FaultToleranceScanner {
+    private final IndexView index;
+    private final AnnotationStore annotationStore;
+
+    private final AnnotationProxyBuildItem proxy;
+    private final ClassOutput output;
+
+    FaultToleranceScanner(IndexView index, AnnotationStore annotationStore, AnnotationProxyBuildItem proxy,
+            ClassOutput output) {
+        this.index = index;
+        this.annotationStore = annotationStore;
+        this.proxy = proxy;
+        this.output = output;
+    }
+
+    boolean hasFTAnnotations(ClassInfo clazz) {
+        // first check annotations on type
+        if (annotationStore.hasAnyAnnotation(clazz, DotNames.FT_ANNOTATIONS)) {
+            return true;
+        }
+
+        // then check on the methods
+        for (MethodInfo method : clazz.methods()) {
+            if (annotationStore.hasAnyAnnotation(method, DotNames.FT_ANNOTATIONS)) {
+                return true;
+            }
+        }
+
+        // then check on the parent
+        DotName parentClassName = clazz.superName();
+        if (parentClassName == null || parentClassName.equals(DotNames.OBJECT)) {
+            return false;
+        }
+        ClassInfo parentClass = index.getClassByName(parentClassName);
+        if (parentClass == null) {
+            return false;
+        }
+        return hasFTAnnotations(parentClass);
+    }
+
+    void forEachMethod(ClassInfo clazz, Consumer<MethodInfo> action) {
+        for (MethodInfo method : clazz.methods()) {
+            if (method.name().startsWith("<")) {
+                // constructors (or static init blocks) can't be intercepted
+                continue;
+            }
+            if (method.isSynthetic()) {
+                // synthetic methods can't be intercepted
+                continue;
+            }
+
+            action.accept(method);
+        }
+
+        DotName parentClassName = clazz.superName();
+        if (parentClassName == null || parentClassName.equals(DotNames.OBJECT)) {
+            return;
+        }
+        ClassInfo parentClass = index.getClassByName(parentClassName);
+        if (parentClass == null) {
+            return;
+        }
+        forEachMethod(parentClass, action);
+    }
+
+    FaultToleranceMethod createFaultToleranceMethod(ClassInfo beanClass, MethodInfo method) {
+        Set<Class<? extends Annotation>> annotationsPresentDirectly = new HashSet<>();
+
+        FaultToleranceMethod result = new FaultToleranceMethod();
+
+        result.beanClass = load(beanClass.name());
+        result.method = createMethodDescriptor(method);
+
+        result.asynchronous = getAnnotation(Asynchronous.class, method, beanClass, annotationsPresentDirectly);
+        result.bulkhead = getAnnotation(Bulkhead.class, method, beanClass, annotationsPresentDirectly);
+        result.circuitBreaker = getAnnotation(CircuitBreaker.class, method, beanClass, annotationsPresentDirectly);
+        result.fallback = getAnnotation(Fallback.class, method, beanClass, annotationsPresentDirectly);
+        result.retry = getAnnotation(Retry.class, method, beanClass, annotationsPresentDirectly);
+        result.timeout = getAnnotation(Timeout.class, method, beanClass, annotationsPresentDirectly);
+
+        result.circuitBreakerName = getAnnotation(CircuitBreakerName.class, method, beanClass, annotationsPresentDirectly);
+        result.customBackoff = getAnnotation(CustomBackoff.class, method, beanClass, annotationsPresentDirectly);
+        result.exponentialBackoff = getAnnotation(ExponentialBackoff.class, method, beanClass, annotationsPresentDirectly);
+        result.fibonacciBackoff = getAnnotation(FibonacciBackoff.class, method, beanClass, annotationsPresentDirectly);
+
+        result.blocking = getAnnotation(Blocking.class, method, beanClass, annotationsPresentDirectly);
+        result.nonBlocking = getAnnotation(NonBlocking.class, method, beanClass, annotationsPresentDirectly);
+
+        result.annotationsPresentDirectly = annotationsPresentDirectly;
+
+        return result;
+    }
+
+    private MethodDescriptor createMethodDescriptor(MethodInfo method) {
+        MethodDescriptor result = new MethodDescriptor();
+        result.declaringClass = load(method.declaringClass().name());
+        result.name = method.name();
+        result.parameterTypes = method.parameters()
+                .stream()
+                .map(JandexUtil::loadRawType)
+                .toArray(Class[]::new);
+        result.returnType = JandexUtil.loadRawType(method.returnType());
+        return result;
+    }
+
+    private <A extends Annotation> A getAnnotation(Class<A> annotationType, MethodInfo method,
+            ClassInfo beanClass, Set<Class<? extends Annotation>> directlyPresent) {
+
+        DotName annotationName = DotName.createSimple(annotationType.getName());
+        if (annotationStore.hasAnnotation(method, annotationName)) {
+            directlyPresent.add(annotationType);
+            AnnotationInstance annotation = annotationStore.getAnnotation(method, annotationName);
+            return createAnnotation(annotationType, annotation);
+        }
+
+        return getAnnotationFromClass(annotationType, beanClass);
+    }
+
+    private <A extends Annotation> A getAnnotationFromClass(Class<A> annotationType, ClassInfo clazz) {
+        DotName annotationName = DotName.createSimple(annotationType.getName());
+        if (annotationStore.hasAnnotation(clazz, annotationName)) {
+            AnnotationInstance annotation = annotationStore.getAnnotation(clazz, annotationName);
+            return createAnnotation(annotationType, annotation);
+        }
+
+        // then check on the parent
+        DotName parentClassName = clazz.superName();
+        if (parentClassName == null || parentClassName.equals(DotNames.OBJECT)) {
+            return null;
+        }
+        ClassInfo parentClass = index.getClassByName(parentClassName);
+        if (parentClass == null) {
+            return null;
+        }
+        return getAnnotationFromClass(annotationType, parentClass);
+    }
+
+    private <A extends Annotation> A createAnnotation(Class<A> annotationType, AnnotationInstance instance) {
+        return proxy.builder(instance, annotationType).build(output);
+    }
+
+    private static Class<?> load(DotName name) {
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(name.toString());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -17,13 +17,7 @@ import javax.enterprise.inject.spi.DefinitionException;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.faulttolerance.Asynchronous;
-import org.eclipse.microprofile.faulttolerance.Bulkhead;
-import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
-import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
-import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
@@ -43,20 +37,24 @@ import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
-import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationTypeBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
+import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusAsyncExecutorProvider;
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusExistingCircuitBreakerNames;
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusFallbackHandlerProvider;
@@ -67,7 +65,8 @@ import io.smallrye.faulttolerance.ExecutorHolder;
 import io.smallrye.faulttolerance.FaultToleranceBinding;
 import io.smallrye.faulttolerance.FaultToleranceInterceptor;
 import io.smallrye.faulttolerance.RequestContextIntegration;
-import io.smallrye.faulttolerance.api.CircuitBreakerName;
+import io.smallrye.faulttolerance.SpecCompatibility;
+import io.smallrye.faulttolerance.autoconfig.FaultToleranceMethod;
 import io.smallrye.faulttolerance.core.util.RunnableWrapper;
 import io.smallrye.faulttolerance.internal.RequestContextControllerProvider;
 import io.smallrye.faulttolerance.internal.StrategyCache;
@@ -76,18 +75,6 @@ import io.smallrye.faulttolerance.propagation.ContextPropagationRequestContextCo
 import io.smallrye.faulttolerance.propagation.ContextPropagationRunnableWrapper;
 
 public class SmallRyeFaultToleranceProcessor {
-
-    private static final Set<DotName> FT_ANNOTATIONS = new HashSet<>();
-    static {
-        // @Blocking and @NonBlocking alone do _not_ trigger the fault tolerance interceptor,
-        // only in combination with other fault tolerance annotations
-        FT_ANNOTATIONS.add(DotName.createSimple(Asynchronous.class.getName()));
-        FT_ANNOTATIONS.add(DotName.createSimple(Bulkhead.class.getName()));
-        FT_ANNOTATIONS.add(DotName.createSimple(CircuitBreaker.class.getName()));
-        FT_ANNOTATIONS.add(DotName.createSimple(Fallback.class.getName()));
-        FT_ANNOTATIONS.add(DotName.createSimple(Retry.class.getName()));
-        FT_ANNOTATIONS.add(DotName.createSimple(Timeout.class.getName()));
-    }
 
     @BuildStep
     public void build(BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer,
@@ -98,7 +85,8 @@ public class SmallRyeFaultToleranceProcessor {
             BuildProducer<SystemPropertyBuildItem> systemProperty,
             CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod) {
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> config) {
 
         feature.produce(new FeatureBuildItem(Feature.SMALLRYE_FAULT_TOLERANCE));
 
@@ -125,7 +113,7 @@ public class SmallRyeFaultToleranceProcessor {
             additionalBean.produce(fallbackHandlersBeans.build());
         }
         // Add reflective access to fallback methods
-        for (AnnotationInstance annotation : index.getAnnotations(DotName.createSimple(Fallback.class.getName()))) {
+        for (AnnotationInstance annotation : index.getAnnotations(DotNames.FALLBACK)) {
             AnnotationValue fallbackMethodValue = annotation.value("fallbackMethod");
             if (fallbackMethodValue == null) {
                 continue;
@@ -161,8 +149,12 @@ public class SmallRyeFaultToleranceProcessor {
                 classesToScan.addAll(clazz.interfaceNames());
             }
         }
+        // Add reflective access to custom backoff strategies
+        for (ClassInfo strategy : index.getAllKnownImplementors(DotNames.CUSTOM_BACKOFF_STRATEGY)) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, strategy.name().toString()));
+        }
 
-        for (DotName annotation : FT_ANNOTATIONS) {
+        for (DotName annotation : DotNames.FT_ANNOTATIONS) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, annotation.toString()));
             // also make them bean defining annotations
             additionalBda.produce(new BeanDefiningAnnotationBuildItem(annotation));
@@ -177,7 +169,7 @@ public class SmallRyeFaultToleranceProcessor {
 
             @Override
             public void transform(TransformationContext context) {
-                if (FT_ANNOTATIONS.contains(context.getTarget().asClass().name())) {
+                if (DotNames.FT_ANNOTATIONS.contains(context.getTarget().asClass().name())) {
                     context.transform().add(FaultToleranceBinding.class).done();
                 }
             }
@@ -187,7 +179,7 @@ public class SmallRyeFaultToleranceProcessor {
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
         // Also register MP FT annotations so that they are recognized as interceptor bindings
         // Note that MP FT API jar is nor indexed, nor contains beans.xml so it is not part of the app index
-        for (DotName ftAnnotation : FT_ANNOTATIONS) {
+        for (DotName ftAnnotation : DotNames.FT_ANNOTATIONS) {
             builder.addBeanClass(ftAnnotation.toString());
         }
         builder.addBeanClasses(FaultToleranceInterceptor.class,
@@ -199,13 +191,16 @@ public class SmallRyeFaultToleranceProcessor {
                 QuarkusAsyncExecutorProvider.class,
                 MetricsProvider.class,
                 CircuitBreakerMaintenanceImpl.class,
-                RequestContextIntegration.class);
+                RequestContextIntegration.class,
+                SpecCompatibility.class);
         additionalBean.produce(builder.build());
 
         if (!metricsCapability.isPresent()) {
             //disable fault tolerance metrics with the MP sys props
             systemProperty.produce(new SystemPropertyBuildItem("MP_Fault_Tolerance_Metrics_Enabled", "false"));
         }
+
+        config.produce(new RunTimeConfigurationDefaultBuildItem("smallrye.faulttolerance.mp-compatibility", "false"));
     }
 
     @BuildStep
@@ -243,73 +238,81 @@ public class SmallRyeFaultToleranceProcessor {
     void validateFaultToleranceAnnotations(SmallRyeFaultToleranceRecorder recorder,
             ValidationPhaseBuildItem validationPhase,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
+            AnnotationProxyBuildItem annotationProxy,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<ValidationPhaseBuildItem.ValidationErrorBuildItem> errors) {
+
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
-        Set<String> beanNames = new HashSet<>();
         IndexView index = beanArchiveIndexBuildItem.getIndex();
+        // only generating annotation literal classes for MicroProfile/SmallRye Fault Tolerance annotations,
+        // none of them are application classes
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, false);
+
+        FaultToleranceScanner scaner = new FaultToleranceScanner(index, annotationStore, annotationProxy, classOutput);
+
+        List<FaultToleranceMethod> ftMethods = new ArrayList<>();
+        List<Throwable> exceptions = new ArrayList<>();
 
         for (BeanInfo info : validationPhase.getContext().beans()) {
-            if (hasFTAnnotations(index, annotationStore, info.getImplClazz())) {
-                beanNames.add(info.getBeanClass().toString());
+            ClassInfo beanClass = info.getImplClazz();
+            if (beanClass == null) {
+                continue;
+            }
+
+            if (scaner.hasFTAnnotations(beanClass)) {
+                scaner.forEachMethod(beanClass, method -> {
+                    FaultToleranceMethod ftMethod = scaner.createFaultToleranceMethod(beanClass, method);
+                    if (ftMethod.isLegitimate()) {
+                        ftMethods.add(ftMethod);
+
+                        if (method.hasAnnotation(DotNames.BLOCKING) && method.hasAnnotation(DotNames.NON_BLOCKING)) {
+                            exceptions.add(
+                                    new DefinitionException("Both @Blocking and @NonBlocking present on '" + method + "'"));
+                        }
+                    }
+                });
+
+                if (beanClass.classAnnotation(DotNames.BLOCKING) != null
+                        && beanClass.classAnnotation(DotNames.NON_BLOCKING) != null) {
+                    exceptions.add(new DefinitionException("Both @Blocking and @NonBlocking present on '" + beanClass + "'"));
+                }
             }
         }
 
-        recorder.createFaultToleranceOperation(beanNames);
-
-        DotName circuitBreakerName = DotName.createSimple(CircuitBreakerName.class.getName());
+        recorder.createFaultToleranceOperation(ftMethods);
 
         Map<String, Set<String>> existingCircuitBreakerNames = new HashMap<>();
-        for (AnnotationInstance it : index.getAnnotations(circuitBreakerName)) {
+        for (AnnotationInstance it : index.getAnnotations(DotNames.CIRCUIT_BREAKER_NAME)) {
             if (it.target().kind() == Kind.METHOD) {
                 MethodInfo method = it.target().asMethod();
                 existingCircuitBreakerNames.computeIfAbsent(it.value().asString(), ignored -> new HashSet<>())
                         .add(method + " @ " + method.declaringClass());
             }
         }
-
-        List<Throwable> exceptions = new ArrayList<>();
         for (Map.Entry<String, Set<String>> entry : existingCircuitBreakerNames.entrySet()) {
             if (entry.getValue().size() > 1) {
                 exceptions.add(new DefinitionException("Multiple circuit breakers have the same name '"
                         + entry.getKey() + "': " + entry.getValue()));
             }
         }
+
+        for (DotName backoffAnnotation : DotNames.BACKOFF_ANNOTATIONS) {
+            for (AnnotationInstance it : index.getAnnotations(backoffAnnotation)) {
+                if (it.target().kind() == Kind.CLASS && it.target().asClass().classAnnotation(DotNames.RETRY) == null) {
+                    exceptions.add(new DefinitionException("Backoff annotation @" + backoffAnnotation.withoutPackagePrefix()
+                            + " present on '" + it.target() + "', but @Retry is missing"));
+                } else if (it.target().kind() == Kind.METHOD && !it.target().asMethod().hasAnnotation(DotNames.RETRY)) {
+                    exceptions.add(new DefinitionException("Backoff annotation @" + backoffAnnotation.withoutPackagePrefix()
+                            + " present on '" + it.target() + "', but @Retry is missing"));
+                }
+            }
+        }
+
         if (!exceptions.isEmpty()) {
             errors.produce(new ValidationPhaseBuildItem.ValidationErrorBuildItem(exceptions));
         }
 
         recorder.initExistingCircuitBreakerNames(existingCircuitBreakerNames.keySet());
-    }
-
-    private boolean hasFTAnnotations(IndexView index, AnnotationStore annotationStore, ClassInfo info) {
-        if (info == null) {
-            //should not happen, but guard against it
-            //happens in this case due to a bug involving array types
-
-            return false;
-        }
-        // first check annotations on type
-        if (annotationStore.hasAnyAnnotation(info, FT_ANNOTATIONS)) {
-            return true;
-        }
-
-        // then check on the methods
-        for (MethodInfo method : info.methods()) {
-            if (annotationStore.hasAnyAnnotation(method, FT_ANNOTATIONS)) {
-                return true;
-            }
-        }
-
-        // then check on the parent
-        DotName parentClassName = info.superName();
-        if (parentClassName == null || parentClassName.equals(DotNames.OBJECT)) {
-            return false;
-        }
-        ClassInfo parentClassInfo = index.getClassByName(parentClassName);
-        if (parentClassInfo == null) {
-            return false;
-        }
-        return hasFTAnnotations(index, annotationStore, parentClassInfo);
     }
 
     @BuildStep

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnClassService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnClassService.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.additional;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+
+@ApplicationScoped
+@Blocking
+@NonBlocking
+public class BlockingNonBlockingOnClassService {
+    @Retry
+    public CompletionStage<String> hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnClassTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnClassTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.additional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BlockingNonBlockingOnClassTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BlockingNonBlockingOnClassService.class))
+            .assertException(e -> {
+                assertEquals(DefinitionException.class, e.getClass());
+                assertTrue(e.getMessage().contains("Both @Blocking and @NonBlocking present"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnMethodService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnMethodService.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.additional;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+
+@ApplicationScoped
+public class BlockingNonBlockingOnMethodService {
+    @Retry
+    @Blocking
+    @NonBlocking
+    public CompletionStage<String> hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnMethodTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/additional/BlockingNonBlockingOnMethodTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.additional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BlockingNonBlockingOnMethodTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BlockingNonBlockingOnMethodService.class))
+            .assertException(e -> {
+                assertEquals(DefinitionException.class, e.getClass());
+                assertTrue(e.getMessage().contains("Both @Blocking and @NonBlocking present"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/noncompat/NoncompatAsyncTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/noncompat/NoncompatAsyncTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.noncompat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoncompatAsyncTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(NoncompatHelloService.class));
+
+    @Inject
+    NoncompatHelloService service;
+
+    @Test
+    public void noThreadOffloadAndFallback() throws Exception {
+        Thread mainThread = Thread.currentThread();
+
+        CompletionStage<String> future = service.hello();
+        assertThat(future.toCompletableFuture().get()).isEqualTo("hello");
+
+        // no delay between retries, all executions happen on the same thread
+        // if there _was_ a delay, subsequent retries would be offloaded to another thread
+        assertThat(service.getHelloThreads()).allSatisfy(thread -> {
+            assertThat(thread).isSameAs(mainThread);
+        });
+        assertThat(service.getHelloStackTraces()).allSatisfy(stackTrace -> {
+            assertThat(stackTrace).anySatisfy(frame -> {
+                assertThat(frame.getClassName()).contains("io.smallrye.faulttolerance.core");
+            });
+        });
+
+        // 1 initial execution + 3 retries
+        assertThat(service.getInvocationCounter()).hasValue(4);
+
+        assertThat(service.getFallbackThread()).isSameAs(mainThread);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/noncompat/NoncompatHelloService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/noncompat/NoncompatHelloService.java
@@ -1,0 +1,54 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.noncompat;
+
+import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+@Retry(maxRetries = 3, delay = 0, jitter = 0)
+public class NoncompatHelloService {
+    private final List<Thread> helloThreads = new CopyOnWriteArrayList<>();
+    private final List<StackTraceElement[]> helloStackTraces = new CopyOnWriteArrayList<>();
+
+    private final AtomicInteger invocationCounter = new AtomicInteger();
+
+    private volatile Thread fallbackThread;
+
+    @Fallback(fallbackMethod = "fallback")
+    public CompletionStage<String> hello() {
+        invocationCounter.incrementAndGet();
+        helloThreads.add(Thread.currentThread());
+        helloStackTraces.add(new Throwable().getStackTrace());
+        return failedFuture(new RuntimeException());
+    }
+
+    public CompletionStage<String> fallback() {
+        fallbackThread = Thread.currentThread();
+        return completedFuture("hello");
+    }
+
+    List<Thread> getHelloThreads() {
+        return helloThreads;
+    }
+
+    List<StackTraceElement[]> getHelloStackTraces() {
+        return helloStackTraces;
+    }
+
+    AtomicInteger getInvocationCounter() {
+        return invocationCounter;
+    }
+
+    Thread getFallbackThread() {
+        return fallbackThread;
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/ClassAndMethodBackoffService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/ClassAndMethodBackoffService.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+
+@ApplicationScoped
+@Retry
+@ExponentialBackoff
+public class ClassAndMethodBackoffService {
+    @FibonacciBackoff
+    public void hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/ClassAndMethodBackoffTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/ClassAndMethodBackoffTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClassAndMethodBackoffTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ClassAndMethodBackoffService.class))
+            .assertException(e -> {
+                assertEquals(DefinitionException.class, e.getClass());
+                assertTrue(e.getMessage().contains("Backoff annotation"));
+                assertTrue(e.getMessage().contains("@Retry is missing"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnClassBackoffOnMethodService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnClassBackoffOnMethodService.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+
+@ApplicationScoped
+@Retry
+public class RetryOnClassBackoffOnMethodService {
+    @ExponentialBackoff
+    public void hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnClassBackoffOnMethodTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnClassBackoffOnMethodTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RetryOnClassBackoffOnMethodTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RetryOnClassBackoffOnMethodService.class))
+            .assertException(e -> {
+                assertEquals(DefinitionException.class, e.getClass());
+                assertTrue(e.getMessage().contains("Backoff annotation"));
+                assertTrue(e.getMessage().contains("@Retry is missing"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnMethodBackoffOnClassService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnMethodBackoffOnClassService.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+
+@ApplicationScoped
+@FibonacciBackoff
+public class RetryOnMethodBackoffOnClassService {
+    @Retry
+    public void hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnMethodBackoffOnClassTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/RetryOnMethodBackoffOnClassTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RetryOnMethodBackoffOnClassTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RetryOnMethodBackoffOnClassService.class))
+            .assertException(e -> {
+                assertEquals(DefinitionException.class, e.getClass());
+                assertTrue(e.getMessage().contains("Backoff annotation"));
+                assertTrue(e.getMessage().contains("@Retry is missing"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/TwoBackoffsOnMethodService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/TwoBackoffsOnMethodService.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+
+@ApplicationScoped
+public class TwoBackoffsOnMethodService {
+    @Retry
+    @ExponentialBackoff
+    @FibonacciBackoff
+    public void hello() {
+        throw new IllegalArgumentException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/TwoBackoffsOnMethodTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/retry/backoff/TwoBackoffsOnMethodTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.smallrye.faulttolerance.test.retry.backoff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TwoBackoffsOnMethodTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TwoBackoffsOnMethodService.class))
+            .assertException(e -> {
+                assertEquals(DeploymentException.class, e.getClass());
+                assertTrue(e.getMessage().contains("More than one backoff defined"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFallbackHandlerProvider.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFallbackHandlerProvider.java
@@ -11,7 +11,6 @@ import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 
 import io.smallrye.faulttolerance.FallbackHandlerProvider;
-import io.smallrye.faulttolerance.config.FallbackConfig;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 @Dependent
@@ -30,7 +29,7 @@ public class QuarkusFallbackHandlerProvider implements FallbackHandlerProvider {
                 @SuppressWarnings("unchecked")
                 @Override
                 public T handle(ExecutionContext context) {
-                    Class<? extends FallbackHandler<?>> clazz = operation.getFallback().get(FallbackConfig.VALUE);
+                    Class<? extends FallbackHandler<?>> clazz = operation.getFallback().value();
                     FallbackHandler<T> fallbackHandlerInstance = (FallbackHandler<T>) instance.select(clazz).get();
                     try {
                         return fallbackHandlerInstance.handle(context);

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
@@ -13,6 +13,7 @@ import javax.inject.Singleton;
 import org.jboss.logging.Logger;
 
 import io.smallrye.faulttolerance.FaultToleranceOperationProvider;
+import io.smallrye.faulttolerance.config.FaultToleranceMethods;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 @Singleton
@@ -45,7 +46,7 @@ public class QuarkusFaultToleranceOperationProvider implements FaultToleranceOpe
 
     private FaultToleranceOperation createAtRuntime(CacheKey key) {
         LOG.debugf("FaultToleranceOperation not found in the cache for %s creating it at runtime", key);
-        return FaultToleranceOperation.of(key.beanClass, key.method);
+        return FaultToleranceOperation.create(FaultToleranceMethods.create(key.beanClass, key.method));
     }
 
     static class CacheKey {

--- a/tcks/microprofile-fault-tolerance/pom.xml
+++ b/tcks/microprofile-fault-tolerance/pom.xml
@@ -21,6 +21,7 @@
                     <systemPropertyVariables>
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
+                        <smallrye.faulttolerance.mp-compatibility>true</smallrye.faulttolerance.mp-compatibility>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->
@@ -32,6 +33,9 @@
                     <excludes>
                         <!-- We do not support enablement via beans.xml -->
                         <exclude>org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest</exclude>
+                        <!-- Jandex bug: https://github.com/wildfly/jandex/pull/114 -->
+                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest</exclude>
+                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This SmallRye Fault Tolerance release includes a significant
refactoring of the configuration system, which has been done
with Quarkus in mind.

This commit moves a lot of fault tolerance method discovery
to build time. It also reads fault tolerance annotations from
ArC's `AnnotationStore`, so that extensions are finally able
to transform fault tolerance annotations.

Also, more build-time validations are added, corresponding to
deployment-time validations added in SmallRye Fault Tolerance.

Resolves #17207