### PR TITLE
Cut down stack traces

### DIFF
--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/CurrentAppExceptionHighlighter.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/CurrentAppExceptionHighlighter.java
@@ -1,8 +1,6 @@
 package io.quarkus.dev.console;
 
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.logging.LogRecord;
+import java.util.function.BiFunction;
 
 /**
  * A bit of a hack, but currently there is no other way to do this.
@@ -13,6 +11,11 @@ import java.util.logging.LogRecord;
  */
 public class CurrentAppExceptionHighlighter {
 
-    public static volatile BiConsumer<LogRecord, Consumer<LogRecord>> THROWABLE_FORMATTER;
+    public static volatile BiFunction<Throwable, Target, AutoCloseable> THROWABLE_FORMATTER;
+
+    public enum Target {
+        ANSI,
+        HTML
+    }
 
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -33,4 +33,22 @@ public class LogBuildTimeConfig {
     @ConfigItem(name = "category")
     @ConfigDocSection
     public Map<String, CategoryBuildTimeConfig> categories;
+
+    /**
+     * If this is true then in development mode classes from the current application will be underlined
+     * in stack traces, to make it easier to differentiate between framework and application code.
+     *
+     * This only applies to the console log.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean highlightAppCode;
+
+    /**
+     * If this is true then in development and test mode stack traces will be trimmed to start at the point
+     * that application code starts executing, to reduce noise.
+     *
+     * This only applies to the console log.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean trimStackTraces;
 }


### PR DESCRIPTION
This removes all the caller information, as the user does not really
need the details from the internals of the HTTP/messaging stack.