### PR TITLE
Provide actionable error message when Jackson can't serialize in native-mode

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
 import io.quarkus.resteasy.reactive.jackson.runtime.mappers.DefaultMismatchedInputException;
+import io.quarkus.resteasy.reactive.jackson.runtime.mappers.NativeInvalidDefinitionExceptionMapper;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.BasicServerJacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.FullyFeaturedServerJacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.ServerJacksonMessageBodyReader;
@@ -22,6 +23,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonA
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonObjectMessageBodyReader;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonObjectMessageBodyWriter;
+import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterBuildItem;
@@ -50,7 +52,8 @@ public class ResteasyReactiveJacksonProcessor {
             BuildProducer<AdditionalBeanBuildItem> additionalBean,
             BuildProducer<MessageBodyReaderBuildItem> additionalReaders,
             BuildProducer<MessageBodyWriterBuildItem> additionalWriters,
-            BuildProducer<ExceptionMapperBuildItem> exceptionMappers) {
+            BuildProducer<ExceptionMapperBuildItem> exceptionMappers,
+            BuildProducer<CustomExceptionMapperBuildItem> customExceptionMapper) {
         boolean applicationNeedsSpecialJacksonFeatures = jacksonFeatureBuildItems.isEmpty();
         // make these beans to they can get instantiated with the Quarkus CDI configured ObjectMapper object
         additionalBean.produce(AdditionalBeanBuildItem.builder()
@@ -84,6 +87,9 @@ public class ResteasyReactiveJacksonProcessor {
 
         exceptionMappers.produce(new ExceptionMapperBuildItem(DefaultMismatchedInputException.class.getName(),
                 MismatchedInputException.class.getName(), Priorities.USER + 100, false));
+
+        customExceptionMapper
+                .produce(new CustomExceptionMapperBuildItem(NativeInvalidDefinitionExceptionMapper.class.getName()));
     }
 
     private String getJacksonMessageBodyWriter(boolean applicationNeedsSpecialJacksonFeatures) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/NativeInvalidDefinitionExceptionMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/NativeInvalidDefinitionExceptionMapper.java
@@ -1,0 +1,47 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.mappers;
+
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
+import com.fasterxml.jackson.databind.type.SimpleType;
+
+import io.quarkus.bootstrap.graal.ImageInfo;
+
+public class NativeInvalidDefinitionExceptionMapper {
+
+    protected static final Logger log = Logger.getLogger(NativeInvalidDefinitionExceptionMapper.class);
+
+    @ServerExceptionMapper(priority = Priorities.USER + 100)
+    public Response toResponse(InvalidDefinitionException e, SimpleResourceInfo resourceInfo) {
+        if (ImageInfo.inImageRuntimeCode() && (e.getMessage().startsWith("No serializer found"))) {
+            JavaType effectiveType = determineType(e.getType());
+            if (effectiveType != null) {
+                log.error("Jackson was unable to serialize type '" + effectiveType.toCanonical()
+                        + "'. Consider annotating the class with '@RegisterForReflection' or using 'org.jboss.resteasy.reactive.RestResponse' as a response type of '"
+                        + resourceInfo.getResourceClass().getName() + "#" + resourceInfo.getMethodName(), e);
+            } else {
+                // we were not able to determine the type, so just log the exception
+                log.error(e);
+            }
+        }
+        return Response.serverError().build();
+    }
+
+    private JavaType determineType(JavaType providedType) {
+        if (providedType instanceof SimpleType) {
+            return providedType;
+        }
+        if (providedType instanceof CollectionLikeType) {
+            return determineType(providedType.getContentType());
+        }
+        // TODO: add more types
+        return null;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/PreserveTargetException.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/PreserveTargetException.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.reactive.common;
+
+/**
+ * Marker exception that indicates to RESTEasy Reactive that the target should be preserved.
+ * This is very useful for providing good contextual error messages
+ */
+public class PreserveTargetException extends RuntimeException {
+
+    public PreserveTargetException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Executor;
 import javax.ws.rs.container.CompletionCallback;
 import javax.ws.rs.container.ConnectionCallback;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.PreserveTargetException;
 import org.jboss.resteasy.reactive.spi.RestHandler;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
@@ -164,7 +165,11 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
                     }
                 } catch (Throwable t) {
                     boolean over = handlers == abortHandlerChain;
-                    handleException(t);
+                    if (t instanceof PreserveTargetException) {
+                        handleException(t.getCause(), true);
+                    } else {
+                        handleException(t);
+                    }
                     if (over) {
                         running = false;
                         return;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
@@ -31,6 +31,7 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.WriterInterceptor;
 import org.jboss.resteasy.reactive.FilePart;
 import org.jboss.resteasy.reactive.PathPart;
+import org.jboss.resteasy.reactive.common.PreserveTargetException;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
@@ -234,12 +235,13 @@ public class ServerSerialisers extends Serialisers {
             //and the pre commit listener will interfere with that
             context.serverResponse().setPreCommitListener(null);
             if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
+                throw new PreserveTargetException(e);
             } else if (e instanceof IOException) {
-                throw (IOException) e;
+                throw new PreserveTargetException(e);
             } else {
-                throw new RuntimeException(e);
+                throw new PreserveTargetException(new RuntimeException(e));
             }
+
         }
     }
 


### PR DESCRIPTION
The idea here is to gives users an actionable error message when Jackson throws something like the following:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.acme.rest.json.Legume and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
```

which users would likely not know what to do with