### PR TITLE
Don't run dokka and kapt on Java 16+ for now, drop --add-opens

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -239,12 +239,11 @@ jobs:
             maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
             os-name: "ubuntu-latest"
           }
-          # all the jdk.compiler ones are for Kotlin Kapt
           - {
             name: "16",
             java-version: 16,
             maven_args: "$JVM_TEST_MAVEN_ARGS -pl '!devtools/gradle'",
-            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g --add-opens java.base/java.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
             os-name: "ubuntu-latest"
           }
           - {

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -27,9 +27,7 @@ jobs:
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     timeout-minutes: 360
     env:
-      # "--add-opens ..." to work around https://youtrack.jetbrains.com/issue/KT-43704
-      # all the jdk.compiler ones are for Kotlin Kapt
-      MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m --add-opens java.base/java.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+      MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m
     steps:
 
       - name: Set up JDK

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -820,7 +820,7 @@
                 <property>
                     <name>dokka</name>
                 </property>
-                <jdk>[,16)</jdk>
+                <jdk>(,16)</jdk>
                 <file>
                     <exists>src/main/kotlin</exists>
                 </file>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -174,11 +174,13 @@
         </plugins>
     </build>
     <profiles>
-        <!-- Execute kapt, but not on Java 17 or higher due to https://youtrack.jetbrains.com/issue/KT-47583 -->
+        <!-- Execute kapt, but not on Java 16 or higher due to
+            - https://youtrack.jetbrains.com/issue/KT-45545 (Java 16+)
+            - https://youtrack.jetbrains.com/issue/KT-47583 (Java 17+) -->
         <profile>
-            <id>kapt-not-on-jdk17</id>
+            <id>kapt-not-on-jdk16</id>
             <activation>
-                <jdk>(,17)</jdk>
+                <jdk>(,16)</jdk>
             </activation>
             <build>
                 <plugins>

--- a/extensions/smallrye-reactive-messaging/kotlin/pom.xml
+++ b/extensions/smallrye-reactive-messaging/kotlin/pom.xml
@@ -109,30 +109,6 @@
                     <failOnError>false</failOnError>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jetbrains.dokka</groupId>
-                <artifactId>dokka-maven-plugin</artifactId>
-                <version>${dokka.version}</version>
-                <executions>
-                    <execution>
-                        <id>javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>javadocJar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jdkVersion>11</jdkVersion>
-                    <outputFormat>html</outputFormat>
-                    <externalDocumentationLinks>
-                        <link>
-                            <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
-                            <url>https://docs.oracle.com/en/java/javase/11/docs/api/</url>
-                        </link>
-                    </externalDocumentationLinks>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This went through CI and EA build (Java 17-ea _and_ 16, just in case) in my fork.

See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/CI.2C.20Java.2016.2B.3A.20skip.20kapt.2C.20drop.20--add-opens