### PR TITLE
Reduce log clutter in RESTEasy Reactive tests

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestResource.java
@@ -45,6 +45,8 @@ import io.vertx.core.http.HttpServerResponse;
 @Path("/simple")
 public class SimpleQuarkusRestResource {
 
+    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+
     @Inject
     HelloService service;
 
@@ -177,19 +179,25 @@ public class SimpleQuarkusRestResource {
     @GET
     @Path("mapped-exception")
     public String mappedException() {
-        throw new TestException();
+        TestException exception = new TestException();
+        exception.setStackTrace(EMPTY_STACK_TRACE);
+        throw exception;
     }
 
     @GET
     @Path("feature-mapped-exception")
     public String featureMappedException() {
-        throw new FeatureMappedException();
+        FeatureMappedException exception = new FeatureMappedException();
+        exception.setStackTrace(EMPTY_STACK_TRACE);
+        throw exception;
     }
 
     @GET
     @Path("unknown-exception")
     public String unknownException() {
-        throw new RuntimeException("OUCH");
+        RuntimeException exception = new RuntimeException("OUCH");
+        exception.setStackTrace(EMPTY_STACK_TRACE);
+        throw exception;
     }
 
     @GET


### PR DESCRIPTION
We just remove the stacktraces which don't provide any useful information