### PR TITLE
Use bright blue instead of plain blue in the console

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/MessageFormat.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/MessageFormat.java
@@ -4,7 +4,7 @@ public class MessageFormat {
 
     public static final String RED = "\u001B[91m";
     public static final String GREEN = "\u001b[32m";
-    public static final String BLUE = "\u001b[34m";
+    public static final String BLUE = "\u001b[94m";
     public static final String RESET = "\u001b[39m";
     public static final String UNDERLINE = "\u001b[4m";
     public static final String NO_UNDERLINE = "\u001b[24m";


### PR DESCRIPTION
This color is much easier to read for me on dark background,
while still perfectly readable on light background. It also
seems to be what Maven uses for highlighting its log level
(though they also make it bold).