### PR TITLE
Drop .adoc from links between Quarkus guides

### DIFF
--- a/docs/src/main/asciidoc/dev-mode-differences.adoc
+++ b/docs/src/main/asciidoc/dev-mode-differences.adoc
@@ -19,7 +19,7 @@ during development but should *NEVER* be used in production.
 
 Feature sets aside, the Quarkus application that is run under dev-mode differs architecturally from the production application (i.e. the one that is run using `java -jar ...`).
 
-In dev-mode, Quarkus uses a ClassLoader hierarchy (explained in detail link:class-loading-reference.adoc[here]) that enables the live reload of user code
+In dev-mode, Quarkus uses a ClassLoader hierarchy (explained in detail link:class-loading-reference[here]) that enables the live reload of user code
 without requiring a rebuild and restart of the application.
 
 In a production application, the aforementioned class loading infrastructure is entirely absent - there is a single, purpose built ClassLoader that loads (almost) all classes and dependencies.
@@ -34,7 +34,7 @@ This mightily important feature needs no introduction and has already been menti
 
 === Dev UI
 
-Quarkus provides a very useful link:dev-ui.adoc[UI] accessible from the browser at `/q/dev`. This UI allows a developer to see the state of the application, but
+Quarkus provides a very useful link:dev-ui[UI] accessible from the browser at `/q/dev`. This UI allows a developer to see the state of the application, but
 also provides access to various actions that can change that state (depending on the extensions that are present).
 Examples of such operations are:
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -163,7 +163,7 @@ You can install all extensions which match a globbing pattern:
 [[dev-mode]]
 == Development mode
 
