### PR TITLE
Improve Kafka Avro serializer/deserializer autodetection

### DIFF
--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -179,10 +179,10 @@ To achieve this, edit the `application.properties` file, and add the following c
 
 [source,properties]
 ----
-# set the connector to use for the `movies` channel to smallrye-kafka
+# set the connector for the outgoing channel to `smallrye-kafka`
 mp.messaging.outgoing.movies.connector=smallrye-kafka
 
-# the name of the corresponding Kafka topic to `movies`
+# set the topic name for the channel to `movies`
 mp.messaging.outgoing.movies.topic=movies
 
 # automatically register the schema with the registry, if not present
@@ -249,12 +249,11 @@ mp.messaging.incoming.movies-from-kafka.topic=movies
 mp.messaging.incoming.movies-from-kafka.enable.auto.commit=false
 
 mp.messaging.incoming.movies-from-kafka.auto.offset.reset=earliest
-mp.messaging.incoming.movies-from-kafka.apicurio.registry.use-specific-avro-reader=true
 ----
 
 TIP: You might have noticed that we didn't define the `value.deserializer`.
 That's because Quarkus can xref:kafka.adoc#serialization-autodetection[autodetect] that `io.apicurio.registry.serde.avro.AvroKafkaDeserializer` is appropriate here, based on the `@Channel` declaration, structure of the `Movie` type, and presence of the Apicurio Registry libraries.
-We still have to define the `apicurio.registry.use-specific-avro-reader` property.
+We don't have to define the `apicurio.registry.use-specific-avro-reader` property either, that is also configured automatically.
 
 == Running the application
 
