### PR TITLE
Add a category to SmallRye GraphQL Client

### DIFF
--- a/extensions/smallrye-graphql-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-graphql-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,5 +7,7 @@ metadata:
   - "graphql"
   - "graphql-client"
   - "microprofile-graphql"
+  categories:
+  - "web"
   guide: "https://quarkus.io/guides/smallrye-graphql-client"
   status: "preview"


### PR DESCRIPTION
Without that, it doesn't appear on code.quarkus.io.