### PR TITLE
Avoid trying to set permissions on the cache directory on windows

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -259,9 +260,13 @@ public class VertxCoreRecorder {
                 if (!tmp.mkdirs()) {
                     LOGGER.warnf("Unable to create Vert.x cache directory : %s", tmp.getAbsolutePath());
                 }
-                if (!(tmp.setReadable(true, false) && tmp.setWritable(true, false))) {
-                    LOGGER.warnf("Unable to make the Vert.x cache directory (%s) world readable and writable",
-                            tmp.getAbsolutePath());
+                String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+                if (!os.contains("windows")) {
+                    // Do not execute the following on windows.
+                    if (!(tmp.setReadable(true, false) && tmp.setWritable(true, false))) {
+                        LOGGER.warnf("Unable to make the Vert.x cache directory (%s) world readable and writable",
+                                tmp.getAbsolutePath());
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix #16895

@rsvoboda This is the approach not trying to set the permission on windows. However, not sure it works on Windows using the WSL emulation. 