### PR TITLE
Add Configuration option to enable Hibernate's LOG_SLOW_QUERY feature

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -389,8 +389,14 @@ public class HibernateOrmConfigPersistenceUnit {
         @ConfigItem(defaultValueDocumentation = "depends on dialect")
         public Optional<Boolean> jdbcWarnings;
 
+        /**
+         * If set, Hibernate will log queries that took more than specified number of milliseconds to execute.
+         */
+        @ConfigItem
+        public Optional<Long> queriesSlowerThanMs;
+
         public boolean isAnyPropertySet() {
-            return sql || !formatSql || jdbcWarnings.isPresent();
+            return sql || !formatSql || jdbcWarnings.isPresent() || queriesSlowerThanMs.isPresent();
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -367,40 +367,6 @@ public class HibernateOrmConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public static class HibernateOrmConfigPersistenceUnitLog {
-
-        /**
-         * Show SQL logs and format them nicely.
-         * <p>
-         * Setting it to true is obviously not recommended in production.
-         */
-        @ConfigItem
-        public boolean sql;
-
-        /**
-         * Format the SQL logs if SQL log is enabled
-         */
-        @ConfigItem(defaultValue = "true")
-        public boolean formatSql;
-
-        /**
-         * Whether JDBC warnings should be collected and logged.
-         */
-        @ConfigItem(defaultValueDocumentation = "depends on dialect")
-        public Optional<Boolean> jdbcWarnings;
-
-        /**
-         * If set, Hibernate will log queries that took more than specified number of milliseconds to execute.
-         */
-        @ConfigItem
-        public Optional<Long> queriesSlowerThanMs;
-
-        public boolean isAnyPropertySet() {
-            return sql || !formatSql || jdbcWarnings.isPresent() || queriesSlowerThanMs.isPresent();
-        }
-    }
-
-    @ConfigGroup
     public static class HibernateOrmConfigPersistenceUnitCache {
         /**
          * The cache expiration configuration.

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -372,6 +372,11 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             runtimeSettingsBuilder.put(AvailableSettings.LOG_JDBC_WARNINGS,
                     persistenceUnitConfig.log.jdbcWarnings.get().toString());
         }
+
+        if (persistenceUnitConfig.log.queriesSlowerThanMs.isPresent()) {
+            runtimeSettingsBuilder.put(AvailableSettings.LOG_SLOW_QUERY,
+                    persistenceUnitConfig.log.queriesSlowerThanMs.get());
+        }
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -149,8 +149,14 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         @ConfigItem(defaultValueDocumentation = "depends on dialect")
         public Optional<Boolean> jdbcWarnings = Optional.empty();
 
+        /**
+         * If set, Hibernate will log queries that took more than specified number of milliseconds to execute.
+         */
+        @ConfigItem
+        public Optional<Long> queriesSlowerThanMs;
+
         public boolean isAnyPropertySet() {
-            return sql || !formatSql || jdbcWarnings.isPresent();
+            return sql || !formatSql || jdbcWarnings.isPresent() || queriesSlowerThanMs.isPresent();
         }
     }
 


### PR DESCRIPTION
Resolves: #18634

Prints something like:

```
2021-08-03 18:59:43,851 INFO  [org.hib.SQL_SLOW] (executor-thread-0) SlowQuery: 7 milliseconds. SQL: 'wrapped[ select fruit0_.id as id1_0_, fruit0_.name as name2_0_ from Fruit fruit0_ ]'
```

when the query is takes longer than the specified value.

_The reason I went ahead and did this is because I wanted us to have a feature that Spring Data JPA already has and because the initial reporter hadn't responded to our query if they were willing to take this up_