### PR TITLE
SplitPackageProcessor should also include information about type and classifier of any given app archive

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
@@ -94,7 +94,8 @@ public class SplitPackageProcessor {
                             }
                         }
                     } else {
-                        splitPackages.add(a.getGroupId() + ":" + a.getArtifactId());
+                        // Generates an app archive information in form of groupId:artifactId:classifier:type
+                        splitPackages.add(a.toString());
                     }
                 }
                 splitPackagesWarning.append(splitPackages.stream().collect(Collectors.joining(", ", "[", "]")));


### PR DESCRIPTION
Partial improvement for https://github.com/quarkusio/quarkus/issues/19030

@famod can you let me know if this gives you more sensible warning messages?