### PR TITLE
Bump gRPC version and a way to override protoc-os-classifier

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -189,9 +189,9 @@
         <google-http-client.version>1.38.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.35.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
-        <grpc-jprotoc.version>1.0.1</grpc-jprotoc.version>
-        <protobuf-java.version>3.14.0</protobuf-java.version>
+        <grpc.version>1.38.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc-jprotoc.version>1.2.0</grpc-jprotoc.version>
+        <protobuf-java.version>3.17.3</protobuf-java.version>
         <protoc.version>${protobuf-java.version}</protoc.version>
         <picocli.version>4.6.1</picocli.version>
         <google-cloud-functions.version>1.0.1</google-cloud-functions.version>

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -65,8 +65,11 @@ With this configuration, you can put your service and message definitions in the
 `quarkus-maven-plugin` will generate Java files from your `proto` files.
 
 `quarkus-maven-plugin` retrieves a version of `protoc` (the protobuf compiler) from Maven repositories. The retrieved version matches your operating system and CPU architecture.
-If this retrieved version does not work in your context, you can download the suitable binary and specify the location via
+If this retrieved version does not work in your context, you can either force to use a different OS classifier with
+`-Dquarkus.grpc.protoc-os-classifier=your-os-classifier` (e.g. `osx-x86_64`).
+You can also download the suitable binary and specify the location via
 `-Dquarkus.grpc.protoc-path=/path/to/protoc`.
+
 
 Alternatively to using the `generate-code` goal of the `quarkus-maven-plugin`, you can use `protobuf-maven-plugin` to generate these files, more in <<Generating Java files from proto with protobuf-maven-plugin>>
 

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
@@ -113,7 +113,7 @@ public class GrpcCodeGen implements CodeGenProvider {
                         int resultCode = process.waitFor();
                         if (resultCode != 0) {
                             throw new CodeGenException("Failed to generate Java classes from proto files: " + protoFiles +
-                                    " to " + outDir.toAbsolutePath().toString());
+                                    " to " + outDir.toAbsolutePath());
                         }
                         return true;
                     }
@@ -199,7 +199,7 @@ public class GrpcCodeGen implements CodeGenProvider {
         if (executables == null) {
             Path protocPath;
             String protocPathProperty = System.getProperty("quarkus.grpc.protoc-path");
-            String classifier = osClassifier();
+            String classifier = System.getProperty("quarkus.grpc.protoc-os-classifier", osClassifier());
             if (protocPathProperty == null) {
                 protocPath = findArtifactPath(model, PROTOC_GROUPID, PROTOC, classifier, EXE);
             } else {
@@ -310,7 +310,7 @@ public class GrpcCodeGen implements CodeGenProvider {
 
     private static void writePluginExeCmd(Path pluginPath, BufferedWriter writer) throws IOException {
         writer.write("\"" + JavaBinFinder.findBin() + "\" -cp \"" +
-                pluginPath.toAbsolutePath().toString() + "\" " + quarkusProtocPluginMain);
+                pluginPath.toAbsolutePath() + "\" " + quarkusProtocPluginMain);
         writer.newLine();
     }
 

--- a/extensions/grpc/protoc/src/main/java/io/quarkus/grpc/protoc/plugin/MutinyGrpcGenerator.java
+++ b/extensions/grpc/protoc/src/main/java/io/quarkus/grpc/protoc/plugin/MutinyGrpcGenerator.java
@@ -2,6 +2,7 @@ package io.quarkus.grpc.protoc.plugin;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,6 +34,11 @@ public class MutinyGrpcGenerator extends Generator {
 
     private String getMethodJavaDocPrefix() {
         return "        ";
+    }
+
+    @Override
+    protected List<PluginProtos.CodeGeneratorResponse.Feature> supportedFeatures() {
+        return Collections.singletonList(PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL);
     }
 
     @Override

--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -23,6 +23,28 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
this change does three things:

- upgrades grpc libs
- adds support for optional fields in proto files
- adds a way to override the OS classifier for protoc

fixes #16451