### PR TITLE
Propagate quarkus.tls.trust-all in quarkus-spring-cloud-config-client extension

### DIFF
--- a/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
+++ b/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationSourceValueBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.spring.cloud.config.client.runtime.Response;
 import io.quarkus.spring.cloud.config.client.runtime.SpringCloudConfigClientConfig;
 import io.quarkus.spring.cloud.config.client.runtime.SpringCloudConfigClientRecorder;
@@ -36,9 +37,10 @@ public class SpringCloudConfigProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(SpringCloudConfigClientRecorder recorder,
             SpringCloudConfigClientConfig springCloudConfigClientConfig,
-            ApplicationConfig applicationConfig) {
+            ApplicationConfig applicationConfig,
+            TlsConfig tlsConfig) {
         return new RunTimeConfigurationSourceValueBuildItem(
-                recorder.create(springCloudConfigClientConfig, applicationConfig));
+                recorder.create(springCloudConfigClientConfig, applicationConfig, tlsConfig));
     }
 
 }

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientRecorder.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientRecorder.java
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.ApplicationConfig;
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ProfileManager;
 
@@ -17,7 +18,7 @@ public class SpringCloudConfigClientRecorder {
     private static final Logger log = Logger.getLogger(SpringCloudConfigClientRecorder.class);
 
     public RuntimeValue<ConfigSourceProvider> create(SpringCloudConfigClientConfig springCloudConfigClientConfig,
-            ApplicationConfig applicationConfig) {
+            ApplicationConfig applicationConfig, TlsConfig tlsConfig) {
         if (!springCloudConfigClientConfig.enabled) {
             log.debug(
                     "No attempt will be made to obtain configuration from the Spring Cloud Config Server because the functionality has been disabled via configuration");
@@ -31,7 +32,7 @@ public class SpringCloudConfigClientRecorder {
         }
 
         return new RuntimeValue<>(new SpringCloudConfigServerClientConfigSourceProvider(
-                springCloudConfigClientConfig, applicationConfig.name.get(), ProfileManager.getActiveProfile()));
+                springCloudConfigClientConfig, applicationConfig.name.get(), ProfileManager.getActiveProfile(), tlsConfig));
     }
 
     private RuntimeValue<ConfigSourceProvider> emptyRuntimeValue() {

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigServerClientConfigSourceProvider.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigServerClientConfigSourceProvider.java
@@ -11,6 +11,8 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.TlsConfig;
+
 public class SpringCloudConfigServerClientConfigSourceProvider implements ConfigSourceProvider {
 
     private static final Logger log = Logger.getLogger(SpringCloudConfigServerClientConfigSourceProvider.class);
@@ -23,12 +25,12 @@ public class SpringCloudConfigServerClientConfigSourceProvider implements Config
 
     public SpringCloudConfigServerClientConfigSourceProvider(SpringCloudConfigClientConfig springCloudConfigClientConfig,
             String applicationName,
-            String activeProfile) {
+            String activeProfile, TlsConfig tlsConfig) {
         this.springCloudConfigClientConfig = springCloudConfigClientConfig;
         this.applicationName = applicationName;
         this.activeProfile = activeProfile;
 
-        springCloudConfigClientGateway = new VertxSpringCloudConfigGateway(springCloudConfigClientConfig);
+        springCloudConfigClientGateway = new VertxSpringCloudConfigGateway(springCloudConfigClientConfig, tlsConfig);
     }
 
     @Override

--- a/extensions/spring-cloud-config-client/runtime/src/test/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientGatewayTest.java
+++ b/extensions/spring-cloud-config-client/runtime/src/test/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientGatewayTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
+import io.quarkus.runtime.TlsConfig;
+
 class SpringCloudConfigClientGatewayTest {
 
     private static final int MOCK_SERVER_PORT = 9300;
@@ -24,7 +26,7 @@ class SpringCloudConfigClientGatewayTest {
 
     private static final SpringCloudConfigClientConfig springCloudConfigClientConfig = configForTesting();
     private final SpringCloudConfigClientGateway sut = new VertxSpringCloudConfigGateway(
-            springCloudConfigClientConfig);
+            springCloudConfigClientConfig, new TlsConfig());
 
     @BeforeAll
     static void start() {


### PR DESCRIPTION
The `quarkus.tls.trust-all` was not used in this extension. 
This allow to globally trust all certificate in extensions. 

This branch adds support for it. 