### PR TITLE
Fixes CLI --refresh option

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
@@ -43,7 +43,12 @@ public class MavenRegistryCache implements RegistryCache {
             }
             if (Files.exists(dir)) {
                 try {
-                    Files.list(dir).forEach(path -> path.toFile().deleteOnExit());
+                    Files.list(dir).forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                        }
+                    });
                 } catch (IOException e) {
                     throw new RegistryResolutionException("Failed to read directory " + dir, e);
                 }


### PR DESCRIPTION
The cache cleaning was originally meant to be a separate command. Now that it's triggered by an argument for other commands, instead of using `File.deleteOnExit()`, it should actually be deleting the files immediately.