### PR TITLE
InfinispanClientProcessor - use logger instead of stdout

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -137,7 +137,9 @@ class InfinispanClientProcessor {
 
                         while (protoFiles.hasNext()) {
                             Path path = protoFiles.next();
-                            System.out.println("  " + path.toAbsolutePath());
+                            if (log.isDebugEnabled()) {
+                                log.debug("  " + path.toAbsolutePath());
+                            }
                             byte[] bytes = Files.readAllBytes(path);
                             // This uses the default file encoding - should we enforce UTF-8?
                             properties.put(InfinispanClientProducer.PROTOBUF_FILE_PREFIX + path.getFileName().toString(),


### PR DESCRIPTION
InfinispanClientProcessor - use logger instead of stdout

logger is already used in InfinispanClientProcessor, logging on debug level as https://github.com/quarkusio/quarkus/pull/8001/files#diff-9b3c084c3ece3bb0a1ef7a69edb5719fe49c6bc948a634d97d967e4edddeac85R141 looks like helper print. 