### PR TITLE
Fix RESTEasy reactive race

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -121,7 +121,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     @Override
     public void run() {
         running = true;
-        boolean submittedToExecutor = false;
+        boolean processingSuspended = false;
         //if this is a blocking target we don't activate for the initial non-blocking part
         //unless there are pre-mapping filters as these may require CDI
         boolean disasociateRequestScope = false;
@@ -153,13 +153,14 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
                                 this.executor = null;
                             } else if (suspended) {
                                 running = false;
+                                processingSuspended = true;
                                 return;
                             }
                         }
                         if (exec != null) {
                             //outside sync block
                             exec.execute(this);
-                            submittedToExecutor = true;
+                            processingSuspended = true;
                             return;
                         }
                     }
@@ -183,7 +184,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         } finally {
             // we need to make sure we don't close the underlying stream in the event loop if the task
             // has been offloaded to the executor
-            if (position == handlers.length && !suspended && !submittedToExecutor) {
+            if (position == handlers.length && !processingSuspended) {
                 close();
             } else {
                 if (disasociateRequestScope) {


### PR DESCRIPTION
This fixes the 'java.lang.IllegalStateException: Client request did not complete' intermittent failures we have been seeing lately (hopefully).