### PR TITLE
Add ssl config to fix JaasClientOauthLoginCallbackHandler for kakfa

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1323,11 +1323,13 @@ mp.messaging.connector.smallrye-kafka.sasl.jaas.config=org.apache.kafka.common.s
   oauth.client.secret="team-a-client-secret" \
   oauth.token.endpoint.uri="http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/token" ;
 mp.messaging.connector.smallrye-kafka.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
+
+quarkus.ssl.native=true
 ----
 
 Update the `oauth.client.id`, `oauth.client.secret` and `oauth.token.endpoint.uri` values.
 
-OAuth authentication works for both JVM and native modes.
+OAuth authentication works for both JVM and native modes. Since SSL in not enabled by default in native mode, `quarkus.ssl.native=true` must be added to support JaasClientOauthLoginCallbackHandler, which uses SSL. (See the xref:native-and-ssl.adoc[Using SSL with Native Executables] guide for more details.)
 
 == Testing a Kafka application
 


### PR DESCRIPTION
…auth in native mode.

Apps will fail on auth in native mode unless SSL has been enabled explicitly prior to the native build. This is because JaasClientOauthLoginCallbackHandler uses SSL. The requirement for SSL, and the setting needed, should be called out in the guide.