### PR TITLE
Avoid SmallRyeContextPropagationRecorder to leak the classloader

### DIFF
--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
@@ -56,6 +56,8 @@ public class SmallRyeContextPropagationRecorder {
                 contextManagerProvider.releaseContextManager(contextManager);
             }
         });
+        //Avoid leaking the classloader:
+        this.builder = null;
     }
 
     public Supplier<Object> initializeManagedExecutor(ExecutorService executorService) {


### PR DESCRIPTION
Flagging as urgent as CI jobs are struggling with the leaks.