### PR TITLE
ArC micro optimizations

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -76,9 +76,24 @@ public final class Types {
     }
 
     static ResultHandle getTypeHandle(BytecodeCreator creator, Type type, ResultHandle tccl) {
+        return getTypeHandle(creator, type, tccl, null);
+    }
+
+    static ResultHandle getTypeHandle(BytecodeCreator creator, Type type, ResultHandle tccl,
+            Map<Type, ResultHandle> sharedTypes) {
+        if (sharedTypes != null) {
+            ResultHandle sharedType = sharedTypes.get(type);
+            if (sharedType != null) {
+                return sharedType;
+            }
+        }
         if (Kind.CLASS.equals(type.kind())) {
             String className = type.asClassType().name().toString();
-            return doLoadClass(creator, className, tccl);
+            ResultHandle classHandle = doLoadClass(creator, className, tccl);
+            if (sharedTypes != null) {
+                sharedTypes.put(type, classHandle);
+            }
+            return classHandle;
         } else if (Kind.TYPE_VARIABLE.equals(type.kind())) {
             // E.g. T -> new TypeVariableImpl("T")
             TypeVariable typeVariable = type.asTypeVariable();
@@ -89,40 +104,51 @@ public final class Types {
             } else {
                 boundsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(bounds.size()));
                 for (int i = 0; i < bounds.size(); i++) {
-                    creator.writeArrayValue(boundsHandle, i, getTypeHandle(creator, bounds.get(i), tccl));
+                    creator.writeArrayValue(boundsHandle, i, getTypeHandle(creator, bounds.get(i), tccl, sharedTypes));
                 }
             }
-            return creator.newInstance(
+            ResultHandle typeVariableHandle = creator.newInstance(
                     MethodDescriptor.ofConstructor(TypeVariableImpl.class, String.class, java.lang.reflect.Type[].class),
                     creator.load(typeVariable.identifier()), boundsHandle);
+            if (sharedTypes != null) {
+                sharedTypes.put(typeVariable, typeVariableHandle);
+            }
+            return typeVariableHandle;
 
         } else if (Kind.PARAMETERIZED_TYPE.equals(type.kind())) {
             // E.g. List<String> -> new ParameterizedTypeImpl(List.class, String.class)
-            ParameterizedType parameterizedType = type.asParameterizedType();
-
-            return getParameterizedType(creator, tccl, parameterizedType);
+            return getParameterizedType(creator, tccl, type.asParameterizedType(), sharedTypes);
 
         } else if (Kind.ARRAY.equals(type.kind())) {
             Type componentType = type.asArrayType().component();
             // E.g. String[] -> new GenericArrayTypeImpl(String.class)
-            return creator.newInstance(MethodDescriptor.ofConstructor(GenericArrayTypeImpl.class, java.lang.reflect.Type.class),
-                    getTypeHandle(creator, componentType, tccl));
+            ResultHandle arrayHandle = creator.newInstance(
+                    MethodDescriptor.ofConstructor(GenericArrayTypeImpl.class, java.lang.reflect.Type.class),
+                    getTypeHandle(creator, componentType, tccl, sharedTypes));
+            if (sharedTypes != null) {
+                sharedTypes.put(type, arrayHandle);
+            }
+            return arrayHandle;
 
         } else if (Kind.WILDCARD_TYPE.equals(type.kind())) {
             // E.g. ? extends Number -> WildcardTypeImpl.withUpperBound(Number.class)
             WildcardType wildcardType = type.asWildcardType();
-
+            ResultHandle wildcardHandle;
             if (wildcardType.superBound() == null) {
-                return creator.invokeStaticMethod(
+                wildcardHandle = creator.invokeStaticMethod(
                         MethodDescriptor.ofMethod(WildcardTypeImpl.class, "withUpperBound",
                                 java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
-                        getTypeHandle(creator, wildcardType.extendsBound(), tccl));
+                        getTypeHandle(creator, wildcardType.extendsBound(), tccl, sharedTypes));
             } else {
-                return creator.invokeStaticMethod(
+                wildcardHandle = creator.invokeStaticMethod(
                         MethodDescriptor.ofMethod(WildcardTypeImpl.class, "withLowerBound",
                                 java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
-                        getTypeHandle(creator, wildcardType.superBound(), tccl));
+                        getTypeHandle(creator, wildcardType.superBound(), tccl, sharedTypes));
             }
+            if (sharedTypes != null) {
+                sharedTypes.put(wildcardType, wildcardHandle);
+            }
+            return wildcardHandle;
         } else if (Kind.PRIMITIVE.equals(type.kind())) {
             switch (type.asPrimitiveType().primitive()) {
                 case INT:
@@ -149,17 +175,37 @@ public final class Types {
         }
     }
 
-    public static ResultHandle getParameterizedType(BytecodeCreator creator, ResultHandle tccl,
-            ParameterizedType parameterizedType) {
+    static ResultHandle getParameterizedType(BytecodeCreator creator, ResultHandle tccl,
+            ParameterizedType parameterizedType, Map<Type, ResultHandle> sharedTypes) {
         List<Type> arguments = parameterizedType.arguments();
         ResultHandle typeArgsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(arguments.size()));
         for (int i = 0; i < arguments.size(); i++) {
-            creator.writeArrayValue(typeArgsHandle, i, getTypeHandle(creator, arguments.get(i), tccl));
+            creator.writeArrayValue(typeArgsHandle, i, getTypeHandle(creator, arguments.get(i), tccl, sharedTypes));
         }
-        return creator.newInstance(
+        Type rawType = Type.create(parameterizedType.name(), Kind.CLASS);
+        ResultHandle rawTypeHandle = null;
+        if (sharedTypes != null) {
+            rawTypeHandle = sharedTypes.get(rawType);
+        }
+        if (rawTypeHandle == null) {
+            rawTypeHandle = doLoadClass(creator, parameterizedType.name().toString(), tccl);
+            if (sharedTypes != null) {
+                sharedTypes.put(rawType, rawTypeHandle);
+            }
+        }
+        ResultHandle parameterizedTypeHandle = creator.newInstance(
                 MethodDescriptor.ofConstructor(ParameterizedTypeImpl.class, java.lang.reflect.Type.class,
                         java.lang.reflect.Type[].class),
-                doLoadClass(creator, parameterizedType.name().toString(), tccl), typeArgsHandle);
+                rawTypeHandle, typeArgsHandle);
+        if (sharedTypes != null) {
+            sharedTypes.put(parameterizedType, parameterizedTypeHandle);
+        }
+        return parameterizedTypeHandle;
+    }
+
+    public static ResultHandle getParameterizedType(BytecodeCreator creator, ResultHandle tccl,
+            ParameterizedType parameterizedType) {
+        return getParameterizedType(creator, tccl, parameterizedType, null);
     }
 
     private static ResultHandle doLoadClass(BytecodeCreator creator, String className, ResultHandle tccl) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RemovedBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RemovedBean.java
@@ -15,7 +15,7 @@ public interface RemovedBean {
     InjectableBean.Kind getKind();
 
     /**
-     * @return the description
+     * @return the description of the declaring java member for producers
      */
     String getDescription();
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CollectionHelpers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CollectionHelpers.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.impl;
 
-import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -13,16 +13,20 @@ final class CollectionHelpers {
         //do not instantiate
     }
 
+    @SuppressWarnings("unchecked")
     static <T> Set<T> toImmutableSmallSet(Set<T> set) {
         if (set == null)
             return null;
         switch (set.size()) {
             case 0:
-                return Collections.emptySet();
+                return Set.of();
             case 1:
-                return Collections.singleton(set.iterator().next());
+                return Set.of(set.iterator().next());
+            case 2:
+                Iterator<T> it = set.iterator();
+                return Set.of(it.next(), it.next());
             default:
-                return Collections.unmodifiableSet(set);
+                return (Set<T>) Set.of(set.toArray());
         }
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RemovedBeanImpl.java
@@ -14,16 +14,15 @@ public final class RemovedBeanImpl implements RemovedBean {
     private final Set<Annotation> qualifiers;
 
     public RemovedBeanImpl(Kind kind, String description, Set<Type> types, Set<Annotation> qualifiers) {
-        this.kind = kind != null ? kind : Kind.CLASS;
+        this.kind = kind;
         this.description = description;
         this.types = CollectionHelpers.toImmutableSmallSet(types);
-        this.qualifiers = qualifiers != null ? CollectionHelpers.toImmutableSmallSet(qualifiers)
-                : Qualifiers.DEFAULT_QUALIFIERS;
+        this.qualifiers = CollectionHelpers.toImmutableSmallSet(qualifiers);
     }
 
     @Override
     public Kind getKind() {
-        return kind;
+        return kind != null ? kind : Kind.CLASS;
     }
 
     @Override
@@ -38,7 +37,7 @@ public final class RemovedBeanImpl implements RemovedBean {
 
     @Override
     public Set<Annotation> getQualifiers() {
-        return qualifiers;
+        return qualifiers != null ? qualifiers : Qualifiers.DEFAULT_QUALIFIERS;
     }
 
     @Override


### PR DESCRIPTION
- trim list of removed Beans
- trim Resource reference providers
- trim active Beans
- do not use LinkedList
- share qualifier annotation literals and Type instances in the
generated ComponentsProvider

Co-authored-by: Sanne Grinovero <sanne@hibernate.org>