### PR TITLE
Fix usage of @TestHTTPResource with random ports in integration tests

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -180,6 +180,7 @@ public final class LauncherUtil {
         System.setProperty("quarkus.http.port", effectivePort.toString()); //set the port as a system property in order to have it applied to Config
         System.setProperty("quarkus.http.test-port", effectivePort.toString()); // needed for RestAssuredManager
         installAndGetSomeConfig(); // reinitialize the configuration to make sure the actual port is used
+        System.clearProperty("test.url"); // make sure the old value does not interfere with setting the new one
         System.setProperty("test.url", TestHTTPResourceManager.getUri());
     }
 


### PR DESCRIPTION
This was tested with the `getting-started-quickstart`. A test
was **not** added to main test-suite because these random port
tests have proven unstable in the past

Fixes: #12237