### PR TITLE
Remove instantiation of com.sun.jndi.ldap.LdapCtxFactory for JDK16+ compatibility

### DIFF
--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
@@ -2,7 +2,6 @@ package io.quarkus.elytron.security.ldap;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.elytron.security.ldap.rest.ParametrizedPathsResource;
@@ -34,7 +33,6 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
-    @Tag("failsOnJDK16")
     public void testNotSearchingRecursiveFailure() {
         RestAssured.given().auth().preemptive().basic("subUser", "subUserPassword")
                 .when().get("/servlet-secured").then()
@@ -42,7 +40,6 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
-    @Tag("failsOnJDK16")
     public void testSecureRoleFailure() {
         RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUserPassword")
                 .when().get("/servlet-secured").then()
@@ -50,7 +47,6 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test()
-    @Tag("failsOnJDK16")
     public void testSecureAccessSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/servlet-secured").then()
@@ -70,7 +66,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, but no authorization. should see 403 error code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsGetRoleFailure() {
         RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUserPassword")
                 .when().get("/jaxrs-secured/roles-class").then()
@@ -81,7 +76,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsGetRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/roles-class").then()
@@ -92,7 +86,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsPathAdminRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("adminUser", "adminUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
@@ -100,7 +93,6 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsPathAdminRoleFailure() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
@@ -111,7 +103,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsPathUserRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/parameterized-paths/my/banking/view").then()
@@ -122,7 +113,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsUserRoleSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/secured").then()
@@ -131,7 +121,6 @@ public abstract class LdapSecurityRealmTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsInjectedPrincipalSuccess() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/principal-secured").then()
@@ -162,7 +151,6 @@ public abstract class LdapSecurityRealmTest {
      * Test access a @DenyAll secured jaxrs resource with authentication. should see a 403 success code.
      */
     @Test
-    @Tag("failsOnJDK16")
     public void testJaxrsGetDenyAllWithAuth() {
         RestAssured.given().auth().preemptive().basic("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/denied").then()

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
@@ -2,7 +2,6 @@ package io.quarkus.elytron.security.ldap;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -26,7 +25,6 @@ public class SearchRecursiveTest {
                     .addAsResource("search-recursive/application.properties", "application.properties"));
 
     @Test()
-    @Tag("failsOnJDK16")
     public void testNotSearchingRecursiveFailure() {
         RestAssured.given().auth().preemptive().basic("subUser", "subUserPassword")
                 .when().get("/servlet-secured").then()

--- a/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
+++ b/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
@@ -2,7 +2,6 @@ package io.quarkus.elytron.security.ldap.it;
 
 import static org.hamcrest.Matchers.containsString;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -32,7 +31,6 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     void standard_role_authenticated() {
         RestAssured.given()
                 .redirects().follow(false)
@@ -44,7 +42,6 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     void standard_role_not_authorized() {
         RestAssured.given()
                 .redirects().follow(false)
@@ -56,7 +53,6 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     void admin_role_authorized() {
         RestAssured.given()
                 .when()
@@ -77,7 +73,6 @@ class ElytronSecurityLdapTest {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     void admin_role_not_authorized() {
         RestAssured.given()
                 .redirects().follow(false)


### PR DESCRIPTION
Resolves #17092

The following change in Spring led me to try out removing it and lo and behold, it worked: https://github.com/spring-projects/spring-ldap/pull/568

See #8651 and #8696 for more context of that instantiation.

Not sure who can review this... @sberyozkin maybe? Or @galderz?