@@ -480,7 +479,7 @@ public class MovieResourceTest {
 
         source.open();
 
-        // check if, after at most 5 seconds, we have at last 2 items collected, and they are what we expect:
+        // check if, after at most 5 seconds, we have at least 2 items collected, and they are what we expect
         await().atMost(5, SECONDS).until(() -> received.size() >= 2);
         assertThat(received, Matchers.hasItems("'The Shawshank Redemption' from 1994",
                 "'12 Angry Men' from 1957"));

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1252,15 +1252,16 @@ The full set of types supported by the serializer/deserializer autodetection is:
 * `io.vertx.core.buffer.Buffer`
 * `io.vertx.core.json.JsonObject`
 * `io.vertx.core.json.JsonArray`
-* classes generated from Avro schemas, if Confluent or Apicurio _serde_ is present
-** see link:kafka-schema-registry-avro[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio libraries
+* classes generated from Avro schemas, as well as Avro `GenericRecord`, if Confluent or Apicurio Registry _serde_ is present
+** see link:kafka-schema-registry-avro[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio Registry libraries
 * classes for which a subclass of `ObjectMapperSerializer` / `ObjectMapperDeserializer` is present, as described in <<jackson-serialization>>
 ** it is technically not needed to subclass `ObjectMapperSerializer`, but in such case, autodetection isn't possible
 * classes for which a subclass of `JsonbSerializer` / `JsonbDeserializer` is present, as described in <<jsonb-serialization>>
 ** it is technically not needed to subclass `JsonbSerializer`, but in such case, autodetection isn't possible
 
-In case you have any issues with serializer autodetection, you can switch it off completely by setting `quarkus.reactive-messaging.kafka.serializer-autodetection.enabled=false`.
 If a serializer/deserializer is set by configuration, it won't be replaced by the autodetection.
+
+In case you have any issues with serializer autodetection, you can switch it off completely by setting `quarkus.reactive-messaging.kafka.serializer-autodetection.enabled=false`.
 If you find you need to do this, please file a bug in the link:https://github.com/quarkusio/quarkus/issues[Quarkus issue tracker] so we can fix whatever problem you have.
 
 == Using Schema Registry

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
@@ -1,8 +1,10 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -19,7 +21,7 @@ class DefaultSerdeDiscoveryState {
     private final IndexView index;
 
     private final Map<String, Boolean> isKafkaConnector = new HashMap<>();
-    private final Map<String, String> serdeConfigMap = new HashMap<>();
+    private final Set<String> alreadyConfigured = new HashSet<>();
 
     private Boolean hasConfluent;
     private Boolean hasApicurio1;
@@ -41,9 +43,9 @@ class DefaultSerdeDiscoveryState {
         });
     }
 
-    void runIfConfigIsAbsent(String key, String value, Runnable runnable) {
-        if (value != null && !serdeConfigMap.containsKey(key)) {
-            serdeConfigMap.put(key, value);
+    void ifNotYetConfigured(String key, Runnable runnable) {
+        if (!alreadyConfigured.contains(key)) {
+            alreadyConfigured.add(key);
             runnable.run();
         }
     }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
@@ -29,6 +29,7 @@ final class DotNames {
     static final DotName MULTI = DotName.createSimple(io.smallrye.mutiny.Multi.class.getName());
 
     static final DotName AVRO_GENERATED = DotName.createSimple("org.apache.avro.specific.AvroGenerated");
+    static final DotName AVRO_GENERIC_RECORD = DotName.createSimple("org.apache.avro.generic.GenericRecord");
     static final DotName OBJECT_MAPPER_DESERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.ObjectMapperDeserializer.class.getName());
     static final DotName OBJECT_MAPPER_SERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.ObjectMapperSerializer.class.getName());
     static final DotName JSONB_DESERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.JsonbDeserializer.class.getName());

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/Result.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/Result.java
@@ -1,0 +1,32 @@
+package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class Result {
+    final String value; // serializer/deserializer type
+    final Map<String, String> additionalProperties;
+
+    static Result of(String result) {
+        return new Result(result, new HashMap<>());
+    }
+
+    private Result(String value, Map<String, String> additionalProperties) {
+        this.value = value;
+        this.additionalProperties = additionalProperties;
+    }
+
+    Result with(String key, String value) {
+        return with(true, key, value);
+    }
+
+    Result with(boolean condition, String key, String value) {
+        if (!condition) {
+            return this;
+        }
+
+        Map<String, String> additionalProperties = new HashMap<>(this.additionalProperties);
+        additionalProperties.put(key, value);
+        return new Result(this.value, additionalProperties);
+    }
+}

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.AvroGenerated;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -726,6 +727,363 @@ public class DefaultSerdeConfigTest {
         @Incoming("channel64")
         @Outgoing("channel65")
         Multi<AvroDto> method43(Multi<byte[]> payload) {
+            return null;
+        }
+    }
+
+    // ---
+
+    @Test
+    public void avroDtoInGenericRecordOut() {
+        // @formatter:off
+        Tuple[] expectations = {
+                tuple("mp.messaging.outgoing.channel1.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel2.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel3.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel4.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel5.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel6.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel7.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel8.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel9.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel10.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel11.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.outgoing.channel12.value.serializer", "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+
+                tuple("mp.messaging.incoming.channel13.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel13.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel14.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel14.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel15.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel15.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel16.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel16.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel17.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel17.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel18.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel18.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel19.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel19.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel20.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel20.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.incoming.channel21.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel21.apicurio.registry.use-specific-avro-reader", "true"),
+
+                tuple("mp.messaging.incoming.channel22.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel22.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel23.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel24.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel24.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel25.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel26.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel26.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel27.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel28.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel28.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel29.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel30.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel30.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel31.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel32.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel32.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel33.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel34.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel34.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel35.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel36.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel36.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel37.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel38.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel38.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel39.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel40.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel40.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel41.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel42.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel42.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel43.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel44.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel44.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel45.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel46.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel46.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel47.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel48.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel48.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel49.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel50.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel50.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel51.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel52.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel52.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel53.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+
+                tuple("mp.messaging.incoming.channel54.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel54.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel55.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel56.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel56.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel57.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel58.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel58.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel59.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel60.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel60.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel61.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel62.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel62.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel63.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+                tuple("mp.messaging.incoming.channel64.value.deserializer", "io.apicurio.registry.serde.avro.AvroKafkaDeserializer"),
+                tuple("mp.messaging.incoming.channel64.apicurio.registry.use-specific-avro-reader", "true"),
+                tuple("mp.messaging.outgoing.channel65.value.serializer",   "io.apicurio.registry.serde.avro.AvroKafkaSerializer"),
+        };
+        // @formatter:on
+
+        doTest(expectations, AvroDto.class, AvroDtoInGenericRecordOut.class);
+    }
+
+    private static class AvroDtoInGenericRecordOut {
+        // @Outgoing
+
+        @Outgoing("channel1")
+        Publisher<Message<GenericRecord>> method1() {
+            return null;
+        }
+
+        @Outgoing("channel2")
+        Publisher<GenericRecord> method2() {
+            return null;
+        }
+
+        @Outgoing("channel3")
+        PublisherBuilder<Message<GenericRecord>> method3() {
+            return null;
+        }
+
+        @Outgoing("channel4")
+        PublisherBuilder<GenericRecord> method4() {
+            return null;
+        }
+
+        @Outgoing("channel5")
+        Multi<Message<GenericRecord>> method5() {
+            return null;
+        }
+
+        @Outgoing("channel6")
+        Multi<GenericRecord> method6() {
+            return null;
+        }
+
+        @Outgoing("channel7")
+        Message<GenericRecord> method7() {
+            return null;
+        }
+
+        @Outgoing("channel8")
+        GenericRecord method8() {
+            return null;
+        }
+
+        @Outgoing("channel9")
+        CompletionStage<Message<GenericRecord>> method9() {
+            return null;
+        }
+
+        @Outgoing("channel10")
+        CompletionStage<GenericRecord> method10() {
+            return null;
+        }
+
+        @Outgoing("channel11")
+        Uni<Message<GenericRecord>> method11() {
+            return null;
+        }
+
+        @Outgoing("channel12")
+        Uni<GenericRecord> method12() {
+            return null;
+        }
+
+        // @Incoming
+
+        @Incoming("channel13")
+        Subscriber<Message<AvroDto>> method13() {
+            return null;
+        }
+
+        @Incoming("channel14")
+        Subscriber<AvroDto> method14() {
+            return null;
+        }
+
+        @Incoming("channel15")
+        SubscriberBuilder<Message<AvroDto>, Void> method15() {
+            return null;
+        }
+
+        @Incoming("channel16")
+        SubscriberBuilder<AvroDto, Void> method16() {
+            return null;
+        }
+
+        @Incoming("channel17")
+        void method17(AvroDto msg) {
+        }
+
+        @Incoming("channel18")
+        CompletionStage<?> method18(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel19")
+        CompletionStage<?> method19(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel20")
+        Uni<?> method20(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel21")
+        Uni<?> method21(AvroDto payload) {
+            return null;
+        }
+
+        // @Incoming @Outgoing
+
+        @Incoming("channel22")
+        @Outgoing("channel23")
+        Processor<Message<AvroDto>, Message<GenericRecord>> method22() {
+            return null;
+        }
+
+        @Incoming("channel24")
+        @Outgoing("channel25")
+        Processor<AvroDto, GenericRecord> method23() {
+            return null;
+        }
+
+        @Incoming("channel26")
+        @Outgoing("channel27")
+        ProcessorBuilder<Message<AvroDto>, Message<GenericRecord>> method24() {
+            return null;
+        }
+
+        @Incoming("channel28")
+        @Outgoing("channel29")
+        ProcessorBuilder<AvroDto, GenericRecord> method25() {
+            return null;
+        }
+
+        @Incoming("channel30")
+        @Outgoing("channel31")
+        Publisher<Message<GenericRecord>> method26(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel32")
+        @Outgoing("channel33")
+        Publisher<GenericRecord> method27(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel34")
+        @Outgoing("channel35")
+        PublisherBuilder<Message<GenericRecord>> method28(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel36")
+        @Outgoing("channel37")
+        PublisherBuilder<GenericRecord> method29(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel38")
+        @Outgoing("channel39")
+        Multi<Message<GenericRecord>> method30(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel40")
+        @Outgoing("channel41")
+        Multi<GenericRecord> method31(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel42")
+        @Outgoing("channel43")
+        Message<GenericRecord> method32(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel44")
+        @Outgoing("channel45")
+        GenericRecord method33(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel46")
+        @Outgoing("channel47")
+        CompletionStage<Message<GenericRecord>> method34(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel48")
+        @Outgoing("channel49")
+        CompletionStage<GenericRecord> method35(AvroDto payload) {
+            return null;
+        }
+
+        @Incoming("channel50")
+        @Outgoing("channel51")
+        Uni<Message<GenericRecord>> method36(Message<AvroDto> msg) {
+            return null;
+        }
+
+        @Incoming("channel52")
+        @Outgoing("channel53")
+        Uni<GenericRecord> method37(AvroDto payload) {
+            return null;
+        }
+
+        // @Incoming @Outgoing stream manipulation
+
+        @Incoming("channel54")
+        @Outgoing("channel55")
+        Publisher<Message<GenericRecord>> method38(Publisher<Message<AvroDto>> msg) {
+            return null;
+        }
+
+        @Incoming("channel56")
+        @Outgoing("channel57")
+        Publisher<GenericRecord> method39(Publisher<AvroDto> payload) {
+            return null;
+        }
+
+        @Incoming("channel58")
+        @Outgoing("channel59")
+        PublisherBuilder<Message<GenericRecord>> method40(PublisherBuilder<Message<AvroDto>> msg) {
+            return null;
+        }
+
+        @Incoming("channel60")
+        @Outgoing("channel61")
+        PublisherBuilder<GenericRecord> method41(PublisherBuilder<AvroDto> payload) {
+            return null;
+        }
+
+        @Incoming("channel62")
+        @Outgoing("channel63")
+        Multi<Message<GenericRecord>> method42(Multi<Message<AvroDto>> msg) {
+            return null;
+        }
+
+        @Incoming("channel64")
+        @Outgoing("channel65")
+        Multi<GenericRecord> method43(Multi<AvroDto> payload) {
             return null;
         }
     }
@@ -2015,7 +2373,6 @@ public class DefaultSerdeConfigTest {
 
         @Incoming("channel2")
         void channel2Duplicate(JacksonDto jacksonDto) {
-
         }
 
         @Channel("channel3")
@@ -2023,7 +2380,6 @@ public class DefaultSerdeConfigTest {
 
         @Incoming("channel3")
         void channel3Duplicate(Record<Integer, JacksonDto> jacksonDto) {
-
         }
 
         @Channel("channel4")
@@ -2032,7 +2388,6 @@ public class DefaultSerdeConfigTest {
         @Outgoing("channel4")
         ProducerRecord<String, Integer> method4() {
             return null;
-        };
-
+        }
     }
 }


### PR DESCRIPTION
When the key/value class is `@AvroGenerated`, we autodetect
the corresponding Confluent / Apicurio Registry serde, which is
enough on the serialization side. On the deserialization side,
users had to add `specific.avro.reader=true` for Confluent or
`apicurio.registry.use-specific-avro-reader=true` for Apicurio
Registry. If they didn't, the deserializer would produce
a `GenericRecord`, which would always fail (we already detected
that users want the `@AvroGenerated` class).

With this commit, we automatically configure this property too,
and also support the `GenericRecord` class. This makes serde
autodetection for Avro more convenient.

Partially addresses #18195.