### PR TITLE
Only add the consumer group id if the Kafka config is not empty

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
@@ -38,7 +38,7 @@ public class KafkaRuntimeConfigProducer {
             result.put(effectivePropertyName, value);
         }
 
-        if (!result.containsKey(GROUP_ID) && app.name.isPresent()) {
+        if (!result.isEmpty() && !result.containsKey(GROUP_ID) && app.name.isPresent()) {
             result.put(GROUP_ID, app.name.get());
         }
 


### PR DESCRIPTION
Fix #18811