### PR TITLE
CLI: Add debugPort to DevModeLauncher

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -34,6 +35,8 @@ import io.quarkus.runtime.util.JavaVersionUtil;
 import io.quarkus.utilities.JavaBinFinder;
 
 public abstract class QuarkusDevModeLauncher {
+    final Pattern validDebug = Pattern.compile("^(true|false|client|[0-9]+)$");
+    final Pattern validPort = Pattern.compile("^[0-9]+$");
 
     public class Builder<R extends QuarkusDevModeLauncher, B extends Builder<R, B>> {
 
@@ -251,7 +254,14 @@ public abstract class QuarkusDevModeLauncher {
 
         public B debugHost(String host) {
             if ((null != host) && !host.isEmpty()) {
-                debugHost = host;
+                QuarkusDevModeLauncher.this.debugHost = host;
+            }
+            return (B) this;
+        }
+
+        public B debugPort(String port) {
+            if ((null != port) && !port.isEmpty()) {
+                QuarkusDevModeLauncher.this.debugPort = port;
             }
             return (B) this;
         }
@@ -268,6 +278,7 @@ public abstract class QuarkusDevModeLauncher {
     private Boolean debugPortOk;
     private String suspend;
     private String debugHost = "localhost";
+    private String debugPort = "5005";
     private File projectDir;
     private File buildDir;
     private File outputDir;
@@ -326,39 +337,40 @@ public abstract class QuarkusDevModeLauncher {
             suspend = "n";
         }
 
-        if (debug == null) {
-            // debug mode not specified
-            // make sure 5005 is not used, we don't want to just fail if something else is using it
+        int port = 5005;
+
+        if (debugPort != null && validPort.matcher(debugPort).matches()) {
+            port = Integer.parseInt(debugPort);
+        }
+        if (debug != null) {
+            if (!validDebug.matcher(debug).matches()) {
+                throw new Exception(
+                        "Invalid value for debug parameter: " + debug + " must be true|false|client|{port}");
+            }
+            if (validPort.matcher(debug).matches()) {
+                port = Integer.parseInt(debug);
+            }
+        }
+        if (port <= 0) {
+            throw new Exception("The specified debug port must be greater than 0");
+        }
+
+        if (debug != null && debug.toLowerCase().equals("client")) {
+            args.add("-agentlib:jdwp=transport=dt_socket,address=" + debugHost + ":" + port + ",server=n,suspend=" + suspend);
+        } else if (debug == null || !debug.toLowerCase().equals("false")) {
+            // make sure the debug port is not used, we don't want to just fail if something else is using it
             // we don't check this on restarts, as the previous process is still running
             if (debugPortOk == null) {
-                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), 5005)) {
-                    error("Port 5005 in use, not starting in debug mode");
+                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), port)) {
+                    error("Port " + port + " in use, not starting in debug mode");
                     debugPortOk = false;
                 } catch (IOException e) {
                     debugPortOk = true;
                 }
             }
             if (debugPortOk) {
-                args.add("-Xdebug");
-                args.add("-Xrunjdwp:transport=dt_socket,address=" + debugHost + ":5005,server=y,suspend=" + suspend);
-            }
-        } else if (debug.toLowerCase().equals("client")) {
-            args.add("-Xdebug");
-            args.add("-Xrunjdwp:transport=dt_socket,address=" + debugHost + ":5005,server=n,suspend=" + suspend);
-        } else if (debug.toLowerCase().equals("true")) {
-            args.add("-Xdebug");
-            args.add("-Xrunjdwp:transport=dt_socket,address=" + debugHost + ":5005,server=y,suspend=" + suspend);
-        } else if (!debug.toLowerCase().equals("false")) {
-            try {
-                int port = Integer.parseInt(debug);
-                if (port <= 0) {
-                    throw new Exception("The specified debug port must be greater than 0");
-                }
-                args.add("-Xdebug");
-                args.add("-Xrunjdwp:transport=dt_socket,address=" + debugHost + ":" + port + ",server=y,suspend=" + suspend);
-            } catch (NumberFormatException e) {
-                throw new Exception(
-                        "Invalid value for debug parameter: " + debug + " must be true|false|client|{port}");
+                args.add("-agentlib:jdwp=transport=dt_socket,address=" + debugHost + ":" + port + ",server=y,suspend="
+                        + suspend);
             }
         }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -214,7 +214,10 @@ public class GradleRunner implements BuildSystemRunner {
         } else if (output.isAnsiEnabled()) {
             args.add("--console=rich");
         }
