### PR TITLE
Upgrade to Mutiny 1.0.0 and Vert.x bindings 2.12.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -53,7 +53,7 @@
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>2.11.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>2.12.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>3.7.1</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -134,7 +134,7 @@
         <netty.version>4.1.65.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.2.Final</jboss-logging.version>
-        <mutiny.version>0.19.2</mutiny.version>
+        <mutiny.version>1.0.0</mutiny.version>
         <kafka2.version>2.8.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -41,7 +41,7 @@
         <version.jboss-logging>3.4.2.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>0.19.2</version.smallrye-mutiny>
+        <version.smallrye-mutiny>1.0.0</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -50,9 +50,9 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>
-        <mutiny.version>0.19.2</mutiny.version>
+        <mutiny.version>1.0.0</mutiny.version>
         <smallrye-common.version>1.6.0</smallrye-common.version>
-        <vertx.version>4.1.1</vertx.version>
+        <vertx.version>4.1.2</vertx.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>


### PR DESCRIPTION
Also aligned a Vert.x dependency in resteasy-reactive.