### PR TITLE
Rename quarkus.datasource.devservices to quarkus.datasource.devservices.enabled

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -509,7 +509,7 @@ include::{generated-dir}/config/quarkus-datasource-config-group-dev-services-bui
 
 When using DevServices the default datasource will always be created, but to specify a named datasource you need to have
 at least one build time property so Quarkus knows to create the datasource. In general you will usually either specify
-the `db-kind` property, or explicitly enable DevDb: `quarkus.datasource."named".devservices=true`.
+the `db-kind` property, or explicitly enable DevDb: `quarkus.datasource."name".devservices.enabled=true`.
 
 [[in-memory-databases]]
 == Testing with in-memory databases

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -264,8 +264,9 @@ class AgroalProcessor {
 
         Optional<String> effectiveDbKind = DefaultDataSourceDbKindBuildItem
                 .resolve(dataSourcesBuildTimeConfig.defaultDataSource.dbKind, defaultDbKinds,
-                        dataSourcesBuildTimeConfig.defaultDataSource.devservices.enabled
-                                .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                        dataSourcesBuildTimeConfig.defaultDataSource.devservices.enabled.orElse(
+                                dataSourcesBuildTimeConfig.defaultDataSource.devservices.enabledDeprecated
+                                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty())),
                         curateOutcomeBuildItem);
 
         if (effectiveDbKind.isPresent()) {

--- a/extensions/agroal/deployment/src/test/resources/application-multiple-devservices-datasources.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-multiple-devservices-datasources.properties
@@ -1,3 +1,3 @@
-quarkus.datasource.devservices=true
-quarkus.datasource.users.devservices=true
-quarkus.datasource.inventory.devservices=true
+quarkus.datasource.devservices.enabled=true
+quarkus.datasource.users.devservices.enabled=true
+quarkus.datasource.inventory.devservices.enabled=true

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -196,18 +196,22 @@ public class DevServicesDatasourceProcessor {
             Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configurationHandlerBuildItems,
             Map<String, String> propertiesMap, List<Closeable> closeableList,
             LaunchMode launchMode) {
-        Optional<Boolean> enabled = dataSourceBuildTimeConfig.devservices.enabled;
-        if (enabled.isPresent() && !enabled.get()) {
+        boolean explicitlyDisabled = !(dataSourceBuildTimeConfig.devservices.enabled
+                .orElse(dataSourceBuildTimeConfig.devservices.enabledDeprecated.orElse(true)));
+        if (explicitlyDisabled) {
             //explicitly disabled
             log.debug("Not starting devservices for " + (dbName == null ? "default datasource" : dbName)
                     + " as it has been disabled in the config");
             return null;
         }
 
+        Boolean enabled = dataSourceBuildTimeConfig.devservices.enabled
+                .orElse(dataSourceBuildTimeConfig.devservices.enabledDeprecated.orElse(!hasNamedDatasources));
+
         Optional<String> defaultDbKind = DefaultDataSourceDbKindBuildItem.resolve(
                 dataSourceBuildTimeConfig.dbKind,
                 installedDrivers,
-                dbName != null || enabled.orElse(!hasNamedDatasources),
+                dbName != null || enabled,
                 curateOutcomeBuildItem);
 
         if (!defaultDbKind.isPresent()) {
@@ -224,7 +228,8 @@ public class DevServicesDatasourceProcessor {
             return null;
         }
 
-        if (!enabled.isPresent()) {
+        if (dataSourceBuildTimeConfig.devservices.enabled.isEmpty()
+                && dataSourceBuildTimeConfig.devservices.enabledDeprecated.isEmpty()) {
             for (DevServicesDatasourceConfigurationHandlerBuildItem i : configHandlers) {
                 if (i.getCheckConfiguredFunction().test(dbName)) {
                     //this database has explicit configuration

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -16,8 +16,21 @@ public class DevServicesBuildTimeConfig {
      *
      * When DevServices is enabled Quarkus will attempt to automatically configure and start
      * a database when running in Dev or Test mode.
+     *
+     * @deprecated Use .enabled instead.
      */
     @ConfigItem(name = ConfigItem.PARENT)
+    @Deprecated(forRemoval = true, since = "2.1")
+    public Optional<Boolean> enabledDeprecated = Optional.empty();
+
+    /**
+     * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled
+     * by default, unless there is an existing configuration present.
+     *
+     * When DevServices is enabled Quarkus will attempt to automatically configure and start
+     * a database when running in Dev or Test mode.
+     */
+    @ConfigItem
     public Optional<Boolean> enabled = Optional.empty();
 
     /**

--- a/extensions/flyway/deployment/src/test/resources/config-empty.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-empty.properties
@@ -1,1 +1,1 @@
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false

--- a/extensions/liquibase/deployment/src/test/resources/config-empty.properties
+++ b/extensions/liquibase/deployment/src/test/resources/config-empty.properties
@@ -1,1 +1,1 @@
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-commented-out.properties
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/resources/application-commented-out.properties
@@ -1,5 +1,5 @@
 #quarkus.datasource.db-kind=h2
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false
 #quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 #
 #quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/resources/application.properties
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/resources/application.properties
@@ -2,6 +2,6 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=hibernate_orm_test
 quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.reactive.url=${postgres.reactive.url}
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false
 
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/jpa-without-entity/src/main/resources/application.properties
+++ b/integration-tests/jpa-without-entity/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false

--- a/integration-tests/micrometer-prometheus/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus/src/main/resources/application.properties
@@ -13,7 +13,7 @@ quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.metrics.enabled=true
 
 quarkus.datasource.db-kind=h2
-quarkus.datasource.devservices=true
+quarkus.datasource.devservices.enabled=true
 
 # This is the old property, should still be used
 quarkus.micrometer.binder.vertx.ignore-patterns=/fruit/create


### PR DESCRIPTION
For consistency with the other devservices and also for the other
features we can enable.

Fixes #18844