### PR TITLE
Fixed guide URL for OpenShift extension

### DIFF
--- a/extensions/kubernetes/openshift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kubernetes/openshift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   keywords:
   - "kubernetes"
   - "openshift"
-  guide: "https://quarkus.io/guides/openshift"
+  guide: "https://quarkus.io/guides/deploying-to-openshift"
   categories:
   - "cloud"
   status: "stable"


### PR DESCRIPTION
Should fix https://issues.redhat.com/browse/QUARKUS-977, once the change is propagated through to the code.quarkus.redhat.com and code.quarkus.io services.