### PR TITLE
CLI registry clear-cache command

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -25,8 +25,8 @@ import picocli.CommandLine.UnmatchedArgumentException;
 
 @QuarkusMain
 @CommandLine.Command(name = "quarkus", versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = true, subcommands = {
-        Create.class, Build.class, Dev.class, ProjectExtensions.class, Completion.class,
-        Version.class }, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+        Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Version.class,
+        Completion.class }, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
 
     static {

--- a/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
@@ -1,0 +1,24 @@
+package io.quarkus.cli;
+
+import java.util.List;
+
+import io.quarkus.cli.registry.BaseRegistryCommand;
+import io.quarkus.cli.registry.RegistryListCommand;
+import picocli.CommandLine;
+import picocli.CommandLine.ParseResult;
+import picocli.CommandLine.Unmatched;
+
+@CommandLine.Command(name = "registry", sortOptions = false, mixinStandardHelpOptions = false, header = "Manage extension registries.", subcommands = {
+        RegistryListCommand.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+public class Registry extends BaseRegistryCommand {
+
+    @Unmatched // avoids throwing errors for unmatched arguments
+    List<String> unmatchedArgs;
+
+    @Override
+    public Integer call() throws Exception {
+        final ParseResult result = spec.commandLine().getParseResult();
+        final CommandLine appCommand = spec.subcommands().get("list");
+        return appCommand.execute(result.originalArgs().stream().filter(x -> !"registry".equals(x)).toArray(String[]::new));
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
@@ -6,7 +6,7 @@ import java.nio.file.Paths;
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
-import io.quarkus.cli.common.RegistryClientMixin;
+import io.quarkus.cli.common.ToggleRegistryClientMixin;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import picocli.CommandLine;
@@ -19,7 +19,7 @@ public class BaseBuildCommand {
     protected OutputOptionMixin output;
 
     @CommandLine.Mixin
-    protected RegistryClientMixin registryClient;
+    protected ToggleRegistryClientMixin registryClient;
 
     @CommandLine.Mixin
     protected HelpOption helpOption;

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/ToggleRegistryClientMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/ToggleRegistryClientMixin.java
@@ -1,0 +1,14 @@
+package io.quarkus.cli.common;
+
+import picocli.CommandLine;
+
+public class ToggleRegistryClientMixin extends RegistryClientMixin {
+
+    @CommandLine.Option(names = { "--registry-client" }, description = "Use the Quarkus extension catalog", negatable = true)
+    boolean useRegistryClient = false;
+
+    @Override
+    public boolean enabled() {
+        return useRegistryClient;
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
@@ -7,8 +7,8 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import io.quarkus.cli.common.OutputOptionMixin;
-import io.quarkus.cli.common.RegistryClientMixin;
 import io.quarkus.cli.common.TargetQuarkusVersionGroup;
+import io.quarkus.cli.common.ToggleRegistryClientMixin;
 import io.quarkus.devtools.commands.CreateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.project.BuildTool;
@@ -37,7 +37,7 @@ public class CreateProjectMixin {
     String targetDirectory;
 
     @Mixin
-    RegistryClientMixin registryClient;
+    ToggleRegistryClientMixin registryClient;
 
     public void setTestOutputDirectory(Path testOutputDirectory) {
         if (testOutputDirectory != null && targetDirectory == null) {
@@ -54,7 +54,7 @@ public class CreateProjectMixin {
 
     /**
      * Resolve and remember the configured project directory.
-     * 
+     *
      * @param log Output Mixin that will be used to emit error messages
      * @return true IFF configured project root directory already exists
      */

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
@@ -1,0 +1,28 @@
+package io.quarkus.cli.registry;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.common.HelpOption;
+import io.quarkus.cli.common.OutputOptionMixin;
+import picocli.CommandLine;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+public class BaseRegistryCommand implements Callable<Integer> {
+
+    @Mixin(name = "output")
+    protected OutputOptionMixin output;
+
+    @Mixin
+    protected HelpOption helpOption;
+
+    @Spec
+    protected CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        spec.commandLine().usage(output.out());
+        return CommandLine.ExitCode.OK;
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryListCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryListCommand.java
@@ -1,0 +1,39 @@
+package io.quarkus.cli.registry;
+
+import java.nio.file.Path;
+
+import io.quarkus.cli.common.RegistryClientMixin;
+import io.quarkus.registry.config.RegistriesConfig;
+import io.quarkus.registry.config.RegistriesConfigLocator;
+import io.quarkus.registry.config.RegistryConfig;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "list", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List enabled Quarkus registries", description = "%n"
+        + "This command will list currently enabled Quarkus extension registries", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class RegistryListCommand extends BaseRegistryCommand {
+
+    @CommandLine.Mixin
+    protected RegistryClientMixin registryClient;
+
+    @Override
+    public Integer call() throws Exception {
+
+        registryClient.refreshRegistryCache(output);
+
+        output.info("Available Quarkus extension registries:");
+        final RegistriesConfig config = RegistriesConfigLocator.resolveConfig();
+        for (RegistryConfig r : config.getRegistries()) {
+            if (r.isDisabled()) {
+                continue;
+            }
+            output.info("- " + r.getId());
+        }
+
+        final Path configYaml = RegistriesConfigLocator.locateConfigYaml();
+        if (configYaml != null) {
+            output.info("(Read from " + configYaml + ")");
+        }
+
+        return CommandLine.ExitCode.OK;
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -132,6 +132,11 @@ public class TestRegistryClient implements RegistryClient {
         return config;
     }
 
+    @Override
+    public void clearCache() {
+        log.debug("% clearCache not supported", config.getId());
+    }
+
     public static RegistryConfig getDefaultConfig() {
 
         final JsonRegistryConfig config = new JsonRegistryConfig();

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -469,13 +469,6 @@ public class ExtensionCatalogResolver {
         return catalog;
     }
 
-    private void ensureRegistriesConfigured() throws RegistryResolutionException {
-        final int registriesTotal = registries.size();
-        if (registriesTotal == 0) {
-            throw new RegistryResolutionException("No registries configured");
-        }
-    }
-
     public ExtensionCatalog resolveExtensionCatalog(Collection<ArtifactCoords> platforms)
             throws RegistryResolutionException {
         if (platforms.isEmpty()) {
@@ -516,6 +509,19 @@ public class ExtensionCatalogResolver {
         }
         appendNonPlatformExtensions(registriesByQuarkusCore, null, catalogs);
         return JsonCatalogMerger.merge(catalogs);
+    }
+
+    public void clearRegistryCache() throws RegistryResolutionException {
+        for (RegistryExtensionResolver registry : registries) {
+            registry.clearCache();
+        }
+    }
+
+    private void ensureRegistriesConfigured() throws RegistryResolutionException {
+        final int registriesTotal = registries.size();
+        if (registriesTotal == 0) {
+            throw new RegistryResolutionException("No registries configured");
+        }
     }
 
     private ExtensionCatalog resolvePlatformExtensions(ArtifactCoords bom, List<RegistryExtensionResolver> registries) {

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -74,4 +74,8 @@ class RegistryExtensionResolver {
     ExtensionCatalog resolvePlatformExtensions(ArtifactCoords platform) throws RegistryResolutionException {
         return extensionResolver.resolvePlatformExtensions(platform);
     }
+
+    void clearCache() throws RegistryResolutionException {
+        extensionResolver.clearCache();
+    }
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryCache.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryCache.java
@@ -1,0 +1,8 @@
+package io.quarkus.registry.client;
+
+import io.quarkus.registry.RegistryResolutionException;
+
+public interface RegistryCache {
+
+    void clearCache() throws RegistryResolutionException;
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryClient.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryClient.java
@@ -7,5 +7,5 @@ package io.quarkus.registry.client;
  * the other way around - provide only non-platform extensions but not platforms.
  */
 public interface RegistryClient extends RegistryNonPlatformExtensionsResolver, RegistryPlatformExtensionsResolver,
-        RegistryPlatformsResolver, RegistryConfigResolver {
+        RegistryPlatformsResolver, RegistryConfigResolver, RegistryCache {
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryClientDispatcher.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/RegistryClientDispatcher.java
@@ -12,15 +12,24 @@ public class RegistryClientDispatcher implements RegistryClient {
     private final RegistryPlatformsResolver platforms;
     private final RegistryPlatformExtensionsResolver platformExtensions;
     private final RegistryNonPlatformExtensionsResolver nonPlatformExtensions;
+    private final RegistryCache registryCache;
     protected RegistryConfig config;
 
     public RegistryClientDispatcher(RegistryConfig config, RegistryPlatformsResolver platforms,
             RegistryPlatformExtensionsResolver platformExtensions,
             RegistryNonPlatformExtensionsResolver nonPlatformExtensions) {
+        this(config, platforms, platformExtensions, nonPlatformExtensions, null);
+    }
+
+    public RegistryClientDispatcher(RegistryConfig config, RegistryPlatformsResolver platforms,
+            RegistryPlatformExtensionsResolver platformExtensions,
+            RegistryNonPlatformExtensionsResolver nonPlatformExtensions,
+            RegistryCache registryCache) {
         this.config = config;
         this.platforms = platforms;
         this.platformExtensions = Objects.requireNonNull(platformExtensions);
         this.nonPlatformExtensions = nonPlatformExtensions;
+        this.registryCache = registryCache;
     }
 
     @Override
@@ -43,5 +52,12 @@ public class RegistryClientDispatcher implements RegistryClient {
     @Override
     public RegistryConfig resolveRegistryConfig() throws RegistryResolutionException {
         return config;
+    }
+
+    @Override
+    public void clearCache() throws RegistryResolutionException {
+        if (registryCache != null) {
+            registryCache.clearCache();
+        }
     }
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolver.java
@@ -8,5 +8,7 @@ public interface MavenRegistryArtifactResolver {
 
     Path resolve(Artifact artifact) throws BootstrapMavenException;
 
+    Path findArtifactDirectory(Artifact artifact) throws BootstrapMavenException;
+
     String getLatestVersionFromRange(Artifact artifact, String versionRange) throws BootstrapMavenException;
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryArtifactResolverWithCleanup.java
@@ -29,6 +29,13 @@ public class MavenRegistryArtifactResolverWithCleanup implements MavenRegistryAr
     }
 
     @Override
+    public Path findArtifactDirectory(Artifact artifact) throws BootstrapMavenException {
+        final LocalRepositoryManager localRepo = resolver.getSession().getLocalRepositoryManager();
+        return localRepo.getRepository().getBasedir().toPath().resolve(localRepo.getPathForLocalArtifact(artifact))
+                .getParent();
+    }
+
+    @Override
     public String getLatestVersionFromRange(Artifact artifact, String versionRange) throws BootstrapMavenException {
         return resolver.getLatestVersionFromRange(artifact, versionRange);
     }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
@@ -1,0 +1,53 @@
+package io.quarkus.registry.client.maven;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.client.RegistryCache;
+import io.quarkus.registry.config.RegistryConfig;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+public class MavenRegistryCache implements RegistryCache {
+
+    private final RegistryConfig config;
+    private final Collection<ArtifactCoords> artifacts;
+    private final MavenRegistryArtifactResolver resolver;
+    private final MessageWriter log;
+
+    public MavenRegistryCache(RegistryConfig config, MavenRegistryArtifactResolver resolver,
+            MessageWriter log) {
+        this.config = config;
+        this.artifacts = Arrays.asList(config.getDescriptor().getArtifact(),
+                config.getNonPlatformExtensions().getArtifact(), config.getPlatforms().getArtifact());
+        this.resolver = Objects.requireNonNull(resolver);
+        this.log = Objects.requireNonNull(log);
+    }
+
+    @Override
+    public void clearCache() throws RegistryResolutionException {
+        log.debug("%s clearCache", config.getId());
+        for (ArtifactCoords coords : artifacts) {
+            final Path dir;
+            try {
+                dir = resolver.findArtifactDirectory(new DefaultArtifact(coords.getGroupId(), coords.getArtifactId(),
+                        coords.getClassifier(), coords.getType(), coords.getVersion()));
+            } catch (BootstrapMavenException e) {
+                throw new RegistryResolutionException("Failed to resolve " + coords + " locally", e);
+            }
+            if (Files.exists(dir)) {
+                try {
+                    Files.list(dir).forEach(path -> path.toFile().deleteOnExit());
+                } catch (IOException e) {
+                    throw new RegistryResolutionException("Failed to read directory " + dir, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
An attempt to add `registry clear-cache` CLI command to clear the local registry cache.

Other `registry` sub-commands could include:
* `list` to list currently enabled registries;
* `add` to add another registry to the devtools config;
* `remove` to remove a registry from the config;
* `disable` to temporarily disable a registry in the config;
* `enable` to (re-)enable a registry in the config.

A config file could be either a global (in the user home dir) or in the project dir.