### PR TITLE
Support `config:boolean` and `config:integer`in Qute

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1476,7 +1476,16 @@ TIP: A list element can be accessed directly: `{list.10}` or `{list[10]}`.
 ** `{config:foo}` or `{config:['property.with.dot.in.name']}`
 
 * `config:property(name)`: Returns the config value for the given property name; the name can be obtained dynamically by an expression 
-** `{config:property('quarkus.foo')}` or `{config:property(foo.getPropertyName())}`
+** `{config:property('quarkus.foo')}`
+** `{config:property(foo.getPropertyName())}`
+
+* `config:boolean(name)`: Returns the config value for the given property name as a boolean; the name can be obtained dynamically by an expression
+** `{config:boolean('quarkus.foo.boolean') ?: 'Not Found'}`
+** `{config:boolean(foo.getPropertyName()) ?: 'property is false'}`
+
+* `config:integer(name)`: Returns the config value for the given property name as an integer; the name can be obtained dynamically by an expression
+** `{config:integer('quarkus.foo')}`
+** `{config:integer(foo.getPropertyName())}`
 
 ===== Time
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ConfigTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/ConfigTemplateExtensionsTest.java
@@ -19,16 +19,30 @@ public class ConfigTemplateExtensionsTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset(
-                            "{config:foo}={config:property('foo')} {config:nonExistent ?: 'NOT_FOUND'}={config:property('nonExistent') ?: 'NOT_FOUND'} {config:['foo.bar.baz']}={config:property('foo.bar.baz')} {config:['quarkus.qute.remove-standalone-lines']}={config:property('quarkus.qute.remove-standalone-lines')} {config:property(name)}"),
+                            "{config:foo}={config:property('foo')}\n" +
+                                    "{config:nonExistent ?: 'NOT_FOUND'}={config:property('nonExistent') ?: 'NOT_FOUND'}\n" +
+                                    "{config:['foo.bar.baz']}={config:property('foo.bar.baz')}\n" +
+                                    "{config:['quarkus.qute.remove-standalone-lines']}={config:property('quarkus.qute.remove-standalone-lines')}\n"
+                                    +
+                                    "{config:property(name)}\n" +
+                                    "{config:boolean('foo.bool') ?: 'NOT_FOUND'} {config:boolean('foo.boolean') ?: 'NOT_FOUND'}\n"
+                                    +
+                                    "{config:integer('foo.bar.baz')}"),
                             "templates/foo.html")
-                    .addAsResource(new StringAsset("foo=false\nfoo.bar.baz=11"), "application.properties"));
+                    .addAsResource(new StringAsset("foo=false\nfoo.bar.baz=11\nfoo.bool=true"), "application.properties"));
 
     @Inject
     Template foo;
 
     @Test
     public void testGetProperty() {
-        assertEquals("false=false NOT_FOUND=NOT_FOUND 11=11 true=true false",
+        assertEquals("false=false\n" +
+                "NOT_FOUND=NOT_FOUND\n" +
+                "11=11\n" +
+                "true=true\n" +
+                "false\n" +
+                "true NOT_FOUND\n" +
+                "11",
                 foo.data("name", "foo").render());
     }
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/ConfigTemplateExtensions.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/ConfigTemplateExtensions.java
@@ -30,4 +30,17 @@ public class ConfigTemplateExtensions {
         return val.isPresent() ? val.get() : Results.NotFound.from(propertyName);
     }
 
+    // {config:boolean(foo.getPropertyName())}
+    @TemplateExtension(namespace = CONFIG, priority = DEFAULT_PRIORITY + 2, matchName = "boolean")
+    static Object booleanProperty(String propertyName) {
+        Optional<Boolean> val = ConfigProvider.getConfig().getOptionalValue(propertyName, Boolean.class);
+        return val.isPresent() ? val.get() : Results.NotFound.from(propertyName);
+    }
+
+    // {config:integer(foo.getPropertyName())}
+    @TemplateExtension(namespace = CONFIG, priority = DEFAULT_PRIORITY + 2, matchName = "integer")
+    static Object integerProperty(String propertyName) {
+        Optional<Integer> val = ConfigProvider.getConfig().getOptionalValue(propertyName, Integer.class);
+        return val.isPresent() ? val.get() : Results.NotFound.from(propertyName);
+    }
 }


### PR DESCRIPTION
This adds support for `config:boolean('my.prop')` and `config:integer('my.prop')` - useful on `if` statements
As discussed in https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Accessing.20configuration.20in.20a.20Qute.20template