### PR TITLE
Fix quarkus.oidc.tenant-enabled typo in KeycloakDevServicesProcessor

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -53,7 +53,7 @@ public class KeycloakDevServicesProcessor {
     private static final Logger LOG = Logger.getLogger(KeycloakDevServicesProcessor.class);
 
     private static final String CONFIG_PREFIX = "quarkus.oidc.";
-    private static final String TENANT_ENABLED_CONFIG_KEY = CONFIG_PREFIX + "tenant.enabled";
+    private static final String TENANT_ENABLED_CONFIG_KEY = CONFIG_PREFIX + "tenant-enabled";
     private static final String AUTH_SERVER_URL_CONFIG_KEY = CONFIG_PREFIX + "auth-server-url";
     private static final String APPLICATION_TYPE_CONFIG_KEY = CONFIG_PREFIX + "application-type";
     private static final String CLIENT_ID_CONFIG_KEY = CONFIG_PREFIX + "client-id";


### PR DESCRIPTION
This PR fixes a typo in how `quarkus.oidc.tenant-enabled` property is referred to in `KeycloakDevServicesProcessor`.
The current side-effect is that a `quarkus-oidc/deployment` `SecurityDisabledTestCase` starts a Dev Services container due to this typo since it does not explicitly disable it with `quarkus,keycloak.devservices.enabled=false`