-Quarkus comes with a built-in development mode. The best way to run this is via the link:cli-tooling.adoc[Quarkus CLI]
+Quarkus comes with a built-in development mode. The best way to run this is via the link:cli-tooling[Quarkus CLI]
 Run your application with:
 
 [source,bash]

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -287,7 +287,7 @@ The default priority, used if the interceptor does not implement the `Prioritize
 == Testing your services
 
 The easiest way to test a gRPC service is to use a gRPC client as described
-in link:./grpc-service-consumption.adoc[Consuming a gRPC Service].
+in link:grpc-service-consumption[Consuming a gRPC Service].
 
 Please note that in the case of using a client to test an exposed service that does not use TLS,
 there is no need to provide any configuration. E.g. to test the `HelloService`

--- a/docs/src/main/asciidoc/grpc.adoc
+++ b/docs/src/main/asciidoc/grpc.adoc
@@ -24,6 +24,6 @@ It:
 
 Quarkus gRPC is based on https://vertx.io/docs/vertx-grpc/java/[Vert.x gRPC].
 
-* link:./grpc-getting-started.adoc[Getting Started]
-* link:./grpc-service-implementation.adoc[Implementing a gRPC Service]
-* link:./grpc-service-consumption.adoc[Consuming a gRPC Service]
+* link:grpc-getting-started[Getting Started]
+* link:grpc-service-implementation[Implementing a gRPC Service]
+* link:grpc-service-consumption[Consuming a gRPC Service]

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -11,7 +11,7 @@ This guide shows how your Quarkus application can use Apache Kafka, http://avro.
 records, and connect to a schema registry (such as the https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry] or https://www.apicur.io/registry/[Apicurio Registry].
 
 If you are not familiar with Kafka and Kafka in Quarkus in particular, consider
-first going through the link:kafka.adoc[Using Apache Kafka with Reactive Messaging] guide.
+first going through the link:kafka[Using Apache Kafka with Reactive Messaging] guide.
 
 == Prerequisites
 
@@ -530,7 +530,7 @@ To run it, execute `mvn verify -Dnative`, or `mvn clean install -Dnative`
 
 === Manual setup
 
-If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio Registry instance manually, we would define a link:getting-started-testing.adoc#quarkus-test-resource[QuarkusTestResourceLifecycleManager].
+If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio Registry instance manually, we would define a link:getting-started-testing#quarkus-test-resource[QuarkusTestResourceLifecycleManager].
 
 [source,xml]
 ----

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -71,7 +71,7 @@ mp.messaging.incoming.prices.connector=smallrye-kafka <2>
 ----
 
 <1> Configure the broker location for the production profile. You can configure it globally or per channel using `mp.messaging.incoming.$channel.bootstrap.servers` property.
-In dev mode and when running tests, link:kafka-dev-services.adoc[Dev Services for Kafka] automatically starts a Kafka broker.
+In dev mode and when running tests, link:kafka-dev-services[Dev Services for Kafka] automatically starts a Kafka broker.
 When not provided this property defaults to `localhost:9092`.
 <2> Configure the connector to manage the prices channel. By default the topic name is same as the channel name. You can configure the topic attribute to override it.
 
@@ -552,7 +552,7 @@ mp.messaging.outgoing.prices-out.topic=prices <3>
 ----
 
 <1> Configure the broker location for the production profile. You can configure it globally or per channel using `mp.messaging.outgoing.$channel.bootstrap.servers` property.
-In dev mode and when running tests, link:kafka-dev-services.adoc[Dev Services for Kafka] automatically starts a Kafka broker.
+In dev mode and when running tests, link:kafka-dev-services[Dev Services for Kafka] automatically starts a Kafka broker.
 When not provided this property defaults to `localhost:9092`.
 <2> Configure the connector to manage the prices channel.
 <3> By default the topic name is same as the channel name. You can configure the topic attribute to override it.
@@ -1162,7 +1162,7 @@ that will deserialize to a `io.vertx.core.json.JsonObject`. The corresponding se
 
 == Avro Serialization
 
-This is described in a dedicated guide: link:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro].
+This is described in a dedicated guide: link:kafka-schema-registry-avro[Using Apache Kafka with Schema Registry and Avro].
 
 [[serialization-autodetection]]
 == Serializer/deserializer autodetection
@@ -1221,7 +1221,7 @@ The full set of types supported by the serializer/deserializer autodetection is:
 * `io.vertx.core.json.JsonObject`
 * `io.vertx.core.json.JsonArray`
 * classes generated from Avro schemas, if Confluent or Apicurio _serde_ is present
-** see link:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio libraries
+** see link:kafka-schema-registry-avro[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio libraries
 * classes for which a subclass of `ObjectMapperSerializer` / `ObjectMapperDeserializer` is present, as described in <<jackson-serialization>>
 ** it is technically not needed to subclass `ObjectMapperSerializer`, but in such case, autodetection isn't possible
 * classes for which a subclass of `JsonbSerializer` / `JsonbDeserializer` is present, as described in <<jsonb-serialization>>
@@ -1233,7 +1233,7 @@ If you find you need to do this, please file a bug in the link:https://github.co
 
 == Using Schema Registry
 
-This is described in a dedicated guide: link:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro].
+This is described in a dedicated guide: link:kafka-schema-registry-avro[Using Apache Kafka with Schema Registry and Avro].
 
 [[kafka-health-check]]
 == Health Checks
@@ -1279,7 +1279,7 @@ Note that, to achieve this, an _admin connection_ is required.
 
 == Kafka Streams
 
-This is described in a dedicated guide: link:kafka-streams.adoc[Using Apache Kafka Streams].
+This is described in a dedicated guide: link:kafka-streams[Using Apache Kafka Streams].
 
 == Using Snappy for message compression
 
@@ -1447,7 +1447,7 @@ include::kafka-dev-services.adoc[leveloffset=+1]
 == Kubernetes Service Bindings
 
 Quarkus Kafka extension supports
-link:deploying-to-kubernetes.adoc[Service Binding Specification for Kubernetes].
+link:deploying-to-kubernetes[Service Binding Specification for Kubernetes].
 You can enable this by adding the `quarkus-kubernetes-service-binding` extension to your application.
 
 When running in appropriately configured Kubernetes clusters, Kafka extension will pull its Kafka broker connection configuration from the service binding available inside the cluster, without the need for user configuration.

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -593,7 +593,7 @@ The client to be created are configured using the usual <<config-reference,Redis
 
 [NOTE]
 ====
-This is useful to create a client dynamically in a non-CDI bean e.g a link:hibernate-orm-panache.adoc[Panache entity].
+This is useful to create a client dynamically in a non-CDI bean e.g a link:hibernate-orm-panache[Panache entity].
 Or to create a different client when running in pub/sub mode. This mode requires two different connections
 because once a connection invokes a subscriber mode then it cannot be used for running other commands
 than the command to leave that mode.

--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -10,7 +10,7 @@ include::./attributes.adoc[]
 This guide explains how to use the REST Client Reactive in order to interact with REST APIs.
 REST Client Reactive is a non-blocking counterpart of the RESTEasy REST Client.
 
-If your application uses a client and exposes REST endpoints, please use link:resteasy-reactive.adoc[RESTEasy Reactive]
+If your application uses a client and exposes REST endpoints, please use link:resteasy-reactive[RESTEasy Reactive]
 for the server part.
 
 == Prerequisites
@@ -623,7 +623,7 @@ You can also generate the native executable with `./mvnw clean package -Pnative`
 == Using a Mock HTTP Server for tests
 
 For tests, you can easily mock the HTTP server with Wiremock.
-The link:rest-client.adoc#using-a-mock-http-server-for-tests[Wiremock section of the Quarkus - Using the REST Client]
+The link:rest-client#using-a-mock-http-server-for-tests[Wiremock section of the Quarkus - Using the REST Client]
 describes how to set it up in detail.
 
 == Known limitations

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1904,4 +1904,4 @@ In addition to the Server side, RESTEasy Reactive comes with a new MicroProfile 
 
 Please note that the `quarkus-rest-client` extension may not work properly with RESTEasy Reactive.
 
-See link:rest-client-reactive.adoc[REST Client Reactive Guide] for more information about the reactive client.
+See link:rest-client-reactive[REST Client Reactive Guide] for more information about the reactive client.


### PR DESCRIPTION
Drop .adoc from links between Quarkus guides.

People get 404 error now when they click on these links in Quarkus guides