### PR TITLE
Replace key-location by key.location in SmallRye JWT doc

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -755,7 +755,7 @@ public class SecuredResource {
 == Token Decryption
 
 If your application needs to accept the tokens with the encrypted claims or with the encrypted inner signed claims then all you have to do is to set
-`smallrye.jwt.decrypt.key-location` pointing to the decryption key.
+`smallrye.jwt.decrypt.key.location` pointing to the decryption key.
 
 If this is the only key property which is set then the incoming token is expected to contain the encrypted claims only.
 If either `mp.jwt.verify.publickey` or `mp.jwt.verify.publickey.location` verification properties are also set then the incoming token is expected to contain
@@ -1042,7 +1042,7 @@ The only minor difference is that encrypting the claims always requires a `jwe()
 import io.smallrye.jwt.build.Jwt;
 ...
 
-// Encrypt the claims using the public key loaded from the location set with a 'smallrye.jwt.encrypt.key-location' property.
+// Encrypt the claims using the public key loaded from the location set with a 'smallrye.jwt.encrypt.key.location' property.
 String jwt1 = Jwt.claims("/tokenClaims.json").jwe().encrypt();
 
 // Set the headers and encrypt the claims with an RSA public key loaded in the code (the implementation of this method is omitted).

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -695,7 +695,7 @@ You can also use a local inlined public key for testing your `quarkus-oidc` `ser
 quarkus.oidc.client-id=test
 quarkus.oidc.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB
 
-smallrye.jwt.sign.key-location=/privateKey.pem
+smallrye.jwt.sign.key.location=/privateKey.pem
 ----
 
 copy `privateKey.pem` from the `integration-tests/oidc-tenancy` in the `main` Quarkus repository and use a test code similar to the one in the `Wiremock` section above to generate JWT tokens. You can use your own test keys if preferred.


### PR DESCRIPTION
@sberyozkin can you have a look? AFAICS, it's what the migration guide is saying.