### PR TITLE
Bump to GraalVM 21.2

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -576,7 +576,7 @@ jobs:
         uses: DeLaGuardo/setup-graalvm@master
         if: startsWith(matrix.os-name, 'windows')
         with:
-          graalvm-version: '21.1.0.java11'
+          graalvm-version: '21.2.0.java11'
       - name: Install native-image component
         if: startsWith(matrix.os-name, 'windows')
         run: |

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -83,7 +83,7 @@
         <plexus-utils.version>3.2.1</plexus-utils.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
-        <graal-sdk.version>21.1.0</graal-sdk.version>
+        <graal-sdk.version>21.2.0</graal-sdk.version>
         <gizmo.version>1.0.9.Final</gizmo.version>
         <jackson.version>2.12.4</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -36,8 +36,8 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>21.1.0</graal-sdk.version-for-documentation>
-        <mandrel.version-for-documentation>21.0</mandrel.version-for-documentation>
+        <graal-sdk.version-for-documentation>21.2.0</graal-sdk.version-for-documentation>
+        <mandrel.version-for-documentation>21.2</mandrel.version-for-documentation>
 
         <htmlunit.version>2.40.0</htmlunit.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
@@ -132,7 +132,7 @@
         <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
 
         <!-- platform properties - this is a floating tag -->
-        <platform.quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.1-java11</platform.quarkus.native.builder-image>
+        <platform.quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.2-java11</platform.quarkus.native.builder-image>
 
         <script.extension>sh</script.extension>
         <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -12,11 +12,11 @@ final class GraalVM {
 
         static final Version UNVERSIONED = new Version("Undefined", -1, -1, Distribution.ORACLE);
         static final Version VERSION_20_3 = new Version("GraalVM 20.3", 20, 3, Distribution.ORACLE);
-        static final Version VERSION_21_0 = new Version("GraalVM 21.0", 21, 0, Distribution.ORACLE);
         static final Version VERSION_21_1 = new Version("GraalVM 21.1", 21, 1, Distribution.ORACLE);
+        static final Version VERSION_21_2 = new Version("GraalVM 21.2", 21, 2, Distribution.ORACLE);
 
         static final Version MINIMUM = VERSION_20_3;
-        static final Version CURRENT = VERSION_21_0;
+        static final Version CURRENT = VERSION_21_2;
 
         final String fullVersion;
         final int major;

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -25,13 +25,15 @@ public class GraalVMTest {
         assertVersion(20, 3, MANDREL, Version
                 .of(Stream.of("GraalVM Version 20.3.1.2-dev (Mandrel Distribution) (Java Version 11.0.8)")));
         assertVersion(21, 1, MANDREL, Version
-                .of(Stream.of("native-image 21.1.0.0 Java 11 Mandrel Distribution (Java Version 11.0.11)")));
+                .of(Stream.of("native-image 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)")));
         assertVersion(21, 1, MANDREL, Version
-                .of(Stream.of("GraalVM 21.1.0.0 Java 11 Mandrel Distribution (Java Version 11.0.11)")));
+                .of(Stream.of("GraalVM 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)")));
         assertVersion(21, 1, ORACLE, Version
                 .of(Stream.of("GraalVM 21.1.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)")));
         assertVersion(21, 1, ORACLE, Version
                 .of(Stream.of("native-image 21.1.0.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)")));
+        assertVersion(21, 2, MANDREL, Version
+                .of(Stream.of("native-image 21.2.0.0-Final Mandrel Distribution (Java Version 11.0.12+7)")));
     }
 
     static void assertVersion(int major, int minor, Distribution distro, Version version) {

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -512,7 +512,7 @@ Sample Dockerfile for building with Maven:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:21.1.0-java11 AS build
+FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
 COPY pom.xml /project/
 COPY mvnw /project/mvnw
 COPY .mvn /project/.mvn
@@ -550,7 +550,7 @@ Sample Dockerfile for building with Gradle:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:21.1.0-java11 AS build
+FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
 COPY gradlew /project/gradlew
 COPY gradle /project/gradle
 COPY build.gradle /project/
@@ -665,7 +665,7 @@ The process for Gradle is analogous.
 
 Running the build process in a container is also possible:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ---
 cd target/native-image
 docker run \
@@ -674,13 +674,13 @@ docker run \
   --v $(pwd):/work <1>
   -w /work <2>
   --entrypoint bin/sh \
-  quay.io/quarkus/ubi-quarkus-native-image:21.1.0-java11 \ <3>
+  quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} \ <3>
   -c "native-image $(cat native-image.args) -J-Xmx4g" <4>
 ---
 
 <1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
 <2> Switch the working directory to `/work`, which we have mounted in <1>.
-<3> Use the `quay.io/quarkus/ubi-quarkus-native-image:21.1.0-java11` docker image introduced in <<#multistage-docker,Using a multi-stage Docker build>> to build the native image.
+<3> Use the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}` docker image introduced in <<#multistage-docker,Using a multi-stage Docker build>> to build the native image.
 <4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory limitation to 4 Gigabyte.
 
 In a CI/CD setup, we would:

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -124,9 +124,9 @@ public class NativeConfig {
 In this case the default value for `quarkus.native.builder-image` will be provided by the platform. The user will still be able to set the desired value for `quarkus.native.builder-image` in its `application.properties`, of course. But in case it's not customized by the user, the default value will be coming from the platform properties.
 A platform properties file for the example above would contain (the actual value is provided as an example):
 
-[source,text]
+[source,text,subs=attributes+]
 ----
-platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:21.1.0-java11
+platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}
 ----
 
 There is also a Maven plugin goal that validates the platform properties content and its artifact coordinates and also checks whether the platform properties artifact is present in the platform's BOM. Here is a sample plugin configuration:

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -35,7 +35,7 @@
         <jboss-logmanager-embedded.version>1.0.9</jboss-logmanager-embedded.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
-        <graal-sdk.version>21.1.0</graal-sdk.version>
+        <graal-sdk.version>21.2.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <smallrye-common.version>1.6.0</smallrye-common.version>


### PR DESCRIPTION
GraalVM builder images are ready, the Mandrel ones are to appear soon.

Note: there are is no Java16 release of GraalVM CE 21.2 yet, it's expected sometime next week.