### PR TITLE
Disable the Kafka Connector graceful shutdown in dev mode

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ReactiveMessagingKafkaConfig.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ReactiveMessagingKafkaConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.smallrye.reactivemessaging.kafka;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "reactive-messaging.kafka")
+public class ReactiveMessagingKafkaConfig {
+
+    /**
+     * Enables the graceful shutdown in dev and test modes.
+     * The graceful shutdown waits until the inflight records have been processed and the offset committed to Kafka.
+     * While this setting is highly recommended in production, in dev and test modes, it's disabled by default.
+     * This setting allows to re-enable it.
+     */
+    @ConfigProperty(defaultValue = "false")
+    public boolean enableGracefulShutdownInDevAndTestMode;
+
+}


### PR DESCRIPTION
Also, propose an option to re-enable it.
The graceful shutdown waits until the inflight records have been processed and the offset committed to Kafka.
While this setting is highly recommended in production, in dev mode, it introduces slowness on shutdown.
