### PR TITLE
Add capability for mongodb-client

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -53,6 +53,7 @@ public interface Capability {
 
     String TIKA = QUARKUS_PREFIX + "tika";
 
+    String MONGODB_CLIENT = QUARKUS_PREFIX + "mongodb-client";
     String MONGODB_PANACHE = QUARKUS_PREFIX + "mongodb.panache";
     String MONGODB_PANACHE_KOTLIN = MONGODB_PANACHE + ".kotlin";
 

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -117,6 +117,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.mongodb-client</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
I'm currently creating an extension and I'd like to use capabilities to enable certain features.

My extension already works with SQL Datasources (if agroal capability is present) and I also would like that it works with MongoDB. But, to do so, the capability must off-course be present.