### PR TITLE
Stricter tests for Panache Reactive

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/deployment/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JAXBEntity.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JAXBEntity.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.reactive.panache.test;
+package io.quarkus.hibernate.orm.panache.deployment.test;
 
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -8,7 +8,7 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
 @Entity
 @XmlRootElement(name = "JAXBEntity")

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JAXBTestResource.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JAXBTestResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.reactive.panache.test;
+package io.quarkus.hibernate.orm.panache.deployment.test;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PanacheJAXBTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PanacheJAXBTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.reactive.panache.test;
+package io.quarkus.hibernate.orm.panache.deployment.test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,8 +30,7 @@ public class PanacheJAXBTest {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(JAXBEntity.class, JAXBTestResource.class)
-                    .addAsResource("application.properties"));
+                    .addClasses(JAXBEntity.class, JAXBTestResource.class));
 
     @Test
     public void testJaxbAnnotationTransfer() throws Exception {

--- a/extensions/panache/hibernate-reactive-panache-common/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-common/deployment/pom.xml
@@ -51,6 +51,22 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -82,12 +82,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                    <systemPropertyVariables>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -55,22 +55,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdWithParentTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdWithParentTest.java
@@ -14,6 +14,7 @@ public class DuplicateIdWithParentTest {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setExpectedException(BuildException.class)
+            .overrideConfigKey("quarkus.datasource.devservices", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(DuplicateIdWithParentEntity.class, DuplicateIdParentEntity.class));
 

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/MyOtherTestResource.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/MyOtherTestResource.java
@@ -2,12 +2,11 @@ package io.quarkus.hibernate.reactive.panache.test;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import io.smallrye.mutiny.Uni;
 
@@ -17,7 +16,7 @@ public class MyOtherTestResource {
     @GET
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<MyOtherEntity> get(@PathParam long id) {
+    public Uni<MyOtherEntity> get(@PathParam("id") long id) {
         return MyOtherEntity.<MyOtherEntity> findById(id)
                 .onItem().ifNull().failWith(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/MyTestResource.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/MyTestResource.java
@@ -2,12 +2,11 @@ package io.quarkus.hibernate.reactive.panache.test;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import io.smallrye.mutiny.Uni;
 
@@ -17,7 +16,7 @@ public class MyTestResource {
     @GET
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<MyEntity> get(@PathParam long id) {
+    public Uni<MyEntity> get(@PathParam("id") long id) {
         return MyEntity.<MyEntity> findById(id)
                 .onItem().ifNull().failWith(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }


### PR DESCRIPTION
This enables some stricter assertions in Hibernate Rective, which highlight the need to test Panache Reactive as fully running in non-blocking mode.

Many of these tests were still being run with RESTEasy "classic".

We also need to prepare as I'll be introducing even stricter assertions, and mixing the classic RESTEasy with Panache Reactive won't be possible.