### PR TITLE
Dev services cleanup

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesConfigResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesConfigResultBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Configuration property that is the result of start dev services.
+ *
+ * Used to start and configure dev services, any processor starting dev services should produce these items.
+ *
+ * Quarkus will make sure the relevant settings are present in both JVM and native modes.
+ */
+public final class DevServicesConfigResultBuildItem extends MultiBuildItem {
+
+    final String key;
+    final String value;
+
+    public DevServicesConfigResultBuildItem(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesLauncherConfigResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesLauncherConfigResultBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Build item that contains the final results of all
+ */
+public final class DevServicesLauncherConfigResultBuildItem extends SimpleBuildItem {
+
+    final Map<String, String> config;
+
+    public DevServicesLauncherConfigResultBuildItem(Map<String, String> config) {
+        this.config = config;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNativeConfigResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNativeConfigResultBuildItem.java
@@ -3,10 +3,9 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Configuration property that is the result of start dev services.
- *
- * Used to start and configure dev services in native mode.
+ * see {@link DevServicesConfigResultBuildItem} and {@link DevServicesLauncherConfigResultBuildItem}
  */
+@Deprecated
 public final class DevServicesNativeConfigResultBuildItem extends MultiBuildItem {
 
     final String key;

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
@@ -1,0 +1,65 @@
+package io.quarkus.deployment.steps;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.builditem.DevServicesConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+
+class DevServicesConfigBuildStep {
+
+    @BuildStep
+    List<DevServicesConfigResultBuildItem> deprecated(List<DevServicesNativeConfigResultBuildItem> items) {
+        return items.stream().map(s -> new DevServicesConfigResultBuildItem(s.getKey(), s.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    DevServicesLauncherConfigResultBuildItem setup(BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeConfig,
+            List<DevServicesConfigResultBuildItem> devServicesConfigResultBuildItems,
+            LiveReloadBuildItem liveReloadBuildItem) {
+        Map<String, String> newProperties = new HashMap<>(devServicesConfigResultBuildItems.stream().collect(
+                Collectors.toMap(DevServicesConfigResultBuildItem::getKey, DevServicesConfigResultBuildItem::getValue)));
+        Config config = ConfigProvider.getConfig();
+        PreviousConfig oldProperties = liveReloadBuildItem.getContextObject(PreviousConfig.class);
+        //check if there are existing already started dev services
+        //if there were no changes to the processors they don't produce config
+        //so we merge existing config from previous runs
+        //we also check the current config, as the dev service may have been disabled by explicit config
+        if (oldProperties != null) {
+            for (Map.Entry<String, String> entry : oldProperties.config.entrySet()) {
+                if (!newProperties.containsKey(entry.getKey())
+                        && config.getOptionalValue(entry.getKey(), String.class).isEmpty()) {
+                    newProperties.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        for (Map.Entry<String, String> entry : newProperties.entrySet()) {
+            runtimeConfig.produce(new RunTimeConfigurationDefaultBuildItem(entry.getKey(), entry.getValue()));
+        }
+        liveReloadBuildItem.setContextObject(PreviousConfig.class, new PreviousConfig(newProperties));
+        return new DevServicesLauncherConfigResultBuildItem(Collections.unmodifiableMap(newProperties));
+    }
+
+    static class PreviousConfig {
+        final Map<String, String> config;
+
+        public PreviousConfig(Map<String, String> config) {
+            this.config = config;
+        }
+    }
+}

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -12,7 +12,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesConfigResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.extest.runtime.classpath.ClasspathEntriesRecorder;
 import io.quarkus.extest.runtime.classpath.RecordedClasspathEntries;
@@ -39,7 +39,7 @@ public class ClasspathEntryRecordingBuildStep {
     @Produce(FeatureBuildItem.class)
     // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
     // so that we can reproduce a problem that happens in the Hibernate ORM extension.
-    @Produce(DevServicesNativeConfigResultBuildItem.class)
+    @Produce(DevServicesConfigResultBuildItem.class)
     void recordDuringAugmentation(TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);
@@ -54,7 +54,7 @@ public class ClasspathEntryRecordingBuildStep {
     @Record(ExecutionTime.STATIC_INIT)
     // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
     // so that we can reproduce a problem that happens in the Hibernate ORM extension.
-    @Produce(DevServicesNativeConfigResultBuildItem.class)
+    @Produce(DevServicesConfigResultBuildItem.class)
     void recordDuringStaticInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);
@@ -69,7 +69,7 @@ public class ClasspathEntryRecordingBuildStep {
     @Record(ExecutionTime.RUNTIME_INIT)
     // This makes sure we execute this in io.quarkus.test.junit.IntegrationTestUtil.handleDevDb,
     // so that we can reproduce a problem that happens in the Hibernate ORM extension.
-    @Produce(DevServicesNativeConfigResultBuildItem.class)
+    @Produce(DevServicesConfigResultBuildItem.class)
     void recordDuringRuntimeInit(ClasspathEntriesRecorder classpathEntriesRecorder, TestBuildTimeConfig config)
             throws IOException {
         List<String> resourcesToRecord = getResourcesToRecord(config);

--- a/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/DevServicesApicurioRegistryProcessor.java
@@ -14,10 +14,7 @@ import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
-import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
-import io.quarkus.runtime.LaunchMode;
+import io.quarkus.deployment.builditem.DevServicesConfigResultBuildItem;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
 /**
@@ -39,19 +36,13 @@ public class DevServicesApicurioRegistryProcessor {
     private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
 
     @BuildStep(onlyIfNot = IsNormal.class)
-    public void startApicurioRegistryDevService(
-            LaunchModeBuildItem launchMode,
-            ApicurioRegistryDevServicesBuildTimeConfig apicurioRegistryDevServices,
-            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfiguration,
-            BuildProducer<DevServicesNativeConfigResultBuildItem> devServicesConfiguration) {
+    public void startApicurioRegistryDevService(ApicurioRegistryDevServicesBuildTimeConfig apicurioRegistryDevServices,
+            BuildProducer<DevServicesConfigResultBuildItem> devServicesConfiguration) {
 
         ApicurioRegistryDevServiceCfg configuration = getConfiguration(apicurioRegistryDevServices);
 
         if (closeable != null) {
-            boolean restartRequired = launchMode.getLaunchMode() == LaunchMode.TEST;
-            if (!restartRequired) {
-                restartRequired = !configuration.equals(cfg);
-            }
+            boolean restartRequired = !configuration.equals(cfg);
             if (!restartRequired) {
                 return;
             }
@@ -67,9 +58,7 @@ public class DevServicesApicurioRegistryProcessor {
         cfg = configuration;
         closeable = apicurioRegistry.getCloseable();
 
-        runTimeConfiguration.produce(new RunTimeConfigurationDefaultBuildItem(
-                REGISTRY_URL_CONFIG, apicurioRegistry.getUrl() + "/apis/registry/v2"));
-        devServicesConfiguration.produce(new DevServicesNativeConfigResultBuildItem(
+        devServicesConfiguration.produce(new DevServicesConfigResultBuildItem(
                 REGISTRY_URL_CONFIG, apicurioRegistry.getUrl() + "/apis/registry/v2"));
 
         log.infof("Dev Services for Apicurio Registry started. The registry is available at %s", apicurioRegistry.getUrl());

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -18,7 +18,7 @@ public class KeycloakDevConsoleProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     public void setConfigProperties(BuildProducer<DevConsoleTemplateInfoBuildItem> console,
-            Optional<DevServicesConfigBuildItem> configProps) {
+            Optional<KeycloakDevServicesConfigBuildItem> configProps) {
         if (configProps.isPresent()) {
             console.produce(
                     new DevConsoleTemplateInfoBuildItem("devServicesEnabled", config.devservices.enabled));
@@ -40,7 +40,7 @@ public class KeycloakDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void invokeEndpoint(BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,
-            Optional<DevServicesConfigBuildItem> configProps) {
+            Optional<KeycloakDevServicesConfigBuildItem> configProps) {
         if (configProps.isPresent()) {
             @SuppressWarnings("unchecked")
             Map<String, String> users = (Map<String, String>) configProps.get().getProperties().get("oidc.users");

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
@@ -4,11 +4,11 @@ import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
-public final class DevServicesConfigBuildItem extends SimpleBuildItem {
+public final class KeycloakDevServicesConfigBuildItem extends SimpleBuildItem {
 
     private final Map<String, Object> properties;
 
-    public DevServicesConfigBuildItem(Map<String, Object> configProperties) {
+    public KeycloakDevServicesConfigBuildItem(Map<String, Object> configProperties) {
         this.properties = configProperties;
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -42,7 +42,7 @@ import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.model.gradle.QuarkusModel;
 import io.quarkus.bootstrap.util.PathsUtils;
 import io.quarkus.bootstrap.utils.BuildToolHelper;
-import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.PathTestHelper;
@@ -276,7 +276,7 @@ public final class IntegrationTestUtil {
             public void accept(String s, String s2) {
                 propertyMap.put(s, s2);
             }
-        }, DevServicesNativeConfigResultBuildItem.class.getName());
+        }, DevServicesLauncherConfigResultBuildItem.class.getName());
 
         if (isDockerAppLaunch) {
             // obtain the ID of the shared network - this needs to be done after the augmentation has been run

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -1,19 +1,18 @@
 package io.quarkus.test.junit;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import io.quarkus.builder.BuildResult;
-import io.quarkus.deployment.builditem.DevServicesNativeConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 
 public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
     @Override
     public void accept(Object o, BuildResult buildResult) {
         BiConsumer<String, String> propertyConsumer = (BiConsumer<String, String>) o;
 
-        List<DevServicesNativeConfigResultBuildItem> devServicesProperties = buildResult
-                .consumeMulti(DevServicesNativeConfigResultBuildItem.class);
-        for (DevServicesNativeConfigResultBuildItem entry : devServicesProperties) {
+        DevServicesLauncherConfigResultBuildItem devServicesProperties = buildResult
+                .consume(DevServicesLauncherConfigResultBuildItem.class);
+        for (var entry : devServicesProperties.getConfig().entrySet()) {
             propertyConsumer.accept(entry.getKey(), entry.getValue());
         }
 


### PR DESCRIPTION
- Don't restart in test mode, it slows down continuous testing
- Processors only produce DevServicesConfigResultBuildItem, quarkus
  handles turning it into runtime config
- If no changes are made Quarkus handles the cached config, so the
  processor does not have to

Fixes #19044