### PR TITLE
Update Keycloak DevUI to store manually entered paths in the local storage

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -253,6 +253,14 @@ function printResponseData(data, message){
     $('#results').append("<span class='text-primary px-1'>" + message + "</span>, result : ");
     $('#results').append("<span class='text-primary px-1'>" + data + "</span>");
     $('#results').append("<br/>");
+    if(data is not "404"){
+        var serviceGetMethods = [];
+        if (locaStorage.getItem("serviceGetMethods")) {
+           serviceGetMethods = JSON.parse(locaStorage.getItem("serviceGetMethods"));
+        }
+        serviceGetMethods.push($('#servicePath').val());
+        localStorage.setItem("serviceGetMethods", JSON.stringify(serviceGetMethods));
+    }
 }
 
 function signInToService(servicePath) {


### PR DESCRIPTION
As discussed with Phillip and Stuart, the current basic way of entering the service paths manually in Keycloak Dev UI is, well, just a very basic option to get started.
The ultimate goal is to support testing the tokens from within a Swagger UI - however this option will only be available if the users will choose to exercise it, i.e having a swagger-ui/openapi dependency should really not be a prerequisite for using this Dev UI.

This Draft PR prototypes some code where:
1) an attempt is made to parse an openapi doc - if that does not work then it is not a problem - but if it does then the parsed response (get method paths) is kept in a local strorage (something Phillip also suggested with respect to the service paths)
2) when a test service path is not 404 then this path is also added

3) yet to be prototyped - have an editable service paths combo box which will check this local storage object, possibly with a look ahead

The idea is to provide something less basic for entering the service paths OOB - and it is not meant to conflict with the idea of using Swagger UI directly at some point in the future - if Swagger UI will be chosen then the mentioned options won't be activated

CC @phillip-kruger @stuartwdouglas 

Phillip, have a look please during the next couple of weeks, or lets discuss in a couple of weeks, as I'm now real real gone :-)