### PR TITLE
Hibernate Reactive: make sure JTA context propagation doesn't fail if the user imports it

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -36,7 +36,7 @@
         <google-auth.version>0.22.0</google-auth.version>
         <microprofile-config-api.version>2.0</microprofile-config-api.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
-        <microprofile-context-propagation.version>1.2</microprofile-context-propagation.version>
+        <microprofile-context-propagation.version>1.2.1</microprofile-context-propagation.version>
         <microprofile-opentracing-api.version>2.0</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>2.0</microprofile-rest-client.version>

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -22,6 +22,11 @@
     </properties>
 
     <dependencies>
+        <!-- Make sure we force import of SR-CP-JTA to test https://github.com/quarkusio/quarkus/issues/18565 -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-context-propagation-jta</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-reactive-panache</artifactId>


### PR DESCRIPTION
This makes sure we don't remove its essential class from CDI, which is a side-effect of HR
importing ORM with excluding quarkus-narayana which would mark this class as unremovable.

This requires a new SR-CP release to get rid of a preliminary exception: https://github.com/smallrye/smallrye-context-propagation/pull/299 so it won't pass CI until that is merged and released.

Fixes #18565