### PR TITLE
Small OpenAPI and Swagger UI enhancements

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-config.version>2.4.2</smallrye-config.version>
         <smallrye-health.version>3.1.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.8</smallrye-open-api.version>
+        <smallrye-open-api.version>2.1.9</smallrye-open-api.version>
         <smallrye-graphql.version>1.3.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -51,6 +51,12 @@ public final class SmallRyeOpenApiConfig {
     public String securitySchemeDescription;
 
     /**
+     * This will automatically add the security requirement to all methods/classes that has a `RolesAllowed` annotation.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean autoAddSecurityRequirement;
+
+    /**
      * Add a scheme value to the Basic HTTP Security Scheme
      */
     @ConfigItem(defaultValue = "basic")

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.openapi.common.deployment;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -32,6 +33,13 @@ public final class SmallRyeOpenApiConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean ignoreStaticDocument;
+
+    /**
+     * A list of local directories that should be scanned for yaml and/or json files to be included in the static model.
+     * Example: `META-INF/openapi/`
+     */
+    @ConfigItem
+    public Optional<List<Path>> additionalDocsDirectory;
 
     /**
      * Add a certain SecurityScheme with config

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -564,6 +564,14 @@ public class SmallRyeOpenApiProcessor {
     private OpenApiDocument loadDocument(OpenAPI staticModel, OpenAPI annotationModel,
             List<AddToOpenAPIDefinitionBuildItem> openAPIBuildItems) {
         OpenApiDocument document = prepareOpenApiDocument(staticModel, annotationModel, openAPIBuildItems);
+
+        Config c = ConfigProvider.getConfig();
+        String title = c.getOptionalValue("quarkus.application.name", String.class).orElse("Generated");
+        String version = c.getOptionalValue("quarkus.application.version", String.class).orElse("1.0");
+
+        document.archiveName(title);
+        document.version(version);
+
         document.initialize();
         return document;
     }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/security/SecurityConfigFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/security/SecurityConfigFilter.java
@@ -1,17 +1,25 @@
 package io.quarkus.smallrye.openapi.deployment.security;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
 import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 import org.jboss.logging.Logger;
 
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+import io.smallrye.openapi.api.models.OperationImpl;
+import io.smallrye.openapi.api.models.security.SecurityRequirementImpl;
 
 /**
  * Add Basic Security via Config
@@ -20,14 +28,17 @@ public class SecurityConfigFilter implements OASFilter {
     private static final Logger log = Logger.getLogger("io.quarkus.smallrye.openapi");
 
     private final SmallRyeOpenApiConfig config;
+    private final Map<String, List<String>> methodReferences;
 
-    public SecurityConfigFilter(SmallRyeOpenApiConfig config) {
+    public SecurityConfigFilter(SmallRyeOpenApiConfig config, Map<String, List<String>> methodReferences) {
         this.config = config;
+        this.methodReferences = methodReferences;
     }
 
     @Override
     public void filterOpenAPI(OpenAPI openAPI) {
 
+        // Add a security scheme from config
         if (config.securityScheme.isPresent()) {
 
             // Make sure components are created
@@ -35,7 +46,7 @@ public class SecurityConfigFilter implements OASFilter {
                 openAPI.setComponents(OASFactory.createComponents());
             }
 
-            Map<String, SecurityScheme> securitySchemes = new HashMap();
+            Map<String, SecurityScheme> securitySchemes = new HashMap<>();
 
             // Add any existing security
             if (openAPI.getComponents().getSecuritySchemes() != null
@@ -90,6 +101,32 @@ public class SecurityConfigFilter implements OASFilter {
             if (securitySchemes.size() > 1) {
                 log.warn("Detected multiple Security Schemes, only one scheme is supported at the moment "
                         + securitySchemes.keySet().toString());
+            }
+
+            // Also add Security requirement for all methods annotated with Roles allowed
+            if (config.autoAddSecurityRequirement && !securitySchemes.isEmpty() && !methodReferences.isEmpty()) {
+                Paths paths = openAPI.getPaths();
+                if (paths != null) {
+                    Map<String, PathItem> pathItems = paths.getPathItems();
+                    if (pathItems != null && !pathItems.isEmpty()) {
+                        Set<Map.Entry<String, PathItem>> pathItemsEntries = pathItems.entrySet();
+                        for (Map.Entry<String, PathItem> pathItem : pathItemsEntries) {
+                            Map<PathItem.HttpMethod, Operation> operations = pathItem.getValue().getOperations();
+                            if (operations != null && !operations.isEmpty()) {
+                                for (Operation operation : operations.values()) {
+                                    OperationImpl operationImpl = (OperationImpl) operation;
+                                    if (methodReferences.keySet().contains(operationImpl.getMethodRef())) {
+                                        SecurityRequirement securityRequirement = new SecurityRequirementImpl();
+                                        List<String> roles = methodReferences.get(operationImpl.getMethodRef());
+                                        String name = securitySchemes.keySet().iterator().next();
+                                        securityRequirement = securityRequirement.addScheme(name, roles);
+                                        operation = operation.addSecurityRequirement(securityRequirement);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRequirementTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRequirementTestCase.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoSecurityRequirementTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ResourceBean.class, OpenApiResourceSecuredAtClassLevel.class,
+                            OpenApiResourceSecuredAtMethodLevel.class, OpenApiResourceSecuredAtMethodLevel2.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=jwt\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=JWT Authentication"),
+
+                            "application.properties"));
+
+    @Test
+    public void testAutoSecurityRequirement() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("type", "http"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication",
+                        Matchers.hasEntry("description", "JWT Authentication"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("scheme", "bearer"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("bearerFormat", "JWT"))
+                .and()
+                .body("paths.'/resource2/test-security/annotated'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/naked'.get.security.JWTCompanyAuthentication", Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/1'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/2'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/3'.get.security.MyOwnName",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource3/test-security/annotated'.get.security.AtClassLevel", Matchers.notNullValue());
+
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/resource2")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+@RolesAllowed("admin")
+public class OpenApiResourceSecuredAtClassLevel {
+
+    private ResourceBean resourceBean;
+
+    @GET
+    @Path("/test-security/classLevel/1")
+    public String secureEndpoint1() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/classLevel/2")
+    public String secureEndpoint2() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/classLevel/3")
+    @SecurityRequirement(name = "MyOwnName")
+    public String secureEndpoint3() {
+        return "secret";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
@@ -1,0 +1,53 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/resource2")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+public class OpenApiResourceSecuredAtMethodLevel {
+
+    private ResourceBean resourceBean;
+
+    @GET
+    @Path("/test-security/naked")
+    @RolesAllowed("admin")
+    public String secureEndpointWithoutSecurityAnnotation() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/annotated")
+    @RolesAllowed("admin")
+    @SecurityRequirement(name = "JWTCompanyAuthentication")
+    public String secureEndpointWithSecurityAnnotation() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/1")
+    @RolesAllowed("admin")
+    public String secureEndpoint1() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/2")
+    @RolesAllowed("admin")
+    public String secureEndpoint2() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/public")
+    public String publicEndpoint() {
+        return "boo";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel2.java
@@ -1,0 +1,26 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/resource3")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+@SecurityRequirement(name = "AtClassLevel")
+public class OpenApiResourceSecuredAtMethodLevel2 {
+
+    private ResourceBean resourceBean;
+
+    @GET
+    @Path("/test-security/annotated")
+    @RolesAllowed("admin")
+    public String secureEndpointWithSecurityAnnotation() {
+        return "secret";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStaticModelsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiStaticModelsTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.io.IOException;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiStaticModelsTestCase {
+
+    private static String directory = "META-INF/openapi/";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsManifestResource("test-openapi.yaml", "openapi/model1.yaml")
+                    .addAsManifestResource("test-openapi2.yaml", "openapi/model2.yaml")
+                    .addAsManifestResource("test-openapi3.yaml", "openapi/model3.yaml")
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.additional-docs-directory=" + directory),
+                            "application.properties"));
+
+    @Test
+    public void testMultipleStaticFiles() throws IOException {
+
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("paths.'/openapi'.get.operationId", Matchers.equalTo("someOperation"))
+                .and().body("paths.'/openapi2'.get.operationId", Matchers.equalTo("someOperation2"))
+                .and().body("paths.'/openapi3'.get.operationId", Matchers.equalTo("someOperation3"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.openapi.test.jaxrs;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
@@ -8,4 +9,10 @@ public class ResourceBean {
     public String toString() {
         return "resource";
     }
+
+    @RolesAllowed("admin")
+    public String anotherMethod() {
+        return "bla";
+    }
+
 }

--- a/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi2.yaml
+++ b/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi2.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: Test OpenAPI
+  description: Some description
+  version: 4.2
+paths:
+  /openapi2:
+    get:
+      operationId: someOperation2
+      responses:
+        200:
+          description: Ok

--- a/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi3.yaml
+++ b/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi3.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: Test OpenAPI
+  description: Some description
+  version: 4.2
+paths:
+  /openapi3:
+    get:
+      operationId: someOperation3
+      responses:
+        200:
+          description: Ok

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -260,6 +260,8 @@ public class SwaggerUiProcessor {
 
         if (swaggerUiConfig.oauth2RedirectUrl.isPresent()) {
             options.put(Option.oauth2RedirectUrl, swaggerUiConfig.oauth2RedirectUrl.get());
+        } else {
+            options.put(Option.oauth2RedirectUrl, swaggerUiPath + "/oauth2-redirect.html");
         }
 
         if (swaggerUiConfig.requestInterceptor.isPresent()) {

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
@@ -31,7 +31,7 @@ public class SwaggerOptionsTest {
                         containsString("https://petstore.swagger.io/v2/swagger.json"),
                         containsString("theme-newspaper.css"),
                         containsString("docExpansion: 'full'"),
-                        containsString("oauth2RedirectUrl: '/somesecure/page/oauth.html'"),
+                        containsString("var oar = \"/somesecure/page/oauth.html\";"),
                         containsString("validatorUrl: 'localhost'"),
                         containsString("displayRequestDuration: true"),
                         containsString("supportedSubmitMethods: ['get', 'post']"),

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
@@ -43,7 +43,7 @@ public class OpenApiTestCase {
         Assertions.assertNotNull(obj);
 
         Assertions.assertEquals("3.0.3", obj.getString("openapi"));
-        Assertions.assertEquals("Generated API", obj.getJsonObject("info").getString("title"));
+        Assertions.assertEquals("main-integration-test API", obj.getJsonObject("info").getString("title"));
         Assertions.assertEquals("1.0", obj.getJsonObject("info").getString("version"));
 
         JsonObject paths = obj.getJsonObject("paths");


### PR DESCRIPTION
This PR contains some small enhancements to the OpenAPI and Swagger UI extensions:

- Auto add the `Security Requirement` for REST Endpoints that has `RolesAllowed` 
- Set a more appropriate default title and version
- Set the correct default `oauth2RedirectUrl ` in swagger-ui
- Allow multiple static OpenAPI model documents
- Upgrade to SmallRye OpenAPI 2.1.9 (see https://github.com/smallrye/smallrye-open-api/releases/tag/2.1.9)

Fix #18614
Fix #19113
Fix #19131

It might be easier to review per commit.