### PR TITLE
Use RESTEasy Reactive in oidc integration test

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InstanceHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InstanceHandler.java
@@ -22,6 +22,7 @@ public class InstanceHandler implements ServerRestHandler {
         if (instance == null) {
             synchronized (this) {
                 if (instance == null) {
+                    requestContext.requireCDIRequestScope();
                     instance = factory.createInstance().getInstance();
                 }
             }

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
This is done in order to address: https://github.com/quarkusio/quarkus/pull/19201#pullrequestreview-722280680

Also fix a bug with request scope handling in RESTEasy Reactive that the use of the integration test uncovered