### PR TITLE
Upgrade to JBoss Threads 3.4.1.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -108,7 +108,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.16.1.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
-        <jboss-threads.version>3.4.0.Final</jboss-threads.version>
+        <jboss-threads.version>3.4.1.Final</jboss-threads.version>
         <vertx.version>4.1.2</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>


### PR DESCRIPTION
Resolves a classloader leak in live-reload.
 - https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/memory.20leaks.20via.20JBoss.20Threads