### PR TITLE
ClassLoader leak fixes

### DIFF
--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
@@ -1,6 +1,8 @@
 package io.quarkus.dev.console;
 
+import java.io.Console;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -24,6 +26,23 @@ public class BasicConsole extends QuarkusConsole {
     final boolean color;
 
     volatile boolean readingLine;
+
+    public BasicConsole(boolean color, boolean inputSupport, PrintStream printStream, Console console) {
+        this(color, inputSupport, (s) -> {
+            if (console != null) {
+                console.writer().print(s);
+                console.writer().flush();
+            } else {
+                printStream.print(s);
+            }
+        }, () -> {
+            try {
+                return System.in.read();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
 
     public BasicConsole(boolean color, boolean inputSupport, Consumer<String> output) {
         this(color, inputSupport, output, () -> {

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
@@ -1,11 +1,11 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-inconsistent-storage-engines.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-inconsistent-storage-engines.properties
@@ -1,11 +1,11 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm.dialect=io.quarkus.hibernate.orm.multiplepersistenceunits.MultiplePersistenceUnitsInconsistentStorageEnginesTest$H2DialectWithMySQLInTheName
 quarkus.hibernate-orm.dialect.storage-engine=engine1

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-unaffected-entities.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-unaffected-entities.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm."inventory".database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-undefined-packages.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-undefined-packages.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:tcp://localhost/mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:tcp://localhost/mem:users
 
 quarkus.hibernate-orm."users".dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm."users".log.sql=true

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,11 +1,11 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-default-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-default-value.properties
@@ -1,8 +1,8 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm."users".dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm."users".database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-true-value.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-pu-discriminator-ignore-explicit-for-joined-true-value.properties
@@ -1,8 +1,8 @@
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
+quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm."users".dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm."users".database.generation=drop-and-create


### PR DESCRIPTION
- In tests don't hold into the initial ClassLoader via the BasicConsole
- DB_CLOSE_DELAY=-1 will hold onto the ClassLoader, as the DB will never
  be closed