### PR TITLE
Throw an error in case a configured registry isn't available and suggest a workaround

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -74,7 +74,7 @@ public class MavenRunner implements BuildSystemRunner {
         return BuildTool.MAVEN;
     }
 
-    QuarkusProject quarkusProject() {
+    QuarkusProject quarkusProject() throws Exception {
         return MavenProjectBuildFile.getProject(projectRoot, output, Version::clientVersion);
     }
 

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -28,6 +28,7 @@ import io.quarkus.devtools.project.buildfile.GradleKotlinProjectBuildFile;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.platform.tools.ToolsUtils;
 import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public abstract class QuarkusPlatformTask extends QuarkusTask {
@@ -38,9 +39,14 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
 
     private ExtensionCatalog extensionsCatalog(boolean limitExtensionsToImportedPlatforms, MessageWriter log) {
         final List<ArtifactCoords> platforms = importedPlatforms();
-        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
-                ? QuarkusProjectHelper.getCatalogResolver(log)
-                : ExtensionCatalogResolver.empty();
+        ExtensionCatalogResolver catalogResolver;
+        try {
+            catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                    ? QuarkusProjectHelper.getCatalogResolver(log)
+                    : ExtensionCatalogResolver.empty();
+        } catch (RegistryResolutionException e) {
+            throw new RuntimeException("Failed to initialize Quarkus extension catalog resolver", e);
+        }
         if (catalogResolver.hasRegistries() && !limitExtensionsToImportedPlatforms) {
             try {
                 return catalogResolver.resolveExtensionCatalog(platforms);

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
@@ -30,6 +30,7 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 import io.quarkus.platform.tools.maven.MojoMessageWriter;
+import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 @Mojo(name = "create-jbang", requiresProject = false)
@@ -98,11 +99,16 @@ public class CreateJBangMojo extends AbstractMojo {
         }
 
         final MessageWriter log = new MojoMessageWriter(getLog());
-        final ExtensionCatalog catalog = CreateProjectMojo.resolveExtensionsCatalog(
-                StringUtils.defaultIfBlank(bomGroupId, null),
-                StringUtils.defaultIfBlank(bomArtifactId, null),
-                StringUtils.defaultIfBlank(bomVersion, null),
-                QuarkusProjectHelper.getCatalogResolver(mvn, log), mvn, log);
+        ExtensionCatalog catalog;
+        try {
+            catalog = CreateProjectMojo.resolveExtensionsCatalog(
+                    StringUtils.defaultIfBlank(bomGroupId, null),
+                    StringUtils.defaultIfBlank(bomArtifactId, null),
+                    StringUtils.defaultIfBlank(bomVersion, null),
+                    QuarkusProjectHelper.getCatalogResolver(mvn, log), mvn, log);
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException("Failed to resolve Quarkus extension catalog", e);
+        }
 
         final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder()
                 .catalog(catalog)

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -207,9 +207,14 @@ public class CreateProjectMojo extends AbstractMojo {
             throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
         }
         final MojoMessageWriter log = new MojoMessageWriter(getLog());
-        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
-                ? QuarkusProjectHelper.getCatalogResolver(mvn, log)
-                : ExtensionCatalogResolver.empty();
+        ExtensionCatalogResolver catalogResolver;
+        try {
+            catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                    ? QuarkusProjectHelper.getCatalogResolver(mvn, log)
+                    : ExtensionCatalogResolver.empty();
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException("Failed to initialize Quarkus extension catalog resolver", e);
+        }
 
         final ExtensionCatalog catalog = resolveExtensionsCatalog(
                 StringUtils.defaultIfBlank(bomGroupId, null),

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -102,7 +102,11 @@ public class QuarkusProjectHelper {
 
     public static QuarkusProject getProject(Path projectDir, BuildTool buildTool) {
         if (BuildTool.MAVEN.equals(buildTool)) {
-            return MavenProjectBuildFile.getProject(projectDir, messageWriter(), null);
+            try {
+                return MavenProjectBuildFile.getProject(projectDir, messageWriter(), null);
+            } catch (RegistryResolutionException e) {
+                throw new RuntimeException("Failed to initialize the Quarkus Maven extension manager", e);
+            }
         }
         final ExtensionCatalog catalog;
         try {
@@ -138,16 +142,17 @@ public class QuarkusProjectHelper {
                 log, extManager);
     }
 
-    public static ExtensionCatalogResolver getCatalogResolver() {
+    public static ExtensionCatalogResolver getCatalogResolver() throws RegistryResolutionException {
         return catalogResolver == null ? catalogResolver = getCatalogResolver(true, messageWriter())
                 : catalogResolver;
     }
 
-    public static ExtensionCatalogResolver getCatalogResolver(MessageWriter log) {
+    public static ExtensionCatalogResolver getCatalogResolver(MessageWriter log) throws RegistryResolutionException {
         return getCatalogResolver(true, log);
     }
 
-    public static ExtensionCatalogResolver getCatalogResolver(boolean enableRegistryClient, MessageWriter log) {
+    public static ExtensionCatalogResolver getCatalogResolver(boolean enableRegistryClient, MessageWriter log)
+            throws RegistryResolutionException {
         if (catalogResolver == null) {
             if (enableRegistryClient) {
                 catalogResolver = getCatalogResolver(artifactResolver(), log);
@@ -158,7 +163,8 @@ public class QuarkusProjectHelper {
         return catalogResolver;
     }
 
-    public static ExtensionCatalogResolver getCatalogResolver(MavenArtifactResolver resolver, MessageWriter log) {
+    public static ExtensionCatalogResolver getCatalogResolver(MavenArtifactResolver resolver, MessageWriter log)
+            throws RegistryResolutionException {
         return ExtensionCatalogResolver.builder()
                 .artifactResolver(resolver)
                 .config(toolsConfig())

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -46,7 +46,8 @@ public class MavenProjectBuildFile extends BuildFile {
 
     private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{(.+)}");
 
-    public static QuarkusProject getProject(Path projectDir, MessageWriter log, Supplier<String> defaultQuarkusVersion) {
+    public static QuarkusProject getProject(Path projectDir, MessageWriter log, Supplier<String> defaultQuarkusVersion)
+            throws RegistryResolutionException {
         final MavenArtifactResolver mvnResolver = getMavenResolver(projectDir);
         final LocalProject currentProject = mvnResolver.getMavenContext().getCurrentProject();
         final Model projectModel;
@@ -66,7 +67,7 @@ public class MavenProjectBuildFile extends BuildFile {
 
     public static QuarkusProject getProject(Artifact projectPom, Model projectModel, Path projectDir,
             Properties projectProps, MavenArtifactResolver mvnResolver, MessageWriter log,
-            Supplier<String> defaultQuarkusVersion) {
+            Supplier<String> defaultQuarkusVersion) throws RegistryResolutionException {
         final List<ArtifactCoords> managedDeps;
         final Supplier<List<ArtifactCoords>> deps;
         final List<ArtifactCoords> importedPlatforms;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -86,7 +86,7 @@ public class ExtensionCatalogResolver {
             return this;
         }
 
-        public ExtensionCatalogResolver build() {
+        public ExtensionCatalogResolver build() throws RegistryResolutionException {
             assertNotBuilt();
             built = true;
             completeConfig();
@@ -113,20 +113,14 @@ public class ExtensionCatalogResolver {
             }
         }
 
-        private void buildRegistryClients() {
+        private void buildRegistryClients() throws RegistryResolutionException {
             registries = new ArrayList<>(config.getRegistries().size());
             for (RegistryConfig config : config.getRegistries()) {
                 if (config.isDisabled()) {
                     continue;
                 }
                 final RegistryClientFactory clientFactory = getClientFactory(config);
-                try {
-                    registries.add(new RegistryExtensionResolver(clientFactory.buildRegistryClient(config), log));
-                } catch (RegistryResolutionException e) {
-                    // TODO this should be enabled once the registry comes to life
-                    log.debug(e.getMessage());
-                    continue;
-                }
+                registries.add(new RegistryExtensionResolver(clientFactory.buildRegistryClient(config), log));
             }
         }
 

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryClientFactory.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryClientFactory.java
@@ -88,16 +88,17 @@ public class MavenRegistryClientFactory implements RegistryClientFactory {
         } catch (BootstrapMavenException e) {
             final StringWriter buf = new StringWriter();
             try (BufferedWriter writer = new BufferedWriter(buf)) {
-                writer.write("Failed to resolve Quarkus extensions registry descriptor ");
+                writer.write("Failed to resolve Quarkus extension registry descriptor ");
                 writer.write(registryDescriptorCoords.toString());
-                writer.write(" using the following repositories:");
+                writer.write(" from");
                 for (RemoteRepository repo : aggregatedRepos) {
-                    writer.newLine();
-                    writer.write("- ");
-                    writer.write(repo.getId());
-                    writer.write(" (");
-                    writer.write(repo.getUrl());
-                    writer.write(")");
+                    if (repo.getPolicy(registryDescriptorCoords.isSnapshot()).isEnabled()) {
+                        writer.append(" ");
+                        writer.write(repo.getId());
+                        writer.write(" (");
+                        writer.write(repo.getUrl());
+                        writer.write(")");
+                    }
                 }
             } catch (IOException e1) {
                 buf.append(e.getLocalizedMessage());


### PR DESCRIPTION
Instead of silently falling back to the default platform, it is now throwing an error and printing a suggestion how to workaround a non-available registry.

````
[aloubyansky@lenora test-devtools]$ qs create --registry-client
Creating an app (default project type, see --help).
Refreshing the local extension catalog cache of playground.io
[WARN] 🔥  None of the configured Quarkus extension registries appear to be available at the moment. It should still be possible to create a new project by providing the exact Quarkus platform BOM coordinates, e.g. 'quarkus create -P io.quarkus:quarkus-universe-bom:999-SNAPSHOT'
[ERROR] ❗  Unable to create project: Failed to resolve Quarkus extension registry descriptor io.playground:quarkus-registry-descriptor:json:1.0-SNAPSHOT from playground.io (http://localhost:8080/registry/maven)
````