### PR TITLE
Bump gradle version used in codestart

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -7,7 +7,7 @@ language:
   base:
     data:
       gradle:
-        version: 6.8.3
+        version: 6.9
     shared-data:
       buildtool:
         cli: ./gradlew

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -314,7 +314,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "proposed-maven-version": "3.8.1",
         "maven-wrapper-version": "0.7.7",
-        "gradle-wrapper-version": "6.8.3"
+        "gradle-wrapper-version": "6.9"
       }
     },
     "codestarts-artifacts": [


### PR DESCRIPTION
This update the version of the gradle wrapper used by codestart for project generation (it has already been updated in all other places).