-        args.add("--project-dir=" + projectRoot.toAbsolutePath());
+        if (output.isCliTest()) {
+            // Make sure we stay where we should
+            args.add("--project-dir=" + projectRoot.toAbsolutePath());
+        }
 
         // add any other discovered properties
         args.addAll(flattenMappedProperties(propertiesOptions.properties));

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/DebugOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/DebugOptions.java
@@ -26,12 +26,19 @@ public class DebugOptions {
     public DebugMode mode = DebugMode.listen;
 
     @CommandLine.Option(order = 10, names = {
-            "--debug-port" }, description = "Debug port.", defaultValue = "" + DEFAULT_PORT)
+            "--debug-port" }, description = "Debug port (must be a number > 0).", defaultValue = "" + DEFAULT_PORT)
     public int port = DEFAULT_PORT;
 
     @CommandLine.Option(order = 11, names = {
             "--suspend" }, description = "In listen mode, suspend until a debugger is attached. Disabled by default.", negatable = true)
     public boolean suspend = false;
+
+    public String getJvmDebugParameter() {
+        return "-agentlib:jdwp=transport=dt_socket"
+                + ",address=" + host + ":" + port
+                + ",server=" + (mode == DebugMode.listen ? "y" : "n")
+                + ",suspend=" + (suspend ? "y" : "n");
+    }
 
     public void addDebugArguments(Collection<String> args, Collection<String> jvmArgs) {
         if (debug) {
@@ -41,11 +48,11 @@ public class DebugOptions {
             if (!LOCALHOST.equals(host)) {
                 args.add("-DdebugHost=" + host);
             }
-            if (mode != DebugMode.listen) {
+            if (mode == DebugMode.connect) {
                 args.add("-Ddebug=client");
-                // TODO: can't set port to listen on in this case.
-            } else if (port != DEFAULT_PORT) {
-                args.add("-Ddebug=" + port);
+            }
+            if (port != DEFAULT_PORT) {
+                args.add("-DdebugPort=" + port);
             }
         } else {
             args.add("-Ddebug=false");

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CreateProjectMixin.java
@@ -100,6 +100,7 @@ public class CreateProjectMixin {
         setValue(ProjectGenerator.PACKAGE_NAME, codeGeneration.packageName);
         setValue(ProjectGenerator.APP_CONFIG, codeGeneration.getAppConfig());
 
+        setValue(CreateProject.NO_CODE, !codeGeneration.includeCode);
         setValue(CreateProject.NO_BUILDTOOL_WRAPPER, !codeGeneration.includeWrapper);
     }
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -7,8 +7,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,11 +24,13 @@ import picocli.CommandLine;
  */
 @Tag("failsOnJDK16")
 public class CliProjectGradleTest {
-    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-project/CliProjectGradleTest");
+    static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("target/test-project/");
+    static final Path workspaceRoot = testProjectRoot.resolve("CliProjectGradleTest");
+    static final Path wrapperRoot = testProjectRoot.resolve("gradle-wrapper");
 
     Path project;
-    File gradle;
+    static File gradle;
 
     @BeforeEach
     public void setupTestDirectories() throws Exception {
@@ -35,37 +38,52 @@ public class CliProjectGradleTest {
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    void startGradleDaemon(boolean useWrapper) throws Exception {
-        if (useWrapper) {
-            gradle = ExecuteUtil.findWrapper(project, GradleRunner.windowsWrapper, GradleRunner.otherWrapper);
-        } else {
-            gradle = ExecuteUtil.findExecutableFile("gradle");
-        }
+    @BeforeAll
+    static void startGradleDaemon() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B",
+                "--no-code",
+                "-o", testProjectRoot.toString(),
+                "gradle-wrapper");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertTrue(result.stdout.contains("SUCCESS"),
+                "Expected confirmation that the project has been created." + result);
+
+        gradle = ExecuteUtil.findWrapper(wrapperRoot, GradleRunner.windowsWrapper, GradleRunner.otherWrapper);
 
         List<String> args = new ArrayList<>();
         args.add(gradle.getAbsolutePath());
         args.add("--daemon");
-        args.add("-q");
-        args.add("--project-dir=" + project.toAbsolutePath());
         CliDriver.preserveLocalRepoSettings(args);
 
-        CliDriver.Result result = CliDriver.executeArbitraryCommand(project, args.toArray(new String[0]));
+        result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
         Assertions.assertEquals(0, result.exitCode, "Gradle daemon should start properly");
     }
 
-    @AfterEach
-    void stopGradleDaemon() throws Exception {
+    @AfterAll
+    static void stopGradleDaemon() throws Exception {
         if (gradle != null) {
-
             List<String> args = new ArrayList<>();
             args.add(gradle.getAbsolutePath());
             args.add("--stop");
-            args.add("--project-dir=" + project.toAbsolutePath());
             CliDriver.preserveLocalRepoSettings(args);
 
-            CliDriver.Result result = CliDriver.executeArbitraryCommand(project, args.toArray(new String[0]));
+            CliDriver.Result result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
             Assertions.assertEquals(0, result.exitCode, "Gradle daemon should stop properly");
         }
+    }
+
+    @Test
+    public void testNoCode() throws Exception {
+        // Inspect the no-code project created to hold the gradle wrapper
+        Assertions.assertTrue(gradle.exists(), "Wrapper should exist");
+
+        Path packagePath = wrapperRoot.resolve("src/main/java/");
+        Assertions.assertTrue(packagePath.toFile().isDirectory(),
+                "Source directory should exist: " + packagePath.toAbsolutePath());
+
+        String[] files = packagePath.toFile().list();
+        Assertions.assertEquals(0, files.length,
+                "Source directory should be empty: " + Arrays.toString(files));
     }
 
     @Test
@@ -85,7 +103,6 @@ public class CliProjectGradleTest {
 
         CliDriver.valdiateGeneratedSourcePackage(project, "org/acme");
 
-        startGradleDaemon(true);
         CliDriver.invokeValidateBuild(project);
     }
 
@@ -119,8 +136,6 @@ public class CliProjectGradleTest {
         CliDriver.valdiateGeneratedSourcePackage(project, "custom/pkg");
         CliDriver.validateApplicationProperties(project, configs);
 
-        startGradleDaemon(true);
-
         result = CliDriver.invokeValidateDryRunBuild(project);
         Assertions.assertTrue(result.stdout.contains("-Dproperty=value1 -Dproperty2=value2"),
                 "result should contain '-Dproperty=value1 -Dproperty2=value2':\n" + result.stdout);
@@ -147,7 +162,6 @@ public class CliProjectGradleTest {
 
         CliDriver.valdiateGeneratedSourcePackage(project, "org/acme");
 
-        startGradleDaemon(true);
         CliDriver.invokeValidateBuild(project);
     }
 
@@ -155,8 +169,6 @@ public class CliProjectGradleTest {
     public void testExtensionList() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
-
-        startGradleDaemon(true);
 
         Path buildGradle = project.resolve("build.gradle");
         String buildGradleContent = CliDriver.readFileAsString(project, buildGradle);
@@ -305,14 +317,17 @@ public class CliProjectGradleTest {
                 "Should contain 'Creating an app', found: " + result.stdout);
         Assertions.assertTrue(result.stdout.contains("GRADLE"),
                 "Should contain MAVEN, found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Omit build tool wrapper   true"),
+
+        // strip spaces to avoid fighting with column whitespace
+        String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
+        Assertions.assertTrue(noSpaces.contains("Omitbuildtoolwrappertrue"),
                 "Should contain 'Omit build tool wrapper   true', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Package Name              custom.pkg"),
-                "Should contain 'Package Name              custom.pkg', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Project ArtifactId        my-project"),
-                "Output should contain 'Project ArtifactId        my-project', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Project GroupId           silly"),
-                "Output should contain 'Project GroupId           silly', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("PackageNamecustom.pkg"),
+                "Should contain 'Package Name   custom.pkg', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("ProjectArtifactIdmy-project"),
+                "Output should contain 'Project ArtifactId   my-project', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("ProjectGroupIdsilly"),
+                "Output should contain 'Project GroupId   silly', found: " + result.stdout);
         Assertions.assertTrue(result.stdout.contains("JAVA"),
                 "Should contain JAVA, found: " + result.stdout);
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -277,8 +277,8 @@ public class CliProjectGradleTest {
                 "gradle command should specify 'GRADLE'\n" + result);
 
         Assertions.assertTrue(
-                result.stdout.contains("-DdebugHost=0.0.0.0 -Ddebug=client"),
-                "gradle command should specify -DdebugHost=0.0.0.0 -Ddebug=client\n" + result);
+                result.stdout.contains("-DdebugHost=0.0.0.0 -Ddebug=client -DdebugPort=8008"),
+                "gradle command should specify -DdebugHost=0.0.0.0 -Ddebug=client -DdebugPort=8008\n" + result);
 
         Assertions.assertFalse(result.stdout.contains("-Dsuspend"),
                 "gradle command should not specify '-Dsuspend'\n" + result);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -273,14 +273,17 @@ public class CliProjectMavenTest {
                 "Should contain 'Creating an app', found: " + result.stdout);
         Assertions.assertTrue(result.stdout.contains("MAVEN"),
                 "Should contain MAVEN, found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Omit build tool wrapper   true"),
+
+        // strip spaces to avoid fighting with column whitespace
+        String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
+        Assertions.assertTrue(noSpaces.contains("Omitbuildtoolwrappertrue"),
                 "Should contain 'Omit build tool wrapper   true', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Package Name              custom.pkg"),
-                "Should contain 'Package Name              custom.pkg', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Project ArtifactId        my-project"),
-                "Output should contain 'Project ArtifactId        my-project', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("Project GroupId           silly"),
-                "Output should contain 'Project GroupId           silly', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("PackageNamecustom.pkg"),
+                "Should contain 'Package Name   custom.pkg', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("ProjectArtifactIdmy-project"),
+                "Output should contain 'Project ArtifactId   my-project', found: " + result.stdout);
+        Assertions.assertTrue(noSpaces.contains("ProjectGroupIdsilly"),
+                "Output should contain 'Project GroupId   silly', found: " + result.stdout);
         Assertions.assertTrue(result.stdout.contains("JAVA"),
                 "Should contain JAVA, found: " + result.stdout);
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -219,8 +219,8 @@ public class CliProjectMavenTest {
                 "quarkus command should specify 'MAVEN'\n" + result);
 
         Assertions.assertTrue(
-                result.stdout.contains("-DdebugHost=0.0.0.0 -Ddebug=client"),
-                "mvn command should specify -DdebugHost=0.0.0.0 -Ddebug=client\n" + result);
+                result.stdout.contains("-DdebugHost=0.0.0.0 -Ddebug=client -DdebugPort=8008"),
+                "mvn command should specify -DdebugHost=0.0.0.0 -Ddebug=client -DdebugPort=8008\n" + result);
 
         Assertions.assertFalse(result.stdout.contains("-Dsuspend"),
                 "mvn command should not specify '-Dsuspend'\n" + result);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -230,7 +230,8 @@ public class QuarkusDev extends QuarkusTask {
                 .buildDir(getBuildDir())
                 .outputDir(getBuildDir())
                 .debug(System.getProperty("debug"))
-                .debugHost(System.getProperty("debugHost", "localhost"))
+                .debugHost(System.getProperty("debugHost"))
+                .debugPort(System.getProperty("debugPort"))
                 .suspend(System.getProperty("suspend"));
         if (System.getProperty(IO_QUARKUS_DEVMODE_ARGS) == null) {
             builder.jvmArgs("-Dquarkus.test.basic-console=true")

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -164,7 +164,9 @@ public class DevMojo extends AbstractMojo {
     /**
      * If this server should be started in debug mode. The default is to start in debug mode and listen on
      * port 5005. Whether or not the JVM is suspended waiting for a debugger to be attached,
-     * depends on the value of {@link #suspend}. {@code debug} supports the following options:
+     * depends on the value of {@link #suspend}.
+     * <p>
+     * {@code debug} supports the following options:
      * <table>
      * <tr>
      * <td><b>Value</b></td>
@@ -176,17 +178,18 @@ public class DevMojo extends AbstractMojo {
      * </tr>
      * <tr>
      * <td><b>true</b></td>
-     * <td>The JVM is started in debug mode and will be listening on port 5005</td>
+     * <td>The JVM is started in debug mode and will be listening on {@code debugHost}:{@code debugPort}</td>
      * </tr>
      * <tr>
      * <td><b>client</b></td>
-     * <td>The JVM is started in client mode, and attempts to connect to localhost:5005</td>
+     * <td>The JVM is started in client mode, and will attempt to connect to {@code debugHost}:{@code debugPort}</td>
      * </tr>
      * <tr>
      * <td><b>{port}</b></td>
-     * <td>The JVM is started in debug mode and will be listening on {port}</td>
+     * <td>The JVM is started in debug mode and will be listening on {@code debugHost}:{port}.</td>
      * </tr>
      * </table>
+     * By default, {@code debugHost} has the value "localhost", and {@code debugPort} is 5005.
      */
     @Parameter(defaultValue = "${debug}")
     private String debug;
@@ -215,6 +218,9 @@ public class DevMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${debugHost}")
     private String debugHost;
+
+    @Parameter(defaultValue = "${debugPort}")
+    private String debugPort;
 
     @Parameter(defaultValue = "${project.build.directory}")
     private File buildDir;
@@ -305,8 +311,6 @@ public class DevMojo extends AbstractMojo {
 
     @Component
     private BuildPluginManager pluginManager;
-
-    private Boolean debugPortOk;
 
     @Component
     private ToolchainManager toolchainManager;
@@ -802,7 +806,7 @@ public class DevMojo extends AbstractMojo {
                 .suspend(suspend)
                 .debug(debug)
                 .debugHost(debugHost)
-                .debugPortOk(debugPortOk)
+                .debugPort(debugPort)
                 .deleteDevJar(deleteDevJar);
 
         setJvmArgs(builder);


### PR DESCRIPTION
Allow specification of a debugPort (old debug={port} will have precedence) to allow specification of host:port for connecting to a remote debugger (client-mode).