### PR TITLE
Upgrade to Hibernate ORM 5.5.5.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.5.4.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.5.5.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR8</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>


### PR DESCRIPTION
Very minor changes:

#### HHH-14755 Allow to instantiate a DefaultIdentifierGeneratorFactory which does not bind to the BeanManager
Will allow us to remove some custom services.

#### HHH-14724 Metamodel generates invalid model classes for converters and user types
Important bugfix

#### HHH-14740 HHH-14740 Still need the nullcheck removed in HHH-14727
Because I screwed up a NPE check in the previous release (reverting)



