### PR TITLE
Provide a clear error message when RESTEasy Reactive and Undertow are used together

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
@@ -60,6 +60,7 @@
                     <capabilities>
                         <provides>io.quarkus.rest</provides>
                         <provides>io.quarkus.resteasy.reactive</provides>
+                        <provides>io.quarkus.servlet-base</provides> <!-- this only exists to conflict with Undertow -->
                     </capabilities>
                 </configuration>
             </plugin>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                 <configuration>
                     <capabilities>
+                        <provides>io.quarkus.servlet-base</provides> <!-- this only exists to conflict with RESTEasy Reactive -->
                         <provides>io.quarkus.servlet</provides>
                     </capabilities>
                     <excludedArtifacts>

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -65,6 +65,9 @@
 
                         <!-- TODO fix this-->
                         <exclude>org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest</exclude>
+
+                        <!-- currently not supported because it brings in Undertow -->
+                        <exclude>io.quarkus.tck.restclient.cdi.CDIInterceptorTest</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Currently these two components don't cause any build time error, but at runtime
RESTEasy Reactive is effectively disabled

Originally reported at https://twitter.com/connolly_s/status/1417155861949124609