### PR TITLE
Upgrade to Hibernate Reactive 1.0.0.CR8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.5.3.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.CR7</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.CR8</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.5.Final</hibernate-search.version>
         <narayana.version>5.12.0.Final</narayana.version>


### PR DESCRIPTION
The release has just finished so it might take a moment for the jar to be available