### PR TITLE
Enable the registry client by default in the dev tools

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/PlatformConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/PlatformConfig.java
@@ -15,13 +15,13 @@ public class PlatformConfig {
     /**
      * groupId of the platform to use
      */
-    @ConfigItem(defaultValue = "io.quarkus")
+    @ConfigItem(defaultValue = "io.quarkus.platform")
     String groupId;
 
     /**
      * artifactId of the platform to use
      */
-    @ConfigItem(defaultValue = "quarkus-universe-bom")
+    @ConfigItem(defaultValue = "quarkus-bom")
     String artifactId;
 
     /**

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -22,6 +22,7 @@ import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.registry.RegistryClientMixin;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.registry.config.RegistriesConfigLocator;
 
 public class GradleRunner implements BuildSystemRunner {
     public static final String[] windowsWrapper = { "gradlew.cmd", "gradlew.bat" };
@@ -223,6 +224,11 @@ public class GradleRunner implements BuildSystemRunner {
             args.add("--project-dir=" + projectRoot.toAbsolutePath());
         }
         args.add(registryClient.getRegistryClientProperty());
+
+        final String configFile = System.getProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY);
+        if (configFile != null) {
+            args.add("-D" + RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY + "=" + configFile);
+        }
 
         // add any other discovered properties
         args.addAll(flattenMappedProperties(propertiesOptions.properties));

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/ToggleRegistryClientMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/ToggleRegistryClientMixin.java
@@ -4,7 +4,7 @@ import picocli.CommandLine;
 
 public class ToggleRegistryClientMixin extends RegistryClientMixin {
 
-    boolean useRegistryClient;
+    boolean useRegistryClient = true;
 
     @CommandLine.Option(names = { "--registry-client" }, description = "Use the Quarkus extension catalog", negatable = true)
     void setRegistryClient(boolean enabled) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 
-import io.quarkus.devtools.project.QuarkusProjectHelper;
-import io.quarkus.registry.config.RegistriesConfigLocator;
 import picocli.CommandLine;
 
 public class CliDriver {
@@ -23,12 +21,6 @@ public class CliDriver {
     static final PrintStream stderr = System.err;
 
     private static final String localRepo = convertToProperty("maven.repo.local");
-
-    public static void afterEachCleanup() {
-        System.clearProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY);
-        System.clearProperty("quarkusRegistryClient");
-        QuarkusProjectHelper.reset();
-    }
 
     public static void preserveLocalRepoSettings(Collection<String> args) {
         if (localRepo != null) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,6 +20,16 @@ import picocli.CommandLine;
 
 public class CliNonProjectTest {
     static Path workspaceRoot;
+
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
 
     @BeforeAll
     public static void initial() throws Exception {
@@ -35,7 +46,6 @@ public class CliNonProjectTest {
                 "Directory list operation should succeed");
         Assertions.assertEquals(0, files.length,
                 "Directory should be empty. Found: " + Arrays.toString(files));
-        CliDriver.afterEachCleanup();
     }
 
     @Test
@@ -92,7 +102,7 @@ public class CliNonProjectTest {
                 "Expected OK return code." + result);
 
         noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
-        Assertions.assertTrue(noSpaces.contains("RegistryClientfalse"),
+        Assertions.assertTrue(noSpaces.contains("RegistryClienttrue"),
                 "Should contain 'Registry Client false', found: " + result.stdout);
         Assertions.assertFalse(Boolean.getBoolean("quarkusRegistryClient"),
                 "Registry Client property should be set to false");

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.cli.build.ExecuteUtil;
 import io.quarkus.cli.build.GradleRunner;
 import io.quarkus.devtools.project.codegen.CreateProjectHelper;
+import io.quarkus.devtools.testing.RegistryClientTestHelper;
 import picocli.CommandLine;
 
 /**
@@ -33,15 +33,20 @@ public class CliProjectGradleTest {
     Path project;
     static File gradle;
 
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
+
     @BeforeEach
     public void setupTestDirectories() throws Exception {
         CliDriver.deleteDir(workspaceRoot);
         project = workspaceRoot.resolve("code-with-quarkus");
-    }
-
-    @AfterEach
-    public void afterEachCleanup() throws Exception {
-        CliDriver.afterEachCleanup();
     }
 
     @BeforeAll

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -5,12 +5,14 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.project.codegen.CreateProjectHelper;
+import io.quarkus.devtools.testing.RegistryClientTestHelper;
 import picocli.CommandLine;
 
 public class CliProjectJBangTest {
@@ -19,15 +21,20 @@ public class CliProjectJBangTest {
 
     Path project;
 
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
+
     @BeforeEach
     public void setupTestDirectories() throws Exception {
         CliDriver.deleteDir(workspaceRoot);
         project = workspaceRoot.resolve("code-with-quarkus");
-    }
-
-    @AfterEach
-    public void afterEachCleanup() throws Exception {
-        CliDriver.afterEachCleanup();
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -5,12 +5,14 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.project.codegen.CreateProjectHelper;
+import io.quarkus.devtools.testing.RegistryClientTestHelper;
 import picocli.CommandLine;
 
 /**
@@ -21,15 +23,20 @@ public class CliProjectMavenTest {
             .resolve("target/test-project/CliProjectMavenTest");
     Path project;
 
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
+
     @BeforeEach
     public void setupTestDirectories() throws Exception {
         CliDriver.deleteDir(workspaceRoot);
         project = workspaceRoot.resolve("code-with-quarkus");
-    }
-
-    @AfterEach
-    public void afterEachCleanup() throws Exception {
-        CliDriver.afterEachCleanup();
     }
 
     @Test

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -348,7 +349,8 @@ public class CreateProjectMojo extends AbstractMojo {
             }
             final ArtifactCoords matchedBom = QuarkusProjectMojoBase.getSingleMatchingBom(groupId, artifactId, version,
                     platformsCatalog);
-            return catalogResolver.resolveExtensionCatalog(Arrays.asList(matchedBom));
+            return catalogResolver
+                    .resolveExtensionCatalog(matchedBom == null ? Collections.emptyList() : Arrays.asList(matchedBom));
         } catch (RegistryResolutionException e) {
             throw new MojoExecutionException("Failed to resolve the extensions catalog", e);
         }

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -20,10 +20,6 @@ import io.quarkus.maven.utilities.MojoUtils;
 
 public final class CreateUtils {
 
-    public static final String DEFAULT_PLATFORM_BOM_GROUP_ID = "io.quarkus";
-    public static final String QUARKUS_CORE_BOM_ARTIFACT_ID = "quarkus-bom";
-    public static final String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
-
     public static final String GRADLE_WRAPPER_PATH = "gradle-wrapper";
     public static final String[] GRADLE_WRAPPER_FILES = new String[] {
             "gradlew",

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -237,7 +237,7 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
         ArtifactCoords platformBom = null;
         List<ArtifactCoords> matches = null;
         for (Platform p : platformCatalog.getPlatforms()) {
-            if (bomGroupId != null && !p.getPlatformKey().equals(bomGroupId)) {
+            if (!p.getPlatformKey().equals(bomGroupId)) {
                 continue;
             }
             for (PlatformStream s : p.getStreams()) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -33,7 +33,7 @@ public class QuarkusProjectHelper {
         if (value == null) {
             value = System.getenv("QUARKUS_REGISTRY_CLIENT");
         }
-        registryClientEnabled = Boolean.parseBoolean(value);
+        registryClientEnabled = value == null || value.isBlank() || Boolean.parseBoolean(value);
     }
 
     public static boolean isRegistryClientEnabled() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -10,8 +10,8 @@ public interface ToolsConstants {
 
     String QUARKUS_MAVEN_PLUGIN = "quarkus-maven-plugin";
 
-    String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS;
-    String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
+    String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS + ".platform";
+    String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-bom";
 
     String PROP_QUARKUS_CORE_VERSION = "quarkus-core-version";
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -93,8 +93,8 @@ public class ToolsUtils {
             throw new IllegalArgumentException("BOM version was not provided");
         }
         Artifact catalogCoords = new DefaultArtifact(
-                bomGroupId == null ? "io.quarkus" : bomGroupId,
-                (bomArtifactId == null ? "quarkus-universe-bom" : bomArtifactId)
+                bomGroupId == null ? ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID : bomGroupId,
+                (bomArtifactId == null ? ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID : bomArtifactId)
                         + BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX,
                 bomVersion, "json", bomVersion);
         Path platformJson = null;
@@ -102,9 +102,9 @@ public class ToolsUtils {
             log.debug("Resolving platform descriptor %s", catalogCoords);
             platformJson = artifactResolver.resolve(catalogCoords).getArtifact().getFile().toPath();
         } catch (Exception e) {
-            if (bomArtifactId == null && catalogCoords.getArtifactId().startsWith("quarkus-universe-bom")) {
+            if (bomGroupId == null && catalogCoords.getArtifactId().startsWith("quarkus-bom")) {
                 catalogCoords = new DefaultArtifact(
-                        catalogCoords.getGroupId(),
+                        ToolsConstants.IO_QUARKUS,
                         "quarkus-bom" + BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX,
                         catalogCoords.getClassifier(), catalogCoords.getExtension(), catalogCoords.getVersion());
                 try {

--- a/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinCreateMavenProjectIT.java
+++ b/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinCreateMavenProjectIT.java
@@ -75,14 +75,16 @@ public class KotlinCreateMavenProjectIT extends QuarkusPlatformAwareMojoTestBase
     private InvocationResult setup(Properties params)
             throws MavenInvocationException, FileNotFoundException, UnsupportedEncodingException {
 
-        params.setProperty("platformArtifactId", "quarkus-bom");
-        params.setProperty("platformVersion", getQuarkusCoreVersion());
+        params.setProperty("platformGroupId", getBomGroupId());
+        params.setProperty("platformArtifactId", getBomArtifactId());
+        params.setProperty("platformVersion", getBomVersion());
 
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBatchMode(true);
         request.setGoals(Collections.singletonList(
                 getMavenPluginGroupId() + ":" + getMavenPluginArtifactId() + ":" + getMavenPluginVersion() + ":create"));
         request.setProperties(params);
+        request.setShowErrors(true);
         File log = new File(testDir, "build-create-" + testDir.getName() + ".log");
         PrintStreamLogger logger = new PrintStreamLogger(new PrintStream(new FileOutputStream(log), false, "UTF-8"),
                 InvokerLogger.DEBUG);

--- a/integration-tests/scala/src/test/java/io/quarkus/scala/maven/it/ScalaCreateMavenProjectIT.java
+++ b/integration-tests/scala/src/test/java/io/quarkus/scala/maven/it/ScalaCreateMavenProjectIT.java
@@ -76,14 +76,9 @@ public class ScalaCreateMavenProjectIT extends QuarkusPlatformAwareMojoTestBase 
     private InvocationResult setup(Properties params)
             throws MavenInvocationException, FileNotFoundException, UnsupportedEncodingException {
 
-        try {
-            params.setProperty("platformGroupId", getBomGroupId());
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
+        params.setProperty("platformGroupId", getBomGroupId());
         params.setProperty("platformArtifactId", getBomArtifactId());
-        params.setProperty("platformVersion", getQuarkusCoreVersion());
+        params.setProperty("platformVersion", getBomVersion());
 
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBatchMode(true);


### PR DESCRIPTION
This PR shows the minimal changes necessary to switch the dev tools to the registry client as the default source of extension metadata and using the `io.quarkus:quarkus-bom` platform for the tests.