### PR TITLE
Adds [App]ArtifactKey.toGacString() method to strip the type from the string

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.util.ZipUtils;
 
 public class ConditionalDependenciesEnabler {
@@ -197,11 +198,11 @@ public class ConditionalDependenciesEnabler {
                 conditionalDependencies.add(DependencyUtils.create(project.getDependencies(), conditionalDep));
             }
         }
-        List<Dependency> constraints = new ArrayList<>();
+        List<AppArtifactKey> constraints = new ArrayList<>();
         if (extensionProperties.containsKey(BootstrapConstants.DEPENDENCY_CONDITION)) {
             String constraintDeps = extensionProperties.getProperty(BootstrapConstants.DEPENDENCY_CONDITION);
             for (String constraint : constraintDeps.split(",")) {
-                constraints.add(DependencyUtils.create(project.getDependencies(), constraint));
+                constraints.add(AppArtifactKey.fromString(constraint));
             }
         }
         return new ExtensionDependency(exentionId, deploymentModule, conditionalDependencies, constraints);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle.dependency;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -18,6 +19,7 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.plugins.JavaPlugin;
 
 import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.bootstrap.model.AppArtifactKey;
 
 public class DependencyUtils {
 
@@ -56,13 +58,11 @@ public class DependencyUtils {
                 dependencyCoords.getVersion()));
     }
 
-    public static boolean exist(Set<ResolvedArtifact> runtimeArtifacts, List<Dependency> dependencies) {
-        for (Dependency dependency : dependencies) {
-            if (!exists(runtimeArtifacts, dependency)) {
-                return false;
-            }
-        }
-        return true;
+    public static boolean exist(Set<ResolvedArtifact> runtimeArtifacts, List<AppArtifactKey> dependencies) {
+        final Set<AppArtifactKey> rtKeys = new HashSet<>(runtimeArtifacts.size());
+        runtimeArtifacts.forEach(r -> rtKeys.add(
+                new AppArtifactKey(r.getModuleVersion().getId().getGroup(), r.getName(), r.getClassifier(), r.getExtension())));
+        return rtKeys.containsAll(dependencies);
     }
 
     public static boolean exists(Set<ResolvedArtifact> runtimeArtifacts, Dependency dependency) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
@@ -12,17 +12,18 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 
 import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.bootstrap.model.AppArtifactKey;
 
 public class ExtensionDependency {
 
     ModuleVersionIdentifier extensionId;
     AppArtifactCoords deploymentModule;
     List<Dependency> conditionalDependencies;
-    List<Dependency> dependencyConditions;
+    List<AppArtifactKey> dependencyConditions;
 
     ExtensionDependency(ModuleVersionIdentifier extensionId, AppArtifactCoords deploymentModule,
             List<Dependency> conditionalDependencies,
-            List<Dependency> dependencyConditions) {
+            List<AppArtifactKey> dependencyConditions) {
         this.extensionId = extensionId;
         this.deploymentModule = deploymentModule;
         this.conditionalDependencies = conditionalDependencies;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
@@ -173,4 +173,13 @@ public class AppArtifactKey implements Serializable {
         }
         return buf.toString();
     }
+
+    public String toGacString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append(groupId).append(':').append(artifactId);
+        if (!classifier.isEmpty()) {
+            buf.append(':').append(classifier);
+        }
+        return buf.toString();
+    }
 }

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -249,9 +249,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (!dependencyCondition.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             int i = 0;
-            buf.append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toString());
+            buf.append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
             while (i < dependencyCondition.size()) {
-                buf.append(' ').append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toString());
+                buf.append(' ').append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
             }
             props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
 
@@ -532,7 +532,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                             extensionDeps.set(deps);
                         }
                         deps.add(new AppArtifactKey(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
-                                .toString());
+                                .toGacString());
                     }
                 }
                 return true;

--- a/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
+++ b/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
@@ -168,4 +168,13 @@ public class ArtifactKey implements Serializable {
         }
         return buf.toString();
     }
+
+    public String toGacString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append(groupId).append(':').append(artifactId);
+        if (!classifier.isEmpty()) {
+            buf.append(':').append(classifier);
+        }
+        return buf.toString();
+    }
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonCategory.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonCategory.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonCategory implements Category {
 
     protected String id;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonExtension.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonExtension.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonExtension implements Extension {
 
     private String name;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonExtensionCatalog.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonExtensionCatalog.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonExtensionCatalog extends JsonExtensionOrigin implements ExtensionCatalog {
 
     private String quarkusCore;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatform.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatform.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonPlatform extends JsonEntityWithAnySupport implements Platform {
 
     private String platformKey;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformCatalog.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformCatalog.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonPlatformCatalog extends JsonEntityWithAnySupport implements PlatformCatalog {
 
     private Map<String, Platform> platforms;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformRelease.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformRelease.java
@@ -9,7 +9,7 @@ import io.quarkus.registry.catalog.PlatformReleaseVersion;
 import java.util.Collection;
 import java.util.Collections;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonPlatformRelease extends JsonEntityWithAnySupport implements PlatformRelease {
 
     private PlatformReleaseVersion version;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformStream.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/json/JsonPlatformStream.java
@@ -12,7 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class JsonPlatformStream extends JsonEntityWithAnySupport implements PlatformStream {
 
     private String id;

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <gitflow-incremental-builder.version>3.14.3</gitflow-incremental-builder.version>
-        <quarkus-platform-bom-plugin.version>0.0.10</quarkus-platform-bom-plugin.version>
+        <quarkus-platform-bom-plugin.version>0.0.22</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Switching from `JsonInclude.Include.NON_EMPTY` to `JsonInclude.Include.NON_DEFAULT` also gets rid of the empty arrays in the json (but once we upgrade to the next version of the `quarkus-platform-bom-maven-plugin`).