### PR TITLE
Make the RestClientBuilderHelper methods public

### DIFF
--- a/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/RestClientBuilderHelper.java
+++ b/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/RestClientBuilderHelper.java
@@ -33,7 +33,7 @@ public final class RestClientBuilderHelper {
         // avoid instantiation
     }
 
-    static RestClientBuilder createRestClientBuilder(ElasticsearchConfig config) {
+    public static RestClientBuilder createRestClientBuilder(ElasticsearchConfig config) {
         List<HttpHost> hosts = new ArrayList<>(config.hosts.size());
         for (InetSocketAddress host : config.hosts) {
             hosts.add(new HttpHost(host.getHostString(), host.getPort(), config.protocol));
@@ -97,7 +97,7 @@ public final class RestClientBuilderHelper {
         return builder;
     }
 
-    static Sniffer createSniffer(RestClient client, ElasticsearchConfig config) {
+    public static Sniffer createSniffer(RestClient client, ElasticsearchConfig config) {
         SnifferBuilder builder = Sniffer.builder(client)
                 .setSniffIntervalMillis((int) config.discovery.refreshInterval.toMillis());
 


### PR DESCRIPTION
Make the methods public on the RestClientBuilderHelper helper class so it can be reused inside the Quarkiverse Elasticsearch reactive client to avoid duplication.

See https://github.com/quarkiverse/quarkus-elasticsearch-reactive/blob/main/runtime/src/main/java/io/quarkiverse/quarkus/elasticsearch/reactive/runtime/RestClientBuilderHelper.java