### PR TITLE
Change the default thread model for RR

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -963,16 +963,28 @@ The event-loop threads (also called IO threads) are responsible for actually per
 operations in an asynchronous way, and to trigger any listener interested in the completion of those
 IO operations.
 
-By default, RESTEasy Reactive will run endpoint methods on the event-loop threads, on the assumption that
-they are going to be fast and only invoke non-blocking operations.
+By default, the thread RESTEasy Reactive will run endpoint methods on depends on the signature of the method.
+If a method returns one of the following types then it is considered non-blocking, and will be run on the IO thread
+by default:
 
-This is the model of execution that leads to best performance if your endpoints do not do any blocking
-operation (such as blocking IO, blocking on an asynchronous operation, or sleeping).
+- `io.smallrye.mutiny.Uni`
+- `io.smallrye.mutiny.Multi`
+- `java.util.concurrent.CompletionStage`
+- `org.reactivestreams.Publisher`
+- Kotlin `suspended` methods
 
-If your endpoint method needs to do any of those blocking operations, you should add the 
+This 'best guess' approach means that the majority of operations will run on the correct thread by default. If you are
+writing reactive code then your method will generally return one of these types, and will be executed on the IO thread.
+If you are writing blocking code your methods will generally return the result directly, and these will be run on a worker
+thread.
+
+You can override this behaviour using the
 https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/1.5.0/io/smallrye/common/annotation/Blocking.html[`@Blocking`]
-annotation on your endpoint and it will instead be invoked on a worker thread. Your endpoint method
-code can remain exactly the same, and it will be allowed to block:
+and
+https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/1.5.0/io/smallrye/common/annotation/NonBlocking.html[`@NonBlocking`]
+annotations. This can be applied at the method, class or `javax.ws.rs.core.Application` level.
+
+The example below will override the default behaviour and always run on a worker thread, even though it returns a `Uni`.
 
 [source,java]
 ----
