### PR TITLE
Release buffer on ResteasyReactiveOutputStream when it is written to overflow

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
@@ -95,6 +95,7 @@ public class ResteasyReactiveOutputStream extends OutputStream {
                     if (last) {
                         closed = true;
                     }
+                    data.release();
                 } else {
                     if (last) {
                         request.response().end(createBuffer(data));


### PR DESCRIPTION
Possible fix for #19257. It seems that under normal circumstances when a buffer is written by netty, netty will release it, however when the buffer is written to the overflow it is not passed to netty, therefore this does not happen and the buffer leaks. Adding this release on the overflow branch seems to fix this.

This logic may be incorrect as it will mean that calling this write has the possibility of releasing the buffer provided as an argument, which may be unexpected behaviour. If this is the case, the write needs to return something to indicate to the caller that the data has been written but the caller needs to release the buffer if needed, specifically this call:

https://github.com/quarkusio/quarkus/blob/main/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java#L212

Needs to understand if its buffer has been consumed and now needs to release it.
