### PR TITLE
Re-enable two rest-client tcks tests on Java 16 after upgrade to RESTEasy 4.7.0

### DIFF
--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -187,10 +187,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <!-- fails with " module java.base does not "opens java.lang.invoke" to unnamed module" -->
-                                <exclude>org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest</exclude>
                                 <!-- the following tests fail for yet unknown reasons (assertion failures) -->
-                                <exclude>org.eclipse.microprofile.rest.client.tck.InvalidInterfaceTest</exclude>
                                 <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest</exclude>
                                 <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest</exclude>
                                 <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest</exclude>


### PR DESCRIPTION
Reminder: CI doesn't run those tests with Java 16 at all, it will only be run in the nightly EA job which is using Java 17 already.
CI only runs the "JVM tests" on Java 16.

Those timeout tests still fail on Java 16, with e.g.:
```
Elapsed time expected under 35 secs, but was 40 secs.
```
Any clue why @asoldano @jamezp? Are there any known limitiations for Java 16?

Relates to #17093