### PR TITLE
Fix OpenTelemetry late bound span processors

### DIFF
--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/LateBoundBatchSpanProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/runtime/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/runtime/LateBoundBatchSpanProcessor.java
@@ -60,7 +60,7 @@ public class LateBoundBatchSpanProcessor implements SpanProcessor {
     public boolean isEndRequired() {
         if (delegate == null) {
             logDelegateNotFound();
-            return false;
+            return true;
         }
         return delegate.isEndRequired();
     }

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/LateBoundBatchSpanProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/LateBoundBatchSpanProcessor.java
@@ -60,7 +60,7 @@ public class LateBoundBatchSpanProcessor implements SpanProcessor {
     public boolean isEndRequired() {
         if (delegate == null) {
             logDelegateNotFound();
-            return false;
+            return true;
         }
         return delegate.isEndRequired();
     }


### PR DESCRIPTION
- Fixes #18575
- Changes default in `LateBoundBatchSpanProcessor` for `isEndRequired()` to `true`. In multiple span processor situation, this is necessary to ensure spans are reported