### PR TITLE
Upgrade to Hibernate Search 6.0.6.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -93,7 +93,7 @@
         <hibernate-orm.version>5.5.4.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR8</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.5.Final</hibernate-search.version>
+        <hibernate-search.version>6.0.6.Final</hibernate-search.version>
         <narayana.version>5.12.0.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.12</agroal.version>


### PR DESCRIPTION
See https://in.relation.to/2021/07/21/hibernate-search-6-0-6-Final/

The only relevant change is a bugfix for the AWS Elasticsearch Service integration.