### PR TITLE
Remove misleading -Dno-descriptor-tests from JDK16 CI job

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -243,7 +243,7 @@ jobs:
           - {
             name: "16",
             java-version: 16,
-            maven_args: "$JVM_TEST_MAVEN_ARGS -pl '!devtools/gradle' -Dno-descriptor-tests",
+            maven_args: "$JVM_TEST_MAVEN_ARGS -pl '!devtools/gradle'",
             maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g --add-opens java.base/java.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             os-name: "ubuntu-latest"
           }


### PR DESCRIPTION
This is the only thing I could find to clean up in context of Java 16, after the update of Kotlin to 1.5.
Everything else is still needed for Java 16+.

Technically, this flag didn't have any effect here, since those descriptor tests are only in the maven IT module which are not executed by this job at all.