### PR TITLE
Remove loglevel property for generated gradle project

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/gradle.tpl.qute.properties
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/gradle.tpl.qute.properties
@@ -4,5 +4,3 @@ quarkusPluginVersion={quarkus.gradle-plugin.version}
 quarkusPlatformGroupId={quarkus.platform.group-id}
 quarkusPlatformArtifactId={quarkus.platform.artifact-id}
 quarkusPlatformVersion={quarkus.platform.version}
-
-org.gradle.logging.level=INFO

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -313,10 +313,6 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         assertThat(new File(testDir, "gradle/wrapper")).isDirectory();
         assertThat(new File(testDir, "src/main/kotlin")).isDirectory();
 
-        File gradleProperties = new File(testDir, "gradle.properties");
-        assertThat(gradleProperties).isFile();
-        check(gradleProperties, "org.gradle.logging.level=INFO");
-
         check(new File(testDir, "src/main/kotlin/org/acme/MyResource.kt"), "package org.acme");
 
         assertThat(FileUtils.readFileToString(new File(testDir, "build.gradle"), "UTF-8"))


### PR DESCRIPTION
By default, we used to set the loglevel to `INFO` in the `gradle.properties` file of generated project. This removes the property.

close #18579 