### PR TITLE
Ensure that rest-client and rest-client-reactive are not used together

### DIFF
--- a/extensions/resteasy-classic/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client/runtime/pom.xml
@@ -72,6 +72,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.rest.client</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
@@ -35,6 +35,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.rest.client</provides>
+                    </capabilities>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This has come up multiple times, with the latest being https://github.com/quarkusio/quarkus/issues/18792

This should not be allowed, but I am not sure if there are any tricky situations that could cause this to fail.

cc @michalszynkiewicz @gsmet @sberyozkin @stuartwdouglas 