### PR TITLE
OpenAPI: Response headers to check CORS Configuration first

### DIFF
--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -2,6 +2,9 @@ package io.quarkus.smallrye.openapi.runtime;
 
 import java.util.List;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.arc.Arc;
 import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.Handler;
@@ -21,14 +24,22 @@ public class OpenApiHandler implements Handler<RoutingContext> {
     private volatile OpenApiDocumentService openApiDocumentService;
     private static final String ALLOWED_METHODS = "GET, HEAD, OPTIONS";
     private static final String QUERY_PARAM_FORMAT = "format";
-    private static final MultiMap RESPONSE_HEADERS = new HeadersMultiMap();
+    private final MultiMap responseHeaders;
 
-    static {
-        RESPONSE_HEADERS.add("access-control-allow-origin", "*");
-        RESPONSE_HEADERS.add("access-control-allow-credentials", "true");
-        RESPONSE_HEADERS.add("access-control-allow-methods", ALLOWED_METHODS);
-        RESPONSE_HEADERS.add("access-control-allow-headers", "Content-Type, Authorization");
-        RESPONSE_HEADERS.add("access-control-max-age", "86400");
+    private final Config config = ConfigProvider.getConfig();
+
+    public OpenApiHandler() {
+        this.responseHeaders = HeadersMultiMap.httpHeaders();
+        this.responseHeaders.add("access-control-allow-origin",
+                config.getOptionalValue("quarkus.http.cors.origins", String.class).orElse("*"));
+        this.responseHeaders.add("access-control-allow-credentials",
+                config.getOptionalValue("quarkus.http.cors.access-control-allow-credentials", String.class).orElse("true"));
+        this.responseHeaders.add("access-control-allow-methods",
+                config.getOptionalValue("quarkus.http.cors.methods", String.class).orElse(ALLOWED_METHODS));
+        this.responseHeaders.add("access-control-allow-headers",
+                config.getOptionalValue("quarkus.http.cors.headers", String.class).orElse("Content-Type, Authorization"));
+        this.responseHeaders.add("access-control-max-age",
+                config.getOptionalValue("quarkus.http.cors.access-control-max-age", String.class).orElse("86400"));
     }
 
     @Override
@@ -37,7 +48,7 @@ public class OpenApiHandler implements Handler<RoutingContext> {
         HttpServerResponse resp = event.response();
 
         if (req.method().equals(HttpMethod.OPTIONS)) {
-            resp.headers().setAll(RESPONSE_HEADERS);
+            resp.headers().setAll(this.responseHeaders);
             resp.headers().set("Allow", ALLOWED_METHODS);
             event.next();
         } else {
@@ -55,7 +66,7 @@ public class OpenApiHandler implements Handler<RoutingContext> {
                 format = Format.JSON;
             }
 
-            resp.headers().setAll(RESPONSE_HEADERS);
+            resp.headers().setAll(this.responseHeaders);
             resp.headers().set("Content-Type", format.getMimeType() + ";charset=UTF-8");
             byte[] schemaDocument = getOpenApiDocumentService().getDocument(format);
             resp.end(Buffer.buffer(schemaDocument));


### PR DESCRIPTION
As discussed here https://github.com/quarkusio/quarkus/issues/18503

This PR change the OpenAPI Response Headers to first check the CORS config values before adding the defaults

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>