### PR TITLE
CLI: registry --streams command option to list the available platform streams

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -339,7 +339,9 @@
                             <maven.home>${maven.home}</maven.home>
                             <maven.repo.local>${settings.localRepository}</maven.repo.local>
                             <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
-                            <project.version>${project.version}</project.version> <!-- some dev tools tests need this -->
+                            <!-- some dev tools tests need the following properties -->
+                            <project.version>${project.version}</project.version>
+                            <project.groupId>${project.groupId}</project.groupId>
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
@@ -358,7 +360,9 @@
                             <maven.home>${maven.home}</maven.home>
                             <maven.repo.local>${settings.localRepository}</maven.repo.local>
                             <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
-                            <project.version>${project.version}</project.version> <!-- some dev tools tests need this -->
+                            <!-- some dev tools tests need the following properties -->
+                            <project.version>${project.version}</project.version>
+                            <project.groupId>${project.groupId}</project.groupId>
                         </systemPropertyVariables>
                         <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
                         <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
@@ -4,6 +4,10 @@ import java.nio.file.Path;
 
 import io.quarkus.cli.registry.BaseRegistryCommand;
 import io.quarkus.cli.registry.RegistryClientMixin;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.catalog.Platform;
+import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.PlatformStream;
 import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistriesConfigLocator;
 import io.quarkus.registry.config.RegistryConfig;
