### PR TITLE
Scheduler - make it possible to record metrics automatically

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -320,6 +320,14 @@ The scheduler can be disabled through the runtime config property `quarkus.sched
 If set to `false` the scheduler is not started even though the application contains scheduled methods.
 You can even disable the scheduler for particular <<getting-started-testing#testing_different_profiles,Test Profiles>>.
 
+== Metrics
+
+Some basic metrics are published out of the box if `quarkus.scheduler.metrics.enabled` is set to `true` and a metrics extension is present. 
+
+If the link:micrometer[Micrometer extension] is present, then a `@io.micrometer.core.annotation.Timed` interceptor binding is added to all `@Scheduled` methods automatically (unless it's already present) and a `io.micrometer.core.instrument.Timer` with name `scheduled.methods` and a `io.micrometer.core.instrument.LongTaskTimer` with name `scheduled.methods.running` are registered. The fully qualified name of the declaring class and the name of a `@Scheduled` method are used as tags.
+
+If the link:smallrye-metrics[SmallRye Metrics extension] is present, then a `@org.eclipse.microprofile.metrics.annotation.Timed`  interceptor binding is added to all `@Scheduled` methods automatically (unless it's already present) and a `org.eclipse.microprofile.metrics.Timer` is created for each `@Scheduled` method. The name consists of the fully qualified name of the declaring class and the name of a `@Scheduled` method. The timer has a tag `scheduled=true`.
+
 == Configuration Reference
 
 include::{generated-dir}/config/quarkus-scheduler.adoc[leveloffset=+1, opts=optional]

--- a/extensions/quartz/deployment/pom.xml
+++ b/extensions/quartz/deployment/pom.xml
@@ -37,6 +37,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/metrics/Jobs.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/metrics/Jobs.java
@@ -1,0 +1,25 @@
+package io.quarkus.quartz.test.metrics;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+import io.quarkus.scheduler.Scheduled;
+
+public class Jobs {
+
+    static final CountDownLatch latch01 = new CountDownLatch(1);
+    static final CountDownLatch latch02 = new CountDownLatch(1);
+
+    @Scheduled(every = "1s")
+    void everySecond() {
+        latch01.countDown();
+    }
+
+    @Timed(name = "foo") // Extension should not override this annotation 
+    @Scheduled(every = "1s")
+    void anotherEverySecond() {
+        latch02.countDown();
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/metrics/MpTimedTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/metrics/MpTimedTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.quartz.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.Timer;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MpTimedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset("quarkus.scheduler.metrics.enabled=true"),
+                            "application.properties"));
+
+    @Inject
+    MetricRegistry metricRegistry;
+
+    @Test
+    void testTimedMethod() throws InterruptedException {
+        assertTrue(Jobs.latch01.await(5, TimeUnit.SECONDS));
+        assertTrue(Jobs.latch02.await(5, TimeUnit.SECONDS));
+        Timer timer1 = metricRegistry
+                .getTimer(new MetricID(Jobs.class.getName() + ".everySecond", new Tag("scheduled", "true")));
+        assertNotNull(timer1);
+        assertTrue(timer1.getCount() > 0);
+        Timer timer2 = metricRegistry.getTimer(new MetricID(Jobs.class.getName() + ".foo"));
+        assertNotNull(timer2);
+        assertTrue(timer2.getCount() > 0);
+    }
+
+}

--- a/extensions/scheduler/deployment/pom.xml
+++ b/extensions/scheduler/deployment/pom.xml
@@ -33,6 +33,11 @@
       </dependency>
       <dependency>
           <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>io.quarkus</groupId>
           <artifactId>quarkus-junit5-internal</artifactId>
           <scope>test</scope>
       </dependency>

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/metrics/MicrometerTimedTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/metrics/MicrometerTimedTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.scheduler.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MicrometerTimedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset("quarkus.scheduler.metrics.enabled=true"),
+                            "application.properties"));
+
+    @Inject
+    MeterRegistry registry;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void testTimedMethod() throws InterruptedException {
+        assertTrue(Jobs.latch01.await(5, TimeUnit.SECONDS));
+        assertTrue(Jobs.latch02.await(5, TimeUnit.SECONDS));
+        Timer timer1 = registry.get("scheduled.methods")
+                .tag("method", "everySecond")
+                .tag("class", "io.quarkus.scheduler.test.metrics.MicrometerTimedTest$Jobs")
+                .tag("exception", "none")
+                .timer();
+        assertNotNull(timer1);
+        assertTrue(timer1.count() > 0);
+        Timer timer2 = registry.get("foo")
+                .tag("method", "anotherEverySecond")
+                .tag("class", "io.quarkus.scheduler.test.metrics.MicrometerTimedTest$Jobs")
+                .tag("exception", "none")
+                .timer();
+        assertNotNull(timer2);
+        assertTrue(timer2.count() > 0);
+    }
+
+    static class Jobs {
+
+        static final CountDownLatch latch01 = new CountDownLatch(1);
+        static final CountDownLatch latch02 = new CountDownLatch(1);
+
+        @Scheduled(every = "1s")
+        void everySecond() {
+            latch01.countDown();
+        }
+
+        @Timed("foo") // Extension should not override this annotation 
+        @Scheduled(every = "1s")
+        void anotherEverySecond() {
+            latch02.countDown();
+        }
+
+    }
+
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
@@ -18,4 +18,10 @@ public class SchedulerConfig {
     @ConfigItem(defaultValue = "quartz")
     public CronType cronType;
 
+    /**
+     * Scheduled task metrics will be enabled if a metrics extension is present and this value is true.
+     */
+    @ConfigItem(name = "metrics.enabled")
+    public boolean metricsEnabled;
+
 }

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -2,7 +2,18 @@ package io.quarkus.smallrye.metrics.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
-import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.*;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.CONCURRENT_GAUGE_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.COUNTER_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.GAUGE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.GAUGE_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.HISTOGRAM_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METER_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRIC;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRICS_ANNOTATIONS;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRICS_BINDING;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRIC_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.SIMPLE_TIMER_INTERFACE;
+import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.TIMER_INTERFACE;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -35,15 +46,19 @@ import io.quarkus.arc.deployment.AutoInjectAnnotationBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
+import io.quarkus.arc.deployment.TransformedAnnotationsBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.arc.processor.InterceptorInfo;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -332,10 +347,11 @@ public class SmallRyeMetricsProcessor {
     @BuildStep
     @Record(STATIC_INIT)
     void registerMetricsFromAnnotatedMethods(SmallRyeMetricsRecorder metrics,
-            BeanArchiveIndexBuildItem beanArchiveIndex) {
+            BeanArchiveIndexBuildItem beanArchiveIndex, TransformedAnnotationsBuildItem transformedAnnotations,
+            ValidationPhaseBuildItem validationPhase) {
         IndexView index = beanArchiveIndex.getIndex();
-        JandexBeanInfoAdapter beanInfoAdapter = new JandexBeanInfoAdapter(index);
-        JandexMemberInfoAdapter memberInfoAdapter = new JandexMemberInfoAdapter(index);
+        JandexBeanInfoAdapter beanInfoAdapter = new JandexBeanInfoAdapter(index, transformedAnnotations);
+        JandexMemberInfoAdapter memberInfoAdapter = new JandexMemberInfoAdapter(index, transformedAnnotations);
 
         Set<MethodInfo> collectedMetricsMethods = new HashSet<>();
         Map<DotName, ClassInfo> collectedMetricsClasses = new HashMap<>();
@@ -344,12 +360,16 @@ public class SmallRyeMetricsProcessor {
         Set<DotName> metricAndStereotypeAnnotations = new HashSet<>();
         metricAndStereotypeAnnotations.addAll(METRICS_ANNOTATIONS);
         for (ClassInfo candidate : beanArchiveIndex.getIndex().getKnownClasses()) {
-            if (candidate.classAnnotation(DotNames.STEREOTYPE) != null &&
-                    candidate.classAnnotations().stream()
+            if (transformedAnnotations.getAnnotation(candidate, DotNames.STEREOTYPE) != null &&
+                    transformedAnnotations.getAnnotations(candidate).stream()
                             .anyMatch(SmallRyeMetricsDotNames::isMetricAnnotation)) {
                 metricAndStereotypeAnnotations.add(candidate.name());
             }
         }
+
+        // First add all class beans with a SmallRye Metrics interceptor associated
+        validationPhase.getContext().beans().classBeans().filter(this::hasMetricsInterceptorAssociated)
+                .forEach(b -> collectMetricsClassAndSubClasses(index, collectedMetricsClasses, b.getTarget().get().asClass()));
 
         for (DotName metricAnnotation : metricAndStereotypeAnnotations) {
             Collection<AnnotationInstance> metricAnnotationInstances = index.getAnnotations(metricAnnotation);
@@ -388,9 +408,9 @@ public class SmallRyeMetricsProcessor {
             // register metrics for all inherited methods as well
             while (superclass != null && superclass.superName() != null) {
                 for (MethodInfo method : superclass.methods()) {
-                    if (!Modifier.isPrivate(method.flags()) && !alreadyRegisteredNames.contains(method.name())) {
+                    if (!Modifier.isPrivate(method.flags()) && !alreadyRegisteredNames.contains(method.toString())) {
                         metrics.registerMetrics(beanInfo, memberInfoAdapter.convert(method));
-                        alreadyRegisteredNames.add(method.name());
+                        alreadyRegisteredNames.add(method.toString());
                     }
                 }
                 superclass = index.getClassByName(superclass.superName());
@@ -419,6 +439,18 @@ public class SmallRyeMetricsProcessor {
         }
     }
 
+    private boolean hasMetricsInterceptorAssociated(io.quarkus.arc.processor.BeanInfo bean) {
+        if (!bean.hasAroundInvokeInterceptors()) {
+            return false;
+        }
+        for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
+            if (interceptor.getBeanClass().toString().startsWith("io.smallrye.metrics.interceptors")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void findNonOverriddenDefaultMethods(ClassInfo interfaceInfo, Set<String> alreadyRegisteredNames,
             SmallRyeMetricsRecorder recorder,
             BeanArchiveIndexBuildItem beanArchiveIndex, JandexMemberInfoAdapter memberInfoAdapter, BeanInfo beanInfo) {
@@ -426,9 +458,9 @@ public class SmallRyeMetricsProcessor {
         // or any of its superclasses. Register a metric for each of them.
         for (MethodInfo method : interfaceInfo.methods()) {
             if (!Modifier.isAbstract(method.flags())) { // only take default methods
-                if (!alreadyRegisteredNames.contains(method.name())) {
+                if (!alreadyRegisteredNames.contains(method.toString())) {
                     recorder.registerMetrics(beanInfo, memberInfoAdapter.convert(method));
-                    alreadyRegisteredNames.add(method.name());
+                    alreadyRegisteredNames.add(method.toString());
                 }
             }
         }
@@ -464,11 +496,10 @@ public class SmallRyeMetricsProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
+    @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     void registerRuntimeExtensionMetrics(
             SmallRyeMetricsRecorder recorder,
-            List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems,
-            ValidationPhaseBuildItem validationPhase,
-            BeanArchiveIndexBuildItem beanArchiveIndex) {
+            List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems) {
         for (MetricsFactoryConsumerBuildItem item : metricsFactoryConsumerBuildItems) {
             if (item.executionTime() == RUNTIME_INIT) {
                 recorder.registerMetrics(item.getConsumer());
@@ -575,6 +606,9 @@ public class SmallRyeMetricsProcessor {
 
     private void collectMetricsClassAndSubClasses(IndexView index, Map<DotName, ClassInfo> collectedMetricsClasses,
             ClassInfo clazz) {
+        if (collectedMetricsClasses.containsKey(clazz.name())) {
+            return;
+        }
         collectedMetricsClasses.put(clazz.name(), clazz);
         for (ClassInfo subClass : index.getAllKnownSubclasses(clazz.name())) {
             collectedMetricsClasses.put(subClass.name(), subClass);

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/jandex/JandexMemberInfoAdapter.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/jandex/JandexMemberInfoAdapter.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.arc.deployment.TransformedAnnotationsBuildItem;
 import io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames;
 import io.smallrye.metrics.elementdesc.AnnotationInfo;
 import io.smallrye.metrics.elementdesc.MemberInfo;
@@ -16,9 +17,11 @@ import io.smallrye.metrics.elementdesc.adapter.MemberInfoAdapter;
 public class JandexMemberInfoAdapter implements MemberInfoAdapter<AnnotationTarget> {
 
     private final IndexView indexView;
+    private final TransformedAnnotationsBuildItem transformedAnnotations;
 
-    public JandexMemberInfoAdapter(IndexView indexView) {
+    public JandexMemberInfoAdapter(IndexView indexView, TransformedAnnotationsBuildItem transformedAnnotations) {
         this.indexView = indexView;
+        this.transformedAnnotations = transformedAnnotations;
     }
 
     @Override
@@ -43,8 +46,7 @@ public class JandexMemberInfoAdapter implements MemberInfoAdapter<AnnotationTarg
             declaringClassName = input.asMethod().declaringClass().name().toString();
             declaringClassSimpleName = input.asMethod().declaringClass().simpleName();
             name = input.asMethod().name();
-            annotationInformation = input.asMethod()
-                    .annotations()
+            annotationInformation = transformedAnnotations.getAnnotations(input)
                     .stream()
                     .filter(SmallRyeMetricsDotNames::isMetricAnnotation)
                     .map(annotationInfoAdapter::convert)
@@ -56,8 +58,7 @@ public class JandexMemberInfoAdapter implements MemberInfoAdapter<AnnotationTarg
             declaringClassName = input.asField().declaringClass().name().toString();
             declaringClassSimpleName = input.asField().declaringClass().simpleName();
             name = input.asField().name();
-            annotationInformation = input.asField()
-                    .annotations()
+            annotationInformation = transformedAnnotations.getAnnotations(input)
                     .stream()
                     .filter(SmallRyeMetricsDotNames::isMetricAnnotation)
                     .map(annotationInfoAdapter::convert)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -345,6 +345,8 @@ public class BeanInfo implements InjectionTargetInfo {
     }
 
     /**
+     * Note that the interceptors are not available until the bean is fully initialized, i.e. they are available after
+     * {@link BeanProcessor#initialize(Consumer, List)}.
      *
      * @return an ordered list of all interceptors associated with the bean
      */
@@ -371,6 +373,12 @@ public class BeanInfo implements InjectionTargetInfo {
         return bound;
     }
 
+    /**
+     * Note that the decorators are not available until the bean is fully initialized, i.e. they are available after
+     * {@link BeanProcessor#initialize(Consumer, List)}.
+     * 
+     * @return an ordered list of all decorators associated with the bean
+     */
     public List<DecoratorInfo> getBoundDecorators() {
         if (decoratedMethods.isEmpty()) {
             return Collections.emptyList();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
@@ -281,6 +281,16 @@ public final class BeanStream implements Iterable<BeanInfo> {
     }
 
     /**
+     * 
+     * @param predicate
+     * @return the new stream
+     */
+    public BeanStream filter(Predicate<BeanInfo> predicate) {
+        stream = stream.filter(predicate);
+        return this;
+    }
+
+    /**
      * Terminal operation.
      * 
      * @return the list of beans


### PR DESCRIPTION
- when a metrics extension is present and
quarkus.scheduler.metrics.enabled=true a timed interceptor binding is
automatically added to a scheduled method

TODO:

* [x] Add test for MP Metrics
* [x] Add docs