### PR TITLE
Remove usage of deprecated gradle API

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -224,8 +224,10 @@ public class QuarkusPlugin implements Plugin<Project> {
 
                     // Register the quarkus-generated-code
                     for (String provider : QuarkusGenerateCode.CODE_GENERATION_PROVIDER) {
-                        mainSourceSet.getJava().srcDir(new File(generatedSourceSet.getJava().getOutputDir(), provider));
-                        testSourceSet.getJava().srcDir(new File(generatedTestSourceSet.getJava().getOutputDir(), provider));
+                        mainSourceSet.getJava().srcDir(
+                                new File(generatedSourceSet.getJava().getClassesDirectory().get().getAsFile(), provider));
+                        testSourceSet.getJava().srcDir(
+                                new File(generatedTestSourceSet.getJava().getClassesDirectory().get().getAsFile(), provider));
                     }
 
                 });

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -81,7 +81,8 @@ public class QuarkusGenerateCode extends QuarkusTask {
     @OutputDirectory
     public File getGeneratedOutputDirectory() {
         final String generatedSourceSetName = test ? QUARKUS_TEST_GENERATED_SOURCES : QUARKUS_GENERATED_SOURCES;
-        return QuarkusGradleUtils.getSourceSet(getProject(), generatedSourceSetName).getJava().getOutputDir();
+        return QuarkusGradleUtils.getSourceSet(getProject(), generatedSourceSetName).getJava().getClassesDirectory().get()
+                .getAsFile();
     }
 
     @TaskAction


### PR DESCRIPTION
This use the privileged gradle API to access the output directory. 

close #18389