### PR TITLE
Allow a trigger of '*' as catch-all for incoming events

### DIFF
--- a/docs/src/main/asciidoc/funqy-knative-events.adoc
+++ b/docs/src/main/asciidoc/funqy-knative-events.adoc
@@ -117,7 +117,7 @@ quarkus.funqy.knative-events.mapping.configChain.response-source=configChain
 In this case, the configuration maps the incoming Cloud Event type `defaultChain.output` to the `configChain` function.
 The `configChain` function maps its response to the `annotated` Cloud Event type, and the Cloud Event source `configChain`.
 
-* `quarkus.funqy.knative-events.mapping.{function name}.trigger` sets the Cloud Event type that triggers a specific function
+* `quarkus.funqy.knative-events.mapping.{function name}.trigger` sets the Cloud Event type that triggers a specific function. It is possible to use the special value `*` as a catch-all value. The function will in this case be used for all event types.
 * `quarkus.funqy.knative-events.mapping.{function name}.response-type` sets the Cloud Event type of the response
 * `quarkus.funqy.knative-events.mapping.{function name}.resource-source` sets the Cloud Event source of the response
 

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/FallbackTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/FallbackTest.java
@@ -1,0 +1,255 @@
+package io.quarkus.funqy.test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.UUID;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.parsing.Parser;
+
+public class FallbackTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("trigger.properties", "application.properties")
+                    .addClasses(PrimitiveFunctionsWithFallback.class, GreetingFunctions.class, Greeting.class,
+                            GreetingService.class,
+                            Identity.class));
+
+    @Test
+    public void testMapping() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "tolower")
+                .header("ce-source", "test")
+                .body("\"HELLO\"")
+                .post("/")
+                .then().statusCode(200)
+                .header("ce-id", notNullValue())
+                .header("ce-type", "lowercase")
+                .header("ce-source", "to.lowercase")
+                .body(equalTo("\"hello\""));
+    }
+
+    @Test
+    public void testAnnotatedMapping() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "echo")
+                .header("ce-source", "test")
+                .body("\"HELLO\"")
+                .post("/")
+                .then().statusCode(200)
+                .header("ce-id", notNullValue())
+                .header("ce-type", "echo.output")
+                .header("ce-source", "echo")
+                .body(equalTo("\"HELLO\""));
+    }
+
+    @Test
+    public void testAnnotatedMappingWithFallback() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "unknown")
+                .header("ce-source", "test")
+                .body("\"HELLO\"")
+                .post("/")
+                .then().statusCode(200)
+                .header("ce-id", notNullValue())
+                .header("ce-type", "fallback.output")
+                .header("ce-source", "echo")
+                .body(equalTo("\"Fallback for HELLO\""));
+    }
+
+    @Test
+    public void testNoopDefaultMapping() {
+        RestAssured.given()
+                .config(RestAssured.config.encoderConfig(
+                        EncoderConfig.encoderConfig().appendDefaultContentCharsetToContentTypeIfUndefined(false)))
+                .contentType("")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "noop")
+                .header("ce-source", "test")
+                .post("/")
+                .then().statusCode(204)
+                .header("ce-id", nullValue())
+                .header("ce-type", nullValue())
+                .header("ce-source", nullValue());
+    }
+
+    @Test
+    public void testNoopDefaultMappingGet() {
+        RestAssured.given()
+                .config(RestAssured.config.encoderConfig(
+                        EncoderConfig.encoderConfig().appendDefaultContentCharsetToContentTypeIfUndefined(false)))
+                .contentType("")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "noop")
+                .header("ce-source", "test")
+                .get("/")
+                .then().statusCode(204)
+                .header("ce-id", nullValue())
+                .header("ce-type", nullValue())
+                .header("ce-source", nullValue());
+    }
+
+    @Test
+    public void testNoopGet() {
+        RestAssured.given()
+                .config(RestAssured.config.encoderConfig(
+                        EncoderConfig.encoderConfig().appendDefaultContentCharsetToContentTypeIfUndefined(false)))
+                .contentType("")
+                .get("/noop")
+                .then().statusCode(204)
+                .header("ce-id", nullValue())
+                .header("ce-type", nullValue())
+                .header("ce-source", nullValue());
+    }
+
+    @Test
+    public void testDefaultMapping() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "doubleIt")
+                .header("ce-source", "test")
+                .body("2")
+                .post("/")
+                .then().statusCode(200)
+                .header("ce-id", notNullValue())
+                .header("ce-type", "doubleIt.output")
+                .header("ce-source", "doubleIt")
+                .body(equalTo("4"));
+    }
+
+    @Test
+    public void testHttp() {
+        RestAssured.given().contentType("application/json")
+                .body("\"HELLO\"")
+                .post("/toLowerCase")
+                .then().statusCode(200)
+                .header("ce-id", nullValue())
+                .header("ce-type", nullValue())
+                .header("ce-source", nullValue())
+                .body(equalTo("\"hello\""));
+    }
+
+    @Test
+    public void testNoTrigger() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", UUID.randomUUID().toString())
+                .header("ce-type", "foo")
+                .header("ce-source", "test")
+                .body("2")
+                .post("/")
+                .then().statusCode(200);
+    }
+
+    static final String tolowercaseEvent = "{ \"id\" : \"1234\", " +
+            "  \"specversion\": \"1.0\", " +
+            "  \"source\": \"test\", " +
+            "  \"type\": \"tolower\", " +
+            "  \"datacontenttype\": \"application/json\", " +
+            "  \"data\": \"HELLO\" " +
+            "}";
+
+    @Test
+    public void testStructuredMapping() {
+        RestAssured.given().contentType("application/cloudevents+json")
+                .body(tolowercaseEvent)
+                .post("/")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("id", notNullValue())
+                .body("specversion", equalTo("1.0"))
+                .body("type", equalTo("lowercase"))
+                .body("source", equalTo("to.lowercase"))
+                .body("datacontenttype", equalTo("application/json"))
+                .body("data", equalTo("hello"));
+    }
+
+    static final String doubleItEvent = "{ \"id\" : \"1234\", " +
+            "  \"specversion\": \"1.0\", " +
+            "  \"source\": \"test\", " +
+            "  \"type\": \"doubleIt\", " +
+            "  \"datacontenttype\": \"application/json\", " +
+            "  \"data\": 2 " +
+            "}";
+
+    @Test
+    public void testStructuredDefaultMapping() {
+        RestAssured.given().contentType("application/cloudevents+json")
+                .body(doubleItEvent)
+                .post("/")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("id", notNullValue())
+                .body("specversion", equalTo("1.0"))
+                .body("type", equalTo("doubleIt.output"))
+                .body("source", equalTo("doubleIt"))
+                .body("datacontenttype", equalTo("application/json"))
+                .body("data", equalTo(4));
+    }
+
+    static final String echoEvent = "{ \"id\" : \"1234\", " +
+            "  \"specversion\": \"1.0\", " +
+            "  \"source\": \"test\", " +
+            "  \"type\": \"echo\", " +
+            "  \"datacontenttype\": \"application/json\", " +
+            "  \"data\": \"HELLO\" " +
+            "}";
+
+    @Test
+    public void testStructuredAnnotatedMapping() {
+        RestAssured.given().contentType("application/cloudevents+json")
+                .body(echoEvent)
+                .post("/")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("id", notNullValue())
+                .body("specversion", equalTo("1.0"))
+                .body("type", equalTo("echo.output"))
+                .body("source", equalTo("echo"))
+                .body("datacontenttype", equalTo("application/json"))
+                .body("data", equalTo("HELLO"));
+    }
+
+    static final String noTriggerEvent = "{ \"id\" : \"1234\", " +
+            "  \"specversion\": \"1.0\", " +
+            "  \"source\": \"test\", " +
+            "  \"type\": \"nobody\", " +
+            "  \"datacontenttype\": \"application/json\", " +
+            "  \"data\": 2 " +
+            "}";
+
+    @Test
+    public void testStructuredNoTrigger() {
+        RestAssured.given().contentType("application/cloudevents+json")
+                .body(noTriggerEvent)
+                .post("/")
+                .then().statusCode(200);
+    }
+
+    static final String noopEvent = "{ \"id\" : \"1234\", " +
+            "  \"specversion\": \"1.0\", " +
+            "  \"source\": \"test\", " +
+            "  \"type\": \"noop\" " +
+            "}";
+
+    @Test
+    public void testStructuredNoop() {
+        RestAssured.given().contentType("application/cloudevents+json")
+                .body(noopEvent)
+                .post("/")
+                .then().statusCode(204);
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/PrimitiveFunctionsWithFallback.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/PrimitiveFunctionsWithFallback.java
@@ -1,0 +1,33 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+
+public class PrimitiveFunctionsWithFallback {
+    @Funq
+    public String toLowerCase(String val) {
+        return val.toLowerCase();
+    }
+
+    @Funq
+    public int doubleIt(int val) {
+        return val * 2;
+    }
+
+    @Funq
+    public void noop() {
+    }
+
+    @Funq
+    @CloudEventMapping(trigger = "echo", responseType = "echo.output", responseSource = "echo")
+    public String annotatedEcho(String echo) {
+        return echo;
+    }
+
+    @Funq
+    @CloudEventMapping(trigger = "*", responseType = "fallback.output", responseSource = "echo")
+    public String annotatedFallback(String echo) {
+        return "Fallback for " + echo;
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -160,6 +160,10 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                     candidates = typeTriggers.get(ceType);
 
                     if (candidates == null || candidates.isEmpty()) {
+                        candidates = typeTriggers.get("*"); // Catch-all
+                    }
+
+                    if (candidates == null || candidates.isEmpty()) {
                         routingContext.fail(404);
                         log.error("Couldn't map CloudEvent type: '" + ceType + "' to a function.");
                         return;


### PR DESCRIPTION
This is a possible solution for #18337.

I am not too happy about the test duplication, but don't see a good way that the "old" way still works in a common code base. Perhaps someone has a better idea.