### PR TITLE
Rest Client Reactive: globally register providers annotated with @Provider

### DIFF
--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -4,6 +4,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -24,8 +25,11 @@ public class OidcClientReactiveFilterBuildStep {
 
     @BuildStep(onlyIf = IsEnabled.class)
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestReactiveFilter.class));
+        additionalIndexedClassesBuildItem
+                .produce(new AdditionalIndexedClassesBuildItem(OidcClientRequestReactiveFilter.class.getName()));
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, OidcClientRequestReactiveFilter.class));
     }
 }

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
@@ -8,7 +8,6 @@ import javax.inject.Inject;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.Provider;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -20,7 +19,6 @@ import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
 import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
-@Provider
 @Priority(Priorities.AUTHENTICATION)
 public class OidcClientRequestReactiveFilter extends AbstractTokensProducer implements ResteasyReactiveClientRequestFilter {
     private static final Logger LOG = Logger.getLogger(OidcClientRequestReactiveFilter.class);

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalFeature.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalFeature.java
@@ -1,0 +1,28 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
+
+@Provider
+public class GlobalFeature implements Feature {
+
+    public static boolean called;
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        context.register(FeatureInstalledFilter.class);
+        return true;
+    }
+
+    public static class FeatureInstalledFilter implements ResteasyReactiveClientRequestFilter {
+
+        @Override
+        public void filter(ResteasyReactiveClientRequestContext requestContext) {
+            called = true;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalRequestFilter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalRequestFilter.java
@@ -1,0 +1,21 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
+
+@Provider
+public class GlobalRequestFilter implements ResteasyReactiveClientRequestFilter {
+    public static final int STATUS = 233;
+
+    public static boolean abort = false;
+
+    @Override
+    public void filter(ResteasyReactiveClientRequestContext requestContext) {
+        if (abort) {
+            requestContext.abortWith(Response.status(STATUS).build());
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalRequestFilterConstrainedToServer.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalRequestFilterConstrainedToServer.java
@@ -1,0 +1,17 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
+
+@Provider
+@ConstrainedTo(RuntimeType.SERVER)
+public class GlobalRequestFilterConstrainedToServer implements ResteasyReactiveClientRequestFilter {
+    @Override
+    public void filter(ResteasyReactiveClientRequestContext requestContext) {
+        throw new RuntimeException("Invoked filter that is constrained to server");
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalResponseFilter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalResponseFilter.java
@@ -1,0 +1,22 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientResponseFilter;
+
+@Provider
+@Priority(20)
+public class GlobalResponseFilter implements ResteasyReactiveClientResponseFilter {
+
+    public static final int STATUS = 222;
+
+    @Override
+    public void filter(ResteasyReactiveClientRequestContext requestContext, ClientResponseContext responseContext) {
+        if (responseContext.getStatus() != GlobalRequestFilter.STATUS) {
+            responseContext.setStatus(STATUS);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalResponseFilterLowPrio.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/GlobalResponseFilterLowPrio.java
@@ -1,0 +1,23 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientResponseFilter;
+
+@Priority(10) // lower prio here means executed later
+@Provider
+public class GlobalResponseFilterLowPrio implements ResteasyReactiveClientResponseFilter {
+
+    public static final int STATUS = 244;
+    public static boolean skip = false;
+
+    @Override
+    public void filter(ResteasyReactiveClientRequestContext requestContext, ClientResponseContext responseContext) {
+        if (!skip) {
+            responseContext.setStatus(STATUS);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/HelloClient.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/HelloClient.java
@@ -1,0 +1,19 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/hello")
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+@RegisterRestClient
+public interface HelloClient {
+    @POST
+    Response echo(String name);
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/HelloClientWithFilter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/HelloClientWithFilter.java
@@ -1,0 +1,21 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/hello")
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+@RegisterProvider(ResponseFilterLowestPrio.class)
+@RegisterRestClient
+public interface HelloClientWithFilter {
+    @POST
+    Response echo(String name);
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderDisabledAutodiscoveryTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderDisabledAutodiscoveryTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class ProviderDisabledAutodiscoveryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class, HelloClient.class, GlobalRequestFilter.class, GlobalResponseFilter.class)
+                    .addAsResource(
+                            new StringAsset(setUrlForClass(HelloClient.class)
+                                    + "quarkus.rest-client-reactive.provider-autodiscovery=false"),
+                            "application.properties"));
+
+    @RestClient
+    HelloClient helloClient;
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void shouldNotUseGlobalFilterForInjectedClient() {
+        Response response = helloClient.echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldNotUseGlobalFilterForBuiltClient() {
+        Response response = helloClient().echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private HelloClient helloClient() {
+        return RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(HelloClient.class);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderPriorityTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderPriorityTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProviderPriorityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class,
+                            HelloClient.class,
+                            HelloClientWithFilter.class,
+                            ResponseFilterLowestPrio.class,
+                            GlobalResponseFilter.class,
+                            GlobalResponseFilterLowPrio.class)
+                    .addAsResource(
+                            new StringAsset(setUrlForClass(HelloClient.class)
+                                    + setUrlForClass(HelloClientWithFilter.class)),
+                            "application.properties"));
+
+    @RestClient
+    HelloClient helloClient;
+
+    @RestClient
+    HelloClientWithFilter helloClientWithFilter;
+
+    @AfterEach
+    void cleanUp() {
+        GlobalResponseFilterLowPrio.skip = false;
+    }
+
+    @Test
+    void shouldApplyLocalLowestPrioFilterLast() {
+        Response response = helloClientWithFilter.echo("foo");
+        assertThat(response.getStatus()).isEqualTo(ResponseFilterLowestPrio.STATUS);
+    }
+
+    @Test
+    void shouldApplyLowPrioFilterLast() {
+        Response response = helloClient.echo("foo");
+        assertThat(response.getStatus()).isEqualTo(GlobalResponseFilterLowPrio.STATUS);
+    }
+
+    @Test
+    void shouldApplyHighPrioFilter() {
+        GlobalResponseFilterLowPrio.skip = true;
+        Response response = helloClient.echo("foo");
+        assertThat(response.getStatus()).isEqualTo(GlobalResponseFilter.STATUS);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ProviderTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class ProviderTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class, HelloClient.class, GlobalRequestFilter.class,
+                            GlobalResponseFilter.class, GlobalRequestFilterConstrainedToServer.class,
+                            GlobalFeature.class)
+                    .addAsResource(
+                            new StringAsset(setUrlForClass(HelloClient.class)),
+                            "application.properties"));
+
+    @RestClient
+    HelloClient helloClient;
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @AfterEach
+    public void cleanUp() {
+        GlobalRequestFilter.abort = false;
+        GlobalFeature.called = false;
+    }
+
+    @Test
+    void shouldNotRegisterFeatureAutomatically() {
+        Response response = helloClient.echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(GlobalResponseFilter.STATUS);
+        assertThat(GlobalFeature.called).isFalse();
+    }
+
+    @Test
+    void shouldUseGlobalRequestFilterForInjectedClient() {
+        GlobalRequestFilter.abort = true;
+        Response response = helloClient.echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(GlobalRequestFilter.STATUS);
+    }
+
+    @Test
+    void shouldUseGlobalResponseFilterForInjectedClient() {
+        Response response = helloClient.echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(GlobalResponseFilter.STATUS);
+    }
+
+    @Test
+    void shouldUseGlobalRequestFilterForBuiltClient() {
+        GlobalRequestFilter.abort = true;
+        Response response = helloClient().echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(GlobalRequestFilter.STATUS);
+    }
+
+    @Test
+    void shouldUseGlobalResponseFilterForBuiltClient() {
+        Response response = helloClient().echo("Michał");
+        assertThat(response.getStatus()).isEqualTo(GlobalResponseFilter.STATUS);
+    }
+
+    private HelloClient helloClient() {
+        return RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(HelloClient.class);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ResponseFilterLowestPrio.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/provider/ResponseFilterLowestPrio.java
@@ -1,0 +1,21 @@
+package io.quarkus.rest.client.reactive.provider;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientResponseContext;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientResponseFilter;
+
+@Priority(1)
+public class ResponseFilterLowestPrio implements ResteasyReactiveClientResponseFilter {
+
+    public static final int STATUS = 266;
+    public static boolean skip = false;
+
+    @Override
+    public void filter(ResteasyReactiveClientRequestContext requestContext, ClientResponseContext responseContext) {
+        if (!skip) {
+            responseContext.setStatus(STATUS);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/AnnotationRegisteredProviders.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/AnnotationRegisteredProviders.java
@@ -1,19 +1,26 @@
 package io.quarkus.rest.client.reactive.runtime;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AnnotationRegisteredProviders {
     private final Map<String, Map<Class<?>, Integer>> providers = new HashMap<>();
+    private final Map<Class<?>, Integer> globalProviders = new HashMap<>();
 
     public Map<Class<?>, Integer> getProviders(Class<?> clientClass) {
-        Map<Class<?>, Integer> providersForClass = providers.get(clientClass.getName());
-        return providersForClass == null ? Collections.emptyMap() : providersForClass;
+        return providers.getOrDefault(clientClass.getName(), globalProviders);
     }
 
     // used by generated code
+    // MUST be called after addGlobalProvider
     public void addProviders(String className, Map<Class<?>, Integer> providersForClass) {
-        this.providers.put(className, providersForClass);
+        Map<Class<?>, Integer> providers = new HashMap<>(providersForClass);
+        providers.putAll(globalProviders);
+        this.providers.put(className, providers);
+    }
+
+    // used by generated code
+    public void addGlobalProvider(Class<?> providerClass, int priority) {
+        globalProviders.put(providerClass, priority);
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
@@ -22,4 +22,11 @@ public class RestClientReactiveConfig {
      */
     @ConfigItem(name = "disable-smart-produces", defaultValue = "false")
     public boolean disableSmartProduces;
+
+    /**
+     * Whether or not providers (filters, etc) annotated with {@link javax.ws.rs.ext.Provider} should be
+     * automatically registered for all the clients in the application.
+     */
+    @ConfigItem(name = "provider-autodiscovery", defaultValue = "true")
+    public boolean providerAutodiscovery = true;
 }

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomFilter.java
@@ -6,7 +6,6 @@ import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
@@ -17,7 +16,6 @@ import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
 import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
-@Provider
 @Priority(Priorities.AUTHENTICATION)
 public class OidcClientRequestCustomFilter extends AbstractTokensProducer implements ResteasyReactiveClientRequestFilter {
     private static final Logger LOG = Logger.getLogger(OidcClientRequestCustomFilter.class);


### PR DESCRIPTION
fixes #18560

This change also adds support for sorting providers by `@Priority`