@@ -16,18 +20,38 @@ public class RegistryListCommand extends BaseRegistryCommand {
     @CommandLine.Mixin
     protected RegistryClientMixin registryClient;
 
+    @CommandLine.Option(names = {
+            "--streams" }, description = "List currently recommended platform streams", defaultValue = "false")
+    boolean streams;
+
     @Override
     public Integer call() throws Exception {
 
         registryClient.refreshRegistryCache(output);
         final RegistriesConfig config = RegistriesConfigLocator.resolveConfig();
 
-        output.info("Configured Quarkus extension registries:");
+        final ExtensionCatalogResolver catalogResolver = streams ? registryClient.getExtensionCatalogResolver(output) : null;
+
+        if (streams) {
+            output.info("Available Quarkus platform streams per registry:");
+        } else {
+            output.info("Configured Quarkus extension registries:");
+        }
         for (RegistryConfig r : config.getRegistries()) {
             if (r.isEnabled()) {
-                output.info("- " + r.getId());
+                output.info(r.getId());
+                if (catalogResolver != null) {
+                    final PlatformCatalog platformCatalog = catalogResolver.resolvePlatformCatalogFromRegistry(r.getId());
+                    if (platformCatalog != null) {
+                        for (Platform p : platformCatalog.getPlatforms()) {
+                            for (PlatformStream s : p.getStreams()) {
+                                output.info("  " + p.getPlatformKey() + ":" + s.getId());
+                            }
+                        }
+                    }
+                }
             } else {
-                output.info("- " + r.getId() + " (disabled)");
+                output.info(r.getId() + " (disabled)");
             }
         }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryClientMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryClientMixin.java
@@ -87,7 +87,7 @@ public class RegistryClientMixin {
         return catalogResolver.resolveExtensionCatalog();
     }
 
-    private ExtensionCatalogResolver getExtensionCatalogResolver(OutputOptionMixin log) throws RegistryResolutionException {
+    public ExtensionCatalogResolver getExtensionCatalogResolver(OutputOptionMixin log) throws RegistryResolutionException {
         return QuarkusProjectHelper.getCatalogResolver(enabled(), log);
     }
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -2,34 +2,28 @@ package io.quarkus.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.BufferedReader;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Objects;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
 import picocli.CommandLine;
 
 public class CliNonProjectTest {
+    private static final String TEST_QUARKUS_REGISTRY = "test.quarkus.registry";
     static Path workspaceRoot;
-
-    @BeforeAll
-    public static void setupTestRegistry() {
-        RegistryClientTestHelper.enableRegistryClientTestConfig();
-    }
-
-    @AfterAll
-    public static void cleanupTestRegistry() {
-        RegistryClientTestHelper.disableRegistryClientTestConfig();
-    }
 
     @BeforeAll
     public static void initial() throws Exception {
@@ -39,6 +33,11 @@ public class CliNonProjectTest {
         Files.createDirectories(workspaceRoot);
     }
 
+    @BeforeEach
+    public void setupTestRegistry() {
+        RegistryClientTestHelper.reenableRegistryClientTestConfig();
+    }
+
     @AfterEach
     public void verifyEmptyDirectory() throws Exception {
         String[] files = workspaceRoot.toFile().list();
@@ -46,6 +45,7 @@ public class CliNonProjectTest {
                 "Directory list operation should succeed");
         Assertions.assertEquals(0, files.length,
                 "Directory should be empty. Found: " + Arrays.toString(files));
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
     }
 
     @Test
@@ -137,19 +137,43 @@ public class CliNonProjectTest {
     }
 
     @Test
+    public void testRegistryStreams() throws Exception {
+
+        CliDriver.Result result;
+
+        // refresh the local cache and list the registries
+        result = CliDriver.execute(workspaceRoot, "registry", "--streams", "-e");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code." + result);
+        try (BufferedReader reader = new BufferedReader(new StringReader(result.stdout))) {
+            String line = reader.readLine();
+            while (line != null && !TEST_QUARKUS_REGISTRY.equals(line)) {
+                line = reader.readLine();
+            }
+            if (line == null) {
+                Assertions.fail("Failed to locate registry " + TEST_QUARKUS_REGISTRY + " in the output");
+            }
+            line = reader.readLine();
+            Assertions.assertNotNull(line, "Expected stream");
+            final String expectedStream = getRequiredProperty("project.groupId") + ":" + getRequiredProperty("project.version");
+            Assertions.assertTrue(line.contains(expectedStream), expectedStream);
+
+            line = reader.readLine();
+            Assertions.assertNotNull(line);
+            Assertions.assertTrue(line.startsWith("(Read from "), "Expected (Read from ...");
+            Assertions.assertNull(reader.readLine(), "No further content expected");
+        }
+    }
+
+    @Test
     public void testRegistryRefresh() throws Exception {
 
         CliDriver.Result result;
 
-        RegistryClientTestHelper.enableRegistryClientTestConfig();
-        try {
-            // refresh the local cache and list the registries
-            result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e");
-            Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
-                    "Expected OK return code." + result);
-        } finally {
-            RegistryClientTestHelper.disableRegistryClientTestConfig();
-        }
+        // refresh the local cache and list the registries
+        result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code." + result);
 
         Path configPath = resolveConfigPath("enabledConfig.yml");
         result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e",
@@ -158,10 +182,10 @@ public class CliNonProjectTest {
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains(configPath.toString()),
                 "Should contain path to config file, found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("- registry.test.local"),
-                "Should contain '- registry.test.local', found: " + result.stdout);
-        Assertions.assertFalse(result.stdout.contains("- registry.quarkus.io"),
-                "Should not contain '- registry.quarkus.io', found: " + result.stdout);
+        Assertions.assertTrue(result.stdout.contains("registry.test.local"),
+                "Should contain 'registry.test.local', found: " + result.stdout);
+        Assertions.assertFalse(result.stdout.contains("registry.quarkus.io"),
+                "Should not contain 'registry.quarkus.io', found: " + result.stdout);
 
         configPath = resolveConfigPath("disabledConfig.yml");
         result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e",
@@ -170,10 +194,15 @@ public class CliNonProjectTest {
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains(configPath.toString()),
                 "Should contain path to config file, found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("- registry.test.local (disabled)"),
+        Assertions.assertTrue(result.stdout.contains("registry.test.local (disabled)"),
                 "Should contain '- registry.test.local (disabled)', found: " + result.stdout);
-        Assertions.assertTrue(result.stdout.contains("- registry.quarkus.io"),
+        Assertions.assertTrue(result.stdout.contains("registry.quarkus.io"),
                 "Should contain '- registry.quarkus.io', found: " + result.stdout);
+    }
+
+    private static String getRequiredProperty(String name) {
+        return Objects.requireNonNull(System.getProperty(name));
+
     }
 
     private static Path resolveConfigPath(String configName) throws URISyntaxException {

--- a/integration-tests/gradle/build.gradle
+++ b/integration-tests/gradle/build.gradle
@@ -55,6 +55,7 @@ test {
         systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
     }
     systemProperty 'project.version', "${version}"
+    systemProperty 'project.groupId', "${quarkusPlatformGroupId}"
     useJUnitPlatform()
 
     // Kotlin compiler does not support Java 14


### PR DESCRIPTION
Adds `--streams` option to the `registry` subcommand to list platform streams each enabled registry provides.

````
[aloubyansky@localhost test]$ qs registry
Configured Quarkus extension registries:
registry.quarkus.io
[aloubyansky@localhost test]$ qs registry --streams
Available Quarkus platform streams per registry:
registry.quarkus.io
  io.quarkus.platform:2.0
  io.quarkus.platform:2.1
  io.quarkus:1.13
````