### PR TITLE
Test that the classpath in tests does not contain duplicate entries

### DIFF
--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -1,6 +1,7 @@
 package io.quarkus.extest.deployment;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -31,21 +32,23 @@ public class ClasspathEntryRecordingBuildStep {
     void recordDuringAugmentation(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
         classpathEntriesRecorder.record(Phase.AUGMENTATION,
-                ClasspathEntriesRecorder.gather(config.classpathEntriesToRecord));
+                ClasspathEntriesRecorder.gather(config.classpathEntriesToRecord.orElse(Collections.emptyList())));
     }
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void recordDuringStaticInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
-        classpathEntriesRecorder.gatherAndRecord(Phase.STATIC_INIT, config.classpathEntriesToRecord);
+        classpathEntriesRecorder.gatherAndRecord(Phase.STATIC_INIT,
+                config.classpathEntriesToRecord.orElse(Collections.emptyList()));
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void recordDuringRuntimeInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
-        classpathEntriesRecorder.gatherAndRecord(Phase.RUNTIME_INIT, config.classpathEntriesToRecord);
+        classpathEntriesRecorder.gatherAndRecord(Phase.RUNTIME_INIT,
+                config.classpathEntriesToRecord.orElse(Collections.emptyList()));
     }
 
 }

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -1,54 +1,87 @@
 package io.quarkus.extest.deployment;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.extest.runtime.classpath.ClasspathEntriesRecorder;
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries.Phase;
 import io.quarkus.extest.runtime.config.TestBuildTimeConfig;
 
 public class ClasspathEntryRecordingBuildStep {
-    /**
-     * Register the CDI beans that are needed by the test extension
-     *
-     * @param additionalBeans - producer for additional bean items
-     */
     @BuildStep
-    void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
-        additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClass(RecordedClasspathEntries.class)
-                .setUnremovable()
-                .build());
+    @Record(ExecutionTime.STATIC_INIT)
+    void registerRecordedClasspathEntries(ClasspathEntriesRecorder classpathEntriesRecorder,
+            TestBuildTimeConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
+        Optional<Path> recordFilePath = config.classpathRecording.recordFile;
+        if (!recordFilePath.isPresent()) {
+            return;
+        }
+        syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(RecordedClasspathEntries.class)
+                .runtimeValue(classpathEntriesRecorder.recordedClasspathEntries(recordFilePath.get().toString().toString()))
+                .done());
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
-    void recordDuringAugmentation(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
+    // This makes sure we execute this step even though it doesn't produce anything useful for the build
+    // (just side-effects).
+    @Produce(FeatureBuildItem.class)
+    void recordDuringAugmentation(TestBuildTimeConfig config)
             throws IOException {
-        classpathEntriesRecorder.record(Phase.AUGMENTATION,
-                ClasspathEntriesRecorder.gather(config.classpathEntriesToRecord.orElse(Collections.emptyList())));
+        List<String> resourcesToRecord = getResourcesToRecord(config);
+        if (resourcesToRecord.isEmpty()) {
+            return;
+        }
+        ClasspathEntriesRecorder.record(getRecordFilePath(config), Phase.AUGMENTATION,
+                ClasspathEntriesRecorder.gather(resourcesToRecord));
     }
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void recordDuringStaticInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
-        classpathEntriesRecorder.gatherAndRecord(Phase.STATIC_INIT,
-                config.classpathEntriesToRecord.orElse(Collections.emptyList()));
+        List<String> resourcesToRecord = getResourcesToRecord(config);
+        if (resourcesToRecord.isEmpty()) {
+            return;
+        }
+        classpathEntriesRecorder.gatherAndRecord(getRecordFilePath(config).toString(),
+                Phase.STATIC_INIT, resourcesToRecord);
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void recordDuringRuntimeInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
-        classpathEntriesRecorder.gatherAndRecord(Phase.RUNTIME_INIT,
-                config.classpathEntriesToRecord.orElse(Collections.emptyList()));
+        List<String> resourcesToRecord = getResourcesToRecord(config);
+        if (resourcesToRecord.isEmpty()) {
+            return;
+        }
+        classpathEntriesRecorder.gatherAndRecord(getRecordFilePath(config).toString(),
+                Phase.RUNTIME_INIT, resourcesToRecord);
+    }
+
+    private static List<String> getResourcesToRecord(TestBuildTimeConfig config) {
+        return config.classpathRecording.resources.orElse(Collections.emptyList());
+    }
+
+    /*
+     * We need to record classpath entries in an external file,
+     * because the application may be started multiple times with different classloaders.
+     */
+    public static Path getRecordFilePath(TestBuildTimeConfig config) {
+        return config.classpathRecording.recordFile
+                .orElseThrow(() -> new IllegalStateException("Classpath entries cannot be recorded"
+                        + " because application property 'quarkus.bt.classpath-recording.record-file' was not set."));
     }
 
 }

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -1,0 +1,51 @@
+package io.quarkus.extest.deployment;
+
+import java.io.IOException;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.extest.runtime.classpath.ClasspathEntriesRecorder;
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries.Phase;
+import io.quarkus.extest.runtime.config.TestBuildTimeConfig;
+
+public class ClasspathEntryRecordingBuildStep {
+    /**
+     * Register the CDI beans that are needed by the test extension
+     *
+     * @param additionalBeans - producer for additional bean items
+     */
+    @BuildStep
+    void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(RecordedClasspathEntries.class)
+                .setUnremovable()
+                .build());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordDuringAugmentation(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
+            throws IOException {
+        classpathEntriesRecorder.record(Phase.AUGMENTATION,
+                ClasspathEntriesRecorder.gather(config.classpathEntriesToRecord));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordDuringStaticInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
+            throws IOException {
+        classpathEntriesRecorder.gatherAndRecord(Phase.STATIC_INIT, config.classpathEntriesToRecord);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void recordDuringRuntimeInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
+            throws IOException {
+        classpathEntriesRecorder.gatherAndRecord(Phase.RUNTIME_INIT, config.classpathEntriesToRecord);
+    }
+
+}

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -12,6 +12,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.extest.runtime.classpath.ClasspathEntriesRecorder;
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
@@ -36,6 +37,9 @@ public class ClasspathEntryRecordingBuildStep {
     // This makes sure we execute this step even though it doesn't produce anything useful for the build
     // (just side-effects).
     @Produce(FeatureBuildItem.class)
+    // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
+    // so that we can reproduce a problem that happens in the Hibernate ORM extension.
+    @Produce(DevServicesNativeConfigResultBuildItem.class)
     void recordDuringAugmentation(TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);
@@ -48,6 +52,9 @@ public class ClasspathEntryRecordingBuildStep {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
+    // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
+    // so that we can reproduce a problem that happens in the Hibernate ORM extension.
+    @Produce(DevServicesNativeConfigResultBuildItem.class)
     void recordDuringStaticInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);
@@ -60,6 +67,9 @@ public class ClasspathEntryRecordingBuildStep {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
+    // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
+    // so that we can reproduce a problem that happens in the Hibernate ORM extension.
+    @Produce(DevServicesNativeConfigResultBuildItem.class)
     void recordDuringRuntimeInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/ClasspathEntriesRecorder.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/ClasspathEntriesRecorder.java
@@ -2,12 +2,14 @@ package io.quarkus.extest.runtime.classpath;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
@@ -27,15 +29,17 @@ public class ClasspathEntriesRecorder {
         return classpathEntries;
     }
 
-    public void gatherAndRecord(RecordedClasspathEntries.Phase phase, List<String> resourceNames)
-            throws IOException {
-        record(phase, gather(resourceNames));
+    public static void record(Path recordFilePath, RecordedClasspathEntries.Phase phase,
+            Map<String, List<String>> classpathEntries) {
+        for (Map.Entry<String, List<String>> entry : classpathEntries.entrySet()) {
+            RecordedClasspathEntries.put(recordFilePath,
+                    new RecordedClasspathEntries.Record(phase, entry.getKey(), entry.getValue()));
+        }
     }
 
-    public void record(RecordedClasspathEntries.Phase phase, Map<String, List<String>> classpathEntries) {
-        for (Map.Entry<String, List<String>> entry : classpathEntries.entrySet()) {
-            RecordedClasspathEntries.put(phase, entry.getKey(), entry.getValue());
-        }
+    public void gatherAndRecord(String recordFilePath, RecordedClasspathEntries.Phase phase, List<String> resourceNames)
+            throws IOException {
+        record(Path.of(recordFilePath), phase, gather(resourceNames));
     }
 
     private static ClassLoader getClassLoader() {
@@ -46,4 +50,7 @@ public class ClasspathEntriesRecorder {
         return cl;
     }
 
+    public RuntimeValue<RecordedClasspathEntries> recordedClasspathEntries(String recordFilePath) {
+        return new RuntimeValue<>(new RecordedClasspathEntries(Path.of(recordFilePath)));
+    }
 }

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/ClasspathEntriesRecorder.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/ClasspathEntriesRecorder.java
@@ -1,0 +1,49 @@
+package io.quarkus.extest.runtime.classpath;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class ClasspathEntriesRecorder {
+
+    public static Map<String, List<String>> gather(List<String> resourceNames)
+            throws IOException {
+        Map<String, List<String>> classpathEntries = new HashMap<>();
+        for (String resourceName : resourceNames) {
+            Enumeration<URL> resourcesEnum = getClassLoader().getResources(resourceName);
+            List<String> resources = new ArrayList<>();
+            while (resourcesEnum.hasMoreElements()) {
+                resources.add(resourcesEnum.nextElement().toString());
+            }
+            classpathEntries.put(resourceName, resources);
+        }
+        return classpathEntries;
+    }
+
+    public void gatherAndRecord(RecordedClasspathEntries.Phase phase, List<String> resourceNames)
+            throws IOException {
+        record(phase, gather(resourceNames));
+    }
+
+    public void record(RecordedClasspathEntries.Phase phase, Map<String, List<String>> classpathEntries) {
+        for (Map.Entry<String, List<String>> entry : classpathEntries.entrySet()) {
+            RecordedClasspathEntries.put(phase, entry.getKey(), entry.getValue());
+        }
+    }
+
+    private static ClassLoader getClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            return ClasspathEntriesRecorder.class.getClassLoader();
+        }
+        return cl;
+    }
+
+}

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/RecordedClasspathEntries.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/classpath/RecordedClasspathEntries.java
@@ -1,0 +1,38 @@
+package io.quarkus.extest.runtime.classpath;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class RecordedClasspathEntries {
+
+    private RecordedClasspathEntries() {
+    }
+
+    private static final Map<Phase, Map<String, List<String>>> content;
+    static {
+        content = new HashMap<>();
+        for (Phase phase : Phase.values()) {
+            content.put(phase, new HashMap<>());
+        }
+    }
+
+    public static void put(Phase phase, String resourceName, List<String> classpathEntries) {
+        content.get(phase).put(resourceName, classpathEntries);
+    }
+
+    public static List<String> get(Phase phase, String resourceName) {
+        List<String> entries = content.get(phase).get(resourceName);
+        if (entries == null) {
+            throw new IllegalStateException("Classpath entries for resource '" + resourceName + "' were not recorded;"
+                    + " make sure to set application property 'bt.augment-phase-classpath-resources-to-record' correctly.");
+        }
+        return entries;
+    }
+
+    public enum Phase {
+        AUGMENTATION,
+        STATIC_INIT,
+        RUNTIME_INIT;
+    }
+}

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.extest.runtime.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -36,7 +37,8 @@ public class TestBuildTimeConfig {
      * 
      * @see RecordedClasspathEntries#get(RecordedClasspathEntries.Phase, String)
      */
-    public List<String> classpathEntriesToRecord;
+    @ConfigItem
+    public Optional<List<String>> classpathEntriesToRecord;
 
     public TestBuildTimeConfig() {
 

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
@@ -1,10 +1,12 @@
 package io.quarkus.extest.runtime.config;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -33,12 +35,33 @@ public class TestBuildTimeConfig {
     public Map<String, Map<String, String>> mapMap;
 
     /**
-     * Names of resources for which classpath entries should be recorded.
-     * 
-     * @see RecordedClasspathEntries#get(RecordedClasspathEntries.Phase, String)
+     * Configuration related to recording of classpath entries.
+     *
+     * @see RecordedClasspathEntries#get(Path, RecordedClasspathEntries.Phase, String)
      */
     @ConfigItem
-    public Optional<List<String>> classpathEntriesToRecord;
+    public ClasspathRecordingConfig classpathRecording;
+
+    @ConfigGroup
+    public static class ClasspathRecordingConfig {
+
+        /**
+         * Names of resources for which classpath entries should be recorded.
+         *
+         * @see RecordedClasspathEntries#get(Path, RecordedClasspathEntries.Phase, String)
+         */
+        @ConfigItem
+        public Optional<List<String>> resources;
+
+        /**
+         * Path to the file to which classpath entry records will be appended.
+         *
+         * @see RecordedClasspathEntries#get(Path, RecordedClasspathEntries.Phase, String)
+         */
+        @ConfigItem
+        public Optional<Path> recordFile;
+
+    }
 
     public TestBuildTimeConfig() {
 

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestBuildTimeConfig.java
@@ -1,7 +1,9 @@
 package io.quarkus.extest.runtime.config;
 
+import java.util.List;
 import java.util.Map;
 
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -28,6 +30,13 @@ public class TestBuildTimeConfig {
     public AllValuesConfig allValues;
 
     public Map<String, Map<String, String>> mapMap;
+
+    /**
+     * Names of resources for which classpath entries should be recorded.
+     * 
+     * @see RecordedClasspathEntries#get(RecordedClasspathEntries.Phase, String)
+     */
+    public List<String> classpathEntriesToRecord;
 
     public TestBuildTimeConfig() {
 

--- a/integration-tests/test-extension/pom.xml
+++ b/integration-tests/test-extension/pom.xml
@@ -83,6 +83,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- See io.quarkus.extest.runtime.classpath.RecordedClasspathEntries -->
+            <classpathEntriesRecordingFile>${build.directory}/recorded-classpath-entries-surefire.txt</classpathEntriesRecordingFile>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- See io.quarkus.extest.runtime.classpath.RecordedClasspathEntries -->
+            <classpathEntriesRecordingFile>${build.directory}/recorded-classpath-entries-failsafe.txt</classpathEntriesRecordingFile>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/integration-tests/test-extension/src/main/java/io/quarkus/it/extension/ClasspathTestEndpoint.java
+++ b/integration-tests/test-extension/src/main/java/io/quarkus/it/extension/ClasspathTestEndpoint.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.extension;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Locale;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries.Phase;
+
+@WebServlet(name = "ClasspathTestEndpoint", urlPatterns = "/core/classpath")
+public class ClasspathTestEndpoint extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        Phase phase = Phase.valueOf(req.getParameter("phase").toUpperCase(Locale.ROOT));
+        String resourceName = req.getParameter("resourceName");
+        try {
+            checkUniqueResource(phase, resourceName);
+            resp.getWriter().write("OK");
+        } catch (Exception | AssertionError e) {
+            reportThrowable(e, resp);
+        }
+    }
+
+    private void checkUniqueResource(Phase phase, String resourceName) throws IOException {
+        List<String> resources = RecordedClasspathEntries.get(phase, resourceName);
+
+        if (resources.size() != 1) {
+            throw new AssertionError(
+                    format("during phase '%s', classpath resources for name '%s' are not unique as expected; got: %s",
+                            phase, resourceName, resources));
+        }
+    }
+
+    private void reportThrowable(final Throwable t, final HttpServletResponse resp) throws IOException {
+        reportThrowable(null, t, resp);
+    }
+
+    private void reportThrowable(String errorMessage, final Throwable t, final HttpServletResponse resp) throws IOException {
+        final PrintWriter writer = resp.getWriter();
+        if (errorMessage != null) {
+            writer.write(errorMessage);
+            writer.write(" ");
+        }
+        t.printStackTrace(writer);
+        writer.append("\n\t");
+    }
+
+}

--- a/integration-tests/test-extension/src/main/java/io/quarkus/it/extension/ClasspathTestEndpoint.java
+++ b/integration-tests/test-extension/src/main/java/io/quarkus/it/extension/ClasspathTestEndpoint.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.Locale;
 
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -14,9 +15,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries.Phase;
+import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries.Record;
 
 @WebServlet(name = "ClasspathTestEndpoint", urlPatterns = "/core/classpath")
 public class ClasspathTestEndpoint extends HttpServlet {
+
+    @Inject
+    RecordedClasspathEntries recordedClasspathEntries;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -31,13 +36,17 @@ public class ClasspathTestEndpoint extends HttpServlet {
     }
 
     private void checkUniqueResource(Phase phase, String resourceName) throws IOException {
-        List<String> resources = RecordedClasspathEntries.get(phase, resourceName);
+        List<Record> records = recordedClasspathEntries.get(phase, resourceName);
 
-        if (resources.size() != 1) {
-            throw new AssertionError(
-                    format("during phase '%s', classpath resources for name '%s' are not unique as expected; got: %s",
-                            phase, resourceName, resources));
+        for (Record record : records) {
+            List<String> resources = record.getClasspathEntries();
+            if (resources.size() != 1) {
+                throw new AssertionError(
+                        format("during phase '%s', classpath resources for name '%s' are not unique as expected; got: %s",
+                                phase, resourceName, resources));
+            }
         }
+
     }
 
     private void reportThrowable(final Throwable t, final HttpServletResponse resp) throws IOException {

--- a/integration-tests/test-extension/src/main/resources/application.properties
+++ b/integration-tests/test-extension/src/main/resources/application.properties
@@ -113,3 +113,4 @@ quarkus.bt.map-map.outer-key.inner-key=1234
 # classpath entries
 ## See ClasspathTestCase
 quarkus.bt.classpath-entries-to-record=io/quarkus/it/extension/ClasspathTestEndpoint.class,some-resource-for-classpath-test.txt
+quarkus.native.resources.includes=some-resource-for-classpath-test.txt

--- a/integration-tests/test-extension/src/main/resources/application.properties
+++ b/integration-tests/test-extension/src/main/resources/application.properties
@@ -112,5 +112,6 @@ quarkus.bt.map-map.outer-key.inner-key=1234
 
 # classpath entries
 ## See ClasspathTestCase
-quarkus.bt.classpath-entries-to-record=io/quarkus/it/extension/ClasspathTestEndpoint.class,some-resource-for-classpath-test.txt
+quarkus.bt.classpath-recording.resources=io/quarkus/it/extension/ClasspathTestEndpoint.class,some-resource-for-classpath-test.txt
+quarkus.bt.classpath-recording.record-file=${project.build.directory}/classpath-entries.txt
 quarkus.native.resources.includes=some-resource-for-classpath-test.txt

--- a/integration-tests/test-extension/src/main/resources/application.properties
+++ b/integration-tests/test-extension/src/main/resources/application.properties
@@ -109,3 +109,7 @@ quarkus.test-property=foo
 quarkus.rt.map-map.outer-key.inner-key=1234
 quarkus.btrt.map-map.outer-key.inner-key=1234
 quarkus.bt.map-map.outer-key.inner-key=1234
+
+# classpath entries
+## See ClasspathTestCase
+quarkus.bt.classpath-entries-to-record=io/quarkus/it/extension/ClasspathTestEndpoint.class,some-resource-for-classpath-test.txt

--- a/integration-tests/test-extension/src/main/resources/application.properties
+++ b/integration-tests/test-extension/src/main/resources/application.properties
@@ -114,4 +114,5 @@ quarkus.bt.map-map.outer-key.inner-key=1234
 ## See ClasspathTestCase
 quarkus.bt.classpath-recording.resources=io/quarkus/it/extension/ClasspathTestEndpoint.class,some-resource-for-classpath-test.txt
 quarkus.bt.classpath-recording.record-file=${project.build.directory}/classpath-entries.txt
+%test.quarkus.bt.classpath-recording.record-file=${project.build.directory}/classpath-entries-jvm-tests.txt
 quarkus.native.resources.includes=some-resource-for-classpath-test.txt

--- a/integration-tests/test-extension/src/main/resources/some-resource-for-classpath-test.txt
+++ b/integration-tests/test-extension/src/main/resources/some-resource-for-classpath-test.txt
@@ -1,0 +1,1 @@
+Content is irrelevant.

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathInGraalITCase.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathInGraalITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.extension;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class ClasspathInGraalITCase extends ClasspathTestCase {
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
@@ -31,8 +31,6 @@ public class ClasspathTestCase {
     }
 
     @Test
-    @Disabled("For some reason, class files are not accessible as resources through the static init classloader;"
-            + " that's beside the point of this PR though, so we'll ignore that.")
     public void testStaticInitMainClassNoDuplicate() {
         given().param("resourceName", CLASS_FILE)
                 .param("phase", "static_init")
@@ -49,7 +47,7 @@ public class ClasspathTestCase {
     }
 
     @Test
-    @Disabled("For some reason, class files are not accessible as resources through the static init classloader;"
+    @Disabled("For some reason, class files are not accessible as resources through the runtime init classloader;"
             + " that's beside the point of this PR though, so we'll ignore that.")
     public void testRuntimeInitMainClassNoDuplicate() {
         given().param("resourceName", CLASS_FILE)

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
@@ -1,0 +1,69 @@
+package io.quarkus.it.extension;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ClasspathTestCase {
+
+    private static final String CLASS_FILE = "io/quarkus/it/extension/ClasspathTestEndpoint.class";
+    private static final String RESOURCE_FILE = "some-resource-for-classpath-test.txt";
+
+    @Test
+    public void testAugmentationMainClassNoDuplicate() {
+        given().param("resourceName", CLASS_FILE)
+                .param("phase", "augmentation")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testAugmentationMainResourceNoDuplicate() {
+        given().param("resourceName", RESOURCE_FILE)
+                .param("phase", "augmentation")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    @Disabled("For some reason, class files are not accessible as resources through the static init classloader;"
+            + " that's beside the point of this PR though, so we'll ignore that.")
+    public void testStaticInitMainClassNoDuplicate() {
+        given().param("resourceName", CLASS_FILE)
+                .param("phase", "static_init")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testStaticInitMainResourceNoDuplicate() {
+        given().param("resourceName", RESOURCE_FILE)
+                .param("phase", "static_init")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    @Disabled("For some reason, class files are not accessible as resources through the static init classloader;"
+            + " that's beside the point of this PR though, so we'll ignore that.")
+    public void testRuntimeInitMainClassNoDuplicate() {
+        given().param("resourceName", CLASS_FILE)
+                .param("phase", "runtime_init")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testRuntimeInitMainResourceNoDuplicate() {
+        given().param("resourceName", RESOURCE_FILE)
+                .param("phase", "runtime_init")
+                .when().get("/core/classpath").then()
+                .body(is("OK"));
+    }
+
+}


### PR DESCRIPTION
Hey @stuartwdouglas , do you think could you have a look at this reproducer? It fails when running tests through failsafe, but not when running tests through surefire.

## The problem

When running an integration test in native mode and calling `ClassLoader#getResources`, it ends up returning two entries for the same source file: `[file:.../integration-tests/my-project/target/classes/the-resource.xml, jar:file:.../integration-tests/my-project/target/my-project-999-SNAPSHOT.jar!the-resource.xml]`. This is problematic because I have code checking for the unicity of resources, for various reasons beyond the scope of this issue, and that duplication causes a false positive and ultimately an exception. So I'm unable to run some tests in native mode (see https://github.com/quarkusio/quarkus/pull/18417#issuecomment-875586522).

## The cause

From what I can see, the problem is actually that we sometime add some classpath elements to our classloaders even though the corresponding resources are already accessible through the parent classloader.

For surefire tests this does not matter, because the parent classloader uses the same URL for the problematic classpath element (`file:.../target/classes/the-resource.xml`) and ultimately `ClassLoader#getResources` will only return one unique URL.

But for failsafe tests it causes problems because the parent classloader uses the JAR  (`jar:file:.../target/my-project-999-SNAPSHOT.jar!the-resource.xml`) while the `QuarkusClassLoader` use the `classes` directory (`file:.../target/classes/the-resource.xml`). So `getResources` end up returning several different URLs for the same underlying resource.

## The fix

I'm not sure how to fix this, however... I've tried removing a few things, but removing [this code in `IntegrationTestUtil`](https://github.com/quarkusio/quarkus/blob/d7bc322026ea16ff1ca67fdb884d8926d04bf1a6/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java#L218-L222) was not enough, and removing [this code in `CuratedApplication`](https://github.com/quarkusio/quarkus/blob/d7bc322026ea16ff1ca67fdb884d8926d04bf1a6/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java#L278-L280) caused unit tests to fail for some reason.

Evidently, there are multiple classloaders involved, used during different phases, and I'm afraid I'm not familiar enough with this code to make the right changes.