### PR TITLE
DevTools: fixes and improvements calculating recommended combinations of extension origins

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -20,13 +20,15 @@ class RegistryExtensionResolver {
 
     private final RegistryConfig config;
     private final RegistryClient extensionResolver;
+    private final int index;
 
     private Pattern recognizedQuarkusVersions;
 
     RegistryExtensionResolver(RegistryClient extensionResolver,
-            MessageWriter log) throws RegistryResolutionException {
+            MessageWriter log, int index) throws RegistryResolutionException {
         this.extensionResolver = Objects.requireNonNull(extensionResolver, "Registry extension resolver is null");
         this.config = extensionResolver.resolveRegistryConfig();
+        this.index = index;
 
         String versionExpr = config.getQuarkusVersions() == null ? null
                 : config.getQuarkusVersions().getRecognizedVersionsExpression();
@@ -37,6 +39,10 @@ class RegistryExtensionResolver {
 
     String getId() {
         return config.getId();
+    }
+
+    int getIndex() {
+        return index;
     }
 
     int checkQuarkusVersion(String quarkusVersion) {

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/selection/OriginSelector.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/selection/OriginSelector.java
@@ -20,21 +20,20 @@ public class OriginSelector {
         }
         select(0, new OriginCombination());
 
-        /*
-         * log all the complete combincations
-         *
-         * System.out.println("OriginSelector.calculateCompatibleCombinations");
-         * if (completeCombinations.isEmpty()) {
-         * System.out.println("  none");
-         * } else {
-         * for (int i = 0; i < completeCombinations.size(); ++i) {
-         * final OriginCombination s = completeCombinations.get(i);
-         * System.out.println("Combination #" + (i + 1));
-         * s.getUniqueSortedOrigins()
-         * .forEach(o -> System.out.println(" - " + o.getCatalog().getBom() + " " + o.getCatalog().isPlatform()));
-         * }
-         * }
-         */
+        // log all the complete combincations
+        //System.out.println("OriginSelector.calculateCompatibleCombinations of " + extOrigins.size() + " extensions");
+        //if (completeCombinations.isEmpty()) {
+        //    System.out.println("  none");
+        //} else {
+        //    for (int i = 0; i < completeCombinations.size(); ++i) {
+        //        final OriginCombination s = completeCombinations.get(i);
+        //        System.out.println("Combination #" + (i + 1) + " score=" + calculateScore(s));
+        //        s.getUniqueSortedOrigins()
+        //                .forEach(o -> System.out.println(
+        //                        " - " + o.getCatalog().getBom() + " " + o.getCatalog().isPlatform() + " " + o.getPreference()));
+        //    }
+        //}
+
     }
 
     public OriginCombination getRecommendedCombination() {
@@ -46,10 +45,10 @@ public class OriginSelector {
         }
         // here we are going to be looking for the combination that include the most extensions
         // in the most preferred registry with the lowest total number of platforms BOMs to be imported
-        int highestScore = 0;
+        double highestScore = 0;
         OriginCombination recommended = null;
         for (OriginCombination combination : completeCombinations) {
-            final int score = calculateScore(combination);
+            final double score = calculateScore(combination);
             if (score > highestScore) {
                 highestScore = score;
                 recommended = combination;
@@ -58,11 +57,12 @@ public class OriginSelector {
         return recommended;
     }
 
-    private int calculateScore(OriginCombination s) {
-        int combinationScore = 0;
+    private double calculateScore(OriginCombination s) {
+        double combinationScore = 0;
         for (OriginWithPreference o : s.getCollectedOrigins()) {
             combinationScore += Math.pow(extOrigins.size(),
-                    highestRegistryPreference + 1 - o.getPreference().registryPreference);
+                    highestRegistryPreference + 1 - o.getPreference().registryPreference)
+                    * ((double) (Integer.MAX_VALUE + 1 - o.getPreference().platformPreference) / Integer.MAX_VALUE);
         }
         return combinationScore;
     }


### PR DESCRIPTION
These fixes are for use-cases involving multiple registries in the devtools config with extensions present in multiple registries and multiple catalogs.

These changes make sure non-platform extension catalogs are added once per registry and that the platform preference number is included into the calculation of an extension combination score when choosing the recommended one.

The existing tests were supposed to cover these use-cases but the registries in the tests appeared to be well-tuned (excluding all sorts of redundant extension and platform listing). Testing the current registry.quarkus.io in combination with some local registry config showed things could get pretty messy. I'll follow up with more tests.
