### PR TITLE
Oracle XE container images 18.4.0-slim now available

### DIFF
--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -22,7 +22,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:11-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:18.4.0-slim
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <oracledb.url>jdbc:oracle:thin:@localhost:1521/XE</oracledb.url>
         <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->
-        <oracle.image>gvenzl/oracle-xe:11-slim</oracle.image>
+        <oracle.image>gvenzl/oracle-xe:18.4.0-slim</oracle.image>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

cc/ @cescoffier FYI

From local testing this seems to work reliably and starts faster than previous versions. Let's see what CI thinks of it :)