### PR TITLE
Remove unused config property

### DIFF
--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
@@ -36,13 +36,4 @@ public class DataSourceRuntimeConfig {
      */
     @ConfigItem
     public Optional<String> credentialsProviderName = Optional.empty();
-
-    /**
-     * If this is true then when running in dev or test mode Quarkus will attempt to start a testcontainers based
-     * database with these provided settings.
-     *
-     * This is not supported for all databases, and will not work in production.
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean startContainer;
 }


### PR DESCRIPTION
Looks like this was accidently left in the config when it was renamed to
dev services. It does not actually have any effect, so it can be removed
rather than deprecated.

Fixes #19269