### PR TITLE
Run jpa-mapping-xml tests in native mode on CI

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -15,7 +15,7 @@
         {
             "category": "Data2",
             "timeout": 65,
-            "test-modules": "jpa, jpa-mysql, jpa-db2, jpa-oracle",
+            "test-modules": "jpa, jpa-mapping-xml/legacy-app, jpa-mapping-xml/modern-app, jpa-mysql, jpa-db2, jpa-oracle",
             "os-name": "ubuntu-latest"
         },
         {


### PR DESCRIPTION
One of the reasons for having dedicated integration test modules for JPA XML mapping was to check that it runs fine in native mode. I ran the tests locally, and they passed locally before I submitted the PR, but I think CI does not run these tests in native mode.

The culprit: I forgot that modules needed to be added to `native-tests.json` in order for CI to run them in native mode.