### PR TITLE
Disable Dev Services for MongoEntityTest

### DIFF
--- a/extensions/panache/mongodb-panache/deployment/src/test/resources/application.properties
+++ b/extensions/panache/mongodb-panache/deployment/src/test/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.mongodb.devservices.enabled=false
+
 quarkus.mongodb.database=test
 
 quarkus.mongodb.cl1-10812.connection-string=mongodb://localhost:27018


### PR DESCRIPTION
Docker is not available in the Windows CI this why this test was
failing.

@loicmathieu that's why the test was failing. I thought it was a transient error at first, thus why I merged it.