### PR TITLE
Ensure that building native image doesn't fail when objcopy is missing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -45,8 +45,8 @@ public abstract class NativeImageBuildRunner {
     public void addShutdownHook(Process buildNativeProcess) {
     }
 
-    public int build(List<String> args, String nativeImageName, String resultingExecutableName, Path outputDir,
-            boolean debugEnabled, boolean processInheritIODisabled)
+    public Result build(List<String> args, String nativeImageName, String resultingExecutableName, Path outputDir,
+            boolean debugSymbolsEnabled, boolean processInheritIODisabled)
             throws InterruptedException, IOException {
         preBuild(args);
         try {
@@ -63,22 +63,26 @@ public abstract class NativeImageBuildRunner {
             executor.shutdown();
             errorReportLatch.await();
             int exitCode = process.waitFor();
+            boolean objcopyExists = objcopyExists();
             if (exitCode != 0) {
-                return exitCode;
+                return new Result(exitCode, objcopyExists);
             }
 
-            if (objcopyExists()) {
-                if (debugEnabled) {
+            if (objcopyExists) {
+                if (debugSymbolsEnabled) {
                     splitDebugSymbols(nativeImageName, resultingExecutableName);
                 } else {
                     // Strip debug symbols regardless, because the underlying JDK might contain them
                     objcopy("--strip-debug", resultingExecutableName);
                 }
             } else {
-                log.warn("objcopy executable not found in PATH. Debug symbols will not be separated from executable.");
-                log.warn("That will result in a larger native image with debug symbols embedded in it.");
+                if (!debugSymbolsEnabled) {
+                    log.warn(
+                            "objcopy executable not found in PATH. Debug symbols will therefore not be separated from the executable.");
+                    log.warn("That also means that resulting native executable is larger as it embeds the debug symbols.");
+                }
             }
-            return 0;
+            return new Result(0, objcopyExists);
         } finally {
             postBuild();
         }
@@ -141,6 +145,24 @@ public abstract class NativeImageBuildRunner {
             if (process != null) {
                 process.destroy();
             }
+        }
+    }
+
+    static class Result {
+        private final int exitCode;
+        private final boolean objcopyExists;
+
+        public Result(int exitCode, boolean objcopyExists) {
+            this.exitCode = exitCode;
+            this.objcopyExists = objcopyExists;
+        }
+
+        public int getExitCode() {
+            return exitCode;
+        }
+
+        public boolean isObjcopyExists() {
+            return objcopyExists;
         }
     }
 }


### PR DESCRIPTION
Fixes: #19079