@@ -988,10 +1000,10 @@ public class Endpoint {
 
     @Blocking
     @GET
-    public String blockingHello() throws InterruptedException {
+    public Uni<String> blockingHello() throws InterruptedException {
         // do a blocking operation
         Thread.sleep(1000);
-        return "Yaaaawwwwnnnnnn…";
+        return Uni.createFrom().item("Yaaaawwwwnnnnnn…");
     }
 }
 ----
@@ -1026,6 +1038,14 @@ public class Endpoint {
 If a method or class is annotated with `javax.transaction.Transactional` then it will also be treated as a blocking
 method. This is because JTA is a blocking technology, and is generally used with other blocking technology such as
 Hibernate and JDBC. An explicit `@Blocking` or `@NonBlocking` on the class will override this behaviour.
+
+==== Overriding the default behaviour
+
+If you want to override the default behaviour you can annotate a `javax.ws.rs.core.Application` subclass in your application
+with `@Blocking` or `@NonBlocking`, and this will set the default for every method that does not have an explicit annotation.
+
+Behaviour can still be overridden on a class or method level by annotating them directly, however all endpoints without
+an annotation will now follow the default, no matter their method signature.
 
 === Exception mapping
 

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -226,7 +226,7 @@ public class JaxrsClientReactiveProcessor {
                 .setInjectableBeans(new HashMap<>())
                 .setFactoryCreator(new QuarkusFactoryCreator(recorder, beanContainerBuildItem.getValue()))
                 .setAdditionalWriters(additionalWriters)
-                .setDefaultBlocking(applicationResultBuildItem.getResult().isBlocking())
+                .setDefaultBlocking(applicationResultBuildItem.getResult().getBlockingDefault())
                 .setHasRuntimeConverters(false)
                 .setDefaultProduces(defaultProducesType)
                 .setSmartDefaultProduces(disableSmartDefaultProduces.isEmpty())

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -28,9 +28,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
 import io.quarkus.runtime.BlockingOperationControl;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 
 @Path("/simple")
+@NonBlocking
 public class SimpleJsonResource extends SuperClass<Person> {
 
     @ServerExceptionMapper

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonResource.java
@@ -15,9 +15,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.runtime.BlockingOperationControl;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 
 @Path("/simple")
+@NonBlocking
 public class SimpleJsonResource extends SuperClass<Person> {
 
     @GET

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -99,6 +99,16 @@ public class KotlinCoroutineIntegrationProcessor {
                 }
                 return null;
             }
+
+            @Override
+            public boolean isMethodSignatureAsync(MethodInfo info) {
+                for (var param : info.parameters()) {
+                    if (param.name().equals(CONTINUATION)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
         });
     }
 
@@ -166,6 +176,11 @@ public class KotlinCoroutineIntegrationProcessor {
                             HandlerChainCustomizer.Phase.AFTER_METHOD_INVOKE));
                 }
                 return Collections.emptyList();
+            }
+
+            @Override
+            public boolean isMethodSignatureAsync(MethodInfo info) {
+                return info.returnType().name().equals(FLOW);
             }
         });
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -343,7 +343,7 @@ public class ResteasyReactiveProcessor {
                     .setHttpAnnotationToMethod(result.getHttpAnnotationToMethod())
                     .setInjectableBeans(injectableBeans)
                     .setAdditionalWriters(additionalWriters)
-                    .setDefaultBlocking(appResult.isBlocking())
+                    .setDefaultBlocking(appResult.getBlockingDefault())
                     .setHasRuntimeConverters(!paramConverterProviders.getParamConverterProviders().isEmpty())
                     .setClassLevelExceptionMappers(
                             classLevelExceptionMappers.isPresent() ? classLevelExceptionMappers.get().getMappers()

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveVertxWebSocketIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveVertxWebSocketIntegrationProcessor.java
@@ -45,6 +45,16 @@ public class ResteasyReactiveVertxWebSocketIntegrationProcessor {
                 }
                 return null;
             }
+
+            @Override
+            public boolean isMethodSignatureAsync(MethodInfo info) {
+                for (var param : info.parameters()) {
+                    if (param.name().equals(SERVER_WEB_SOCKET)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
         });
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ValidNonBlockingFiltersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ValidNonBlockingFiltersTest.java
@@ -29,6 +29,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.Headers;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
 
 public class ValidNonBlockingFiltersTest {
 
@@ -79,8 +80,8 @@ public class ValidNonBlockingFiltersTest {
 
         @Path("nonblocking")
         @GET
-        public Response nonblocking(@Context HttpHeaders headers) {
-            return getResponse(headers);
+        public Uni<Response> nonblocking(@Context HttpHeaders headers) {
+            return Uni.createFrom().item(getResponse(headers));
         }
 
         private Response getResponse(HttpHeaders headers) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResource.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.reactive.RestQuery;
 
 import io.quarkus.runtime.BlockingOperationControl;
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 
 @Path("/multipart")
 public class MultipartResource {
@@ -24,6 +25,7 @@ public class MultipartResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/simple/{times}")
+    @NonBlocking
     public String simple(@MultipartForm FormData formData, Integer times) {
         if (BlockingOperationControl.isBlockingAllowed()) {
             throw new RuntimeException("should not have dispatched");
@@ -41,7 +43,7 @@ public class MultipartResource {
     @Path("/blocking")
     public Response blocking(@DefaultValue("1") @RestQuery Integer times, FormData formData) throws IOException {
         if (!BlockingOperationControl.isBlockingAllowed()) {
-            throw new RuntimeException("should not have dispatched");
+            throw new RuntimeException("should have dispatched");
         }
         return Response.ok(formData.getName() + " - " + times * formData.getNum() + " - " + formData.getStatus())
                 .header("html-size", formData.getHtmlPart().size())
@@ -58,8 +60,8 @@ public class MultipartResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/same-name")
     public String sameName(FormDataSameFileName formData) {
-        if (BlockingOperationControl.isBlockingAllowed()) {
-            throw new RuntimeException("should not have dispatched");
+        if (!BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException("should have dispatched");
         }
         return formData.status + " - " + formData.getHtmlFiles().size() + " - " + formData.txtFiles.size() + " - "
                 + formData.xmlFiles.size();

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResourceWithAllUploads.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartResourceWithAllUploads.java
@@ -10,6 +10,7 @@ import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 import io.quarkus.runtime.BlockingOperationControl;
+import io.smallrye.common.annotation.NonBlocking;
 
 @Path("/multipart-all")
 public class MultipartResourceWithAllUploads {
@@ -17,6 +18,7 @@ public class MultipartResourceWithAllUploads {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @NonBlocking
     @Path("/simple/{times}")
     public String simple(@MultipartForm FormDataWithAllUploads formData, Integer times) {
         if (BlockingOperationControl.isBlockingAllowed()) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/InterfaceWithImplTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/InterfaceWithImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 
 public class InterfaceWithImplTest {
 
@@ -33,6 +34,7 @@ public class InterfaceWithImplTest {
     }
 
     @Path("/hello")
+    @NonBlocking
     public interface Greeting {
 
         @GET

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/lock/prevention/CallMakingResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/lock/prevention/CallMakingResource.java
@@ -8,8 +8,10 @@ import javax.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 
 @Path("/non-blocking")
+@NonBlocking
 public class CallMakingResource {
 
     @RestClient

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/BlockingDefault.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/BlockingDefault.java
@@ -1,0 +1,10 @@
+package org.jboss.resteasy.reactive.common.processor;
+
+public enum BlockingDefault {
+    /**
+     * The nature of the method is determined by the return type
+     */
+    AUTOMATIC,
+    BLOCKING,
+    NON_BLOCKING
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ApplicationScanningResult.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ApplicationScanningResult.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.common.processor.scanning;
 import java.util.Set;
 import javax.ws.rs.core.Application;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.resteasy.reactive.common.processor.BlockingDefault;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 
 public final class ApplicationScanningResult {
@@ -14,11 +15,11 @@ public final class ApplicationScanningResult {
     final boolean filterClasses;
     final Application application;
     final ClassInfo selectedAppClass;
-    final boolean blocking;
+    final BlockingDefault blocking;
 
     public ApplicationScanningResult(Set<String> allowedClasses, Set<String> singletonClasses, Set<String> excludedClasses,
             Set<String> globalNameBindings, boolean filterClasses, Application application,
-            ClassInfo selectedAppClass, boolean blocking) {
+            ClassInfo selectedAppClass, BlockingDefault blocking) {
         this.allowedClasses = allowedClasses;
         this.singletonClasses = singletonClasses;
         this.excludedClasses = excludedClasses;
@@ -83,7 +84,7 @@ public final class ApplicationScanningResult {
         return selectedAppClass;
     }
 
-    public boolean isBlocking() {
+    public BlockingDefault getBlockingDefault() {
         return blocking;
     }
 

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -29,6 +29,7 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.common.processor.BlockingDefault;
 import org.jboss.resteasy.reactive.common.processor.NameBindingUtil;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 
@@ -57,7 +58,7 @@ public class ResteasyReactiveScanner {
         boolean filterClasses = !excludedClasses.isEmpty();
         Application application = null;
         ClassInfo selectedAppClass = null;
-        boolean blocking = false;
+        BlockingDefault blocking = BlockingDefault.AUTOMATIC;
         for (ClassInfo applicationClassInfo : applications) {
             if (Modifier.isAbstract(applicationClassInfo.flags())) {
                 continue;
@@ -94,9 +95,9 @@ public class ResteasyReactiveScanner {
                 throw new RuntimeException("Unable to handle class: " + applicationClass, e);
             }
             if (applicationClassInfo.classAnnotation(ResteasyReactiveDotNames.BLOCKING) != null) {
-                blocking = true;
+                blocking = BlockingDefault.BLOCKING;
             } else if (applicationClassInfo.classAnnotation(ResteasyReactiveDotNames.NON_BLOCKING) != null) {
-                blocking = false;
+                blocking = BlockingDefault.NON_BLOCKING;
             }
         }
         if (selectedAppClass != null) {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -145,6 +145,15 @@ public class ServerEndpointIndexer
         return injectableBean.isFormParamRequired();
     }
 
+    protected boolean doesMethodHaveBlockingSignature(MethodInfo info) {
+        for (var i : methodScanners) {
+            if (i.isMethodSignatureAsync(info)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     protected void handleAdditionalMethodProcessing(ServerResourceMethod method, ClassInfo currentClassInfo, MethodInfo info) {
         Supplier<EndpointInvoker> invokerSupplier = null;

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/AsyncReturnTypeScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/AsyncReturnTypeScanner.java
@@ -39,4 +39,11 @@ public class AsyncReturnTypeScanner implements MethodScanner {
         }
         return Collections.emptyList();
     }
+
+    @Override
+    public boolean isMethodSignatureAsync(MethodInfo method) {
+        DotName returnTypeName = method.returnType().name();
+        return returnTypeName.equals(COMPLETION_STAGE) || returnTypeName.equals(UNI) || returnTypeName.equals(MULTI)
+                || returnTypeName.equals(PUBLISHER);
+    }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/MethodScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/MethodScanner.java
@@ -43,4 +43,8 @@ public interface MethodScanner {
         return null;
     }
 
+    default boolean isMethodSignatureAsync(MethodInfo info) {
+        return false;
+    }
+
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/BlockingOperationSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/BlockingOperationSupport.java
@@ -9,6 +9,9 @@ public class BlockingOperationSupport {
     }
 
     public static boolean isBlockingAllowed() {
+        if (ioThreadDetector == null) {
+            return true;
+        }
         return ioThreadDetector.isBlockingAllowed();
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormDataParser.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormDataParser.java
@@ -31,7 +31,7 @@ public interface FormDataParser extends Closeable {
      * @return The parsed form data
      * @throws IOException If the data could not be read
      */
-    FormData parseBlocking() throws IOException;
+    FormData parseBlocking() throws Exception;
 
     /**
      * Closes the parser, and removes and temporary files that may have been created.

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormEncodedDataDefinition.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/FormEncodedDataDefinition.java
@@ -219,7 +219,7 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
         }
 
         @Override
-        public FormData parseBlocking() throws IOException {
+        public FormData parseBlocking() throws Exception {
             final FormData existing = exchange.getFormData();
             if (existing != null) {
                 return existing;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
@@ -206,7 +206,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
         }
 
         @Override
-        public FormData parseBlocking() throws IOException {
+        public FormData parseBlocking() throws Exception {
             final FormData existing = exchange.getFormData();
             if (existing != null) {
                 return existing;
@@ -221,8 +221,6 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                     throw new IOException("Connection terminated parsing multipart request");
                 }
                 exchange.setFormData(data);
-            } catch (RuntimeException e) {
-                throw new IOException(e);
             }
             return data;
         }


### PR DESCRIPTION
- If an async type is returned (CompletionStage, Uni, Multi etc) then it
  remains non blocking
- If the method is a Kotlin suspended method it remains non-blocking
- All other methods default to blocking, unless explicitly specified
- @(Non)Blocking on an application class works as normal, and will
  override the method signature based defaults