### PR TITLE
Solution for errors with self-signed certificate

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -75,6 +75,15 @@ Building is handled by the link:container-image#s2i[container-image-s2i] extensi
 
 The build that will be performed is an s2i binary build. The input of the build is the jar that has been built locally and the output of the build is an ImageStream that is configured to automatically trigger a deployment.
 
+[NOTE]
+====
+During the build you may find the `Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed` exception due to self-signed certificate. To solve this, just add the following line to your `application.properties`:
+```properties
+quarkus.kubernetes-client.trust-certs=true
+```
+For more information, see link:https://quarkus.io/guides/deploying-to-kubernetes#client-connection-configuration[deploying to kubernetes].
+====
+
 To deploy the container image created in the above step to OpenShift, follow these commands:
 [source,bash,subs=attributes+]
 ----


### PR DESCRIPTION
When using an OpenShift with a self-signed certificate, we may find the following stack trace:

```java
Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
    at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
    at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1946)
    at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:316)
    at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:310)
        at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1639)
```

To solve this we need to add `quarkus.kubernetes-client.trust-certs=true` to the `application properties`. Feel free to improve the English text and formatting style.