### PR TITLE
Get BasicAuthenticationMechanism ordered first so that Basic challenge is sent when equal auth methods exist

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -122,11 +122,36 @@ application this will fail (as you cannot do blocking operations on the IO threa
 `Uni<SecurityIdentity> getDeferredIdentity();` method. You can then subscribe to the resulting `Uni` and will be notified
 when authentication is complete and the identity is available.
 
-[NOTE]
-====
+=== How to customize authentication exception responses
+
 By default the authentication security constraints are enforced before the JAX-RS chain starts.
-Disabling the proactive authentication effectively shifts this process to the moment when the JAX-RS chain starts running thus making it possible to use JAX-RS `ExceptionMapper` to capture Quarkus Security authentication exceptions such as `io.quarkus.security.AuthenticationFailedException` if required.
-====
+Disabling the proactive authentication effectively shifts this process to the moment when the JAX-RS chain starts running thus making it possible to use JAX-RS `ExceptionMapper` to capture Quarkus Security authentication exceptions such as `io.quarkus.security.AuthenticationFailedException`, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.quarkus.security.AuthenticationFailedException;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class AuthenticationFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public Response toResponse(AuthenticationFailedException exception) {
+        return Response.status(401).header("WWW-Authenticate", "Basic realm=\"Quarkus\"").build();
+    }
+}
+----
 
 == References
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
@@ -195,4 +195,9 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
     public HttpCredentialTransport getCredentialTransport() {
         return new HttpCredentialTransport(HttpCredentialTransport.Type.AUTHORIZATION, BASIC);
     }
+
+    @Override
+    public int getPriority() {
+        return 2000;
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
@@ -14,6 +14,8 @@ import io.vertx.ext.web.RoutingContext;
  */
 public interface HttpAuthenticationMechanism {
 
+    int DEFAULT_PRIORITY = 1000;
+
     Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager);
 
     Uni<ChallengeData> getChallenge(RoutingContext context);
@@ -54,5 +56,21 @@ public interface HttpAuthenticationMechanism {
             }
             return true;
         }
+    }
+
+    /**
+     * Returns a priority which determines in which order HttpAuthenticationMechanisms handle the authentication and challenge
+     * requests
+     * when it is not possible to select the best candidate authentication mechanism based on the request credentials or path
+     * specific
+     * configuration.
+     *
+     * Multiple mechanisms are sorted in descending order, so highest priority gets the first chance to send a challenge. The
+     * default priority is equal to 1000.
+     *
+     * @return priority
+     */
+    default int getPriority() {
+        return DEFAULT_PRIORITY;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.security;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,13 @@ public class HttpAuthenticator {
         if (mechanisms.isEmpty()) {
             this.mechanisms = new HttpAuthenticationMechanism[] { new NoAuthenticationMechanism() };
         } else {
+            Collections.sort(mechanisms, new Comparator<HttpAuthenticationMechanism>() {
+                @Override
+                public int compare(HttpAuthenticationMechanism mech1, HttpAuthenticationMechanism mech2) {
+                    //descending order
+                    return Integer.compare(mech2.getPriority(), mech1.getPriority());
+                }
+            });
             this.mechanisms = mechanisms.toArray(new HttpAuthenticationMechanism[mechanisms.size()]);
             //validate that we don't have multiple incompatible mechanisms
             Map<HttpCredentialTransport, HttpAuthenticationMechanism> map = new HashMap<>();

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/AuthenticationCompletionExceptionMapper.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/AuthenticationCompletionExceptionMapper.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.quarkus.security.AuthenticationCompletionException;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<AuthenticationCompletionException> {
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public Response toResponse(AuthenticationCompletionException exception) {
+        return Response.status(401).header("RedirectUri", uriInfo.getAbsolutePath().toString()).build();
+    }
+
+}

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -553,6 +553,8 @@ public class CodeFlowTest {
                 fail("401 status error is expected: " + page.getBody().asText());
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());
+                assertEquals("http://localhost:8081/web-app/callback-before-wrong-redirect",
+                        ex.getResponse().getResponseHeaderValue("RedirectUri"));
             }
             webClient.getCookieManager().clearCookies();
         }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -70,6 +70,16 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testBasicAuthWrongPassword() {
+        RestAssured.given().auth()
+                .preemptive().basic("alice", "wrongpassword")
+                .when().get("/api/users/me")
+                .then()
+                .statusCode(401)
+                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
+    }
+
+    @Test
     public void testSecureAccessSuccessPreferredUsername() {
         for (String username : Arrays.asList("alice", "jdoe", "admin")) {
             RestAssured.given().auth().oauth2(getAccessToken(username))
@@ -131,11 +141,11 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
-    public void testVerificationFailedNoBearerToken() {
+    public void testVerificationFailedNoBearerTokenAndBasicCreds() {
         RestAssured.given()
                 .when().get("/api/users/me").then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("Bearer"));
+                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
     }
 
     @Test
@@ -161,7 +171,8 @@ public class BearerTokenAuthorizationTest {
         RestAssured.given().auth().oauth2(getAccessToken("alice"))
                 .when().get("/basic-only")
                 .then()
-                .statusCode(401);
+                .statusCode(401)
+                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
     }
 
     @Test
@@ -179,11 +190,12 @@ public class BearerTokenAuthorizationTest {
         RestAssured.given().auth().preemptive().basic("alice", "password")
                 .when().get("/bearer-only")
                 .then()
-                .statusCode(401);
+                .statusCode(401)
+                .header("WWW-Authenticate", equalTo("Bearer"));
     }
 
     @Test
-    public void testBearerAuthWhereBasicIsRequired() {
+    public void testBearerAuthWhereBearerIsRequired() {
         RestAssured.given().auth().oauth2(getAccessToken("alice"))
                 .when().get("/bearer-only")
                 .then()


### PR DESCRIPTION
Fixes #18648

Also add a test verifying the same issue can be resolved (as well as to confirm it works in general) with proactive authentication disabled and custom exception mappers.

Note the combination `basic+form` is not affected as in this case the basic mechanism is registered in a `silent` mode.
Effectively this fix ensures a similar behavior for the cases where a non-basic authentication mechanism is meant to be `silent`, ex, `bearer` + `basic`.