### PR TITLE
Disable Vert.x TCCL management

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -85,8 +85,10 @@ public class ConsoleStateManager {
             return;
         }
         initialized = true;
-        console.setInputHandler(INSTANCE.consumer);
-        INSTANCE.installBuiltins(devModeType);
+        if (console.isInputSupported()) {
+            console.setInputHandler(INSTANCE.consumer);
+            INSTANCE.installBuiltins(devModeType);
+        }
     }
 
     void installBuiltins(DevModeType devModeType) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -133,6 +133,12 @@ public class JunitTestRunner {
         long start = System.currentTimeMillis();
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try (QuarkusClassLoader tcl = testApplication.createDeploymentClassLoader()) {
+            synchronized (this) {
+                if (aborted) {
+                    return;
+                }
+                testsRunning = true;
+            }
             Thread.currentThread().setContextClassLoader(tcl);
             Consumer currentTestAppConsumer = (Consumer) tcl.loadClass(CurrentTestApplication.class.getName()).newInstance();
             currentTestAppConsumer.accept(testApplication);
@@ -408,9 +414,18 @@ public class JunitTestRunner {
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            TracingHandler.setTracingHandler(null);
-            QuarkusConsole.INSTANCE.setOutputFilter(null);
-            Thread.currentThread().setContextClassLoader(old);
+            try {
+                TracingHandler.setTracingHandler(null);
+                QuarkusConsole.INSTANCE.setOutputFilter(null);
+                Thread.currentThread().setContextClassLoader(old);
+            } finally {
+                synchronized (this) {
+                    testsRunning = false;
+                    if (aborted) {
+                        notifyAll();
+                    }
+                }
+            }
         }
     }
 
@@ -424,6 +439,13 @@ public class JunitTestRunner {
         }
         aborted = true;
         notifyAll();
+        while (testsRunning) {
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                //ignore
+            }
+        }
     }
 
     public synchronized void pause() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -142,7 +142,11 @@ public class TestSupport implements TestController {
                 cl.addCloseTask(new Runnable() {
                     @Override
                     public void run() {
-                        testCuratedApplication.close();
+                        try {
+                            stop();
+                        } finally {
+                            testCuratedApplication.close();
+                        }
                     }
                 });
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -77,14 +77,6 @@ public class TestTracingProcessor {
                 testSupport.stop();
             }
         }
-
-        QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
-        ((QuarkusClassLoader) cl.parent()).addCloseTask(new Runnable() {
-            @Override
-            public void run() {
-                testSupport.stop();
-            }
-        });
     }
 
     @BuildStep(onlyIf = IsTest.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -236,6 +236,12 @@ public final class LoggingResourceProcessor {
                 }
             }
         };
+        ((QuarkusClassLoader) getClass().getClassLoader()).addCloseTask(new Runnable() {
+            @Override
+            public void run() {
+                CurrentAppExceptionHighlighter.THROWABLE_FORMATTER = null;
+            }
+        });
     }
 
     @BuildStep

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
@@ -156,4 +156,9 @@ public class BasicConsole extends QuarkusConsole {
         write(new String(buf, off, len, StandardCharsets.UTF_8));
     }
 
+    @Override
+    public boolean isInputSupported() {
+        return inputSupport;
+    }
+
 }

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -100,4 +100,7 @@ public abstract class QuarkusConsole {
         this.outputFilter = logHandler;
     }
 
