### PR TITLE
Fix Encoding and implement Accept header requirement from spec

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AbstractGraphQLTest.java
@@ -14,11 +14,16 @@ import javax.json.JsonReader;
 import org.hamcrest.CoreMatchers;
 
 import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
 
 /**
  * Some shared methods
  */
 public abstract class AbstractGraphQLTest {
+
+    static {
+        RestAssured.registerParser("application/graphql+json", Parser.JSON);
+    }
 
     protected void pingTest() {
         pingPongTest("ping", "pong");

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLCDIContextPropagationTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLCDIContextPropagationTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 
 /**
  * Testing scenarios which require CDI context propagation to work under the hood.
@@ -51,8 +50,8 @@ public class GraphQLCDIContextPropagationTest extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(pingRequest)
                 .post("/graphql")
                 .then()
@@ -74,8 +73,8 @@ public class GraphQLCDIContextPropagationTest extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(pingRequest)
                 .post("/graphql")
                 .then()
@@ -98,8 +97,8 @@ public class GraphQLCDIContextPropagationTest extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(pingRequest)
                 .post("/graphql")
                 .then()

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLContextTestCase.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLContextTestCase.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 import io.smallrye.graphql.api.Context;
 
 public class SmallRyeGraphQLContextTestCase extends AbstractGraphQLTest {
@@ -45,8 +44,8 @@ public class SmallRyeGraphQLContextTestCase extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(request)
                 .post("/graphql")
                 .then()
@@ -68,8 +67,8 @@ public class SmallRyeGraphQLContextTestCase extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(request)
                 .post("/graphql")
                 .then()
@@ -91,8 +90,8 @@ public class SmallRyeGraphQLContextTestCase extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(request)
                 .post("/graphql")
                 .then()
@@ -114,8 +113,8 @@ public class SmallRyeGraphQLContextTestCase extends AbstractGraphQLTest {
                 "}");
 
         RestAssured.given().when()
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
                 .body(request)
                 .post("/graphql")
                 .then()

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestResource.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestResource.java
@@ -61,6 +61,11 @@ public class TestResource {
         return new TestPojo(name);
     }
 
+    @Query
+    public String testCharset(String characters) {
+        return characters;
+    }
+
     // <placeholder>
 
     public TestRandom getRandomNumber(@Source TestPojo testPojo) {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
@@ -3,7 +3,6 @@ package io.quarkus.smallrye.graphql.runtime;
 import java.io.StringReader;
 
 import javax.json.Json;
-import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
@@ -28,8 +27,7 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
 
     private volatile ExecutionService executionService;
 
-    private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
-    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
+    protected static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
 
     public SmallRyeGraphQLAbstractHandler(
             CurrentIdentityAssociation currentIdentityAssociation,

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -4,14 +4,13 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.json.Json;
-import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
-import javax.json.JsonReaderFactory;
 
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
@@ -34,9 +33,10 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
     private static final String EXTENSIONS = "extensions";
     private static final String APPLICATION_GRAPHQL = "application/graphql";
     private static final String OK = "OK";
-
-    private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
-    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
+    private static final String DEFAULT_RESPONSE_CONTENT_TYPE = "application/graphql+json; charset="
+            + StandardCharsets.UTF_8.name();
+    private static final String DEFAULT_REQUEST_CONTENT_TYPE = "application/json; charset="
+            + StandardCharsets.UTF_8.name();
 
     public SmallRyeGraphQLExecutionHandler(boolean allowGet, boolean allowPostWithQueryParameters,
             CurrentIdentityAssociation currentIdentityAssociation,
@@ -48,25 +48,33 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
     @Override
     protected void doHandle(final RoutingContext ctx) {
-
         HttpServerRequest request = ctx.request();
         HttpServerResponse response = ctx.response();
 
-        response.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+        String accept = getRequestAccept(ctx);
+        String requestedCharset = getCharset(accept);
 
-        switch (request.method().name()) {
-            case "OPTIONS":
-                handleOptions(response);
-                break;
-            case "POST":
-                handlePost(response, ctx);
-                break;
-            case "GET":
-                handleGet(response, ctx);
-                break;
-            default:
-                ctx.next();
-                break;
+        boolean isValid = isValidAcceptRequest(accept);
+
+        if (!isValid) {
+            handleInvalidAcceptRequest(response);
+        } else {
+            response.headers().set(HttpHeaders.CONTENT_TYPE, accept);
+
+            switch (request.method().name()) {
+                case "OPTIONS":
+                    handleOptions(response);
+                    break;
+                case "POST":
+                    handlePost(response, ctx, requestedCharset);
+                    break;
+                case "GET":
+                    handleGet(response, ctx, requestedCharset);
+                    break;
+                default:
+                    ctx.next();
+                    break;
+            }
         }
     }
 
@@ -75,7 +83,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
         response.setStatusCode(200).setStatusMessage(OK).end();
     }
 
-    private void handlePost(HttpServerResponse response, RoutingContext ctx) {
+    private void handlePost(HttpServerResponse response, RoutingContext ctx, String requestedCharset) {
         try {
             JsonObject jsonObjectFromBody = getJsonObjectFromBody(ctx);
             String postResponse;
@@ -87,13 +95,13 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
             } else {
                 postResponse = doRequest(jsonObjectFromBody);
             }
-            response.setStatusCode(200).setStatusMessage(OK).end(Buffer.buffer(postResponse));
+            response.setStatusCode(200).setStatusMessage(OK).end(Buffer.buffer(postResponse, requestedCharset));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
     }
 
-    private void handleGet(HttpServerResponse response, RoutingContext ctx) {
+    private void handleGet(HttpServerResponse response, RoutingContext ctx, String requestedCharset) {
         if (allowGet) {
             try {
                 JsonObject input = getJsonObjectFromQueryParameters(ctx);
@@ -102,7 +110,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
                     String getResponse = doRequest(input);
                     response.setStatusCode(200)
                             .setStatusMessage(OK)
-                            .end(Buffer.buffer(getResponse));
+                            .end(Buffer.buffer(getResponse, requestedCharset));
 
                 } else {
                     response.setStatusCode(204).end();
@@ -115,30 +123,34 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
         }
     }
 
+    private void handleInvalidAcceptRequest(HttpServerResponse response) {
+        response.setStatusCode(406).end();
+    }
+
     private JsonObject getJsonObjectFromQueryParameters(RoutingContext ctx) throws UnsupportedEncodingException {
         JsonObjectBuilder input = Json.createObjectBuilder();
         // Query
         String query = stripNewlinesAndTabs(readQueryParameter(ctx, QUERY));
         if (query != null && !query.isEmpty()) {
-            input.add(QUERY, URLDecoder.decode(query, "UTF8"));
+            input.add(QUERY, URLDecoder.decode(query, StandardCharsets.UTF_8.name()));
         }
         // OperationName
         String operationName = readQueryParameter(ctx, OPERATION_NAME);
         if (operationName != null && !operationName.isEmpty()) {
-            input.add(OPERATION_NAME, URLDecoder.decode(query, "UTF8"));
+            input.add(OPERATION_NAME, URLDecoder.decode(query, StandardCharsets.UTF_8.name()));
         }
 
         // Variables
         String variables = stripNewlinesAndTabs(readQueryParameter(ctx, VARIABLES));
         if (variables != null && !variables.isEmpty()) {
-            JsonObject jsonObject = toJsonObject(URLDecoder.decode(variables, "UTF8"));
+            JsonObject jsonObject = toJsonObject(URLDecoder.decode(variables, StandardCharsets.UTF_8.name()));
             input.add(VARIABLES, jsonObject);
         }
 
         // Extensions
         String extensions = stripNewlinesAndTabs(readQueryParameter(ctx, EXTENSIONS));
         if (extensions != null && !extensions.isEmpty()) {
-            JsonObject jsonObject = toJsonObject(URLDecoder.decode(extensions, "UTF8"));
+            JsonObject jsonObject = toJsonObject(URLDecoder.decode(extensions, StandardCharsets.UTF_8.name()));
             input.add(EXTENSIONS, jsonObject);
         }
 
@@ -147,7 +159,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
     private JsonObject getJsonObjectFromBody(RoutingContext ctx) throws IOException {
 
-        String contentType = readContentType(ctx);
+        String contentType = getRequestContentType(ctx);
         String body = stripNewlinesAndTabs(readBody(ctx));
 
         // If the content type is application/graphql, the query is in the body
@@ -167,18 +179,43 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
     private String readBody(RoutingContext ctx) {
         if (ctx.getBody() != null) {
-            byte[] bytes = ctx.getBody().getBytes();
-            return new String(bytes);
+            return ctx.getBodyAsString();
         }
         return null;
     }
 
-    private String readContentType(RoutingContext ctx) {
+    private String getRequestContentType(RoutingContext ctx) {
         String contentType = ctx.request().getHeader("Content-Type");
-        if (contentType != null && !contentType.isEmpty()) {
+        if (contentType != null && !contentType.isEmpty() && !contentType.startsWith("*/*")) {
             return contentType;
         }
-        return null;
+        return DEFAULT_REQUEST_CONTENT_TYPE;
+    }
+
+    private String getRequestAccept(RoutingContext ctx) {
+        String accept = ctx.request().getHeader("Accept");
+        if (accept != null && !accept.isEmpty() && !accept.startsWith("*/*")) {
+            return accept;
+        }
+        return DEFAULT_RESPONSE_CONTENT_TYPE;
+    }
+
+    private String getCharset(String mimeType) {
+        if (mimeType != null && mimeType.contains(";")) {
+            String[] parts = mimeType.split(";");
+            for (String part : parts) {
+                if (part.trim().startsWith("charset")) {
+                    return part.split("=")[1];
+                }
+            }
+        }
+        return StandardCharsets.UTF_8.name();
+    }
+
+    private boolean isValidAcceptRequest(String mimeType) {
+        // At this point we only accept two 
+        return mimeType.startsWith("application/json")
+                || mimeType.startsWith("application/graphql+json");
     }
 
     private String readQueryParameter(RoutingContext ctx, String parameterName) {


### PR DESCRIPTION
Fix #18521
And also allow setting of the required encoding in the `Accept` header as per spec:

https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#body

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>