### PR TITLE
Avoid throwing an exception on close if a VertxInputStream is closed

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -141,7 +141,7 @@ public class VertxInputStream extends InputStream {
     @Override
     public void close() throws IOException {
         if (closed) {
-            throw new IOException("Stream is closed");
+            return;
         }
         closed = true;
         try {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -140,7 +140,7 @@ public class VertxInputStream extends InputStream {
     @Override
     public void close() throws IOException {
         if (closed) {
-            throw new IOException("Stream is closed");
+            return;
         }
         closed = true;
         try {


### PR DESCRIPTION
## Motivation

An `IOException` is thrown If we call `close()` on an instance of `VertxInputStream` that is already closed,  while the Javadoc of a [`close`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Closeable.html#close()) states I quote:

> If the stream is already closed then invoking this method has no effect. 

## Modifications

* Changes the code to do nothing on `close()` if the stream is already closed on both existing `VertxInputStream`