### PR TITLE
Introduce @WithOpenShiftTestServer annotation

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -384,6 +384,20 @@ public class OpenShiftClientTest {
 ...
 ----
 
+Or by using the `@WithOpenShiftTestServer` similar to the `@WithKubernetesTestServer` explained in the
+previous section:
+
+[source, java]
+----
+@WithOpenShiftTestServer
+@QuarkusTest
+public class OpenShiftClientTest {
+
+    @OpenShiftTestServer
+    private OpenShiftServer mockOpenShiftServer;
+...
+----
+
 To use this feature, you have to add a dependency on `quarkus-test-openshift-client`:
 
 [source,xml]

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
@@ -42,6 +42,7 @@ public class KubernetesClientUtils {
                 .withProxyUsername(buildConfig.proxyUsername.orElse(base.getProxyUsername()))
                 .withProxyPassword(buildConfig.proxyPassword.orElse(base.getProxyPassword()))
                 .withNoProxy(buildConfig.noProxy.orElse(base.getNoProxy()))
+                .withHttp2Disable(base.isHttp2Disable())
                 .build();
     }
 

--- a/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/OpenShiftClientProducer.java
+++ b/extensions/openshift-client/runtime/src/main/java/io/quarkus/it/openshift/client/runtime/OpenShiftClientProducer.java
@@ -9,6 +9,7 @@ import org.jboss.logging.Logger;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
 import io.quarkus.arc.DefaultBean;
 
 @Singleton
@@ -22,7 +23,10 @@ public class OpenShiftClientProducer {
     @Singleton
     @Produces
     public OpenShiftClient openShiftClient(Config config) {
-        client = new DefaultOpenShiftClient(config);
+        // TODO - Temporary fix for https://github.com/fabric8io/kubernetes-client/pull/3347 + WithOpenShiftTestServer
+        final OpenShiftConfig openShiftConfig = new OpenShiftConfig(config);
+        openShiftConfig.setHttp2Disable(config.isHttp2Disable());
+        client = new DefaultOpenShiftClient(openShiftConfig);
         return client;
     }
 

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>quarkus-kubernetes-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
@@ -43,6 +47,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-openshift-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -52,6 +61,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-config-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/OpenShiftTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/OpenShiftTestServerTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.kubernetes.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.openshift.api.model.ProjectBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.OpenShiftTestServer;
+import io.quarkus.test.kubernetes.client.WithOpenShiftTestServer;
+
+@WithOpenShiftTestServer(setup = OpenShiftTestServerTest.CrudEnvironmentPreparation.class)
+@QuarkusTest
+class OpenShiftTestServerTest {
+
+    @OpenShiftTestServer
+    private OpenShiftServer mockServer;
+
+    @Inject
+    OpenShiftClient client;
+
+    @Test
+    void testInjectionDefaultsToCrud() {
+        mockServer.getOpenshiftClient().projects().createOrReplace(new ProjectBuilder()
+                .withNewMetadata().withName("example-project").addToLabels("project", "crud-is-true").endMetadata()
+                .build());
+        assertThat(client)
+                .isNotSameAs(mockServer.getOpenshiftClient())
+                .isNotSameAs(mockServer.getOpenshiftClient())
+                .returns("crud-is-true",
+                        c -> c.projects().withName("example-project").get().getMetadata().getLabels().get("project"));
+    }
+
+    public static final class CrudEnvironmentPreparation implements Consumer<OpenShiftServer> {
+
+        @Override
+        public void accept(OpenShiftServer openShiftServer) {
+            final OpenShiftClient oc = openShiftServer.getOpenshiftClient();
+            oc.configMaps().createOrReplace(new ConfigMapBuilder()
+                    .withNewMetadata().withName("cmap1").endMetadata()
+                    .addToData("dummy", "I'm required")
+                    .build());
+            oc.configMaps().createOrReplace(new ConfigMapBuilder()
+                    .withNewMetadata().withName("cmap2").endMetadata()
+                    .addToData("dummysecret", "dumb")
+                    .addToData("overridden.secret", "Alex")
+                    .addToData("some.prop1", "I'm required")
+                    .addToData("some.prop2", "I'm required (2)")
+                    .addToData("some.prop3", "I'm required (3)")
+                    .addToData("some.prop4", "I'm required (4)")
+                    .addToData("some.prop5", "I'm required (5)")
+                    .build());
+            oc.secrets().createOrReplace(new SecretBuilder()
+                    .withNewMetadata().withName("s1").endMetadata()
+                    .addToData("secret.prop1", encodeValue("s1cret"))
+                    .addToData("secret.prop2", encodeValue("s2cret"))
+                    .addToData("secret.prop3", encodeValue("s3cret"))
+                    .addToData("secret.prop4", encodeValue("s4cret"))
+                    .build());
+        }
+    }
+
+    private static String encodeValue(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes());
+    }
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
@@ -6,15 +6,18 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-public abstract class AbstractKubernetesTestResource<T> implements QuarkusTestResourceLifecycleManager {
+public abstract class AbstractKubernetesTestResource<T, C extends KubernetesClient>
+        implements QuarkusTestResourceLifecycleManager {
     protected T server;
 
     @Override
     public Map<String, String> start() {
         final Map<String, String> systemProps = new HashMap<>();
         systemProps.put(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+        systemProps.put("quarkus.tls.trust-all", "true");
         systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
         systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
         systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
@@ -37,7 +40,7 @@ public abstract class AbstractKubernetesTestResource<T> implements QuarkusTestRe
         return systemProps;
     }
 
-    protected abstract GenericKubernetesClient<?> getClient();
+    protected abstract GenericKubernetesClient<C> getClient();
 
     /**
      * Can be used by subclasses in order to

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -3,16 +3,18 @@ package io.quarkus.test.kubernetes.client;
 import java.lang.annotation.Annotation;
 
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 
 /**
  * @deprecated use {@link KubernetesServerTestResource}
  */
 @Deprecated
-public class KubernetesMockServerTestResource extends AbstractKubernetesTestResource<KubernetesMockServer> {
+public class KubernetesMockServerTestResource
+        extends AbstractKubernetesTestResource<KubernetesMockServer, NamespacedKubernetesClient> {
 
     @Override
-    protected GenericKubernetesClient<?> getClient() {
+    protected GenericKubernetesClient<NamespacedKubernetesClient> getClient() {
         return server.createClient();
     }
 

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
@@ -6,10 +6,11 @@ import java.util.Collections;
 import java.util.function.Consumer;
 
 import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 
-public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer>
+public class KubernetesServerTestResource extends AbstractKubernetesTestResource<KubernetesServer, NamespacedKubernetesClient>
         implements QuarkusTestResourceConfigurableLifecycleManager<WithKubernetesTestServer> {
 
     private boolean https = false;
@@ -30,7 +31,7 @@ public class KubernetesServerTestResource extends AbstractKubernetesTestResource
     }
 
     @Override
-    protected GenericKubernetesClient<?> getClient() {
+    protected GenericKubernetesClient<NamespacedKubernetesClient> getClient() {
         return server.getClient();
     }
 

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftMockServerTestResource.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftMockServerTestResource.java
@@ -2,6 +2,10 @@ package io.quarkus.test.kubernetes.client;
 
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 
+/**
+ * @deprecated use {@link OpenShiftServerTestResource}
+ */
+@Deprecated
 public class OpenShiftMockServerTestResource extends KubernetesMockServerTestResource {
 
     protected OpenShiftMockServer createMockServer() {

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftServerTestResource.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftServerTestResource.java
@@ -1,0 +1,67 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Consumer;
+
+import io.fabric8.kubernetes.client.GenericKubernetesClient;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+
+public class OpenShiftServerTestResource extends AbstractKubernetesTestResource<OpenShiftServer, NamespacedOpenShiftClient>
+        implements QuarkusTestResourceConfigurableLifecycleManager<WithOpenShiftTestServer> {
+
+    private boolean https = false;
+    private boolean crud = true;
+    private Consumer<OpenShiftServer> setup;
+
+    @Override
+    public void init(WithOpenShiftTestServer annotation) {
+        this.https = annotation.https();
+        this.crud = annotation.crud();
+        try {
+            this.setup = annotation.setup().getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected GenericKubernetesClient<NamespacedOpenShiftClient> getClient() {
+        return server.getOpenshiftClient();
+    }
+
+    @Override
+    protected void initServer() {
+        server.before();
+    }
+
+    @Override
+    protected void configureServer() {
+        if (setup != null)
+            setup.accept(server);
+    }
+
+    @Override
+    protected OpenShiftServer createServer() {
+        return new OpenShiftServer(https, crud);
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.after();
+            server = null;
+        }
+    }
+
+    @Override
+    protected Class<?> getInjectedClass() {
+        return OpenShiftServer.class;
+    }
+
+    @Override
+    protected Class<? extends Annotation> getInjectionAnnotation() {
+        return OpenShiftTestServer.class;
+    }
+}

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftTestServer.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftTestServer.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+
+/**
+ * Used to specify that the field should be injected with the mock OpenShift API server
+ * Can only be used on type {@link OpenShiftServer}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface OpenShiftTestServer {
+}

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/WithOpenShiftTestServer.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/WithOpenShiftTestServer.java
@@ -6,17 +6,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.function.Consumer;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import io.quarkus.test.common.QuarkusTestResource;
 
 /**
- * Use on your test resource to get a mock {@link KubernetesServer} spawn up, and injectable with {@link KubernetesTestServer}.
+ * Use on your test resource to get a mock {@link OpenShiftServer} spawn up, and injectable with {@link OpenShiftTestServer}.
  * This annotation is only active when used on a test class, and only for this test class.
  */
-@QuarkusTestResource(value = KubernetesServerTestResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = OpenShiftServerTestResource.class, restrictToAnnotatedClass = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface WithKubernetesTestServer {
+public @interface WithOpenShiftTestServer {
 
     /**
      * Start it with HTTPS
@@ -29,18 +29,13 @@ public @interface WithKubernetesTestServer {
     boolean crud() default true;
 
     /**
-     * Port to use, defaults to any available port
-     */
-    int port() default 0;
-
-    /**
      * Setup class to call after the mock server is created, for custom setup.
      */
-    Class<? extends Consumer<KubernetesServer>> setup() default NO_SETUP.class;
+    Class<? extends Consumer<OpenShiftServer>> setup() default NO_SETUP.class;
 
-    class NO_SETUP implements Consumer<KubernetesServer> {
+    class NO_SETUP implements Consumer<OpenShiftServer> {
         @Override
-        public void accept(KubernetesServer t) {
+        public void accept(OpenShiftServer t) {
         }
     }
 }


### PR DESCRIPTION
This PR provides a new `@WithOpenShiftTestServer` with similar behavior as `@WithKubernetesTestServer`.

Some work was already performed by @geoand  in scope of #18698 (#18714). I hope this doesn't collide with any pending/active work.

See internal discussion for additional reference: https://chat.google.com/room/AAAAbhT8H5E/uA8h84eEi_g

This implementation allows creating a test such as:

```java
@WithOpenShiftTestServer
@QuarkusTest
class DummyTest {

    @OpenShiftTestServer
    private OpenShiftServer mockServer;
    @Inject
    OpenShiftClient client;

    @Test
    void testHelloEndpoint() {
        mockServer.getOpenshiftClient().projects()
          .createOrReplace(new ProjectBuilder()
            .withNewMetadata()
                .withName("example-project")
                .addToLabels("project", "crud-is-true")
            .endMetadata()
            .build());
        assertEquals("crud-is-true", mockServer.getOpenshiftClient().projects().withName("example-project").get().getMetadata().getLabels().get("project"));
        assertEquals("crud-is-true", client.projects().withName("example-project").get().getMetadata().getLabels().get("project"));
    }

}
```

## Notes
- #9855 Brought a new flag to trust all certificates. However this implementation masked the [provided system property configuration](https://github.com/quarkusio/quarkus/blob/4c6317a4caab98aa4d02e8ec8b32744d7a3c8594/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java#L17). This basically disables the ability to use the mock server with `https`.
I've included a fix for this
- Until [kubernetes-client#3346](https://github.com/fabric8io/kubernetes-client/pull/3346) gets released, non-https mode for the OpenShiftMockServer won't work, since the configuration is ignored.
- I've introduced a workaround for [kubernetes-client#3347](https://github.com/fabric8io/kubernetes-client/pull/3347) to allow the propagation of some configurations that are omitted at the moment for OpenShiftConfig

## Relates to:
- #18698
- #9855
- https://github.com/fabric8io/kubernetes-client/pull/3346
- https://github.com/fabric8io/kubernetes-client/pull/3347