### PR TITLE
Update Keycloak DevConsole to use the authorization code grant by default

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -45,10 +45,9 @@ Click on the `Provider: Keycloak` link and you will see a Keycloak page which wi
 
 By default the Keycloak page can be used to support the development of a link:security-openid-connect[Quarkus OIDC service application].
 
-==== Implicit Grant
+==== Authorization Code Grant
 
-If you set `quarkus.keycloak.devservices.grant.type=implicit` in `applicatin.properties` (this is a default value) then an `implicit` grant will be used to acquire both access and ID tokens.
-Using this grant is recommended to emulate a typical flow where a `Singe Page Application` acquires the tokens and uses them to access Quarkus services.
+If you set `quarkus.keycloak.devservices.grant.type=code` in `applicatin.properties` (this is a default value) then an `authorization_code` grant will be used to acquire both access and ID tokens. Using this grant is recommended to emulate a typical flow where a `Single Page Application` acquires the tokens and uses them to access Quarkus services.
 
 First you will see an option to `Log into Single Page Application`:
 
@@ -62,6 +61,10 @@ Here you can test the service with either the access token or ID token (note tha
 
 Finally you can click a `Logged in` option if you'd like to log out and authenticate to Keycloak as a different user.
 
+==== Implicit Grant
+
+If you set `quarkus.keycloak.devservices.grant.type=implicit` in `applicatin.properties` then an `implicit` grant will be used to acquire both access and ID tokens. Use this grant for emulating a `Single Page Application` only if the authorization code grant does not work (for example, a client is configured in Keycloak to support an implicit grant, etc).
+
 ==== Password Grant
 
 If you set `quarkus.keycloak.devservices.grant.type=password` in `applicatin.properties` then you will see a screen like this one:
@@ -74,7 +77,7 @@ You will also see in the Dev UI console something similar to:
 
 [source,shell]
 ----
-2021-07-19 17:58:11,407 INFO  [io.qua.oid.dep.dev.key.KeycloakDevConsolePostHandler] (security-openid-connect-quickstart-dev.jar) (DEV Console action) Getting token from 'http://localhost:32818/auth/realms/quarkus/protocol/openid-connect/token' for user 'alice' in realm 'quarkus' using client id 'quarkus-app'
+2021-07-19 17:58:11,407 INFO  [io.qua.oid.dep.dev.key.KeycloakDevConsolePostHandler] (security-openid-connect-quickstart-dev.jar) (DEV Console action) Using password grant to get a token from 'http://localhost:32818/auth/realms/quarkus/protocol/openid-connect/token' for user 'alice' in realm 'quarkus' with client id 'quarkus-app'
 2021-07-19 17:58:11,533 INFO  [io.qua.oid.dep.dev.key.KeycloakDevConsolePostHandler] (security-openid-connect-quickstart-dev.jar) (DEV Console action) Test token: eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ6Z2tDazJQZ1JaYnVlVG5kcTFKSW1sVnNoZ2hhbWhtbnBNcXU0QUt5MnJBIn0.ey...
 2021-07-19 17:58:11,536 INFO  [io.qua.oid.dep.dev.key.KeycloakDevConsolePostHandler] (security-openid-connect-quickstart-dev.jar) (DEV Console action) Sending token to 'http://localhost:8080/api/admin'
 2021-07-19 17:58:11,674 INFO  [io.qua.oid.dep.dev.key.KeycloakDevConsolePostHandler] (security-openid-connect-quickstart-dev.jar) (DEV Console action) Result: 200

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -76,6 +76,11 @@ public class DevServicesConfig {
             PASSWORD("password"),
 
             /**
+             * 'authorization_code' grant
+             */
+            CODE("code"),
+
+            /**
              * 'implicit' grant
              */
             IMPLICIT("implicit");
@@ -94,8 +99,8 @@ public class DevServicesConfig {
         /**
          * Grant type which will be used to acquire a token to test the OIDC 'service' applications
          */
-        @ConfigItem(defaultValue = "implicit")
-        public Type type = Type.IMPLICIT;
+        @ConfigItem(defaultValue = "code")
+        public Type type = Type.CODE;
     }
 
     /**

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakAuthorizationCodePostHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakAuthorizationCodePostHandler.java
@@ -1,0 +1,69 @@
+package io.quarkus.oidc.deployment.devservices.keycloak;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+public class KeycloakAuthorizationCodePostHandler extends DevConsolePostHandler {
+    private static final Logger LOG = Logger.getLogger(KeycloakAuthorizationCodePostHandler.class);
+
+    @Override
+    protected void handlePostAsync(RoutingContext event, MultiMap form) throws Exception {
+        WebClient client = KeycloakDevServicesUtils.createWebClient();
+        String keycloakUrl = form.get("keycloakUrl") + "/realms/" + form.get("realm") + "/protocol/openid-connect/token";
+
+        try {
+            LOG.infof("Using authorization_code grant to get a token from '%s' in realm '%s' with client id '%s'",
+                    keycloakUrl, form.get("realm"), form.get("client"));
+
+            HttpRequest<Buffer> request = client.postAbs(keycloakUrl);
+            request.putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
+
+            io.vertx.mutiny.core.MultiMap props = new io.vertx.mutiny.core.MultiMap(MultiMap.caseInsensitiveMultiMap());
+            props.add("client_id", form.get("client"));
+            if (form.get("clientSecret") != null) {
+                props.add("client_secret", form.get("clientSecret"));
+            }
+            props.add("grant_type", "authorization_code");
+            props.add("code", form.get("authorizationCode"));
+            props.add("redirect_uri", form.get("redirectUri"));
+
+            String tokens = request.sendBuffer(OidcCommonUtils.encodeForm(props)).onItem()
+                    .transform(resp -> getBodyAsString(resp))
+                    .await().atMost(KeycloakDevServicesProcessor.capturedDevServicesConfiguration.webClienTimeout);
+
+            event.put("tokens", tokens);
+
+        } catch (Throwable t) {
+            LOG.errorf("Token can not be acquired from Keycloak: %s", t.toString());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    protected void actionSuccess(RoutingContext event) {
+        event.response().setStatusCode(200);
+        String tokens = (String) event.get("tokens");
+        if (tokens != null) {
+            event.response().end(tokens);
+        }
+    }
+
+    private static String getBodyAsString(HttpResponse<Buffer> resp) {
+        if (resp.statusCode() == 200) {
+            return resp.bodyAsString();
+        } else {
+            String errorMessage = resp.bodyAsString();
+            throw new RuntimeException(errorMessage);
+        }
+    }
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsolePostHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsolePostHandler.java
@@ -26,7 +26,7 @@ public class KeycloakDevConsolePostHandler extends DevConsolePostHandler {
         try {
             String token = null;
             if ("password".equals(form.get("grant"))) {
-                LOG.infof("Getting token from '%s' for user '%s' in realm '%s' using client id '%s'",
+                LOG.infof("Using a password grant to get a token from '%s' for user '%s' in realm '%s' with client id '%s'",
                         keycloakUrl, form.get("user"), form.get("realm"), form.get("client"));
 
                 String userName = form.get("user");
@@ -36,7 +36,7 @@ public class KeycloakDevConsolePostHandler extends DevConsolePostHandler {
                         users.get(userName),
                         KeycloakDevServicesProcessor.capturedDevServicesConfiguration.webClienTimeout);
             } else {
-                LOG.infof("Getting token from '%s' in realm '%s' using client id '%s'",
+                LOG.infof("Using a client_credentials grant to get a token token from '%s' in realm '%s' with client id '%s'",
                         keycloakUrl, form.get("realm"), form.get("client"));
 
                 token = KeycloakDevServicesUtils.getClientCredAccessToken(client, keycloakUrl,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -48,6 +48,8 @@ public class KeycloakDevConsoleProcessor {
                     new DevConsoleRouteBuildItem("testService", "POST", new KeycloakDevConsolePostHandler(users)));
             devConsoleRoute.produce(
                     new DevConsoleRouteBuildItem("testServiceWithToken", "POST", new KeycloakImplicitGrantPostHandler()));
+            devConsoleRoute.produce(
+                    new DevConsoleRouteBuildItem("exchangeCodeForTokens", "POST", new KeycloakAuthorizationCodePostHandler()));
         }
     }
 }

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -4,7 +4,7 @@
 {#script}
 
 {#if info:oidcApplicationType is 'service'}
-    {#if info:oidcGrantType is 'implicit'}
+    {#if info:oidcGrantType is 'implicit' || info:oidcGrantType is 'code'}
     var accessToken;
     var idToken;
     var loggedIn = false;
@@ -18,16 +18,21 @@
             var hash = window.location.hash;
             accessToken = hash.match(/access_token=([^&]+)/)[1];
             idToken = hash.match(/id_token=([^&]+)/)[1];
-
             $('#accessTokenArea').text(accessToken);
             $('#idTokenArea').text(idToken);
+        }else if(codeInUrl()){
+            loggedIn === true;
+            $('.implicitLoggedOut').hide();
+            $('.implicitLoggedIn').show();
+            var hash = window.location.hash;
+            var code = hash.match(/code=([^&]+)/)[1];
+            exchangeCodeForTokens(code);
         }else{
             loggedIn === false;
             $('.implicitLoggedOut').show();
             $('.implicitLoggedIn').hide();
             accessToken = null;
             idToken = null;
-
             $('#accessTokenArea').text('');
             $('#idTokenArea').text('');
 
@@ -45,6 +50,10 @@
     function accessTokenInUrl(){
         return inUrl('access_token');
     }
+    
+    function codeInUrl(){
+        return inUrl('code');
+    }
 
     function inUrl(field){
         var url = window.location.href;
@@ -56,11 +65,19 @@
     }
 
     function signInToKeycloakAndGetTokens() {
+      {#if info:oidcGrantType is 'implicit'}
         window.location.href = '{info:keycloakUrl}' + "/realms/" + '{info:keycloakRealm}' + "/protocol/openid-connect/auth"
           + "?client_id=" + '{info:keycloakClient}'
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A8080%2Fq%2Fdev%2Fio.quarkus.quarkus-oidc%2Fprovider"
           + "&scope=openid&response_type=token id_token&response_mode=fragment&prompt=login"
           + "&nonce=" + makeid();
+      {#else}
+        window.location.href = '{info:keycloakUrl}' + "/realms/" + '{info:keycloakRealm}' + "/protocol/openid-connect/auth"
+          + "?client_id=" + '{info:keycloakClient}'
+          + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A8080%2Fq%2Fdev%2Fio.quarkus.quarkus-oidc%2Fprovider"
+          + "&scope=openid&response_type=code&response_mode=fragment&prompt=login"
+          + "&nonce=" + makeid();
+      {/if}    
     }
 
     function testServiceWithAccessToken(){
@@ -118,8 +135,26 @@
     function logout() {
         window.location.assign('{info:keycloakUrl}' + "/realms/" + '{info:keycloakRealm}' + "/protocol/openid-connect/logout"
           + "?post_logout_redirect_uri=" + "http%3A%2F%2Flocalhost%3A8080%2Fq%2Fdev%2Fio.quarkus.quarkus-oidc%2Fprovider");
-    }    
-    
+    }
+        
+    function exchangeCodeForTokens(code){
+        $.post("exchangeCodeForTokens",
+            {
+              keycloakUrl: '{info:keycloakUrl}',
+              realm: '{info:keycloakRealm}',
+              client: '{info:keycloakClient}',
+              clientSecret: '{info:keycloakClientSecret}',
+              authorizationCode: code,
+              redirectUri: "http://localhost:8080/q/dev/io.quarkus.quarkus-oidc/provider"
+            },
+            function(data, status){
+                var tokens = JSON.parse(data);
+                accessToken = tokens.access_token
+                idToken = tokens.id_token
+                $('#accessTokenArea').text(accessToken);
+                $('#idTokenArea').text(idToken);
+            });
+    }
     
     {/if}
 {/if}
@@ -191,7 +226,7 @@ function signInToService(servicePath) {
 
 <div class="container">
 {#if info:oidcApplicationType?? is 'service'}
-    {#if info:oidcGrantType is 'implicit'}
+    {#if info:oidcGrantType is 'implicit' || info:oidcGrantType is 'code'}
         
         <div class="card implicitLoggedOut">
             <div class="card-body">


### PR DESCRIPTION
This PR updates KC dev console to use an `authorization_code` grant by default, `implicit` is not having a good reputation (it was easier to start with), and even though it is a test SPA, it still makes sense to use the code flow by default since it is recommended for SPAs/public clients and KC clients have to be configured to allow the implicit flow - hence a possible mismatch between the real realm configuration and what Dev Console for KC offers by default.

I was not changing `provider.html` card ids like  `implicitLoggedOut` to have diff ids depending on whether it was the implicit or code flow, these are internal ids, all works in both cases
 
Quarkus `web-app` itself uses it too.