### PR TITLE
Fix OpenTelemetry HTTP span naming

### DIFF
--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/VertxTracingAdapter.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/VertxTracingAdapter.java
@@ -99,7 +99,7 @@ public class VertxTracingAdapter extends TracingOptions implements VertxTracer<S
 
             // Add attributes
             currentSpan.setAttribute(HTTP_FLAVOR, convertHttpVersion(httpServerRequest.version()));
-            currentSpan.setAttribute(HTTP_METHOD, httpServerRequest.method().name());
+            currentSpan.setAttribute(HTTP_METHOD, operation);
             currentSpan.setAttribute(HTTP_TARGET, httpServerRequest.path());
             currentSpan.setAttribute(HTTP_SCHEME, httpServerRequest.scheme());
             currentSpan.setAttribute(HTTP_HOST, httpServerRequest.host());
@@ -122,7 +122,12 @@ public class VertxTracingAdapter extends TracingOptions implements VertxTracer<S
 
     private <R> String operationName(R request, String operationName) {
         if (request instanceof HttpServerRequest) {
-            return ((HttpServerRequest) request).uri().substring(1);
+            final String uri = ((HttpServerRequest) request).uri();
+            if (uri.length() > 1) {
+                return uri.substring(1);
+            } else {
+                return "HTTP " + operationName;
+            }
         }
         return operationName;
     }

--- a/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/SimpleResource.java
+++ b/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/SimpleResource.java
@@ -7,12 +7,48 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Path("/")
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("")
 @Produces(MediaType.APPLICATION_JSON)
 public class SimpleResource {
+    @RegisterRestClient(configKey = "simple")
+    public interface SimpleClient {
+        @Path("")
+        @GET
+        TraceData noPath();
+
+        @Path("/")
+        @GET
+        TraceData slashPath();
+    }
 
     @Inject
     TracedService tracedService;
+
+    @Inject
+    @RestClient
+    SimpleClient simpleClient;
+
+    @GET
+    public TraceData noPath() {
+        TraceData data = new TraceData();
+        data.message = "No path trace";
+        return data;
+    }
+
+    @GET
+    @Path("/nopath")
+    public TraceData noPathClient() {
+        return simpleClient.noPath();
+    }
+
+    @GET
+    @Path("/slashpath")
+    public TraceData slashPathClient() {
+        return simpleClient.slashPath();
+    }
 
     @GET
     @Path("/direct")

--- a/integration-tests/opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry/src/main/resources/application.properties
@@ -3,3 +3,4 @@ quarkus.application.name=opentelemetry-integration-test
 quarkus.application.version=999-SNAPSHOT
 
 pingpong/mp-rest/url=${test.url}
+simple/mp-rest/url=${test.url}


### PR DESCRIPTION
- Fixes #18365
- Also ensure we don't overwrite the client span name from `UrlPathTemplate` unless it's length is non-zero
- If client or server path is "/" or "", set the span name to "HTTP {METHOD}" as per semantic conventions
- Add integration tests for "/" and "" case in client and server