### PR TITLE
Fixes Flyway upgrade to 7.12.1

### DIFF
--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/FeatureDetectorSubstitutions.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/FeatureDetectorSubstitutions.java
@@ -47,4 +47,8 @@ public final class FeatureDetectorSubstitutions {
         return false;
     }
 
+    @Substitute
+    public static boolean areExperimentalFeaturesEnabled() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes the build errors introduced by https://github.com/quarkusio/quarkus/pull/19253

Adds the extra method in `org.flywaydb.core.internal.util.FeatureDetector` to work with the GraalVM native build