### PR TITLE
Gradle: look for extension properties only in JARs

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -161,7 +161,7 @@ public class ConditionalDependenciesEnabler {
     private ExtensionDependency getExtensionInfoOrNull(ResolvedArtifact artifact) {
         ModuleVersionIdentifier artifactId = artifact.getModuleVersion().getId();
         File artifactFile = artifact.getFile();
-        if (!artifactFile.exists()) {
+        if (!artifactFile.exists() || !"jar".equals(artifact.getExtension())) {
             return null;
         }
         if (artifactFile.isDirectory()) {


### PR DESCRIPTION
It's not uncommon to see, e.g. a `pom` artifact among the dependencies.