### PR TITLE
Add capability for elasticsearch-rest-high-level-client

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -56,6 +56,8 @@ public interface Capability {
     String MONGODB_PANACHE = QUARKUS_PREFIX + "mongodb.panache";
     String MONGODB_PANACHE_KOTLIN = MONGODB_PANACHE + ".kotlin";
 
+    String ELASTICSEARCH_REST_HIGH_LEVEL_CLIENT = QUARKUS_PREFIX + "elasticsearch-rest-high-level-client";
+
     String FLYWAY = QUARKUS_PREFIX + "flyway";
     String LIQUIBASE = QUARKUS_PREFIX + "liquibase";
 

--- a/extensions/elasticsearch-rest-high-level-client/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-high-level-client/runtime/pom.xml
@@ -97,6 +97,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.elasticsearch-rest-high-level-client</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I'm currently creating an extension and I'd like to use capabilities to enable certain features.

My extension already works with SQL Datasources (if agroal capability is present) and I also would like that it works with ElasticSearch. But, to do so, the capability must off-course be present.