### PR TITLE
Make Quarkus Gradle plugin work with spring dependency management

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -132,15 +132,9 @@ public class ConditionalDependenciesEnabler {
 
     private Configuration createConditionalDependenciesConfiguration(Configuration existingDeps,
             List<ExtensionDependency> extensions) {
-        List<Dependency> toResolve = new ArrayList<>();
-        for (Dependency dependency : existingDeps.getDependencies()) {
-            toResolve.add(dependency);
-        }
-        for (Dependency dependency : collectConditionalDependencies(extensions)) {
-            toResolve.add(dependency);
-        }
-        return project.getConfigurations()
-                .detachedConfiguration(toResolve.toArray(new Dependency[0]));
+        Configuration newConfiguration = existingDeps.copy();
+        newConfiguration.getDependencies().addAll(collectConditionalDependencies(extensions));
+        return newConfiguration;
     }
 
     private Set<Dependency> collectConditionalDependencies(List<ExtensionDependency> extensionDependencies) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -31,7 +31,6 @@ public class DependencyUtils {
         if (configurationCopy != null) {
             project.getConfigurations().remove(configurationCopy);
         }
-
         configurationCopy = project.getConfigurations().create(COPY_CONFIGURATION_NAME);
 
         // We add boms for dependency resolution

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -18,9 +18,7 @@ public class QuarkusGradleModelFactory {
         try (ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(projectDir)
                 .connect()) {
-            connection.newBuild().forTasks(tasks).addJvmArguments(jvmArgs).run();
-
-            return connection.action(new QuarkusModelBuildAction(mode)).run();
+            return connection.action(new QuarkusModelBuildAction(mode)).forTasks(tasks).addJvmArguments(jvmArgs).run();
         }
     }
 

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'io.spring.dependency-management'
+}
+
+repositories {
+    mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+}
+
+dependencyManagement {
+    dependencies {
+        dependency "io.quarkus:quarkus-resteasy:${quarkusPlatformVersion}"
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}") {
+        // We exclude resteasy so Spring dependency management handles it
+        exclude group: 'io.quarkus', module: 'quarkus-resteasy'
+    }
+    implementation "io.quarkus:quarkus-resteasy"
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+      id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "";
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConditionalDependenciesTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConditionalDependenciesTest.java
@@ -23,44 +23,44 @@ public class ConditionalDependenciesTest extends QuarkusGradleWrapperTestBase {
     public void publishTestExtensions() throws IOException, InterruptedException, URISyntaxException {
         File dependencyProject = getProjectDir("conditional-dependencies");
         runGradleWrapper(dependencyProject, ":ext-a:runtime:publishToMavenLocal",
-                ":ext-a:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-b:runtime:publishToMavenLocal",
-                ":ext-b:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-c:runtime:publishToMavenLocal",
-                ":ext-c:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-d:runtime:publishToMavenLocal",
-                ":ext-d:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-e:runtime:publishToMavenLocal",
-                ":ext-e:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-f:runtime:publishToMavenLocal",
-                ":ext-f:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-g:runtime:publishToMavenLocal",
-                ":ext-g:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-h:runtime:publishToMavenLocal",
-                ":ext-h:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-i:runtime:publishToMavenLocal",
-                ":ext-i:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-j:runtime:publishToMavenLocal",
-                ":ext-j:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-k:runtime:publishToMavenLocal",
-                ":ext-k:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-l:runtime:publishToMavenLocal",
-                ":ext-l:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-m:runtime:publishToMavenLocal",
-                ":ext-m:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-n:runtime:publishToMavenLocal",
-                ":ext-n:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-o:runtime:publishToMavenLocal",
-                ":ext-o:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-p:runtime:publishToMavenLocal",
-                ":ext-p:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-r:runtime:publishToMavenLocal",
-                ":ext-r:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-s:runtime:publishToMavenLocal",
-                ":ext-s:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-t:runtime:publishToMavenLocal",
-                ":ext-t:deployment:publishToMavenLocal");
-        runGradleWrapper(dependencyProject, ":ext-u:runtime:publishToMavenLocal",
+                ":ext-a:deployment:publishToMavenLocal",
+                ":ext-b:runtime:publishToMavenLocal",
+                ":ext-b:deployment:publishToMavenLocal",
+                ":ext-c:runtime:publishToMavenLocal",
+                ":ext-c:deployment:publishToMavenLocal",
+                ":ext-d:runtime:publishToMavenLocal",
+                ":ext-d:deployment:publishToMavenLocal",
+                ":ext-e:runtime:publishToMavenLocal",
+                ":ext-e:deployment:publishToMavenLocal",
+                ":ext-f:runtime:publishToMavenLocal",
+                ":ext-f:deployment:publishToMavenLocal",
+                ":ext-g:runtime:publishToMavenLocal",
+                ":ext-g:deployment:publishToMavenLocal",
+                ":ext-h:runtime:publishToMavenLocal",
+                ":ext-h:deployment:publishToMavenLocal",
+                ":ext-i:runtime:publishToMavenLocal",
+                ":ext-i:deployment:publishToMavenLocal",
+                ":ext-j:runtime:publishToMavenLocal",
+                ":ext-j:deployment:publishToMavenLocal",
+                ":ext-k:runtime:publishToMavenLocal",
+                ":ext-k:deployment:publishToMavenLocal",
+                ":ext-l:runtime:publishToMavenLocal",
+                ":ext-l:deployment:publishToMavenLocal",
+                ":ext-m:runtime:publishToMavenLocal",
+                ":ext-m:deployment:publishToMavenLocal",
+                ":ext-n:runtime:publishToMavenLocal",
+                ":ext-n:deployment:publishToMavenLocal",
+                ":ext-o:runtime:publishToMavenLocal",
+                ":ext-o:deployment:publishToMavenLocal",
+                ":ext-p:runtime:publishToMavenLocal",
+                ":ext-p:deployment:publishToMavenLocal",
+                ":ext-r:runtime:publishToMavenLocal",
+                ":ext-r:deployment:publishToMavenLocal",
+                ":ext-s:runtime:publishToMavenLocal",
+                ":ext-s:deployment:publishToMavenLocal",
+                ":ext-t:runtime:publishToMavenLocal",
+                ":ext-t:deployment:publishToMavenLocal",
+                ":ext-u:runtime:publishToMavenLocal",
                 ":ext-u:deployment:publishToMavenLocal");
     }
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SpringDependencyManagementTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SpringDependencyManagementTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+public class SpringDependencyManagementTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testQuarkusBuildShouldWorkWithSpringDependencyManagement()
+            throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("spring-dependency-plugin-project");
+
+        final BuildResult result = runGradleWrapper(projectDir, "clean", "quarkusBuild");
+
+        assertThat(result.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+}


### PR DESCRIPTION
By using configuration.copy() instead of creating detached configuration.

Configuration.copy() copies also all other things, like actions that were applied to configuration etc. Note there exists also copyRecursive() but from current code it looks like just `copy()` is needed: copy calls `getDependencies()` under the hood.

Fixes #19150
