### PR TITLE
Grpc client port default grpc server port

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
@@ -15,7 +15,7 @@ public class GrpcClientConfiguration {
     /**
      * The gRPC service port.
      */
-    @ConfigItem(defaultValue = "9000")
+    @ConfigItem(defaultValue = "${quarkus.grpc.server.port}")
     public int port;
 
     /**


### PR DESCRIPTION
At the moment, when running a Quarkus application with a gRPC server and changing the default port other than 9000, we need to set both `quarkus.grpc.server.port` and `quarkus.grpc.clients.XXX.port` properties.

This PR fixes this issue by setting the clients property the `quarkus.grpc.server.port` value by default instead of 9000.

Fix https://github.com/quarkusio/quarkus/issues/19219