### PR TITLE
Quarkus-security - allow provider registration from extensions

### DIFF
--- a/extensions/security/deployment/pom.xml
+++ b/extensions/security/deployment/pom.xml
@@ -44,6 +44,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-test-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/BouncyCastleJsseProviderBuildItem.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/BouncyCastleJsseProviderBuildItem.java
@@ -1,8 +1,10 @@
 package io.quarkus.security.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import java.util.Objects;
 
-public final class BouncyCastleJsseProviderBuildItem extends SimpleBuildItem {
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class BouncyCastleJsseProviderBuildItem extends MultiBuildItem {
     private final boolean inFipsMode;
 
     public BouncyCastleJsseProviderBuildItem() {
@@ -17,4 +19,18 @@ public final class BouncyCastleJsseProviderBuildItem extends SimpleBuildItem {
         return inFipsMode;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        BouncyCastleJsseProviderBuildItem that = (BouncyCastleJsseProviderBuildItem) o;
+        return inFipsMode == that.inFipsMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inFipsMode);
+    }
 }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/BouncyCastleProviderBuildItem.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/BouncyCastleProviderBuildItem.java
@@ -1,8 +1,10 @@
 package io.quarkus.security.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import java.util.Objects;
 
-public final class BouncyCastleProviderBuildItem extends SimpleBuildItem {
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class BouncyCastleProviderBuildItem extends MultiBuildItem {
     private final boolean inFipsMode;
 
     public BouncyCastleProviderBuildItem() {
@@ -15,5 +17,20 @@ public final class BouncyCastleProviderBuildItem extends SimpleBuildItem {
 
     public boolean isInFipsMode() {
         return inFipsMode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        BouncyCastleProviderBuildItem that = (BouncyCastleProviderBuildItem) o;
+        return inFipsMode == that.inFipsMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inFipsMode);
     }
 }

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/DuplicatedDifferentBouncycastleProviderTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/DuplicatedDifferentBouncycastleProviderTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.security.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicatedDifferentBouncycastleProviderTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-duplicated-different-providers.properties", "application.properties"));
+
+    @Test
+    void shouldThrow() {
+        Assertions.fail("An IllegalStateException should have been thrown due to duplicated bouncycastle providers");
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/DuplicatedTheSameBouncycastleProviderTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/DuplicatedTheSameBouncycastleProviderTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicatedTheSameBouncycastleProviderTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-duplicated-the-same-providers.properties", "application.properties"));
+
+    @Test
+    public void testSuccess() {
+        //execution of the test is enough to confirm that configuration is allowed
+    }
+}

--- a/extensions/security/deployment/src/test/resources/application-duplicated-different-providers.properties
+++ b/extensions/security/deployment/src/test/resources/application-duplicated-different-providers.properties
@@ -1,0 +1,1 @@
+quarkus.security.security-providers=BC,BCFIPS

--- a/extensions/security/deployment/src/test/resources/application-duplicated-the-same-providers.properties
+++ b/extensions/security/deployment/src/test/resources/application-duplicated-the-same-providers.properties
@@ -1,0 +1,1 @@
+quarkus.security.security-providers=BC,BC


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/18615

@sberyozkin 
I've tried to use `java.util.Set` as we discussed, but it fails with `java.lang.IllegalArgumentException: Unsupported method parameter java.util.Set<io.quarkus.security.deployment.BouncyCastleProviderBuildItem>` - so I used `java.util.List`.

I also tried to add 2 tests to cover duplicated provider registration. It makes sense to have these tests in deployment module. I tried to create them (based on test from different modules), but even if there is a `@RegisterExtension`, `SecurityProcessor` is never called - even f there are parameters in app.properties. I don't have any experience with the tests in deployment module, so I'd like to ask, do you know whjat could be wrong?