### PR TITLE
Basic registry client config builder for testing purposes

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/RegistryClientTestHelper.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/RegistryClientTestHelper.java
@@ -1,27 +1,10 @@
 package io.quarkus.devtools.testing;
 
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.ArtifactCoords;
-import io.quarkus.registry.Constants;
-import io.quarkus.registry.catalog.json.JsonCatalogMapperHelper;
-import io.quarkus.registry.catalog.json.JsonPlatform;
-import io.quarkus.registry.catalog.json.JsonPlatformCatalog;
-import io.quarkus.registry.catalog.json.JsonPlatformRelease;
-import io.quarkus.registry.catalog.json.JsonPlatformStream;
 import io.quarkus.registry.config.RegistriesConfigLocator;
-import io.quarkus.registry.config.json.JsonRegistriesConfig;
-import io.quarkus.registry.config.json.JsonRegistryConfig;
-import io.quarkus.registry.config.json.JsonRegistryMavenConfig;
-import io.quarkus.registry.config.json.JsonRegistryMavenRepoConfig;
-import io.quarkus.registry.config.json.JsonRegistryNonPlatformExtensionsConfig;
-import io.quarkus.registry.config.json.JsonRegistryPlatformsConfig;
-import io.quarkus.registry.config.json.RegistriesConfigMapperHelper;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.Collections;
 import java.util.Properties;
 
 public class RegistryClientTestHelper {
@@ -36,104 +19,30 @@ public class RegistryClientTestHelper {
     }
 
     public static void enableRegistryClientTestConfig(Path outputDir, Properties properties) {
-        final Path toolsConfigPath = outputDir.resolve(RegistriesConfigLocator.CONFIG_RELATIVE_PATH);
-        final Path registryRepoPath = outputDir.resolve("test-registry-repo");
-        final Path groupIdDir = registryRepoPath.resolve("io/quarkus/registry/test");
-
-        generateToolsConfig(toolsConfigPath, registryRepoPath);
-        generateRegistryDescriptor(groupIdDir);
-        generatePlatformCatalog(groupIdDir);
-
-        properties.setProperty("io.quarkus.maven.secondary-local-repo", registryRepoPath.toString());
-        properties.setProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY, toolsConfigPath.toString());
-        properties.setProperty("quarkusRegistryClient", "true");
-    }
-
-    private static void generatePlatformCatalog(final Path groupIdDir) {
         final String projectVersion = System.getProperty("project.version");
         if (projectVersion == null) {
             throw new IllegalStateException("System property project.version isn't set");
         }
-        final Path platformsPath = groupIdDir.resolve(Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID)
-                .resolve(Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION)
-                .resolve(Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID + "-"
-                        + Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION + ".json");
-        final Path versionedPlatformsPath = groupIdDir.resolve(Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID)
-                .resolve(Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION)
-                .resolve(Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID + "-"
-                        + Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION + "-" + projectVersion + ".json");
-        if (Files.exists(platformsPath) && Files.exists(versionedPlatformsPath)) {
-            return;
-        }
+
+        final Path toolsConfigPath = outputDir.resolve(RegistriesConfigLocator.CONFIG_RELATIVE_PATH);
+
         final ArtifactCoords bom = new ArtifactCoords("io.quarkus", "quarkus-bom", null, "pom", projectVersion);
-        final JsonPlatformCatalog platforms = new JsonPlatformCatalog();
-        final JsonPlatform platform = new JsonPlatform();
-        platforms.addPlatform(platform);
-        platform.setPlatformKey(bom.getGroupId());
-        final JsonPlatformStream stream = new JsonPlatformStream();
-        platform.setStreams(Collections.singletonList(stream));
-        stream.setId(projectVersion);
-        final JsonPlatformRelease release = new JsonPlatformRelease();
-        stream.setReleases(Collections.singletonList(release));
-        release.setMemberBoms(Collections.singletonList(bom));
-        release.setQuarkusCoreVersion(projectVersion);
-        try {
-            JsonCatalogMapperHelper.serialize(platforms, platformsPath);
-            Files.copy(platformsPath, versionedPlatformsPath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to persist registry platforms config", e);
-        }
-    }
 
-    private static void generateRegistryDescriptor(Path repoGroupIdDir) {
-        final Path descriptorPath = repoGroupIdDir.resolve(Constants.DEFAULT_REGISTRY_DESCRIPTOR_ARTIFACT_ID)
-                .resolve(Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION).resolve(Constants.DEFAULT_REGISTRY_DESCRIPTOR_ARTIFACT_ID
-                        + "-" + Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION + ".json");
-        if (Files.exists(descriptorPath)) {
-            return;
-        }
-        final JsonRegistryConfig descriptor = new JsonRegistryConfig();
-        final JsonRegistryPlatformsConfig platformsConfig = new JsonRegistryPlatformsConfig();
-        descriptor.setPlatforms(platformsConfig);
-        platformsConfig.setArtifact(
-                new ArtifactCoords("io.quarkus.registry.test", Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID, null,
-                        "json", Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION));
-        final JsonRegistryNonPlatformExtensionsConfig nonPlatformsConfig = new JsonRegistryNonPlatformExtensionsConfig();
-        descriptor.setNonPlatformExtensions(nonPlatformsConfig);
-        nonPlatformsConfig.setDisabled(true);
-        try {
-            RegistriesConfigMapperHelper.serialize(descriptor, descriptorPath);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to persist the registry descriptor", e);
-        }
-    }
+        TestRegistryClientBuilder.newInstance()
+                .baseDir(toolsConfigPath.getParent())
+                //.debug()
+                .newRegistry("test.quarkus.registry")
+                .newPlatform(bom.getGroupId())
+                .newStream(projectVersion)
+                .newRelease(projectVersion)
+                .quarkusVersion(projectVersion)
+                .addMemberBom(bom)
+                .registry()
+                .clientBuilder()
+                .build();
 
-    private static void generateToolsConfig(Path toolsConfigPath, Path registryRepoPath) {
-        if (Files.exists(toolsConfigPath)) {
-            return;
-        }
-        final JsonRegistryConfig registryConfig = new JsonRegistryConfig();
-        registryConfig.setId("test.registry.quarkus.io");
-        final JsonRegistryMavenConfig mavenConfig = new JsonRegistryMavenConfig();
-        registryConfig.setMaven(mavenConfig);
-        final JsonRegistryMavenRepoConfig repoConfig = new JsonRegistryMavenRepoConfig();
-        mavenConfig.setRepository(repoConfig);
-        try {
-            repoConfig.setUrl(registryRepoPath.toUri().toURL().toString());
-        } catch (MalformedURLException e) {
-            throw new IllegalStateException("Failed to translate a path to url", e);
-        }
-
-        final JsonRegistriesConfig toolsConfig = new JsonRegistriesConfig();
-        toolsConfig.addRegistry(registryConfig);
-        toolsConfig.setDebug(false);
-
-        try {
-            RegistriesConfigMapperHelper.serialize(toolsConfig,
-                    toolsConfigPath);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to persist the tools config", e);
-        }
+        properties.setProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY, toolsConfigPath.toString());
+        properties.setProperty("quarkusRegistryClient", "true");
     }
 
     public static void disableRegistryClientTestConfig() {
@@ -141,7 +50,6 @@ public class RegistryClientTestHelper {
     }
 
     public static void disableRegistryClientTestConfig(Properties properties) {
-        properties.remove("io.quarkus.maven.secondary-local-repo");
         properties.remove(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY);
         properties.remove("quarkusRegistryClient");
     }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -1,0 +1,121 @@
+package io.quarkus.devtools.testing.registry.client;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.json.JsonCatalogMapperHelper;
+import io.quarkus.registry.catalog.json.JsonExtensionCatalog;
+import io.quarkus.registry.catalog.json.JsonPlatformCatalog;
+import io.quarkus.registry.client.RegistryClient;
+import io.quarkus.registry.client.spi.RegistryClientEnvironment;
+import io.quarkus.registry.config.RegistriesConfigLocator;
+import io.quarkus.registry.config.RegistryConfig;
+import io.quarkus.registry.config.json.JsonRegistryConfig;
+import io.quarkus.registry.config.json.RegistriesConfigMapperHelper;
+import io.quarkus.registry.util.PlatformArtifacts;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+public class TestRegistryClient implements RegistryClient {
+
+    private final MavenArtifactResolver resolver;
+    private final MessageWriter log;
+    private final RegistryConfig config;
+    private final Path registryDir;
+
+    public TestRegistryClient(RegistryClientEnvironment env, RegistryConfig clientConfig) {
+        this.resolver = env.resolver();
+        this.log = env.log();
+        final Path configYaml = RegistriesConfigLocator.locateConfigYaml();
+        if (configYaml == null) {
+            throw new IllegalStateException(
+                    "Failed to locate the dev tools config file (" + RegistriesConfigLocator.CONFIG_RELATIVE_PATH + ")");
+        }
+        registryDir = TestRegistryClientBuilder.getRegistryDir(configYaml.getParent(), clientConfig.getId());
+        if (!Files.exists(registryDir)) {
+            throw new IllegalStateException("The test registry directory " + registryDir + " does not exist");
+        }
+
+        final Path configPath = TestRegistryClientBuilder.getRegistryDescriptorPath(registryDir);
+        final JsonRegistryConfig registryConfig;
+        try {
+            registryConfig = RegistriesConfigMapperHelper.deserialize(configPath, JsonRegistryConfig.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to deserialize registry configuration from " + configPath, e);
+        }
+        registryConfig.setId(clientConfig.getId());
+        if (clientConfig.getNonPlatformExtensions() != null) {
+            registryConfig.setNonPlatformExtensions(clientConfig.getNonPlatformExtensions());
+        }
+
+        if (clientConfig.getPlatforms() != null) {
+            registryConfig.setPlatforms(clientConfig.getPlatforms());
+        }
+        if (clientConfig.getDescriptor() != null) {
+            registryConfig.setDescriptor(clientConfig.getDescriptor());
+        }
+        if (clientConfig.getQuarkusVersions() != null) {
+            registryConfig.setQuarkusVersions(clientConfig.getQuarkusVersions());
+        }
+        this.config = registryConfig;
+    }
+
+    @Override
+    public ExtensionCatalog resolveNonPlatformExtensions(String quarkusVersion) throws RegistryResolutionException {
+        if (config.getNonPlatformExtensions() == null || config.getNonPlatformExtensions().isDisabled()) {
+            return null;
+        }
+        log.info("%s resolveNonPlatformExtensions %s", config.getId(), quarkusVersion);
+        return null;
+    }
+
+    @Override
+    public ExtensionCatalog resolvePlatformExtensions(ArtifactCoords platformCoords)
+            throws RegistryResolutionException {
+        final ArtifactCoords coords = PlatformArtifacts.ensureCatalogArtifact(platformCoords);
+        log.debug("%s resolvePlatformExtensions %s", config.getId(), coords);
+        final Path p;
+        try {
+            p = resolver.resolve(new DefaultArtifact(coords.getGroupId(), coords.getArtifactId(), coords.getClassifier(),
+                    coords.getType(), coords.getVersion())).getArtifact().getFile().toPath();
+        } catch (BootstrapMavenException e) {
+            throw new RegistryResolutionException("Failed to resolve " + coords, e);
+        }
+        try {
+            return JsonCatalogMapperHelper.deserialize(p, JsonExtensionCatalog.class);
+        } catch (IOException e) {
+            throw new RegistryResolutionException("Failed to deserialize " + p, e);
+        }
+    }
+
+    @Override
+    public PlatformCatalog resolvePlatforms(String quarkusVersion) throws RegistryResolutionException {
+        final Path json = TestRegistryClientBuilder.getRegistryPlatformsCatalogPath(registryDir, quarkusVersion);
+        log.debug("%s resolvePlatforms %s", config.getId(), json);
+        try {
+            return JsonCatalogMapperHelper.deserialize(json, JsonPlatformCatalog.class);
+        } catch (IOException e) {
+            throw new RegistryResolutionException("Failed to deserialize " + json, e);
+        }
+    }
+
+    @Override
+    public RegistryConfig resolveRegistryConfig() throws RegistryResolutionException {
+        return config;
+    }
+
+    public static RegistryConfig getDefaultConfig() {
+
+        final JsonRegistryConfig config = new JsonRegistryConfig();
+        config.setId("test.quarkus.registry");
+        config.setAny("client-factory-url",
+                TestRegistryClient.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm());
+        return config;
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -1,0 +1,346 @@
+package io.quarkus.devtools.testing.registry.client;
+
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.Constants;
+import io.quarkus.registry.catalog.Platform;
+import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.PlatformRelease;
+import io.quarkus.registry.catalog.PlatformStream;
+import io.quarkus.registry.catalog.json.JsonExtension;
+import io.quarkus.registry.catalog.json.JsonPlatform;
+import io.quarkus.registry.catalog.json.JsonPlatformCatalog;
+import io.quarkus.registry.catalog.json.JsonPlatformRelease;
+import io.quarkus.registry.catalog.json.JsonPlatformReleaseVersion;
+import io.quarkus.registry.catalog.json.JsonPlatformStream;
+import io.quarkus.registry.config.json.JsonRegistriesConfig;
+import io.quarkus.registry.config.json.JsonRegistryConfig;
+import io.quarkus.registry.config.json.JsonRegistryDescriptorConfig;
+import io.quarkus.registry.config.json.JsonRegistryNonPlatformExtensionsConfig;
+import io.quarkus.registry.config.json.JsonRegistryPlatformsConfig;
+import io.quarkus.registry.config.json.RegistriesConfigMapperHelper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class TestRegistryClientBuilder {
+
+    private Path baseDir;
+    private JsonRegistriesConfig config = new JsonRegistriesConfig();
+    private Map<String, TestRegistryBuilder> registries = new LinkedHashMap<>();
+
+    public static TestRegistryClientBuilder newInstance() {
+        return new TestRegistryClientBuilder();
+    }
+
+    private TestRegistryClientBuilder() {
+    }
+
+    public TestRegistryClientBuilder baseDir(Path baseDir) {
+        this.baseDir = baseDir;
+        return this;
+    }
+
+    public TestRegistryClientBuilder debug() {
+        this.config.setDebug(true);
+        return this;
+    }
+
+    public TestRegistryBuilder newRegistry(String id) {
+        return registries.computeIfAbsent(id, i -> new TestRegistryBuilder(this, id));
+    }
+
+    public void build() {
+        if (baseDir == null) {
+            throw new IllegalStateException("The base directory has not been provided");
+        }
+        if (!Files.exists(baseDir)) {
+            try {
+                Files.createDirectories(baseDir);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to create directory " + baseDir, e);
+            }
+        } else if (!Files.isDirectory(baseDir)) {
+            throw new IllegalStateException(baseDir + " exists and is not a directory");
+        }
+
+        for (TestRegistryBuilder registry : registries.values()) {
+            configureRegistry(registry);
+        }
+
+        final Path configYaml = baseDir.resolve("config.yaml");
+        try {
+            RegistriesConfigMapperHelper.serialize(config, configYaml);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialize registry client configuration " + configYaml, e);
+        }
+    }
+
+    private void configureRegistry(TestRegistryBuilder registry) {
+        registry.configure(getRegistryDir(baseDir, registry.config.getId()));
+        config.addRegistry(registry.config);
+    }
+
+    public static class TestRegistryBuilder {
+
+        private final TestRegistryClientBuilder parent;
+        private final String registryGroupId;
+        private JsonRegistryConfig config;
+        private JsonRegistryDescriptorConfig descrConfig = new JsonRegistryDescriptorConfig();
+        private boolean external;
+        private PlatformCatalog platformCatalog;
+        private List<JsonExtension> nonPlatformExtensions = new ArrayList<>(0);
+
+        private TestRegistryBuilder(TestRegistryClientBuilder parent, String id) {
+            this.parent = parent;
+            this.config = new JsonRegistryConfig();
+            config.setId(Objects.requireNonNull(id));
+
+            registryGroupId = registryIdToGroupId(id);
+            descrConfig.setArtifact(new ArtifactCoords(registryGroupId, Constants.DEFAULT_REGISTRY_DESCRIPTOR_ARTIFACT_ID, null,
+                    "json", Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION));
+        }
+
+        /**
+         * Indicates that this registry is not a test registry.
+         *
+         * @return this instance
+         */
+        public TestRegistryBuilder external() {
+            this.external = true;
+            return this;
+        }
+
+        public TestRegistryBuilder disabled() {
+            config.setDisabled(true);
+            return this;
+        }
+
+        public TestRegistryBuilder platformCatalog(PlatformCatalog platformCatalog) {
+            this.platformCatalog = platformCatalog;
+            return this;
+        }
+
+        public TestPlatformCatalogPlatformBuilder newPlatform(String platformKey) {
+            if (platformCatalog == null) {
+                platformCatalog = new JsonPlatformCatalog();
+            }
+            JsonPlatform platform = (JsonPlatform) platformCatalog.getPlatform(platformKey);
+            if (platform == null) {
+                platform = new JsonPlatform();
+                platform.setPlatformKey(platformKey);
+            }
+            ((JsonPlatformCatalog) platformCatalog).addPlatform(platform);
+            final TestPlatformCatalogPlatformBuilder platformBuilder = new TestPlatformCatalogPlatformBuilder(this,
+                    platform);
+            return platformBuilder;
+        }
+
+        public TestRegistryClientBuilder clientBuilder() {
+            return parent;
+        }
+
+        private void configure(Path registryDir) {
+            if (Files.exists(registryDir)) {
+                if (!Files.isDirectory(registryDir)) {
+                    throw new IllegalStateException(registryDir + " exists and is not a directory");
+                }
+                IoUtils.recursiveDelete(registryDir);
+            }
+            try {
+                Files.createDirectories(registryDir);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to create directory " + registryDir, e);
+            }
+
+            if (!external) {
+                config.setAny("client-factory-url",
+                        TestRegistryClient.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm());
+            }
+
+            final JsonRegistryConfig registryConfig = new JsonRegistryConfig();
+            registryConfig.setId(config.getId());
+            registryConfig.setDescriptor(descrConfig);
+
+            final JsonRegistryPlatformsConfig platformConfig = new JsonRegistryPlatformsConfig();
+            platformConfig
+                    .setArtifact(new ArtifactCoords(registryGroupId, Constants.DEFAULT_REGISTRY_PLATFORMS_CATALOG_ARTIFACT_ID,
+                            null, "json", Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION));
+            if (platformCatalog == null) {
+                platformConfig.setDisabled(true);
+            } else {
+                final Path platformsDir = getRegistryPlatformsDir(registryDir);
+                persistPlatformCatalog(platformCatalog, platformsDir);
+                final Map<String, JsonPlatformCatalog> platformsByQuarkusVersion = new HashMap<>();
+                for (Platform p : platformCatalog.getPlatforms()) {
+                    for (PlatformStream s : p.getStreams()) {
+                        for (PlatformRelease r : s.getReleases()) {
+                            final JsonPlatformCatalog c = platformsByQuarkusVersion.computeIfAbsent(r.getQuarkusCoreVersion(),
+                                    v -> new JsonPlatformCatalog());
+                            JsonPlatform platform = (JsonPlatform) c.getPlatform(p.getPlatformKey());
+                            if (platform == null) {
+                                platform = new JsonPlatform();
+                                platform.setPlatformKey(p.getPlatformKey());
+                                c.addPlatform(platform);
+                            }
+                            JsonPlatformStream stream = (JsonPlatformStream) platform.getStream(s.getId());
+                            if (stream == null) {
+                                stream = new JsonPlatformStream();
+                                stream.setId(s.getId());
+                                platform.addStream(stream);
+                            }
+                            stream.addRelease(r);
+                        }
+                    }
+                }
+                for (Map.Entry<String, JsonPlatformCatalog> entry : platformsByQuarkusVersion.entrySet()) {
+                    persistPlatformCatalog(entry.getValue(), platformsDir.resolve(entry.getKey()));
+                }
+            }
+            registryConfig.setPlatforms(platformConfig);
+
+            final JsonRegistryNonPlatformExtensionsConfig nonPlatformConfig = new JsonRegistryNonPlatformExtensionsConfig();
+            nonPlatformConfig.setArtifact(
+                    new ArtifactCoords(registryGroupId, Constants.DEFAULT_REGISTRY_NON_PLATFORM_EXTENSIONS_CATALOG_ARTIFACT_ID,
+                            null, "json", Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION));
+            if (nonPlatformExtensions.isEmpty()) {
+                nonPlatformConfig.setDisabled(true);
+            }
+            registryConfig.setNonPlatformExtensions(nonPlatformConfig);
+
+            final Path descriptorJson = getRegistryDescriptorPath(registryDir);
+            try {
+                RegistriesConfigMapperHelper.serialize(registryConfig, descriptorJson);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to persist registry descriptor " + descriptorJson, e);
+            }
+        }
+    }
+
+    public static class TestPlatformCatalogPlatformBuilder {
+
+        private final TestRegistryBuilder registry;
+        private final JsonPlatform platform;
+
+        private TestPlatformCatalogPlatformBuilder(TestRegistryBuilder registry, JsonPlatform platform) {
+            this.registry = registry;
+            this.platform = platform;
+        }
+
+        public TestPlatformCatalogStreamBuilder newStream(String id) {
+            final JsonPlatformStream stream = new JsonPlatformStream();
+            stream.setId(id);
+            platform.addStream(stream);
+            return new TestPlatformCatalogStreamBuilder(this, stream);
+        }
+
+        public TestRegistryBuilder registry() {
+            return registry;
+        }
+    }
+
+    public static class TestPlatformCatalogStreamBuilder {
+
+        private final TestPlatformCatalogPlatformBuilder platform;
+        private final JsonPlatformStream stream;
+
+        private TestPlatformCatalogStreamBuilder(TestPlatformCatalogPlatformBuilder platform, JsonPlatformStream stream) {
+            this.platform = platform;
+            this.stream = stream;
+        }
+
+        public TestPlatformCatalogReleaseBuilder newRelease(String version) {
+            final JsonPlatformRelease release = new JsonPlatformRelease();
+            release.setVersion(JsonPlatformReleaseVersion.fromString(version));
+            stream.addRelease(release);
+            return new TestPlatformCatalogReleaseBuilder(this, release);
+        }
+
+        public TestPlatformCatalogPlatformBuilder platform() {
+            return platform;
+        }
+    }
+
+    public static class TestPlatformCatalogReleaseBuilder {
+
+        private final TestPlatformCatalogStreamBuilder stream;
+        private final JsonPlatformRelease release;
+
+        private TestPlatformCatalogReleaseBuilder(TestPlatformCatalogStreamBuilder stream, JsonPlatformRelease release) {
+            this.stream = stream;
+            this.release = release;
+        }
+
+        public TestPlatformCatalogReleaseBuilder quarkusVersion(String quarkusVersion) {
+            this.release.setQuarkusCoreVersion(quarkusVersion);
+            return this;
+        }
+
+        public TestPlatformCatalogReleaseBuilder upstreamQuarkusVersion(String quarkusVersion) {
+            this.release.setUpstreamQuarkusCoreVersion(quarkusVersion);
+            return this;
+        }
+
+        public TestPlatformCatalogReleaseBuilder addMemberBom(ArtifactCoords bom) {
+            if (release.getMemberBoms().isEmpty()) {
+                release.setMemberBoms(new ArrayList<>());
+            }
+            release.getMemberBoms().add(bom);
+            return this;
+        }
+
+        public TestPlatformCatalogStreamBuilder stream() {
+            return stream;
+        }
+
+        public TestRegistryBuilder registry() {
+            return stream.platform.registry;
+        }
+    }
+
+    private static void persistPlatformCatalog(PlatformCatalog catalog, Path dir) {
+        final Path platformsJson = dir.resolve("platforms.json");
+        try {
+            Files.createDirectories(dir);
+            RegistriesConfigMapperHelper.serialize(catalog, platformsJson);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to persist platform catalog " + platformsJson, e);
+        }
+    }
+
+    static Path getRegistryPlatformsCatalogPath(Path registryDir, String quarkusVersion) {
+        return quarkusVersion == null ? getRegistryPlatformsDir(registryDir).resolve("platforms.json")
+                : getRegistryPlatformsDir(registryDir).resolve(quarkusVersion).resolve("platforms.json");
+    }
+
+    private static Path getRegistryPlatformsDir(Path registryDir) {
+        return registryDir.resolve("platforms");
+    }
+
+    static Path getRegistryDescriptorPath(Path registryDir) {
+        return registryDir.resolve("config.json");
+    }
+
+    static Path getRegistryDir(Path baseDir, String registryId) {
+        return baseDir.resolve(registryId);
+    }
+
+    private static String registryIdToGroupId(String id) {
+        final String[] groupIdParts = id.split("\\.");
+        if (groupIdParts.length == 1) {
+            return groupIdParts[0];
+        }
+        final StringJoiner joiner = new StringJoiner(".");
+        for (String part : groupIdParts) {
+            joiner.add(part);
+        }
+        return joiner.toString();
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactory.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactory.java
@@ -1,0 +1,27 @@
+package io.quarkus.devtools.testing.registry.client;
+
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.client.RegistryClient;
+import io.quarkus.registry.client.RegistryClientFactory;
+import io.quarkus.registry.client.spi.RegistryClientEnvironment;
+import io.quarkus.registry.config.RegistryConfig;
+
+public class TestRegistryClientFactory implements RegistryClientFactory {
+
+    private static TestRegistryClientFactory instance;
+
+    public static TestRegistryClientFactory getInstance(RegistryClientEnvironment env) {
+        return instance == null ? instance = new TestRegistryClientFactory(env) : instance;
+    }
+
+    private final RegistryClientEnvironment env;
+
+    private TestRegistryClientFactory(RegistryClientEnvironment env) {
+        this.env = env;
+    }
+
+    @Override
+    public RegistryClient buildRegistryClient(RegistryConfig config) throws RegistryResolutionException {
+        return new TestRegistryClient(env, config);
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactoryProvider.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactoryProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.devtools.testing.registry.client;
+
+import io.quarkus.registry.client.RegistryClientFactory;
+import io.quarkus.registry.client.spi.RegistryClientEnvironment;
+import io.quarkus.registry.client.spi.RegistryClientFactoryProvider;
+
+public class TestRegistryClientFactoryProvider implements RegistryClientFactoryProvider {
+
+    @Override
+    public RegistryClientFactory newRegistryClientFactory(RegistryClientEnvironment env) {
+        return TestRegistryClientFactory.getInstance(env);
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/main/resources/META-INF/services/io.quarkus.registry.client.spi.RegistryClientFactoryProvider
+++ b/independent-projects/tools/devtools-testing/src/main/resources/META-INF/services/io.quarkus.registry.client.spi.RegistryClientFactoryProvider
@@ -1,0 +1,1 @@
+io.quarkus.devtools.testing.registry.client.TestRegistryClientFactoryProvider

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -22,6 +22,7 @@ import io.quarkus.registry.config.RegistryConfig;
 import io.quarkus.registry.union.ElementCatalogBuilder;
 import io.quarkus.registry.union.ElementCatalogBuilder.UnionBuilder;
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -126,10 +127,27 @@ public class ExtensionCatalogResolver {
         }
 
         private RegistryClientFactory getClientFactory(RegistryConfig config) {
-            final Object providerValue = config.getExtra().get("client-factory-artifact");
-            if (providerValue == null) {
+            if (config.getExtra().isEmpty()) {
                 return getDefaultClientFactory();
             }
+            Object provider = config.getExtra().get("client-factory-artifact");
+            if (provider != null) {
+                return loadFromArtifact(config, provider);
+            }
+            provider = config.getExtra().get("client-factory-url");
+            if (provider != null) {
+                final URL url;
+                try {
+                    url = new URL((String) provider);
+                } catch (MalformedURLException e) {
+                    throw new IllegalStateException("Failed to translate " + provider + " to URL", e);
+                }
+                return loadFromUrl(url);
+            }
+            return getDefaultClientFactory();
+        }
+
+        public RegistryClientFactory loadFromArtifact(RegistryConfig config, final Object providerValue) {
             ArtifactCoords providerArtifact = null;
             try {
                 final String providerStr = (String) providerValue;
@@ -148,9 +166,19 @@ public class ExtensionCatalogResolver {
                         "Failed to resolve the registry client factory provider artifact " + providerArtifact, e);
             }
             log.debug("Loading registry client factory for %s from %s", config.getId(), providerArtifact);
+            final URL url;
+            try {
+                url = providerJar.toURI().toURL();
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException("Failed to translate " + providerJar + " to URL", e);
+            }
+            return loadFromUrl(url);
+        }
+
+        private RegistryClientFactory loadFromUrl(final URL url) {
             final ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
             try {
-                ClassLoader providerCl = new URLClassLoader(new URL[] { providerJar.toURI().toURL() }, originalCl);
+                ClassLoader providerCl = new URLClassLoader(new URL[] { url }, originalCl);
                 final Iterator<RegistryClientFactoryProvider> i = ServiceLoader
                         .load(RegistryClientFactoryProvider.class, providerCl).iterator();
                 if (!i.hasNext()) {
@@ -169,7 +197,7 @@ public class ExtensionCatalogResolver {
                 }
                 return provider.newRegistryClientFactory(getClientEnv());
             } catch (Exception e) {
-                throw new IllegalStateException("Failed to load registry client factory from " + providerJar, e);
+                throw new IllegalStateException("Failed to load registry client factory from " + url, e);
             } finally {
                 Thread.currentThread().setContextClassLoader(originalCl);
             }
@@ -277,8 +305,12 @@ public class ExtensionCatalogResolver {
                                 .getOrCreateUnion(new PlatformStackIndex(platformIndex, streamIndex, releaseIndex));
                         for (ArtifactCoords bom : release.getMemberBoms()) {
                             final ExtensionCatalog ec = registry.resolvePlatformExtensions(bom);
-                            catalogs.add(ec);
-                            ElementCatalogBuilder.addUnionMember(union, ec);
+                            if (ec != null) {
+                                catalogs.add(ec);
+                                ElementCatalogBuilder.addUnionMember(union, ec);
+                            } else {
+                                log.warn("Failed to resolve extension catalog for %s from registry %s", bom, registry.getId());
+                            }
                         }
 
                         final Map<String, List<RegistryExtensionResolver>> registriesByQuarkusCore = new HashMap<>(2);

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
@@ -81,7 +81,7 @@ public class RegistriesConfigLocator {
         }
     }
 
-    private static Path locateConfigYaml() {
+    public static Path locateConfigYaml() {
         final String prop = PropertiesUtil.getProperty(CONFIG_FILE_PATH_PROPERTY);
         Path configYaml;
         if (prop != null) {


### PR DESCRIPTION
This allows to relatively easily setup local test registries for a testsuite. This PR covers the basics and switches the current test registry client setup from the maven-based client to a custom one.
This will become the base for a little test framework to write registry client-based tests.