### PR TITLE
Pass arguments arrays to Runtime::exec

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -483,13 +483,13 @@ public class DevConsoleProcessor {
         try {
             switch (os) {
                 case MAC:
-                    rt.exec("open " + url);
+                    rt.exec(new String[] { "open", url });
                     break;
                 case LINUX:
-                    rt.exec("xdg-open " + url);
+                    rt.exec(new String[] { "xdg-open", url });
                     break;
                 case WINDOWS:
-                    rt.exec("rundll32 url.dll,FileProtocolHandler " + url);
+                    rt.exec(new String[] { "rundll32 url.dll,FileProtocolHandler", url });
                     break;
                 case OTHER:
                     log.error("Cannot launch browser on this operating system");


### PR DESCRIPTION
Code scanning tools as in https://github.com/quarkusio/quarkus/security can flag this as a vulnerability.
In this case the URL is actually going to be safe, but it's still a better practice not to concatenate arguments as a String.