### PR TITLE
Make media type negotiation in RESTEasy Reactive more spec compliant

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/NoAcceptMultipleProducesTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/NoAcceptMultipleProducesTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.resteasy.reactive.server.test.mediatype;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.http.ContentType;
+
+public class NoAcceptMultipleProducesTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(DummyResource.class, DummyJsonWriter.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(is("{\"foo\": \"bar\"}"));
+    }
+
+    @Path("dummy")
+    public static class DummyResource {
+
+        @Produces({ "text/plain; qs=0", "application/json; qs=1" })
+        @GET
+        public Map<String, String> dummy() {
+            return Collections.emptyMap(); // the return values doesn't matter as the json writer will write whatever it likes
+        }
+
+    }
+
+    @Provider
+    @Produces("application/json")
+    public static class DummyJsonWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            doDummyWrite(context.getOrCreateOutputStream());
+        }
+
+        @Override
+        public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            doDummyWrite(entityStream);
+        }
+
+        private void doDummyWrite(OutputStream outputStream) throws IOException {
+            outputStream.write("{\"foo\": \"bar\"}".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
@@ -154,7 +154,7 @@ public class ServerMediaType {
                                     if (selectedDesired != null) {
                                         continue;
                                     }
-                                    selectedDesired = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+                                    selectedDesired = provide; // if a wildcard was desired, the return type is the type of the provider
                                 } else if (desired.isWildcardSubtype()) {
                                     // this is only preferable if we don't already have a better
                                     // one


### PR DESCRIPTION
This is meant to better implement point `5` of part `3.8`
of the spec that mentions:

```
For each member of P, p:
– If a is compatible with p, add S(a, p) to M , where the function S returns the most specific
media type of the pair with the q-value of a and server-side qs-value of p.
```

Granted that what I have done here might not be the complete solution, I would however
like to proceed with caution on this (and this only fixed the case reported)
as the media type handling is fraught with a lot of corner cases...

Fixes: #18997