### PR TITLE
gRPC request context: activate before all the interceptors are invoked

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
@@ -31,7 +31,7 @@ public class GrpcContainer {
             return Collections.emptyList();
         }
 
-        return interceptors.stream().sorted(new Comparator<ServerInterceptor>() { // NOSONAR
+        return interceptors.stream().sorted(new Comparator<>() { // NOSONAR
             @Override
             public int compare(ServerInterceptor si1, ServerInterceptor si2) {
                 int p1 = 0;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -43,7 +43,6 @@ import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
 import io.quarkus.grpc.runtime.reflection.ReflectionService;
 import io.quarkus.grpc.runtime.supports.CompressionInterceptor;
 import io.quarkus.grpc.runtime.supports.blocking.BlockingServerInterceptor;
-import io.quarkus.grpc.runtime.supports.context.GrpcRequestContextGrpcInterceptor;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
@@ -427,8 +426,6 @@ public class GrpcServerRecorder {
                 interceptors.add(new BlockingServerInterceptor(vertx, list, devMode));
             }
         }
-        // Order matters! Request scope must be called first (on the event loop) and so should be last in the list...
-        interceptors.add(new GrpcRequestContextGrpcInterceptor());
         return ServerInterceptors.intercept(service.definition, interceptors);
     }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.grpc.runtime.supports.context;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Prioritized;
+
 import org.jboss.logging.Logger;
 
 import io.grpc.ForwardingServerCallListener;
@@ -13,7 +16,8 @@ import io.quarkus.arc.ManagedContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 
-public class GrpcRequestContextGrpcInterceptor implements ServerInterceptor {
+@ApplicationScoped
+public class GrpcRequestContextGrpcInterceptor implements ServerInterceptor, Prioritized {
     private static final Logger log = Logger.getLogger(GrpcRequestContextGrpcInterceptor.class.getName());
 
     private final ManagedContext reqContext;
@@ -131,5 +135,10 @@ public class GrpcRequestContextGrpcInterceptor implements ServerInterceptor {
             log.warn("Unable to activate the request scope - interceptor not called on the Vert.x event loop");
             return next.startCall(call, headers);
         }
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
     }
 }


### PR DESCRIPTION
With this change, user's global interceptors can propagate data in the request context.