### PR TITLE
Update to Vert.x 4.1.2 and friends

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -53,8 +53,8 @@
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>2.9.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.6.0</smallrye-reactive-messaging.version>
+        <smallrye-mutiny-vertx-binding.version>2.11.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-reactive-messaging.version>3.7.1</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
@@ -109,7 +109,7 @@
         <wildfly-elytron.version>1.16.1.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.4.0.Final</jboss-threads.version>
-        <vertx.version>4.1.1</vertx.version>
+        <vertx.version>4.1.2</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>


### PR DESCRIPTION
Update to Vert.x 4.1.2,  Mutiny bindings to 2.11.0, and Smallrye Reactive Messaging 3.7.1.

@Sanne FYI. 
