### PR TITLE
Make @QuarkusIntegrationTest work reliably with testcontainers launched services

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -76,10 +76,9 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             args.addAll(argLine);
         }
         args.add("--rm");
-        args.add("-p");
-        args.add(httpPort + ":" + httpPort);
-        args.add("-p");
-        args.add(httpsPort + ":" + httpsPort);
+        // the only reliable way the application container can talk to services launched via testcontainers, is to use host network
+        // this is because those containers use 'localhost' as their host in the config property they present to Quarkus
+        args.add("--net=host");
         args.addAll(toEnvVar("quarkus.http.port", "" + httpPort));
         args.addAll(toEnvVar("quarkus.http.ssl-port", "" + httpsPort));
         // this won't be correct when using the random port but it's really only used by us for the rest client tests


### PR DESCRIPTION
As services launched with testcontainers (which are under user-control, not ours)
will use localhost as the host they present to the relevant Quarkus configuration,
the only way to reliably make the application container work with these, is to
use host networking.

See https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/testcontainers.20networking.20in.20docker.20mode for a thorough discussion