### PR TITLE
Add missing nexus-staging-maven-plugin.version to bootstrap parent pom

### DIFF
--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -25,6 +25,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
     <modules>
         <module>bom</module>


### PR DESCRIPTION
I have absolutely no idea how it worked before... or when we did break it.