### PR TITLE
Fix conditional dependency parsing

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -194,14 +194,14 @@ public class ConditionalDependenciesEnabler {
         List<Dependency> conditionalDependencies = new ArrayList<>();
         if (extensionProperties.containsKey(BootstrapConstants.CONDITIONAL_DEPENDENCIES)) {
             String conditionalDeps = extensionProperties.get(BootstrapConstants.CONDITIONAL_DEPENDENCIES).toString();
-            for (String conditionalDep : conditionalDeps.split(",")) {
+            for (String conditionalDep : conditionalDeps.split("\\s+")) {
                 conditionalDependencies.add(DependencyUtils.create(project.getDependencies(), conditionalDep));
             }
         }
         List<AppArtifactKey> constraints = new ArrayList<>();
         if (extensionProperties.containsKey(BootstrapConstants.DEPENDENCY_CONDITION)) {
             String constraintDeps = extensionProperties.getProperty(BootstrapConstants.DEPENDENCY_CONDITION);
-            for (String constraint : constraintDeps.split(",")) {
+            for (String constraint : constraintDeps.split("\\s+")) {
                 constraints.add(AppArtifactKey.fromString(constraint));
             }
         }

--- a/integration-tests/gradle/src/test/resources/conditional-dependencies/ext-h/runtime/src/main/resources/META-INF/quarkus-extension.properties
+++ b/integration-tests/gradle/src/test/resources/conditional-dependencies/ext-h/runtime/src/main/resources/META-INF/quarkus-extension.properties
@@ -1,3 +1,3 @@
 deployment-artifact=org.acme\:ext-h-deployment\:1.0-SNAPSHOT
-dependency-condition=org.acme\:ext-i\:\:jar,org.acme\:ext-j\:\:jar
+dependency-condition=org.acme\:ext-i\:\:jar org.acme\:ext-j\:\:jar
 

--- a/integration-tests/gradle/src/test/resources/conditional-dependencies/ext-m/runtime/src/main/resources/META-INF/quarkus-extension.properties
+++ b/integration-tests/gradle/src/test/resources/conditional-dependencies/ext-m/runtime/src/main/resources/META-INF/quarkus-extension.properties
@@ -1,3 +1,3 @@
 deployment-artifact=org.acme\:ext-m-deployment\:1.0-SNAPSHOT
-conditional-dependencies=org.acme\:ext-n\:\:jar\:1.0-SNAPSHOT,org.acme\:ext-r\:\:jar\:1.0-SNAPSHOT
+conditional-dependencies=org.acme\:ext-n\:\:jar\:1.0-SNAPSHOT org.acme\:ext-r\:\:jar\:1.0-SNAPSHOT
 


### PR DESCRIPTION
The Gradle plugin was splitting the conditional dependency list by comma while the `ExtensionDescriptorMojo` joins them by space.
This fix the gradle part to use spaces.