### PR TITLE
Fix CT hang when compile error in application

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadTestCase.java
@@ -85,7 +85,6 @@ public class HibernateHotReloadTestCase {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
 
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/QuarkusTestTypeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/QuarkusTestTypeTestCase.java
@@ -35,7 +35,6 @@ public class QuarkusTestTypeTestCase {
     public void testQuarkusTestMode() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestRunnerSmokeTestCase.java
@@ -39,7 +39,6 @@ public class TestRunnerSmokeTestCase {
     public void checkTestsAreRun() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(3L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -71,7 +70,6 @@ public class TestRunnerSmokeTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
@@ -89,7 +87,6 @@ public class TestRunnerSmokeTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -105,7 +102,6 @@ public class TestRunnerSmokeTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
@@ -122,7 +118,6 @@ public class TestRunnerSmokeTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
@@ -139,10 +134,57 @@ public class TestRunnerSmokeTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());
+        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(0L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(2L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
+
+        //now test compile errors
+        test.modifySourceFile(HelloResource.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replaceAll("\"hello", "\"hello\" world");
+            }
+        });
+        //we just sleep here
+        Thread.sleep(1000);
+        test.modifySourceFile(HelloResource.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replaceAll("\"hello\" world", "\"hello world");
+            }
+        });
+        ts = utils.waitForNextCompletion();
+
+        Assertions.assertEquals(2L, ts.getTestsFailed());
+        Assertions.assertEquals(0L, ts.getTestsPassed());
+        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(2L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(0L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
+
+        //now test compile errors for the test itself
+        test.modifyTestSourceFile(SimpleET.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replaceAll("\"hello", "\"hello\" world");
+            }
+        });
+        //we just sleep here
+        Thread.sleep(1000);
+        test.modifyTestSourceFile(SimpleET.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replaceAll("\"hello\" world", "\"hello world");
+            }
+        });
+        ts = utils.waitForNextCompletion();
+
+        Assertions.assertEquals(0L, ts.getTestsFailed());
+        Assertions.assertEquals(2L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
         Assertions.assertEquals(0L, ts.getTotalTestsFailed());
         Assertions.assertEquals(2L, ts.getTotalTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/UnitTestTypeTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/UnitTestTypeTestCase.java
@@ -35,7 +35,6 @@ public class UnitTestTypeTestCase {
     public void testUnitMode() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(2L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/brokenonly/TestBrokenOnlyTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/brokenonly/TestBrokenOnlyTestCase.java
@@ -38,7 +38,6 @@ public class TestBrokenOnlyTestCase {
     public void testBrokenOnlyMode() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -54,7 +53,6 @@ public class TestBrokenOnlyTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed()); //passing test should not have been run
@@ -67,7 +65,6 @@ public class TestBrokenOnlyTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -81,7 +78,6 @@ public class TestBrokenOnlyTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(0L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/IncludePatternTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/includes/IncludePatternTestCase.java
@@ -39,7 +39,6 @@ public class IncludePatternTestCase {
     public void checkTestsAreRun() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -52,7 +51,6 @@ public class IncludePatternTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
@@ -65,7 +63,6 @@ public class IncludePatternTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/params/TestParameterizedTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/params/TestParameterizedTestCase.java
@@ -37,7 +37,6 @@ public class TestParameterizedTestCase {
     public void testParameterizedTests() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(1L, ts.getTestsFailed());
         Assertions.assertEquals(4L, ts.getTestsPassed());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/IncludeTagsTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/tags/IncludeTagsTestCase.java
@@ -38,7 +38,6 @@ public class IncludeTagsTestCase {
     public void checkTestsAreRun() throws InterruptedException {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         TestStatus ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(2L, ts.getTestsPassed());
@@ -51,7 +50,6 @@ public class IncludeTagsTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(1L, ts.getTestsPassed());
@@ -64,7 +62,6 @@ public class IncludeTagsTestCase {
             }
         });
         ts = utils.waitForNextCompletion();
-        ;
 
         Assertions.assertEquals(0L, ts.getTestsFailed());
         Assertions.assertEquals(5L, ts.getTestsPassed());


### PR DESCRIPTION
If there was a compile error in the application (not the test)
continuous testing would hang until test classes were compiled.