### PR TITLE
Mark @MockServer as deprecated

### DIFF
--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/MockServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/MockServer.java
@@ -10,7 +10,10 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 /**
  * Used to specify that the field should be injected with the mock Kubernetes API server
  * Can only be used on type {@link KubernetesMockServer}
+ *
+ * @deprecated use {@link KubernetesTestServer}
  */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface MockServer {


### PR DESCRIPTION
The backing class (`KubernetesMockServerTestResource`) has already been
deprecated, so let's deprecate the annotation as well