### PR TITLE
Update OidcClient to accept String expires_in values

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -120,9 +120,11 @@ public class OidcClientImpl implements OidcClient {
             JsonObject json = resp.bodyAsJsonObject();
             final String accessToken = json.getString(oidcConfig.grant.accessTokenProperty);
             final String refreshToken = json.getString(oidcConfig.grant.refreshTokenProperty);
+            final Object expiresInValue = json.getValue(oidcConfig.grant.expiresInProperty);
             Long accessTokenExpiresAt;
-            Long accessTokenExpiresIn = json.getLong(oidcConfig.grant.expiresInProperty);
-            if (accessTokenExpiresIn != null) {
+            if (expiresInValue != null) {
+                long accessTokenExpiresIn = expiresInValue instanceof Number ? ((Number) expiresInValue).longValue()
+                        : Long.parseLong(expiresInValue.toString());
                 accessTokenExpiresAt = Instant.now().getEpochSecond() + accessTokenExpiresIn;
             } else {
                 accessTokenExpiresAt = getExpiresJwtClaim(accessToken);

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -41,7 +41,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
-                                "{\"accessToken\":\"access_token_n\", \"expiresIn\":4, \"refreshToken\":\"refresh_token_n\"}")));
+                                "{\"accessToken\":\"access_token_n\", \"expiresIn\":\"4\", \"refreshToken\":\"refresh_token_n\"}")));
 
         server.stubFor(WireMock.post("/tokens")
                 .withRequestBody(matching("grant_type=refresh_token&refresh_token=refresh_token_1"))


### PR DESCRIPTION
Fixes #18374

Standard [expires_in](https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.14) value is a JSON number (long) however some providers may return it as JSON String. This PR, instead of immediately retrieving it as `Long`, casts it to `Long` if the property is an instance of `Long` otherwise converts a `String` representation to `Long`.

One of the `oidc_client_wiremock` tests has been updated to check it (there is another test there which deals with Long) 

CC @chiragrp 