### PR TITLE
Documentation: Changing parameter to ordinal

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -605,7 +605,7 @@ You can reference a named query instead of a (simplified) HQL query by prefixing
 [source,java]
 ----
 @Entity
-@NamedQuery(name = "Person.getByName", query = "from Person where name = :name")
+@NamedQuery(name = "Person.getByName", query = "from Person where name = ?!")
 public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -605,7 +605,7 @@ You can reference a named query instead of a (simplified) HQL query by prefixing
 [source,java]
 ----
 @Entity
-@NamedQuery(name = "Person.getByName", query = "from Person where name = ?!")
+@NamedQuery(name = "Person.getByName", query = "from Person where name = ?1")
 public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;


### PR DESCRIPTION
Using named parameter in find() leads to: java.lang.IllegalArgumentException: Could not locate ordinal parameter [1], expecting one of []