### PR TITLE
Put the JDBC Oracle extension with other JDBC drivers in code.quarkus.io

### DIFF
--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -23,10 +23,11 @@
           "io.quarkus:quarkus-jdbc-postgresql",
           "io.quarkus:quarkus-jdbc-mariadb",
           "io.quarkus:quarkus-jdbc-mysql",
+          "io.quarkus:quarkus-jdbc-h2",
           "io.quarkus:quarkus-jdbc-mssql",
           "io.quarkus:quarkus-jdbc-db2",
-          "io.quarkus:quarkus-jdbc-h2",
-          "io.quarkus:quarkus-jdbc-derby"
+          "io.quarkus:quarkus-jdbc-derby",
+          "io.quarkus:quarkus-jdbc-oracle"
         ]
       }
     },


### PR DESCRIPTION
Also move the H2 driver a bit more to the top as it's a very common one.