+    public boolean isInputSupported() {
+        return true;
+    }
 }

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/ContinuousTestingWebsocketListener.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/ContinuousTestingWebsocketListener.java
@@ -14,7 +14,7 @@ public class ContinuousTestingWebsocketListener {
 
     public static void setStateListener(Consumer<State> stateListener) {
         ContinuousTestingWebsocketListener.stateListener = stateListener;
-        if (lastState != null) {
+        if (lastState != null && stateListener != null) {
             stateListener.accept(lastState);
         }
     }

--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/Fruit.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/Fruit.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.reactive.dev;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.NamedQuery;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "known_fruits")
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
+public class Fruit {
+
+    @Id
+    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
+    @GeneratedValue(generator = "fruitsSequence")
+    private Integer id;
+
+    @Column(length = 40, unique = true)
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "Fruit{" + id + "," + name + '}';
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/FruitMutinyResource.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/FruitMutinyResource.java
@@ -1,0 +1,139 @@
+package io.quarkus.hibernate.reactive.dev;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestPath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("fruits")
+@ApplicationScoped
+@Produces("application/json")
+@Consumes("application/json")
+public class FruitMutinyResource {
+    private static final Logger LOGGER = Logger.getLogger(FruitMutinyResource.class);
+
+    @Inject
+    Mutiny.SessionFactory sf;
+
+    @GET
+    public Uni<List<Fruit>> get() {
+        return sf.withTransaction((s, t) -> s
+                .createNamedQuery("Fruits.findAll", Fruit.class)
+                .getResultList());
+    }
+
+    @GET
+    @Path("{id}")
+    public Uni<Fruit> getSingle(@RestPath Integer id) {
+        return sf.withTransaction((s, t) -> s.find(Fruit.class, id));
+    }
+
+    @POST
+    public Uni<Response> create(Fruit fruit) {
+        if (fruit == null || fruit.getId() != null) {
+            throw new WebApplicationException("Id was invalidly set on request.", 422);
+        }
+
+        return sf.withTransaction((s, t) -> s.persist(fruit))
+                .replaceWith(() -> Response.ok(fruit).status(CREATED).build());
+    }
+
+    @PUT
+    @Path("{id}")
+    public Uni<Response> update(@RestPath Integer id, Fruit fruit) {
+        if (fruit == null || fruit.getName() == null) {
+            throw new WebApplicationException("Fruit name was not set on request.", 422);
+        }
+
+        return sf.withTransaction((s, t) -> s.find(Fruit.class, id)
+                // If entity exists then update it
+                .onItem().ifNotNull().invoke(entity -> entity.setName(fruit.getName()))
+                .onItem().ifNotNull().transform(entity -> Response.ok(entity).build())
+                // If entity not found return the appropriate response
+                .onItem().ifNull()
+                .continueWith(() -> Response.ok().status(NOT_FOUND).build()));
+    }
+
+    @DELETE
+    @Path("{id}")
+    public Uni<Response> delete(@RestPath Integer id) {
+        return sf.withTransaction((s, t) -> s.find(Fruit.class, id)
+                // If entity exists then delete it
+                .onItem().ifNotNull()
+                .transformToUni(entity -> s.remove(entity)
+                        .replaceWith(() -> Response.ok().status(NO_CONTENT).build()))
+                // If entity not found return the appropriate response
+                .onItem().ifNull().continueWith(() -> Response.ok().status(NOT_FOUND).build()));
+    }
+
+    /**
+     * Create a HTTP response from an exception.
+     *
+     * Response Example:
+     *
+     * <pre>
+     * HTTP/1.1 422 Unprocessable Entity
+     * Content-Length: 111
+     * Content-Type: application/json
+     *
+     * {
+     *     "code": 422,
+     *     "error": "Fruit name was not set on request.",
+     *     "exceptionType": "javax.ws.rs.WebApplicationException"
+     * }
+     * </pre>
+     */
+    @Provider
+    public static class ErrorMapper implements ExceptionMapper<Exception> {
+
+        @Inject
+        ObjectMapper objectMapper;
+
+        @Override
+        public Response toResponse(Exception exception) {
+            LOGGER.error("Failed to handle request", exception);
+
+            int code = 500;
+            if (exception instanceof WebApplicationException) {
+                code = ((WebApplicationException) exception).getResponse().getStatus();
+            }
+
+            ObjectNode exceptionJson = objectMapper.createObjectNode();
+            exceptionJson.put("exceptionType", exception.getClass().getName());
+            exceptionJson.put("code", code);
+
+            if (exception.getMessage() != null) {
+                exceptionJson.put("error", exception.getMessage());
+            }
+
+            return Response.status(code)
+                    .entity(exceptionJson)
+                    .build();
+        }
+
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/HibernateReactiveDevModeTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/dev/HibernateReactiveDevModeTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.hibernate.reactive.dev;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.response.Response;
+
+/**
+ * Checks that public field access is correctly replaced with getter/setter calls,
+ * regardless of the field type.
+ */
+public class HibernateReactiveDevModeTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Fruit.class, FruitMutinyResource.class).addAsResource("application.properties")
+                    .addAsResource(new StringAsset("INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');\n" +
+                            "INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');\n" +
+                            "INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');\n"), "import.sql"));
+
+    @Test
+    public void testListAllFruits() {
+        Response response = given()
+                .when()
+                .get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .extract().response();
+        assertThat(response.jsonPath().getList("name")).isEqualTo(Arrays.asList("Apple", "Banana", "Cherry"));
+
+        runner.modifySourceFile(Fruit.class, s -> s.replace("ORDER BY f.name", "ORDER BY f.name desk"));
+        given()
+                .when()
+                .get("/fruits")
+                .then()
+                .statusCode(500);
+
+        runner.modifySourceFile(Fruit.class, s -> s.replace("desk", "desc"));
+        response = given()
+                .when()
+                .get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .extract().response();
+        assertThat(response.jsonPath().getList("name")).isEqualTo(Arrays.asList("Cherry", "Banana", "Apple"));
+    }
+}

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -73,6 +73,11 @@ class VertxCoreProcessor {
     }
 
     @BuildStep
+    LogCleanupFilterBuildItem cleanupVertxWarnings() {
+        return new LogCleanupFilterBuildItem("io.vertx.core.impl.ContextImpl", "You have disabled TCCL checks");
+    }
+
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     IOThreadDetectorBuildItem ioThreadDetector(VertxCoreRecorder recorder) {
         return new IOThreadDetectorBuildItem(recorder.detector());

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -64,6 +64,10 @@ import io.vertx.core.spi.resolver.ResolverProvider;
 @Recorder
 public class VertxCoreRecorder {
 
+    static {
+        System.setProperty("vertx.disableTCCL", "true");
+    }
+
     private static final Logger LOGGER = Logger.getLogger(VertxCoreRecorder.class.getName());
     public static final String VERTX_CACHE = "vertx-cache";
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/tests/TestsProcessor.java
@@ -12,6 +12,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.dev.testing.TestClassResult;
 import io.quarkus.deployment.dev.testing.TestListenerBuildItem;
 import io.quarkus.deployment.dev.testing.TestRunResults;
@@ -45,6 +46,7 @@ public class TestsProcessor {
             DevConsoleRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
+            ShutdownContextBuildItem shutdownContextBuildItem,
             BuildProducer<RouteBuildItem> routeBuildItemBuildProducer,
             BuildProducer<TestListenerBuildItem> testListenerBuildItemBuildProducer) throws IOException {
         DevModeType devModeType = launchModeBuildItem.getDevModeType().orElse(null);
@@ -56,7 +58,7 @@ public class TestsProcessor {
             // Add continuous testing
             routeBuildItemBuildProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .route("dev/test")
-                    .handler(recorder.continousTestHandler())
+                    .handler(recorder.continousTestHandler(shutdownContextBuildItem))
                     .build());
             testListenerBuildItemBuildProducer.produce(new TestListenerBuildItem(new ContinuousTestingWebSocketListener()));
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ContinuousTestWebSocketHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ContinuousTestWebSocketHandler.java
@@ -14,33 +14,30 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.ext.web.RoutingContext;
 
-public class ContinuousTestWebSocketHandler implements Handler<RoutingContext> {
+public class ContinuousTestWebSocketHandler
+        implements Handler<RoutingContext>, Consumer<ContinuousTestingWebsocketListener.State> {
 
     private static final Logger log = Logger.getLogger(ContinuousTestingWebsocketListener.class);
     private static final Set<ServerWebSocket> sockets = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private static volatile String lastMessage;
 
-    static {
-        ContinuousTestingWebsocketListener.setStateListener(new Consumer<ContinuousTestingWebsocketListener.State>() {
-            @Override
-            public void accept(ContinuousTestingWebsocketListener.State state) {
-                Json.JsonObjectBuilder response = Json.object();
-                response.put("running", state.running);
-                response.put("inProgress", state.inProgress);
-                response.put("run", state.run);
-                response.put("passed", state.passed);
-                response.put("failed", state.failed);
-                response.put("skipped", state.skipped);
-                response.put("isBrokenOnly", state.isBrokenOnly);
-                response.put("isTestOutput", state.isTestOutput);
-                response.put("isInstrumentationBasedReload", state.isInstrumentationBasedReload);
+    @Override
+    public void accept(ContinuousTestingWebsocketListener.State state) {
+        Json.JsonObjectBuilder response = Json.object();
+        response.put("running", state.running);
+        response.put("inProgress", state.inProgress);
+        response.put("run", state.run);
+        response.put("passed", state.passed);
+        response.put("failed", state.failed);
+        response.put("skipped", state.skipped);
+        response.put("isBrokenOnly", state.isBrokenOnly);
+        response.put("isTestOutput", state.isTestOutput);
+        response.put("isInstrumentationBasedReload", state.isInstrumentationBasedReload);
 
-                lastMessage = response.build();
-                for (ServerWebSocket i : sockets) {
-                    i.writeTextMessage(lastMessage);
-                }
-            }
-        });
+        lastMessage = response.build();
+        for (ServerWebSocket i : sockets) {
+            i.writeTextMessage(lastMessage);
+        }
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleRecorder.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.dev.testing.ContinuousTestingWebsocketListener;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
@@ -44,8 +45,18 @@ public class DevConsoleRecorder {
         return new DevConsoleStaticHandler(devConsoleFinalDestination);
     }
 
-    public Handler<RoutingContext> continousTestHandler() {
-        return new ContinuousTestWebSocketHandler();
+    public Handler<RoutingContext> continousTestHandler(ShutdownContext context) {
+
+        ContinuousTestWebSocketHandler handler = new ContinuousTestWebSocketHandler();
+        ContinuousTestingWebsocketListener.setStateListener(handler);
+        context.addShutdownTask(new Runnable() {
+            @Override
+            public void run() {
+                ContinuousTestingWebsocketListener.setStateListener(null);
+
+            }
+        });
+        return handler;
     }
 
     private static final class CleanupDevConsoleTempDirectory implements Runnable {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -262,6 +262,7 @@ public class QuarkusDevModeTest
         }
         rootLogger.setHandlers(originalRootLoggerHandlers);
         inMemoryLogHandler.clearRecords();
+        inMemoryLogHandler.setFilter(null);
         ClearCache.clearAnnotationCache();
         GroovyCacheCleaner.clearGroovyCache();
     }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -574,6 +574,7 @@ public class QuarkusUnitTest
         }
         rootLogger.setHandlers(originalHandlers);
         inMemoryLogHandler.clearRecords();
+        inMemoryLogHandler.setFilter(null);
 
         try {
             if (runningQuarkusApplication != null) {


### PR DESCRIPTION
This breaks dev mode, and in general is not needed as Quarkus can
perform it's own TCCL management when required. It also provides a
slight performance boost.

Fixes #18299