### PR TITLE
Report failures in @BeforeAll

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -327,6 +327,24 @@ public class JunitTestRunner {
                                 for (TestRunListener listener : listeners) {
                                     listener.testComplete(result);
                                 }
+                            } else if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {
+                                //if a parent fails we fail the children
+                                Set<TestIdentifier> children = testPlan.getChildren(testIdentifier);
+                                for (TestIdentifier child : children) {
+                                    UniqueId childId = UniqueId.parse(child.getUniqueId());
+                                    result = new TestResult(child.getDisplayName(), testClass.getName(),
+                                            childId,
+                                            testExecutionResult,
+                                            logHandler.captureOutput(), child.isTest(), runId,
+                                            System.currentTimeMillis() - startTimes.get(testIdentifier));
+                                    results.put(childId, result);
+                                    if (child.isTest()) {
+                                        for (TestRunListener listener : listeners) {
+                                            listener.testStarted(child, testClass.getName());
+                                            listener.testComplete(result);
+                                        }
+                                    }
+                                }
                             }
                         }
                         if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestFailingBeforeAllTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/testrunner/TestFailingBeforeAllTestCase.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http.testrunner;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.vertx.http.deployment.devmode.tests.TestStatus;
+
+public class TestFailingBeforeAllTestCase {
+
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(HelloResource.class)
+                            .add(new StringAsset(ContinuousTestingTestUtils.appProperties()),
+                                    "application.properties");
+                }
+            })
+            .setTestArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(SimpleET.class);
+                }
+            });
+
+    @Test
+    public void testBrokenBeforeAllHandling() throws InterruptedException {
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        TestStatus ts = utils.waitForNextCompletion();
+
+        Assertions.assertEquals(1L, ts.getTestsFailed());
+        Assertions.assertEquals(1L, ts.getTestsPassed());
+        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(1L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(1L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
+
+        test.modifyTestSourceFile(SimpleET.class, s -> s.replaceFirst("\\{", "{ \n" +
+                "    @org.junit.jupiter.api.BeforeAll public static void error() { throw new RuntimeException();  }"));
+
+        ts = utils.waitForNextCompletion();
+
+        Assertions.assertEquals(2L, ts.getTestsFailed());
+        Assertions.assertEquals(0L, ts.getTestsPassed());
+        Assertions.assertEquals(0L, ts.getTestsSkipped());
+        Assertions.assertEquals(2L, ts.getTotalTestsFailed());
+        Assertions.assertEquals(0L, ts.getTotalTestsPassed());
+        Assertions.assertEquals(0L, ts.getTotalTestsSkipped());
+
+    }
+}


### PR DESCRIPTION
Just report them as individual test failures for now, as it makes the
reporting a lot more complex otherwise.

Fixes #18733