### PR TITLE
Update Jaeger reporter to use logger

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/graal/Target_LoggingReporter.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/graal/Target_LoggingReporter.java
@@ -10,6 +10,8 @@ import io.jaegertracing.spi.Reporter;
 @TargetClass(className = "io.jaegertracing.internal.reporters.LoggingReporter")
 final public class Target_LoggingReporter implements Reporter {
 
+    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(Target_LoggingReporter.class);
+
     @Substitute
     public Target_LoggingReporter() {
 
@@ -18,7 +20,7 @@ final public class Target_LoggingReporter implements Reporter {
     @Substitute
     @Override
     public void report(JaegerSpan span) {
-        System.err.println("--- not logging: " + span);
+        LOG.infof("Span reported: %s", span);
     }
 
     @Substitute


### PR DESCRIPTION
Updates Jaeger reporter to use proper log instead of println statement.