### PR TITLE
ArC - improved error when unable to add a synthetic no-arg constructor

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -697,10 +697,7 @@ final class Beans {
                         }
 
                     } else {
-                        errors.add(new DeploymentException(
-                                "It's not possible to add a synthetic constructor with no parameters to the unproxyable bean class: "
-                                        +
-                                        beanClass));
+                        errors.add(cannotAddSyntheticNoArgsConstructor(beanClass));
                     }
                 } else {
                     errors.add(new DeploymentException(String
@@ -764,9 +761,7 @@ final class Beans {
                                 classesReceivingNoArgsCtor.add(returnTypeClass.name());
                             }
                         } else {
-                            errors.add(new DeploymentException(String
-                                    .format("It's not possible to add a synthetic constructor with no parameters to the unproxyable return type of "
-                                            + bean)));
+                            errors.add(cannotAddSyntheticNoArgsConstructor(returnTypeClass));
                         }
                     } else {
                         errors.add(new DefinitionException(String
@@ -810,10 +805,7 @@ final class Beans {
                             classesReceivingNoArgsCtor.add(beanClass.name());
                         }
                     } else {
-                        errors.add(new DeploymentException(
-                                "It's not possible to add a synthetic constructor with no parameters to the unproxyable bean class: "
-                                        +
-                                        beanClass));
+                        errors.add(cannotAddSyntheticNoArgsConstructor(beanClass));
                     }
                 } else {
                     errors.add(new DeploymentException(String
@@ -822,6 +814,11 @@ final class Beans {
                 }
             }
         }
+    }
+
+    private static DeploymentException cannotAddSyntheticNoArgsConstructor(ClassInfo beanClass) {
+        String message = "It's not possible to automatically add a synthetic no-args constructor to an unproxyable bean class. You need to manually add a non-private no-args constructor to %s in order to fulfill the requirements for normal scoped/intercepted/decorated beans.";
+        return new DeploymentException(String.format(message, beanClass));
     }
 
     private static void fetchType(Type type, BeanDeployment beanDeployment) {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -120,6 +120,10 @@ public class QuarkusUnitTest
     private List<ClassLoaderEventListener> classLoadListeners = new ArrayList<>();
 
     public QuarkusUnitTest setExpectedException(Class<? extends Throwable> expectedException) {
+        return setExpectedException(expectedException, false);
+    }
+
+    public QuarkusUnitTest setExpectedException(Class<? extends Throwable> expectedException, boolean logMessage) {
         return assertException(t -> {
             Throwable i = t;
             boolean found = false;
@@ -130,8 +134,10 @@ public class QuarkusUnitTest
                 }
                 i = i.getCause();
             }
-
-            assertTrue(found, "Build failed with wrong exception, expected " + expectedException + " but got " + t);
+            if (found && logMessage) {
+                System.out.println("Build failed with the expected exception:" + i);
+            }
+            assertTrue(found, "Build failed with a wrong exception, expected " + expectedException + " but got " + t);
         });
     }
 


### PR DESCRIPTION
- QuarkusUnitTest - make it easy to log/debug the expected exception
- resolves #18592