### PR TITLE
Add a custom connection cache to Agroal

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -171,6 +171,10 @@ public class DataSources {
         if (dataSourceSupport.disableSslSupport) {
             agroalConnectionConfigurer.disableSslSupport(resolvedDbKind, dataSourceConfiguration);
         }
+        //we use a custom cache for two reasons:
+        //fast thread local cache should be faster
+        //and it prevents a thread local leak
+        dataSourceConfiguration.connectionPoolConfiguration().connectionCache(new QuarkusConnectionCache());
 
         agroalConnectionConfigurer.setExceptionSorter(resolvedDbKind, dataSourceConfiguration);
 
@@ -362,4 +366,5 @@ public class DataSources {
             }
         }
     }
+
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusConnectionCache.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusConnectionCache.java
@@ -1,0 +1,41 @@
+package io.quarkus.agroal.runtime;
+
+import org.jboss.threads.JBossThread;
+
+import io.agroal.api.cache.Acquirable;
+import io.agroal.api.cache.ConnectionCache;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+class QuarkusConnectionCache implements ConnectionCache {
+
+    volatile FastThreadLocal<Acquirable> connectionCache = new FastThreadLocal<>();
+
+    @Override
+    public Acquirable get() {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+            //we only want to cache on threads that we control the lifecycle
+            //which are the vert.x and potentially jboss threads
+            //JBossThread still works with FastThreadLocal, it is just slower, and for most apps
+            //this will not be used anyway, as we use VertThread pretty much everywhere if
+            //Vert.x is present
+            Acquirable acquirable = connectionCache.get();
+            return acquirable != null && acquirable.acquire() ? acquirable : null;
+        }
+        return null;
+    }
+
+    @Override
+    public void put(Acquirable acquirable) {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+            connectionCache.set(acquirable);
+        }
+    }
+
+    @Override
+    public void reset() {
+        connectionCache = new FastThreadLocal<>();
+    }
+}


### PR DESCRIPTION
This fixes a ClassLoader leak in QuarkusUnitTest and also should give a
small performance improvement for Vertx threads (which is mostly what we
use now).

Fixes #17304