### PR TITLE
Fix context affinity for the @ConsumeEvent annotation

### DIFF
--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerContextTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerContextTest.java
@@ -1,0 +1,161 @@
+package io.quarkus.vertx.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.Message;
+
+/**
+ * Verify that event consumer are attached to different contexts.
+ */
+public class MessageConsumerContextTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MessageConsumers.class));
+
+    @Inject
+    MessageConsumers messageConsumers;
+
+    @Inject
+    EventBus eventBus;
+
+    @RepeatedTest(5)
+    public void testSend() throws InterruptedException {
+        MessageConsumers.MESSAGES.clear();
+        MessageConsumers.latch = new CountDownLatch(3);
+        eventBus.send("send", "foo");
+        eventBus.send("send", "bar");
+        eventBus.send("send", "baz");
+        assertTrue(MessageConsumers.latch.await(3, TimeUnit.SECONDS));
+        if (Runtime.getRuntime().availableProcessors() > 1) {
+            assertEquals(3, MessageConsumers.MESSAGES.size());
+        } else {
+            assertTrue(MessageConsumers.MESSAGES.size() >= 2);
+        }
+    }
+
+    @RepeatedTest(5)
+    public void testPublish() throws InterruptedException {
+        MessageConsumers.MESSAGES.clear();
+        MessageConsumers.latch = new CountDownLatch(9); // 3 messages x 3 consumers
+        eventBus.publish("pub", "foo");
+        eventBus.publish("pub", "bar");
+        eventBus.publish("pub", "baz");
+        assertTrue(MessageConsumers.latch.await(3, TimeUnit.SECONDS));
+        if (Runtime.getRuntime().availableProcessors() > 1) {
+            // The 2 event loops and additional worker contexts
+            assertTrue(MessageConsumers.MESSAGES.size() >= 3);
+        } else {
+            assertTrue(MessageConsumers.MESSAGES.size() >= 2);
+        }
+    }
+
+    @RepeatedTest(5)
+    public void testRequestReply() throws InterruptedException {
+        MessageConsumers.MESSAGES.clear();
+        Uni<String> uni1 = eventBus.<String> request("req", "foo").map(Message::body);
+        Uni<String> uni2 = eventBus.<String> request("req", "bar").map(Message::body);
+        Uni<String> uni3 = eventBus.<String> request("req", "baz").map(Message::body);
+
+        Uni.combine().all().unis(uni1, uni2, uni3).asTuple()
+                .map(tuple -> {
+                    assertEquals("FOO", tuple.getItem1());
+                    assertEquals("BAR", tuple.getItem2());
+                    assertEquals("BAZ", tuple.getItem3());
+                    return "done";
+                })
+                .await().atMost(Duration.ofSeconds(3));
+
+        if (Runtime.getRuntime().availableProcessors() > 1) {
+            assertEquals(3, MessageConsumers.MESSAGES.size());
+        } else {
+            assertTrue(MessageConsumers.MESSAGES.size() >= 2);
+        }
+    }
+
+    @ApplicationScoped
+    static class MessageConsumers {
+
+        static volatile CountDownLatch latch;
+
+        static final Set<String> MESSAGES = new ConcurrentHashSet<>();
+
+        @ConsumeEvent("pub")
+        void pub1(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("pub")
+        void pub2(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("pub")
+        @Blocking
+        void pub3(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("send")
+        void send1(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("send")
+        void send2(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("send")
+        @Blocking
+        void send3(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("req")
+        String req1(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            return name.toUpperCase();
+        }
+
+        @ConsumeEvent("req")
+        String req2(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            return name.toUpperCase();
+        }
+
+        @ConsumeEvent("req")
+        @Blocking
+        String req3(String name) {
+            MESSAGES.add(Thread.currentThread().getName());
+            return name.toUpperCase();
+        }
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Supplier;
 
@@ -17,6 +18,7 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.vertx.ConsumeEvent;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -24,6 +26,7 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.impl.VertxInternal;
 
 @Recorder
 public class VertxRecorder {
@@ -36,7 +39,7 @@ public class VertxRecorder {
     public void configureVertx(Supplier<Vertx> vertx, Map<String, ConsumeEvent> messageConsumerConfigurations,
             LaunchMode launchMode, ShutdownContext shutdown, Map<Class<?>, Class<?>> codecByClass) {
         VertxRecorder.vertx = vertx.get();
-        VertxRecorder.messageConsumers = new ArrayList<>();
+        VertxRecorder.messageConsumers = new CopyOnWriteArrayList<>();
 
         registerMessageConsumers(messageConsumerConfigurations);
         registerCodecs(codecByClass);
@@ -69,24 +72,48 @@ public class VertxRecorder {
     void registerMessageConsumers(Map<String, ConsumeEvent> messageConsumerConfigurations) {
         if (!messageConsumerConfigurations.isEmpty()) {
             EventBus eventBus = vertx.eventBus();
+            VertxInternal vi = (VertxInternal) VertxRecorder.vertx;
             CountDownLatch latch = new CountDownLatch(messageConsumerConfigurations.size());
-            final List<Throwable> registrationFailures = new ArrayList();
+            final List<Throwable> registrationFailures = new ArrayList<>();
             for (Entry<String, ConsumeEvent> entry : messageConsumerConfigurations.entrySet()) {
                 EventConsumerInvoker invoker = createInvoker(entry.getKey());
                 String address = entry.getValue().value();
-                MessageConsumer<Object> consumer;
-                if (entry.getValue().local()) {
-                    consumer = eventBus.localConsumer(address);
-                } else {
-                    consumer = eventBus.consumer(address);
-                }
-                consumer.handler(new Handler<Message<Object>>() {
+                // Create a context attached to each consumer
+                // If we don't all consumers will use the same event loop and so published messages (dispatched to all
+                // consumers) delivery is serialized.
+                Context context = vi.createEventLoopContext();
+                context.runOnContext(new Handler<Void>() {
                     @Override
-                    public void handle(Message<Object> m) {
-                        if (invoker.isBlocking()) {
-                            vertx.executeBlocking(new Handler<Promise<Object>>() {
-                                @Override
-                                public void handle(Promise<Object> event) {
+                    public void handle(Void x) {
+                        MessageConsumer<Object> consumer;
+                        if (entry.getValue().local()) {
+                            consumer = eventBus.localConsumer(address);
+                        } else {
+                            consumer = eventBus.consumer(address);
+                        }
+
+                        consumer.handler(new Handler<Message<Object>>() {
+                            @Override
+                            public void handle(Message<Object> m) {
+                                if (invoker.isBlocking()) {
+                                    context.executeBlocking(new Handler<Promise<Object>>() {
+                                        @Override
+                                        public void handle(Promise<Object> event) {
+                                            try {
+                                                invoker.invoke(m);
+                                            } catch (Exception e) {
+                                                if (m.replyAddress() == null) {
+                                                    // No reply handler
+                                                    throw wrapIfNecessary(e);
+                                                } else {
+                                                    m.fail(ConsumeEvent.FAILURE_CODE, e.toString());
+                                                }
+                                            }
+                                            event.complete();
+                                        }
+                                    }, invoker.isOrdered(), null);
+                                } else {
+                                    // Will run on the context used for the consumer registration
                                     try {
                                         invoker.invoke(m);
                                     } catch (Exception e) {
@@ -97,34 +124,22 @@ public class VertxRecorder {
                                             m.fail(ConsumeEvent.FAILURE_CODE, e.toString());
                                         }
                                     }
-                                    event.complete();
-                                }
-                            }, invoker.isOrdered(), null);
-                        } else {
-                            try {
-                                invoker.invoke(m);
-                            } catch (Exception e) {
-                                if (m.replyAddress() == null) {
-                                    // No reply handler
-                                    throw wrapIfNecessary(e);
-                                } else {
-                                    m.fail(ConsumeEvent.FAILURE_CODE, e.toString());
                                 }
                             }
-                        }
-                    }
-                });
-                consumer.completionHandler(new Handler<AsyncResult<Void>>() {
+                        });
 
-                    @Override
-                    public void handle(AsyncResult<Void> ar) {
-                        latch.countDown();
-                        if (ar.failed()) {
-                            registrationFailures.add(ar.cause());
-                        }
+                        consumer.completionHandler(new Handler<AsyncResult<Void>>() {
+                            @Override
+                            public void handle(AsyncResult<Void> ar) {
+                                latch.countDown();
+                                if (ar.failed()) {
+                                    registrationFailures.add(ar.cause());
+                                }
+                            }
+                        });
+                        messageConsumers.add(consumer);
                     }
                 });
-                messageConsumers.add(consumer);
             }
             try {
                 latch.await();


### PR DESCRIPTION
In Vert.x 4, the event bus consumer gets associated with a context captured during the consumer registration.
However, because our consumers get all registered from the same thread, they all get associated with the same context.
As a consequence, message delivery is serialized and uses only one context.

This PR creates a new context for each consumer.
It registers the listener in that context, so the message delivery uses that context to execute the listener (if not marked as blocking).

For the record, this is related to https://stackoverflow.com/questions/68244809/has-changed-the-way-vertx-eventbus-multithreading-is-handled-between-quarkus-1-1.