### PR TITLE
Allow creating a Kafka ObjectMapperDeserializer with a TypeReference

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperDeserializer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperDeserializer.java
@@ -7,11 +7,14 @@ import java.util.Map;
 
 import org.apache.kafka.common.serialization.Deserializer;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public class ObjectMapperDeserializer<T> implements Deserializer<T> {
 
-    private final Class<T> type;
+    private final JavaType type;
     private final ObjectMapper objectMapper;
 
     public ObjectMapperDeserializer(Class<T> type) {
@@ -19,7 +22,16 @@ public class ObjectMapperDeserializer<T> implements Deserializer<T> {
     }
 
     public ObjectMapperDeserializer(Class<T> type, ObjectMapper objectMapper) {
-        this.type = type;
+        this.type = TypeFactory.defaultInstance().constructType(type);
+        this.objectMapper = objectMapper;
+    }
+
+    public ObjectMapperDeserializer(TypeReference<T> typeReference) {
+        this(typeReference, ObjectMapperProducer.get());
+    }
+
+    public ObjectMapperDeserializer(TypeReference<T> typeReference, ObjectMapper objectMapper) {
+        this.type = TypeFactory.defaultInstance().constructType(typeReference);
         this.objectMapper = objectMapper;
     }
 

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/CodecEndpoint.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/CodecEndpoint.java
@@ -2,6 +2,7 @@ package io.quarkus.it.kafka.codecs;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import javax.annotation.PostConstruct;
@@ -54,10 +55,28 @@ public class CodecEndpoint {
         return new KafkaProducer<>(props);
     }
 
+    public Producer<String, List<Person>> createPersonListProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "person-list");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonbSerializer.class.getName());
+        return new KafkaProducer<>(props);
+    }
+
     public Producer<String, Movie> createMovieProducer() {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "movie");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectMapperSerializer.class.getName());
+        return new KafkaProducer<>(props);
+    }
+
+    public Producer<String, List<Movie>> createMovieListProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "movie-list");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectMapperSerializer.class.getName());
         return new KafkaProducer<>(props);
@@ -89,6 +108,19 @@ public class CodecEndpoint {
         return consumer;
     }
 
+    public KafkaConsumer<String, List<Person>> createPersonListConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "person-list");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, PersonListDeserializer.class.getName());
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        KafkaConsumer<String, List<Person>> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(Collections.singletonList("person-list"));
+        return consumer;
+    }
+
     public KafkaConsumer<String, Movie> createMovieConsumer() {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
@@ -102,12 +134,29 @@ public class CodecEndpoint {
         return consumer;
     }
 
+    public KafkaConsumer<String, List<Movie>> createMovieListConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bs);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "movie-list");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MovieListDeserializer.class.getName());
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        KafkaConsumer<String, List<Movie>> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(Collections.singletonList("movie-list"));
+        return consumer;
+    }
+
     private Producer<String, Pet> petProducer;
     private Producer<String, Person> personProducer;
     private Consumer<String, Pet> petConsumer;
     private Consumer<String, Person> personConsumer;
     private KafkaConsumer<String, Movie> movieConsumer;
     private Producer<String, Movie> movieProducer;
