### PR TITLE
Apply various improvements to `@QuarkusIntegrationTest`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -127,11 +127,6 @@ public class TestConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean flatClassPath;
-    /**
-     * Duration to wait for the native image to built during testing
-     */
-    @ConfigItem(defaultValue = "PT5M")
-    Duration nativeImageWaitTime;
 
     /**
      * The profile to use when testing the native image
@@ -146,10 +141,20 @@ public class TestConfig {
     Profile profile;
 
     /**
-     * JVM parameters that are used to launch jar based integration tests.
+     * Additional launch parameters to be used when Quarkus launches the produced artifact for {@code @QuarkusIntegrationTest}
+     * When the artifact is a {@code jar}, this string is passed right after the {@code java} command.
+     * When the artifact is a {@code container}, this string is passed right after the {@code docker run} command.
+     * When the artifact is a {@code native binary}, this string is passed right after the native binary name.
      */
-    @ConfigItem
-    Optional<String> integrationJvmArgLine;
+    @ConfigItem(defaultValue = "")
+    Optional<List<String>> argLine;
+
+    /**
+     * Used in {@code @QuarkusIntegrationTest} and {@code NativeImageTest} to determine how long the test will wait for the
+     * application to launch
+     */
+    @ConfigItem(defaultValue = "PT1M")
+    Duration waitTime;
 
     /**
      * Configures the hang detection in @QuarkusTest. If no activity happens (i.e. no test callbacks are called) over

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -325,8 +325,8 @@ Executing [/data/home/gsmet/git/quarkus-quickstarts/getting-started/target/getti
 [TIP]
 ====
 By default, Quarkus waits for 60 seconds for the native image to start before automatically failing the native tests. This
-duration can be changed using the `quarkus.test.native-image-wait-time` system property. For example, to increase the duration
-to 300 seconds, use: `./mvnw verify -Pnative -Dquarkus.test.native-image-wait-time=300`.
+duration can be changed using the `quarkus.test.wait-time` system property. For example, to increase the duration
+to 300 seconds, use: `./mvnw verify -Pnative -Dquarkus.test.wait-time=300`.
 ====
 
 [WARNING]

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -3,6 +3,7 @@ package io.quarkus.test.common;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extends Closeable {
@@ -24,5 +25,7 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
         Duration waitTime();
 
         String testProfile();
+
+        List<String> argLine();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/IntegrationTestStartedNotifier.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/IntegrationTestStartedNotifier.java
@@ -1,0 +1,47 @@
+package io.quarkus.test.common;
+
+import java.nio.file.Path;
+
+/**
+ * Interface than can be implemented to notify the test infrastructure that the produced artifact has started for
+ * non HTTP based {@code @QuarkusIntegrationTest}s.
+ *
+ * Implementations of this class are loaded via the ServiceLoader mechanism.
+ */
+public interface IntegrationTestStartedNotifier {
+
+    /**
+     * This method is called periodically by Quarkus to determine whether or not the application has started.
+     * Quarkus will go through all the implementation of {@code IntegrationTestStartedNotifier} and call this method,
+     * returning the first one that indicates a successful start, or {@link Result.NotStarted} otherwise
+     */
+    Result check(Context context);
+
+    interface Context {
+        Path logFile();
+    }
+
+    interface Result {
+        boolean isStarted();
+
+        boolean isSsl();
+
+        final class NotStarted implements Result {
+
+            public static final NotStarted INSTANCE = new NotStarted();
+
+            private NotStarted() {
+            }
+
+            @Override
+            public boolean isStarted() {
+                return false;
+            }
+
+            @Override
+            public boolean isSsl() {
+                return false;
+            }
+        }
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
@@ -10,8 +10,6 @@ public interface JarArtifactLauncher extends ArtifactLauncher<JarArtifactLaunche
 
     interface JarInitContext extends InitContext {
 
-        String argLine();
-
         Path jarPath();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -8,10 +8,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -65,11 +68,12 @@ public final class LauncherUtil {
                 Duration.ofSeconds(waitTimeSeconds), signal, resultReference);
         new Thread(captureListeningDataReader, "capture-listening-data").start();
         try {
-            signal.await(10, TimeUnit.SECONDS);
+            signal.await(waitTimeSeconds + 2, TimeUnit.SECONDS); // wait enough for the signal to be given by the capturing thread
             ListeningAddress result = resultReference.get();
             if (result != null) {
                 return result;
             }
+            // a null result means that we could not determine the status of the process so we need to abort testing
             destroyProcess(quarkusProcess);
             throw new IllegalStateException(
                     "Unable to determine the status of the running process. See the above logs for details");
@@ -99,6 +103,58 @@ public final class LauncherUtil {
         if (quarkusProcess.isAlive()) {
             quarkusProcess.destroyForcibly();
         }
+    }
+
+    static Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> createStartedFunction() {
+        List<IntegrationTestStartedNotifier> startedNotifiers = new ArrayList<>();
+        for (IntegrationTestStartedNotifier i : ServiceLoader.load(IntegrationTestStartedNotifier.class)) {
+            startedNotifiers.add(i);
+        }
+        if (startedNotifiers.isEmpty()) {
+            return null;
+        }
+        return (ctx) -> {
+            for (IntegrationTestStartedNotifier startedNotifier : startedNotifiers) {
+                IntegrationTestStartedNotifier.Result result = startedNotifier.check(ctx);
+                if (result.isStarted()) {
+                    return result;
+                }
+            }
+            return IntegrationTestStartedNotifier.Result.NotStarted.INSTANCE;
+        };
+    }
+
+    /**
+     * Waits for {@param startedFunction} to indicate that the application has started.
+     *
+     * @return the {@link io.quarkus.test.common.IntegrationTestStartedNotifier.Result} indicating a successful start
+     * @throws RuntimeException if no successful start was indicated by {@param startedFunction}
+     */
+    static IntegrationTestStartedNotifier.Result waitForStartedFunction(
+            Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction,
+            Process quarkusProcess, long waitTimeSeconds, Path logFile) {
+        long bailout = System.currentTimeMillis() + waitTimeSeconds * 1000;
+        IntegrationTestStartedNotifier.Result result = null;
+        SimpleContext context = new SimpleContext(logFile);
+        while (System.currentTimeMillis() < bailout) {
+            if (!quarkusProcess.isAlive()) {
+                throw new RuntimeException("Failed to start target quarkus application, process has exited");
+            }
+            try {
+                Thread.sleep(100);
+                result = startedFunction.apply(context);
+                if (result.isStarted()) {
+                    break;
+                }
+            } catch (Exception ignored) {
+
+            }
+        }
+        if (result == null) {
+            destroyProcess(quarkusProcess);
+            throw new RuntimeException("Unable to start target quarkus application " + waitTimeSeconds + "s");
+        }
+        return result;
     }
 
     /**
@@ -227,6 +283,19 @@ public final class LauncherUtil {
             } catch (IOException e) {
                 //ignore
             }
+        }
+    }
+
+    private static class SimpleContext implements IntegrationTestStartedNotifier.Context {
+        private final Path logFile;
+
+        public SimpleContext(Path logFile) {
+            this.logFile = logFile;
+        }
+
+        @Override
+        public Path logFile() {
+            return logFile;
         }
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageStartedNotifier.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageStartedNotifier.java
@@ -3,7 +3,11 @@ package io.quarkus.test.common;
 /**
  * Interface than can be implemented to notify the test infrastructure that the native image has started for
  * non HTTP based tests.
+ *
+ * This class has been deprecated and users should use {@link IntegrationTestStartedNotifier} instead when working
+ * with {@code @QuarkusIntegrationTest}
  */
+@Deprecated
 public interface NativeImageStartedNotifier {
 
     boolean isNativeImageStarted();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -53,7 +53,7 @@ public final class IntegrationTestUtil {
 
     public static final int DEFAULT_PORT = 8081;
     public static final int DEFAULT_HTTPS_PORT = 8444;
-    public static final long DEFAULT_JAR_WAIT_TIME_SECONDS = 60;
+    public static final long DEFAULT_WAIT_TIME_SECONDS = 60;
 
     private IntegrationTestUtil() {
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.junit;
 
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_HTTPS_PORT;
-import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_JAR_WAIT_TIME_SECONDS;
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_PORT;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndProperties;
 import static io.quarkus.test.junit.IntegrationTestUtil.doProcessTestInstance;
@@ -11,13 +10,11 @@ import static io.quarkus.test.junit.IntegrationTestUtil.getSysPropsToRestore;
 import static io.quarkus.test.junit.IntegrationTestUtil.handleDevDb;
 import static io.quarkus.test.junit.IntegrationTestUtil.startLauncher;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.function.Function;
 
 import org.eclipse.microprofile.config.Config;
@@ -35,6 +32,7 @@ import io.quarkus.test.common.NativeImageLauncher;
 import io.quarkus.test.common.RestAssuredURLManager;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.TestScopeManager;
+import io.quarkus.test.junit.launcher.ConfigUtil;
 import io.quarkus.test.junit.launcher.NativeImageLauncherProvider;
 
 public class NativeTestExtension
@@ -185,9 +183,9 @@ public class NativeTestExtension
         launcher.init(new NativeImageLauncherProvider.DefaultNativeImageInitContext(
                 config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                 config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
-                Duration.ofSeconds(config.getValue("quarkus.test.jar-wait-time", OptionalLong.class)
-                        .orElse(DEFAULT_JAR_WAIT_TIME_SECONDS)),
+                ConfigUtil.waitTimeValue(config),
                 config.getOptionalValue("quarkus.test.native-image-profile", String.class).orElse(null),
+                ConfigUtil.argLineValue(config),
                 System.getProperty("native.image.path"),
                 requiredTestClass));
         return launcher;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ConfigUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ConfigUtil.java
@@ -1,0 +1,41 @@
+package io.quarkus.test.junit.launcher;
+
+import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_WAIT_TIME_SECONDS;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+
+import org.eclipse.microprofile.config.Config;
+
+public final class ConfigUtil {
+
+    private ConfigUtil() {
+    }
+
+    public static List<String> argLineValue(Config config) {
+        List<String> strings = config.getOptionalValues("quarkus.test.arg-line", String.class)
+                .orElse(config.getOptionalValues("quarkus.test.argLine", String.class) // legacy value
+                        .orElse(Collections.emptyList()));
+        if (strings.isEmpty()) {
+            return strings;
+        }
+        List<String> sanitizedString = new ArrayList<>(strings.size());
+        for (String s : strings) {
+            String trimmed = s.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            sanitizedString.add(trimmed);
+        }
+        return sanitizedString;
+    }
+
+    public static Duration waitTimeValue(Config config) {
+        return Duration.ofSeconds(config.getValue("quarkus.test.wait-time", OptionalLong.class)
+                .orElse(config.getValue("quarkus.test.jar-wait-time", OptionalLong.class) // legacy value
+                        .orElse(DEFAULT_WAIT_TIME_SECONDS)));
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DefaultInitContextBase.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DefaultInitContextBase.java
@@ -1,18 +1,21 @@
 package io.quarkus.test.junit.launcher;
 
 import java.time.Duration;
+import java.util.List;
 
 class DefaultInitContextBase {
     private final int httpPort;
     private final int httpsPort;
     private final Duration waitTime;
     private final String testProfile;
+    private final List<String> argLine;
 
-    DefaultInitContextBase(int httpPort, int httpsPort, Duration waitTime, String testProfile) {
+    DefaultInitContextBase(int httpPort, int httpsPort, Duration waitTime, String testProfile, List<String> argLine) {
         this.httpPort = httpPort;
         this.httpsPort = httpsPort;
         this.waitTime = waitTime;
         this.testProfile = testProfile;
+        this.argLine = argLine;
     }
 
     public int httpPort() {
@@ -29,5 +32,9 @@ class DefaultInitContextBase {
 
     public String testProfile() {
         return testProfile;
+    }
+
+    public List<String> argLine() {
+        return argLine;
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -1,11 +1,12 @@
 package io.quarkus.test.junit.launcher;
 
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_HTTPS_PORT;
-import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_JAR_WAIT_TIME_SECONDS;
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_PORT;
+import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_WAIT_TIME_SECONDS;
 
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.ServiceLoader;
@@ -42,8 +43,9 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     Duration.ofSeconds(config.getValue("quarkus.test.jar-wait-time", OptionalLong.class)
-                            .orElse(DEFAULT_JAR_WAIT_TIME_SECONDS)),
+                            .orElse(DEFAULT_WAIT_TIME_SECONDS)),
                     config.getOptionalValue("quarkus.test.native-image-profile", String.class).orElse(null),
+                    ConfigUtil.argLineValue(config),
                     containerImage,
                     pullRequired));
             return launcher;
@@ -58,8 +60,9 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         private final boolean pullRequired;
 
         public DefaultDockerInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+                List<String> argLine,
                 String containerImage, boolean pullRequired) {
-            super(httpPort, httpsPort, waitTime, testProfile);
+            super(httpPort, httpsPort, waitTime, testProfile, argLine);
             this.containerImage = containerImage;
             this.pullRequired = pullRequired;
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -1,12 +1,13 @@
 package io.quarkus.test.junit.launcher;
 
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_HTTPS_PORT;
-import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_JAR_WAIT_TIME_SECONDS;
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_PORT;
+import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_WAIT_TIME_SECONDS;
 
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.ServiceLoader;
@@ -42,9 +43,9 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     Duration.ofSeconds(config.getValue("quarkus.test.jar-wait-time", OptionalLong.class)
-                            .orElse(DEFAULT_JAR_WAIT_TIME_SECONDS)),
+                            .orElse(DEFAULT_WAIT_TIME_SECONDS)),
                     config.getOptionalValue("quarkus.test.native-image-profile", String.class).orElse(null),
-                    config.getOptionalValue("quarkus.test.argLine", String.class).orElse(null),
+                    ConfigUtil.argLineValue(config),
                     context.buildOutputDirectory().resolve(pathStr)));
             return launcher;
         } else {
@@ -54,19 +55,12 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
 
     static class DefaultJarInitContext extends DefaultInitContextBase implements JarArtifactLauncher.JarInitContext {
 
-        private final String argLine;
         private final Path jarPath;
 
-        DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile, String argLine,
+        DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile, List<String> argLine,
                 Path jarPath) {
-            super(httpPort, httpsPort, waitTime, testProfile);
-            this.argLine = argLine;
+            super(httpPort, httpsPort, waitTime, testProfile, argLine);
             this.jarPath = jarPath;
-        }
-
-        @Override
-        public String argLine() {
-            return argLine;
         }
 
         @Override

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -1,13 +1,12 @@
 package io.quarkus.test.junit.launcher;
 
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_HTTPS_PORT;
-import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_JAR_WAIT_TIME_SECONDS;
 import static io.quarkus.test.junit.IntegrationTestUtil.DEFAULT_PORT;
 
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.ServiceLoader;
 
 import org.eclipse.microprofile.config.Config;
@@ -39,9 +38,9 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
             launcher.init(new NativeImageLauncherProvider.DefaultNativeImageInitContext(
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
-                    Duration.ofSeconds(config.getValue("quarkus.test.jar-wait-time", OptionalLong.class)
-                            .orElse(DEFAULT_JAR_WAIT_TIME_SECONDS)),
+                    ConfigUtil.waitTimeValue(config),
                     config.getOptionalValue("quarkus.test.native-image-profile", String.class).orElse(null),
+                    ConfigUtil.argLineValue(config),
                     System.getProperty("native.image.path"),
                     context.testClass()));
             return launcher;
@@ -57,8 +56,9 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
         private final Class<?> testClass;
 
         public DefaultNativeImageInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+                List<String> argLine,
                 String nativeImagePath, Class<?> testClass) {
-            super(httpPort, httpsPort, waitTime, testProfile);
+            super(httpPort, httpsPort, waitTime, testProfile, argLine);
             this.nativeImagePath = nativeImagePath;
             this.testClass = testClass;
         }


### PR DESCRIPTION
* Add argLine to all IT launchers and clean up related legacy configuration
* Fix issue with wait time in @QuarkusIntegrationTest
* Introduce new SPI for custom startup handling in @QuarkusIntegrationTest

Relates to #18399 and #17560 but doesn't quite close them as I have a few more things in mind for a follow up, plus I need to add documentation about all these features