### PR TITLE
Use a different signature for registerSubstitution

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -194,7 +194,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
 
     @Override
     public <F, T> void registerSubstitution(Class<F> from, Class<T> to,
-            Class<? extends ObjectSubstitution<F, T>> substitution) {
+            Class<? extends ObjectSubstitution<? super F, ? super T>> substitution) {
         substitutions.put(from, new SubstitutionHolder(from, to, substitution));
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
@@ -30,7 +30,8 @@ public interface RecorderContext {
      * @param to The class to serialize to
      * @param substitution The subclass of {@link ObjectSubstitution} that performs the substitution
      */
-    <F, T> void registerSubstitution(Class<F> from, Class<T> to, Class<? extends ObjectSubstitution<F, T>> substitution);
+    <F, T> void registerSubstitution(Class<F> from, Class<T> to,
+            Class<? extends ObjectSubstitution<? super F, ? super T>> substitution);
 
     /**
      * Register an object loader.


### PR DESCRIPTION
This allows for a single substitution object to handle a whole heirachy.