### PR TITLE
Unify console color handling

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.deployment;
+package io.quarkus.deployment.console;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -8,7 +8,7 @@ public class ConsoleConfig {
 
     /**
      * If test results and status should be displayed in the console.
-     *
+     * <p>
      * If this is false results can still be viewed in the dev console.
      */
     @ConfigItem(defaultValue = "true")
@@ -16,24 +16,17 @@ public class ConsoleConfig {
 
     /**
      * Disables the ability to enter input on the console.
-     *
      */
     @ConfigItem(defaultValue = "false")
     public boolean disableInput;
+
     /**
      * Disable the testing status/prompt message at the bottom of the console
      * and log these messages to STDOUT instead.
-     *
+     * <p>
      * Use this option if your terminal does not support ANSI escape sequences.
      */
     @ConfigItem(defaultValue = "false")
     public boolean basic;
 
-    /**
-     * Disable color in the testing status and prompt messages.
-     *
-     * Use this option if your terminal does not support color.
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean disableColor;
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
@@ -1,0 +1,64 @@
+package io.quarkus.deployment.console;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.dev.BrowserOpenerBuildItem;
+import io.quarkus.deployment.dev.console.ConsoleHelper;
+import io.quarkus.deployment.dev.testing.TestConfig;
+import io.quarkus.deployment.dev.testing.TestConsoleHandler;
+import io.quarkus.deployment.dev.testing.TestListenerBuildItem;
+import io.quarkus.deployment.dev.testing.TestSetupBuildItem;
+import io.quarkus.deployment.dev.testing.TestSupport;
+import io.quarkus.runtime.console.ConsoleRuntimeConfig;
+
+public class ConsoleProcessor {
+
+    private static boolean consoleInstalled = false;
+
+    /**
+     * Installs the interactive console for continuous testing (and other usages)
+     * <p>
+     * This is only installed for dev and test mode, and runs in the build process rather than
+     * a recorder to install this as early as possible
+     */
+    @BuildStep(onlyIf = IsDevelopment.class)
+    @Produce(TestSetupBuildItem.class)
+    void setupConsole(TestConfig config, BuildProducer<TestListenerBuildItem> testListenerBuildItemBuildProducer,
+            LaunchModeBuildItem launchModeBuildItem, Capabilities capabilities, ConsoleConfig consoleConfig,
+            Optional<BrowserOpenerBuildItem> browserOpener) {
+        //note that this bit needs to be refactored so it is no longer tied to continuous testing
+        if (!TestSupport.instance().isPresent() || config.continuousTesting == TestConfig.Mode.DISABLED
+                || config.flatClassPath) {
+            return;
+        }
+        if (consoleInstalled) {
+            return;
+        }
+        consoleInstalled = true;
+        if (config.console.orElse(consoleConfig.enabled)) {
+            //this is a bit of a hack, but we can't just inject this normally
+            //this is a runtime property value, but also a build time property value
+            //as when running in dev mode they are both basically equivalent
+            ConsoleRuntimeConfig consoleRuntimeConfig = new ConsoleRuntimeConfig();
+            consoleRuntimeConfig.color = ConfigProvider.getConfig().getOptionalValue("quarkus.console.color", Boolean.class);
+            io.quarkus.runtime.logging.ConsoleConfig loggingConsoleConfig = new io.quarkus.runtime.logging.ConsoleConfig();
+            loggingConsoleConfig.color = ConfigProvider.getConfig().getOptionalValue("quarkus.log.console.color",
+                    Boolean.class);
+            ConsoleHelper.installConsole(config, consoleConfig, consoleRuntimeConfig, loggingConsoleConfig);
+            TestConsoleHandler consoleHandler = new TestConsoleHandler(launchModeBuildItem.getDevModeType().get(),
+                    browserOpener.map(BrowserOpenerBuildItem::getBrowserOpener).orElse(null),
+                    capabilities.isPresent(Capability.VERTX_HTTP));
+            consoleHandler.install();
+            testListenerBuildItemBuildProducer.produce(new TestListenerBuildItem(consoleHandler));
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/console/ConsoleHelper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/console/ConsoleHelper.java
@@ -1,48 +1,82 @@
 package io.quarkus.deployment.dev.console;
 
 import java.io.IOException;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.aesh.readline.tty.terminal.TerminalConnection;
 import org.aesh.terminal.Connection;
 
-import io.quarkus.deployment.ConsoleConfig;
+import io.quarkus.deployment.console.ConsoleConfig;
 import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.dev.console.BasicConsole;
 import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.dev.console.RedirectPrintStream;
+import io.quarkus.runtime.console.ConsoleRuntimeConfig;
+import io.quarkus.runtime.util.ColorSupport;
 
 public class ConsoleHelper {
 
-    public static synchronized void installConsole(TestConfig config, ConsoleConfig consoleConfig) {
+    public static synchronized void installConsole(TestConfig config, ConsoleConfig consoleConfig,
+            ConsoleRuntimeConfig consoleRuntimeConfig, io.quarkus.runtime.logging.ConsoleConfig logConfig) {
         if (QuarkusConsole.installed) {
             return;
         }
+        boolean colorEnabled = ColorSupport.isColorEnabled(consoleRuntimeConfig, logConfig);
         QuarkusConsole.installed = true;
-        if (config.basicConsole.orElse(consoleConfig.basic)) {
-            QuarkusConsole.INSTANCE = new BasicConsole(config.disableColor.orElse(consoleConfig.disableColor),
-                    !config.disableConsoleInput.orElse(consoleConfig.disableInput), System.out);
-        } else {
-            try {
-                new TerminalConnection(new Consumer<Connection>() {
-                    @Override
-                    public void accept(Connection connection) {
-                        if (connection.supportsAnsi()) {
-                            QuarkusConsole.INSTANCE = new AeshConsole(connection,
-                                    !config.disableConsoleInput.orElse(consoleConfig.disableInput));
-                        } else {
-                            connection.close();
-                            QuarkusConsole.INSTANCE = new BasicConsole(config.disableColor.orElse(consoleConfig.disableColor),
-                                    !config.disableConsoleInput.orElse(consoleConfig.disableInput),
-                                    System.out);
-                        }
-                    }
-                });
-            } catch (IOException e) {
-                QuarkusConsole.INSTANCE = new BasicConsole(config.disableColor.orElse(consoleConfig.disableColor),
-                        !config.disableConsoleInput.orElse(consoleConfig.disableInput), System.out);
-            }
+        //if there is no color we need a basic console
+        Consumer<String> consumer = System.out::print;
+        if (System.console() != null) {
+            consumer = (s) -> {
+                System.console().writer().print(s);
+                System.console().writer().flush();
+            };
         }
+        try {
+            new TerminalConnection(new Consumer<Connection>() {
+                @Override
+                public void accept(Connection connection) {
+                    if (connection.supportsAnsi() && !config.basicConsole.orElse(consoleConfig.basic)) {
+                        QuarkusConsole.INSTANCE = new AeshConsole(connection,
+                                !config.disableConsoleInput.orElse(consoleConfig.disableInput));
+                    } else {
+                        LinkedBlockingDeque<Integer> queue = new LinkedBlockingDeque<>();
+                        connection.openNonBlocking();
+                        connection.setStdinHandler(new Consumer<int[]>() {
+                            @Override
+                            public void accept(int[] ints) {
+                                for (int i : ints) {
+                                    queue.add(i);
+                                }
+                            }
+                        });
+                        connection.setCloseHandler(new Consumer<Void>() {
+                            @Override
+                            public void accept(Void unused) {
+                                queue.add(-1);
+                            }
+                        });
+                        QuarkusConsole.INSTANCE = new BasicConsole(colorEnabled,
+                                !config.disableConsoleInput.orElse(consoleConfig.disableInput),
+                                connection::write, new Supplier<Integer>() {
+                                    @Override
+                                    public Integer get() {
+                                        try {
+                                            return queue.takeFirst();
+                                        } catch (InterruptedException e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                });
+                    }
+                }
+            });
+        } catch (IOException e) {
+            QuarkusConsole.INSTANCE = new BasicConsole(colorEnabled,
+                    !config.disableConsoleInput.orElse(consoleConfig.disableInput), consumer);
+        }
+
         RedirectPrintStream ps = new RedirectPrintStream();
         System.setOut(ps);
         System.setErr(ps);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -198,7 +198,6 @@ public class TestConsoleHandler implements TestListener {
     public void listenerRegistered(TestController testController) {
         this.testController = testController;
         promptHandler.setPrompt(hasHttp ? PAUSED_PROMPT : PAUSED_PROMPT_NO_HTTP);
-
     }
 
     public void printUsage() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -64,6 +64,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.configuration.ConfigInstantiator;
+import io.quarkus.runtime.console.ConsoleRuntimeConfig;
 import io.quarkus.runtime.logging.CategoryBuildTimeConfig;
 import io.quarkus.runtime.logging.CleanupFilterConfig;
 import io.quarkus.runtime.logging.InheritableLevel;
@@ -143,6 +144,7 @@ public final class LoggingResourceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     LoggingSetupBuildItem setupLoggingRuntimeInit(LoggingSetupRecorder recorder, LogConfig log, LogBuildTimeConfig buildLog,
+            ConsoleRuntimeConfig consoleRuntimeConfig,
             List<LogHandlerBuildItem> handlerBuildItems,
             List<NamedLogHandlersBuildItem> namedHandlerBuildItems, List<LogConsoleFormatBuildItem> consoleFormatItems,
             Optional<ConsoleFormatterBannerBuildItem> possibleBannerBuildItem,
@@ -164,7 +166,7 @@ public final class LoggingResourceProcessor {
             if (bannerBuildItem != null) {
                 possibleSupplier = bannerBuildItem.getBannerSupplier();
             }
-            recorder.initializeLogging(log, buildLog, handlers, namedHandlers,
+            recorder.initializeLogging(log, buildLog, consoleRuntimeConfig, handlers, namedHandlers,
                     consoleFormatItems.stream().map(LogConsoleFormatBuildItem::getFormatterValue).collect(Collectors.toList()),
                     possibleSupplier, launchModeBuildItem.getLaunchMode());
             LogConfig logConfig = new LogConfig();
@@ -177,7 +179,9 @@ public final class LoggingResourceProcessor {
                         : filterElement.getTargetLevel();
                 logConfig.filters.put(filterElement.getLoggerName(), value);
             }
-            LoggingSetupRecorder.initializeBuildTimeLogging(logConfig, buildLog, launchModeBuildItem.getLaunchMode());
+            ConsoleRuntimeConfig crc = new ConsoleRuntimeConfig();
+            ConfigInstantiator.handleObject(crc);
+            LoggingSetupRecorder.initializeBuildTimeLogging(logConfig, buildLog, crc, launchModeBuildItem.getLaunchMode());
             ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(new Runnable() {
                 @Override
                 public void run() {

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -31,7 +31,7 @@ public abstract class QuarkusConsole {
             && "xterm".equals(System.getenv("TERM"));
     protected final ArrayDeque<InputHolder> inputHandlers = new ArrayDeque<>();
 
-    public static volatile QuarkusConsole INSTANCE = new BasicConsole(false, false, System.out);
+    public static volatile QuarkusConsole INSTANCE = new BasicConsole(hasColorSupport(), false, System.out::print);
 
     public static volatile boolean installed;
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/console/ConsoleRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/console/ConsoleRuntimeConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.runtime.console;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "console", phase = ConfigPhase.RUN_TIME)
+public class ConsoleRuntimeConfig {
+
+    /**
+     * If color should be enabled or disabled.
+     *
+     * If this is not present then an attempt will be made to guess if the terminal supports color
+     */
+    @ConfigItem
+    public Optional<Boolean> color;
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -39,9 +39,13 @@ public class ConsoleConfig {
      * best guess based on operating system and environment.
      * Note that this value will be ignored if an extension is present that takes
      * control of console formatting (e.g. an XML or JSON-format extension).
+     *
+     * This has been deprecated, and replaced with quarkus.console.color instead,
+     * as quarkus now provides more console based functionality than just logging.
      */
     @ConfigItem
-    Optional<Boolean> color;
+    @Deprecated
+    public Optional<Boolean> color;
 
     /**
      * Specify how much the colors should be darkened.

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ColorSupport.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ColorSupport.java
@@ -1,0 +1,18 @@
+package io.quarkus.runtime.util;
+
+import io.quarkus.dev.console.QuarkusConsole;
+import io.quarkus.runtime.console.ConsoleRuntimeConfig;
+import io.quarkus.runtime.logging.ConsoleConfig;
+
+public class ColorSupport {
+
+    public static boolean isColorEnabled(ConsoleRuntimeConfig consoleConfig, ConsoleConfig logConfig) {
+        if (consoleConfig.color.isPresent()) {
+            return consoleConfig.color.get();
+        }
+        if (logConfig.color.isPresent()) {
+            return logConfig.color.get();
+        }
+        return QuarkusConsole.hasColorSupport();
+    }
+}


### PR DESCRIPTION
- quarkus.console.color is now the canonical source of color
- quarkus.logging.console.color is now deprecated (same as
  quarkus.test.disable-color)
- If color is disable the advanced ANSI console will also be disabled

Previously color was only the concern of logging, but now that we have
the continuous testing console it also matters for the testing console.

Fixes #18288