### PR TITLE
Fix lambda http base64 encoding and binary types

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -9,11 +9,10 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.jboss.logging.Logger;
@@ -138,7 +137,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                     if (baos != null) {
                         if (isBinary(responseBuilder.getHeaders().get("Content-Type"))) {
                             responseBuilder.setIsBase64Encoded(true);
-                            responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
+                            responseBuilder.setBody(Base64.getEncoder().encodeToString(baos.toByteArray()));
                         } else {
                             responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
                         }
@@ -187,7 +186,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
         HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
         if (request.getBody() != null) {
             if (request.getIsBase64Encoded()) {
-                ByteBuf body = Unpooled.wrappedBuffer(Base64.getMimeDecoder().decode(request.getBody()));
+                ByteBuf body = Unpooled.wrappedBuffer(Base64.getDecoder().decode(request.getBody()));
                 requestContent = new DefaultLastHttpContent(body);
             } else {
                 ByteBuf body = Unpooled.copiedBuffer(request.getBody(), StandardCharsets.UTF_8); //TODO: do we need to look at the request encoding?
@@ -213,23 +212,10 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
         return baos;
     }
 
-    static Set<String> binaryTypes = new HashSet<>();
-
-    static {
-        binaryTypes.add("application/octet-stream");
-        binaryTypes.add("image/jpeg");
-        binaryTypes.add("image/png");
-        binaryTypes.add("image/gif");
-    }
-
     private boolean isBinary(String contentType) {
         if (contentType != null) {
-            int index = contentType.indexOf(';');
-            if (index >= 0) {
-                return binaryTypes.contains(contentType.substring(0, index));
-            } else {
-                return binaryTypes.contains(contentType);
-            }
+            String ct = contentType.toLowerCase(Locale.ROOT);
+            return !(ct.startsWith("text") || ct.contains("json") || ct.contains("xml") || ct.contains("yaml"));
         }
         return false;
     }


### PR DESCRIPTION
Lambda http/rest plugins were not correctly base64 encoding binary types.  Also, treat everything as a binary type unless it is "text", xml", "json", or "yaml".