### PR TITLE
Revert "Bump flyway-core from 7.12.0 to 7.12.1"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -156,7 +156,7 @@
         <awaitility.version>4.1.0</awaitility.version>
         <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
         <jgit.version>5.12.0.202106070339-r</jgit.version>
-        <flyway.version>7.12.1</flyway.version>
+        <flyway.version>7.12.0</flyway.version>
         <yasson.version>1.0.9</yasson.version>
         <liquibase.version>4.3.5</liquibase.version>
         <snakeyaml.version>1.29</snakeyaml.version>


### PR DESCRIPTION
Reverts quarkusio/quarkus#19253

Just saw this in the build logs: 

```
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method org.flywaydb.core.internal.util.FeatureDetector.areExperimentalFeaturesEnabled() is reachable: The declaring class of this element has been substituted, but this element is not present in the substitution class
```