### PR TITLE
Optimized stripping of tabs and newlines in GraphQL (micro-optimization)

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -5,6 +5,7 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
@@ -189,6 +190,8 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
         return null;
     }
 
+    private static final Pattern PATTERN_NEWLINE_OR_TAB = Pattern.compile("\\n|\\t");
+
     /**
      * Strip away unescaped tabs and line breaks from the incoming JSON document so that it can be
      * successfully parsed by a JSON parser.
@@ -197,12 +200,12 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
      * but we want to seamlessly support queries from Java text blocks, for example,
      * which preserve line breaks and tab characters.
      */
-    private String stripNewlinesAndTabs(String input) {
+    private static String stripNewlinesAndTabs(final String input) {
         if (input == null || input.isEmpty()) {
             return input;
         }
-        return input.replaceAll("\\n", " ")
-                .replaceAll("\\t", " ");
+
+        return PATTERN_NEWLINE_OR_TAB.matcher(input).replaceAll(" ");
     }
 
     private boolean hasQueryParameters(RoutingContext ctx) {


### PR DESCRIPTION
The current implementation of the `stripNewlinesAndTabs()` method compiles 2 _regular-expressions_ (`"\n"` and `"\t"`) each time that the method is invoked and then performs 2 matchings.

The optimized version compiles the _regular-expression_ only once when the class is loaded and performs only one mathiching on method invocation.