### PR TITLE
Log that a token can not be introspected if the introspection address is null

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -144,6 +144,13 @@ public class OidcProvider {
     }
 
     public Uni<TokenVerificationResult> introspectToken(String token) {
+        if (client.getMetadata().getIntrospectionUri() == null) {
+            LOG.debugf(
+                    "Token issued to client %s can not be introspected because the introspection endpoint address is unknown - "
+                            + "please check if your OpenId Connect Provider supports the token introspection",
+                    oidcConfig.clientId.get());
+            throw new AuthenticationFailedException();
+        }
         return client.introspectToken(token).onItemOrFailure()
                 .transform(new BiFunction<TokenIntrospection, Throwable, TokenVerificationResult>() {
 


### PR DESCRIPTION
I've got 500 with a long NPE when trying to verify an Auth0 access token in a binary format from Dev UI - since Auth0 does not have an introspection endpoint and JWKs can be used in this case.
 