### PR TITLE
[OpenTelemetry OTLP Exporter extension] Add support for gRPC headers

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -114,11 +114,14 @@ The first approach is by providing the properties within the `src/main/resources
 quarkus.application.name=myservice // <1>
 quarkus.opentelemetry.enabled=true // <2>
 quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680 // <3>
+
+quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret // <4>
 ----
 
 <1> All spans created from the application will include an OpenTelemetry `Resource` indicating the span was created by the `myservice` application. If not set, it will default to the artifact id.
 <2> Whether OpenTelemetry is enabled or not. The default is `true`, but shown here to indicate how it can be disabled
-<3> gRPC endpoint for sending spans.
+<3> gRPC endpoint for sending spans
+<4> Optional gRPC headers commonly used for authentication
 
 == Run the application
 

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/OtlpExporterConfig.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/OtlpExporterConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.opentelemetry.exporter.otlp.runtime;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -28,6 +29,17 @@ public class OtlpExporterConfig {
         public Optional<String> endpoint;
 
         /**
+         * Key-value pairs to be used as headers associated with gRPC requests.
+         * The format is similar to the {@code OTEL_EXPORTER_OTLP_HEADERS} environment variable,
+         * a list of key-value pairs separated by the "=" character.
+         * See <a href=
+         * "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
+         * Specifying headers</a> for more details.
+         */
+        @ConfigItem()
+        Optional<List<String>> headers;
+
+        /**
          * The maximum amount of time to wait for the collector to process exported spans before an exception is thrown.
          * A value of `0` will disable the timeout: the exporter will continue waiting until either exported spans are
          * processed,
@@ -35,5 +47,6 @@ public class OtlpExporterConfig {
          */
         @ConfigItem(defaultValue = "10S")
         public Duration exportTimeout;
+
     }
 }

--- a/extensions/opentelemetry/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/runtime/pom.xml
@@ -58,6 +58,17 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.opentelemetry.runtime;
 
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -47,5 +49,25 @@ public final class OpenTelemetryUtil {
                 .collect(Collectors.toSet());
 
         return ContextPropagators.create(TextMapPropagator.composite(selectedPropagators));
+    }
+
+    /**
+     * Converts a list of "key=value" pairs into a map.
+     * Empty entries will be removed.
+     * In case of duplicate keys, the latest takes precedence.
+     *
+     * @param headers nullable list of "key=value" pairs
+     * @return non null map of key-value pairs
+     */
+    public static Map<String, String> convertKeyValueListToMap(List<String> headers) {
+        if (headers == null) {
+            return new LinkedHashMap();
+        }
+
+        return headers.stream()
+                .filter(header -> !header.isEmpty())
+                .map(keyValuePair -> keyValuePair.split("=", 2))
+                .map(keyValuePair -> new AbstractMap.SimpleImmutableEntry<>(keyValuePair[0].trim(), keyValuePair[1].trim()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (first, next) -> next, LinkedHashMap::new));
     }
 }

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
@@ -1,16 +1,13 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
-import java.util.AbstractMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.quarkus.opentelemetry.runtime.OpenTelemetryUtil;
 
 public class TracerUtil {
     private TracerUtil() {
@@ -19,11 +16,7 @@ public class TracerUtil {
     public static Resource mapResourceAttributes(List<String> resourceAttributes) {
         AttributesBuilder attributesBuilder = Attributes.builder();
 
-        resourceAttributes.stream()
-                .map(keyValuePair -> keyValuePair.split("=", 2))
-                .map(keyValuePair -> new AbstractMap.SimpleImmutableEntry<>(keyValuePair[0].trim(), keyValuePair[1].trim()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (first, next) -> next, LinkedHashMap::new))
-                .forEach(attributesBuilder::put);
+        OpenTelemetryUtil.convertKeyValueListToMap(resourceAttributes).forEach(attributesBuilder::put);
 
         return Resource.create(attributesBuilder.build());
     }

--- a/extensions/opentelemetry/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtilTest.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtilTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.opentelemetry.runtime;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OpenTelemetryUtilTest {
+
+    @Test
+    public void testConvertKeyValueListToMap() {
+        Map<String, String> actual = OpenTelemetryUtil
+                .convertKeyValueListToMap(Arrays.asList(
+                        "service.name=myservice",
+                        "service.version=1.0",
+                        "deployment.environment=production"));
+        Assertions.assertThat(actual).containsExactly(
+                new AbstractMap.SimpleEntry<>("service.name", "myservice"),
+                new AbstractMap.SimpleEntry<>("service.version", "1.0"),
+                new AbstractMap.SimpleEntry<>("deployment.environment", "production"));
+    }
+
+    @Test
+    public void testConvertKeyValueListToMap_skip_empty_values() {
+        Map<String, String> actual = OpenTelemetryUtil
+                .convertKeyValueListToMap(Arrays.asList(
+                        "service.name=myservice",
+                        "service.version=1.0",
+                        "deployment.environment=production",
+                        ""));
+        Assertions.assertThat(actual).containsExactly(
+                new AbstractMap.SimpleEntry<>("service.name", "myservice"),
+                new AbstractMap.SimpleEntry<>("service.version", "1.0"),
+                new AbstractMap.SimpleEntry<>("deployment.environment", "production"));
+    }
+
+    @Test
+    public void testConvertKeyValueListToMap_last_value_takes_precedence() {
+        Map<String, String> actual = OpenTelemetryUtil
+                .convertKeyValueListToMap(Arrays.asList(
+                        "service.name=myservice to be overwritten",
+                        "service.version=1.0",
+                        "deployment.environment=production",
+                        "service.name=myservice",
+                        ""));
+        Assertions.assertThat(actual).containsExactly(
+                new AbstractMap.SimpleEntry<>("service.name", "myservice"),
+                new AbstractMap.SimpleEntry<>("service.version", "1.0"),
+                new AbstractMap.SimpleEntry<>("deployment.environment", "production"));
+    }
+
+    @Test
+    public void testConvertKeyValueListToMap_empty_value() {
+        Map<String, String> actual = OpenTelemetryUtil
+                .convertKeyValueListToMap(Collections.emptyList());
+        Assertions.assertThat(actual).containsExactly();
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+public class TracerUtilTest {
+
+    @Test
+    public void testMapResourceAttributes() {
+        List<String> resourceAttributes = Arrays.asList(
+                "service.name=myservice",
+                "service.namespace=mynamespace",
+                "service.version=1.0",
+                "deployment.environment=production");
+        Resource resource = TracerUtil.mapResourceAttributes(resourceAttributes);
+        Attributes attributes = resource.getAttributes();
+        Assertions.assertThat(attributes.size()).isEqualTo(4);
+        Assertions.assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("myservice");
+        Assertions.assertThat(attributes.get(ResourceAttributes.SERVICE_NAMESPACE)).isEqualTo("mynamespace");
+        Assertions.assertThat(attributes.get(ResourceAttributes.SERVICE_VERSION)).isEqualTo("1.0");
+        Assertions.assertThat(attributes.get(ResourceAttributes.DEPLOYMENT_ENVIRONMENT)).isEqualTo("production");
+    }
+}


### PR DESCRIPTION
The OTLP protocol extensively uses gRPC headers for authentication. The headers configuration is known in the [OpenTelemetry exporter specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md) as the `OTEL_EXPORTER_OTLP_HEADERS` environment variable.

This Pull Request addq support for configuring headers on the OTLP gRPC Exporter of the OpenTelemetry extension introducing a new config entry `quarkus.opentelemetry.tracer.exporter.otlp.headers`.

Change successfully tested with Elastic Observability that requires an `Authorization=Bearer ...` gRPC header. 
The `application.properties` file looks like:

```
quarkus.application.name=myservice3
quarkus.opentelemetry.enabled=true
quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:8200
quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret_token
```
