### PR TITLE
Honor read timeout in reactive rest client

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -166,6 +166,10 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         requestOptions.setURI(uri.getPath() + (uri.getQuery() == null ? "" : "?" + uri.getQuery()));
         requestOptions.setFollowRedirects(followRedirects);
         requestOptions.setSsl(isHttps);
+        Object readTimeout = state.getConfiguration().getProperty(QuarkusRestClientProperties.READ_TIMEOUT);
+        if (readTimeout instanceof Long) {
+            requestOptions.setTimeout((Long) readTimeout);
+        }
         return httpClient.request(requestOptions);
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InvocationBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InvocationBuilderImpl.java
@@ -10,8 +10,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.CompletionStageRxInvoker;
@@ -197,8 +195,8 @@ public class InvocationBuilderImpl implements Invocation.Builder {
             throw new BlockingNotAllowedException();
         }
         try {
-            return c.get(readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | TimeoutException e) {
+            return c.get();
+        } catch (InterruptedException e) {
             throw new ProcessingException(e);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof ProcessingException) {


### PR DESCRIPTION
Before this change the read timeout only had an effect when doing
a synchronous call (and even then it didn't result in the proper Vert.x exception)

The connect timeout handling doesn't need any changes because it is properly handled
when org.jboss.resteasy.reactive.client.impl.ClientImpl is created

Fixes: #17526