### PR TITLE
Upgrade SmallRye OpenAPI to 2.1.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-config.version>2.4.2</smallrye-config.version>
         <smallrye-health.version>3.1.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.7</smallrye-open-api.version>
+        <smallrye-open-api.version>2.1.8</smallrye-open-api.version>
         <smallrye-graphql.version>1.2.8</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>


### PR DESCRIPTION
See https://github.com/smallrye/smallrye-open-api/releases/tag/2.1.8

Most importantly support for `RestResponse<T>` type (from #18269) - Thanks @MikeEdgar !

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>