+    private Producer<String, List<Person>> personListProducer;
+    private Consumer<String, List<Person>> personListConsumer;
+    private Producer<String, List<Movie>> movieListProducer;
+    private Consumer<String, List<Movie>> movieListConsumer;
 
     @PostConstruct
     public void create() {
@@ -117,6 +166,10 @@ public class CodecEndpoint {
         personConsumer = createPersonConsumer();
         movieProducer = createMovieProducer();
         movieConsumer = createMovieConsumer();
+        personListProducer = createPersonListProducer();
+        personListConsumer = createPersonListConsumer();
+        movieListProducer = createMovieListProducer();
+        movieListConsumer = createMovieListConsumer();
     }
 
     @POST
@@ -134,10 +187,24 @@ public class CodecEndpoint {
     }
 
     @POST
+    @Path("/person-list")
+    public void postListOfPersons(List<Person> persons) {
+        personListProducer.send(new ProducerRecord<>("person-list", persons));
+        personListProducer.flush();
+    }
+
+    @POST
     @Path("/movies")
     public void post(Movie movie) {
         movieProducer.send(new ProducerRecord<>("movies", movie));
         movieProducer.flush();
+    }
+
+    @POST
+    @Path("/movie-list")
+    public void postListOfMovies(List<Movie> movies) {
+        movieListProducer.send(new ProducerRecord<>("movie-list", movies));
+        movieListProducer.flush();
     }
 
     @GET
@@ -161,9 +228,29 @@ public class CodecEndpoint {
     }
 
     @GET
+    @Path("/person-list")
+    public List<Person> listPersons() {
+        final ConsumerRecords<String, List<Person>> records = personListConsumer.poll(Duration.ofMillis(60000));
+        if (records.isEmpty()) {
+            return null;
+        }
+        return records.iterator().next().value();
+    }
+
+    @GET
     @Path("/movies")
     public Movie getMovie() {
         final ConsumerRecords<String, Movie> records = movieConsumer.poll(Duration.ofMillis(60000));
+        if (records.isEmpty()) {
+            return null;
+        }
+        return records.iterator().next().value();
+    }
+
+    @GET
+    @Path("/movie-list")
+    public List<Movie> listMovie() {
+        final ConsumerRecords<String, List<Movie>> records = movieListConsumer.poll(Duration.ofMillis(60000));
         if (records.isEmpty()) {
             return null;
         }

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/MovieListDeserializer.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/MovieListDeserializer.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.kafka.codecs;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
+
+public class MovieListDeserializer extends ObjectMapperDeserializer<List<Movie>> {
+    public MovieListDeserializer() {
+        super(new TypeReference<List<Movie>>() {
+        });
+    }
+}

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/PersonListDeserializer.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/codecs/PersonListDeserializer.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.kafka.codecs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+
+public class PersonListDeserializer extends JsonbDeserializer<List<Person>> {
+    public PersonListDeserializer() {
+        super(new ArrayList<Person>() {
+        }.getClass().getGenericSuperclass());
+    }
+}

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
@@ -66,4 +66,47 @@ public class KafkaCodecTest {
 
     }
 
+    @Test
+    public void testJsonbCodecWithList() {
+        RestAssured
+                .given()
+                .header("Content-Type", "application/json")
+                .body("[{\"name\":\"kate\", \"id\":\"1234\"},{\"name\":\"john\", \"id\":\"2345\"}]")
+                .post("/codecs/person-list");
+
+        RestAssured
+                .given()
+                .header("Accept", "application/json")
+                .get("/codecs/person-list")
+                .then()
+                .body("size()", is(2))
+                .body("[0].name", is("kate"))
+                .body("[0].id", is(1234))
+                .body("[1].name", is("john"))
+                .body("[1].id", is(2345));
+        ;
+
+    }
+
+    @Test
+    public void testJacksonCodecWithList() {
+        RestAssured
+                .given()
+                .header("Content-Type", "application/json")
+                .body("[{\"title\":\"Inception\", \"year\":\"2010\"},{\"title\":\"Terminator\", \"year\":\"1984\"}]")
+                .post("/codecs/movie-list");
+
+        RestAssured
+                .given()
+                .header("Accept", "application/json")
+                .get("/codecs/movie-list")
+                .then()
+                .body("size()", is(2))
+                .body("[0].title", is("Inception"))
+                .body("[0].year", is(2010))
+                .body("[1].title", is("Terminator"))
+                .body("[1].year", is(1984));
+
+    }
+
 }


### PR DESCRIPTION
This is needed to handle more complex deserialization features, like deserializing to a collection type.

This is the same as what has been done to the JsonDeserializer that now accept to be created based on a `Type` and not only a class.

Note that Jackson also allows to deserialize thanks to a `JavaType` and a `ResolvedType`, not sure those needs to be supported by Quarkus. Using a `TypeReference` allows to deserialize to a collection which is the most common use case.