### PR TITLE
Fall back to ThreadLocal if Netty is not present

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ClassLoadingConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ClassLoadingConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.configuration;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -27,7 +28,7 @@ public class ClassLoadingConfig {
      * WARNING: This config property can only be set in application.properties
      */
     @ConfigItem(defaultValue = "")
-    public Optional<String> parentFirstArtifacts;
+    public Optional<List<String>> parentFirstArtifacts;
 
     /**
      * Artifacts that are loaded in the runtime ClassLoader in dev mode, so they will be dropped
@@ -46,6 +47,13 @@ public class ClassLoadingConfig {
      */
     @ConfigItem(defaultValue = "")
     public Optional<String> reloadableArtifacts;
+
+    /**
+     * Artifacts that will never be loaded by the class loader, and will not be packed into the final application. This allows
+     * you to explicitly remove artifacts from your application even though they may be present on the class path.
+     */
+    @ConfigItem(defaultValue = "")
+    public Optional<List<String>> removedArtifacts;
 
     /**
      * Resources that should be removed/hidden from dependencies.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -230,12 +230,13 @@ public class JarResultBuildStep {
                 || packageConfig.type.equalsIgnoreCase(PackageConfig.UBER_JAR))) {
             return buildUberJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses, applicationArchivesBuildItem,
                     packageConfig, applicationInfo, generatedClasses, generatedResources, uberJarMergedResourceBuildItems,
-                    uberJarIgnoredResourceBuildItems, mainClassBuildItem);
+                    uberJarIgnoredResourceBuildItems, mainClassBuildItem, classLoadingConfig);
         } else if (!legacyJarRequired.isEmpty() || packageConfig.isLegacyJar()
                 || packageConfig.type.equalsIgnoreCase(PackageConfig.LEGACY)) {
             return buildLegacyThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem,
-                    packageConfig, applicationInfo, generatedClasses, generatedResources, mainClassBuildItem);
+                    packageConfig, applicationInfo, generatedClasses, generatedResources, mainClassBuildItem,
+                    classLoadingConfig);
         } else {
             return buildThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses, applicationArchivesBuildItem,
                     packageConfig, classLoadingConfig, applicationInfo, generatedClasses, generatedResources,
@@ -281,7 +282,8 @@ public class JarResultBuildStep {
             List<GeneratedResourceBuildItem> generatedResources,
             List<UberJarMergedResourceBuildItem> mergeResources,
             List<UberJarIgnoredResourceBuildItem> ignoredResources,
-            MainClassBuildItem mainClassBuildItem) throws Exception {
+            MainClassBuildItem mainClassBuildItem,
+            ClassLoadingConfig classLoadingConfig) throws Exception {
 
         //we use the -runner jar name, unless we are building both types
         Path runnerJar = outputTargetBuildItem.getOutputDirectory()
@@ -299,6 +301,7 @@ public class JarResultBuildStep {
                 mergeResources,
                 ignoredResources,
                 mainClassBuildItem,
+                classLoadingConfig,
                 runnerJar);
 
         //for uberjars we move the original jar, so there is only a single jar in the output directory
@@ -326,6 +329,7 @@ public class JarResultBuildStep {
             List<UberJarMergedResourceBuildItem> mergedResources,
             List<UberJarIgnoredResourceBuildItem> ignoredResources,
             MainClassBuildItem mainClassBuildItem,
+            ClassLoadingConfig classLoadingConfig,
             Path runnerJar) throws Exception {
         try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
 
@@ -337,6 +341,7 @@ public class JarResultBuildStep {
             final Set<String> mergeResourcePaths = mergedResources.stream()
                     .map(UberJarMergedResourceBuildItem::getPath)
                     .collect(Collectors.toSet());
+            final Set<AppArtifactKey> removed = getRemovedKeys(classLoadingConfig);
             Set<String> finalIgnoredEntries = new HashSet<>(IGNORED_ENTRIES);
             packageConfig.userConfiguredIgnoredEntries.ifPresent(finalIgnoredEntries::addAll);
             ignoredResources.stream()
@@ -356,7 +361,7 @@ public class JarResultBuildStep {
 
                 // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
                 // and are not part of the optional dependencies to include
-                if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies())) {
+                if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removed)) {
                     continue;
                 }
 
@@ -416,13 +421,17 @@ public class JarResultBuildStep {
      * @param optionalDependencies the optional dependencies to include into the final package.
      * @return {@code true} if the dependency should be included, {@code false} otherwise.
      */
-    private static boolean includeAppDep(AppDependency appDep, Optional<Set<AppArtifactKey>> optionalDependencies) {
+    private static boolean includeAppDep(AppDependency appDep, Optional<Set<AppArtifactKey>> optionalDependencies,
+            Set<AppArtifactKey> removedArtifacts) {
         if (!"jar".equals(appDep.getArtifact().getType())) {
             return false;
         }
         if (appDep.isOptional()) {
             return optionalDependencies.map(appArtifactKeys -> appArtifactKeys.contains(appDep.getArtifact().getKey()))
                     .orElse(true);
+        }
+        if (removedArtifacts.contains(appDep.getArtifact().getKey())) {
+            return false;
         }
         return true;
     }
@@ -488,7 +497,8 @@ public class JarResultBuildStep {
             ApplicationInfoBuildItem applicationInfo,
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
-            MainClassBuildItem mainClassBuildItem) throws Exception {
+            MainClassBuildItem mainClassBuildItem,
+            ClassLoadingConfig classLoadingConfig) throws Exception {
 
         Path runnerJar = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + packageConfig.runnerSuffix + ".jar");
@@ -502,7 +512,8 @@ public class JarResultBuildStep {
 
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo,
-                    packageConfig, generatedResources, libDir, generatedClasses, runnerZipFs, mainClassBuildItem);
+                    packageConfig, generatedResources, libDir, generatedClasses, runnerZipFs, mainClassBuildItem,
+                    classLoadingConfig);
         }
         runnerJar.toFile().setReadable(true, false);
 
@@ -652,12 +663,13 @@ public class JarResultBuildStep {
         }
         final Set<AppArtifactKey> parentFirstKeys = getParentFirstKeys(curateOutcomeBuildItem, classLoadingConfig);
         StringBuilder classPath = new StringBuilder();
+        final Set<AppArtifactKey> removed = getRemovedKeys(classLoadingConfig);
         for (AppDependency appDep : curateOutcomeBuildItem.getEffectiveModel().getUserDependencies()) {
             if (rebuild) {
                 jars.addAll(appDep.getArtifact().getPaths().toList());
             } else {
                 copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, mainLib, baseLib, jars, true,
-                        classPath, appDep, transformedClasses);
+                        classPath, appDep, transformedClasses, removed);
             }
             if (parentFirstKeys.contains(appDep.getArtifact().getKey())) {
                 parentFirst.addAll(appDep.getArtifact().getPaths().toList());
@@ -729,7 +741,7 @@ public class JarResultBuildStep {
                 for (AppDependency appDep : curateOutcomeBuildItem.getEffectiveModel().getFullDeploymentDeps()) {
                     copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, deploymentLib, baseLib, jars,
                             false, classPath,
-                            appDep, new TransformedClassesBuildItem(Collections.emptyMap())); //we don't care about transformation here, so just pass in an empty item
+                            appDep, new TransformedClassesBuildItem(Collections.emptyMap()), removed); //we don't care about transformation here, so just pass in an empty item
                 }
 
                 Map<AppArtifactKey, List<String>> relativePaths = new HashMap<>();
@@ -803,12 +815,25 @@ public class JarResultBuildStep {
                 curateOutcomeBuildItem.getEffectiveModel().getRunnerParentFirstArtifacts());
         classLoadingConfig.parentFirstArtifacts.ifPresent(
                 parentFirstArtifacts -> {
-                    String[] artifacts = parentFirstArtifacts.split(",");
-                    for (String artifact : artifacts) {
+                    for (String artifact : parentFirstArtifacts) {
                         parentFirstKeys.add(new AppArtifactKey(artifact.split(":")));
                     }
                 });
         return parentFirstKeys;
+    }
+
+    /**
+     * @return a {@code Set} containing the key of the artifacts to load from the parent ClassLoader first.
+     */
+    private Set<AppArtifactKey> getRemovedKeys(ClassLoadingConfig classLoadingConfig) {
+        final Set<AppArtifactKey> removed = new HashSet<>();
+        classLoadingConfig.removedArtifacts.ifPresent(
+                removedArtifacts -> {
+                    for (String artifact : removedArtifacts) {
+                        removed.add(new AppArtifactKey(artifact.split(":")));
+                    }
+                });
+        return removed;
     }
 
     private boolean downloadFernflowerJar(PackageConfig packageConfig, Path fernflowerJar) {
@@ -866,13 +891,13 @@ public class JarResultBuildStep {
     private void copyDependency(Set<AppArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
             Map<AppArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, List<Path> jars,
             boolean allowParentFirst, StringBuilder classPath, AppDependency appDep,
-            TransformedClassesBuildItem transformedClasses)
+            TransformedClassesBuildItem transformedClasses, Set<AppArtifactKey> removedDeps)
             throws IOException {
         final AppArtifact depArtifact = appDep.getArtifact();
 
         // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
         // and are not part of the optional dependencies to include
-        if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies())) {
+        if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDeps)) {
             return;
         }
         if (runtimeArtifacts.containsKey(depArtifact.getKey())) {
@@ -952,6 +977,7 @@ public class JarResultBuildStep {
             MainClassBuildItem mainClassBuildItem,
             List<UberJarRequiredBuildItem> uberJarRequired,
             List<UberJarMergedResourceBuildItem> mergeResources,
+            ClassLoadingConfig classLoadingConfig,
             List<UberJarIgnoredResourceBuildItem> ignoreResources) throws Exception {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
@@ -973,7 +999,7 @@ public class JarResultBuildStep {
                     applicationArchivesBuildItem,
                     packageConfig, applicationInfo, allClasses, generatedResources, mergeResources,
                     ignoreResources, mainClassBuildItem,
-                    targetDirectory);
+                    targetDirectory, classLoadingConfig);
             // additionally copy any json config files to a location accessible by native-image tool during
             // native-image generation
             copyJsonConfigFiles(applicationArchivesBuildItem, targetDirectory);
@@ -981,7 +1007,8 @@ public class JarResultBuildStep {
         } else {
             return buildNativeImageThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem,
-                    applicationInfo, packageConfig, allClasses, generatedResources, mainClassBuildItem, targetDirectory);
+                    applicationInfo, packageConfig, allClasses, generatedResources, mainClassBuildItem, targetDirectory,
+                    classLoadingConfig);
         }
     }
 
@@ -994,7 +1021,8 @@ public class JarResultBuildStep {
             List<GeneratedClassBuildItem> allClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             MainClassBuildItem mainClassBuildItem,
-            Path targetDirectory) throws Exception {
+            Path targetDirectory,
+            ClassLoadingConfig classLoadingConfig) throws Exception {
         copyJsonConfigFiles(applicationArchivesBuildItem, targetDirectory);
 
         Path runnerJar = targetDirectory
@@ -1008,7 +1036,7 @@ public class JarResultBuildStep {
 
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,
-                    runnerZipFs, mainClassBuildItem);
+                    runnerZipFs, mainClassBuildItem, classLoadingConfig);
         }
         runnerJar.toFile().setReadable(true, false);
         return new NativeImageSourceJarBuildItem(runnerJar, libDir);
@@ -1025,7 +1053,8 @@ public class JarResultBuildStep {
             List<UberJarMergedResourceBuildItem> mergeResources,
             List<UberJarIgnoredResourceBuildItem> ignoreResources,
             MainClassBuildItem mainClassBuildItem,
-            Path targetDirectory) throws Exception {
+            Path targetDirectory,
+            ClassLoadingConfig classLoadingConfig) throws Exception {
         //we use the -runner jar name, unless we are building both types
         Path runnerJar = targetDirectory
                 .resolve(outputTargetBuildItem.getBaseName() + packageConfig.runnerSuffix + ".jar");
@@ -1041,6 +1070,7 @@ public class JarResultBuildStep {
                 mergeResources,
                 ignoreResources,
                 mainClassBuildItem,
+                classLoadingConfig,
                 runnerJar);
 
         return new NativeImageSourceJarBuildItem(runnerJar, null);
@@ -1082,7 +1112,8 @@ public class JarResultBuildStep {
             Path libDir,
             List<GeneratedClassBuildItem> allClasses,
             FileSystem runnerZipFs,
-            MainClassBuildItem mainClassBuildItem)
+            MainClassBuildItem mainClassBuildItem,
+            ClassLoadingConfig classLoadingConfig)
             throws IOException {
         final Map<String, String> seen = new HashMap<>();
         final StringBuilder classPath = new StringBuilder();
@@ -1092,8 +1123,9 @@ public class JarResultBuildStep {
         final Set<String> finalIgnoredEntries = new HashSet<>(IGNORED_ENTRIES);
         packageConfig.userConfiguredIgnoredEntries.ifPresent(finalIgnoredEntries::addAll);
 
+        final Set<AppArtifactKey> removed = getRemovedKeys(classLoadingConfig);
         copyLibraryJars(runnerZipFs, outputTargetBuildItem, transformedClasses, libDir, classPath, appDeps, services,
-                finalIgnoredEntries);
+                finalIgnoredEntries, removed);
 
         AppArtifact appArtifact = curateOutcomeBuildItem.getEffectiveModel().getAppArtifact();
         // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
@@ -1108,14 +1140,14 @@ public class JarResultBuildStep {
     private void copyLibraryJars(FileSystem runnerZipFs, OutputTargetBuildItem outputTargetBuildItem,
             TransformedClassesBuildItem transformedClasses, Path libDir,
             StringBuilder classPath, List<AppDependency> appDeps, Map<String, List<byte[]>> services,
-            Set<String> ignoredEntries) throws IOException {
+            Set<String> ignoredEntries, Set<AppArtifactKey> removedDependencies) throws IOException {
 
         for (AppDependency appDep : appDeps) {
             final AppArtifact depArtifact = appDep.getArtifact();
 
             // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
             // and are not part of the optional dependencies to include
-            if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies())) {
+            if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDependencies)) {
                 continue;
             }
 

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoNettyDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoNettyDataSourceConfigTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.agroal.test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoNettyDataSourceConfigTest {
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("base.properties")
+            //this is a bit yuck, but lots of deps used by other tests bring in Netty as transitive dependencies
+            //we need to exclude them all
+            //this removes the need to have a whole new module just for this test
+            .overrideConfigKey("quarkus.class-loading.removed-artifacts",
+                    "io.netty:netty-common,io.quarkus:quarkus-vertx-core,io.quarkus:quarkus-vertx-core-deployment," +
+                            "io.quarkus:quarkus-resteasy-deployment,io.quarkus:quarkus-resteasy," +
+                            "io.quarkus:quarkus-resteasy-server-common-deployment, io.quarkus:quarkus-resteasy-server-common," +
+                            "io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-vertx-http-deployment," +
+                            "io.quarkus:quarkus-netty,io.quarkus:quarkus-netty-deployment," +
+                            "io.quarkus:quarkus-smallrye-metrics,io.quarkus:quarkus-smallrye-metrics-deployment," +
+                            "io.quarkus:quarkus-smallrye-open-api,io.quarkus:quarkus-smallrye-open-api-deployment," +
+                            "io.quarkus:quarkus-smallrye-health-deployment,io.quarkus:quarkus-smallrye-health,");
+
+    @Test
+    public void testNoNetty() throws SQLException {
+        AgroalConnectionPoolConfiguration configuration = defaultDataSource.getConfiguration().connectionPoolConfiguration();
+
+        try (Connection connection = defaultDataSource.getConnection()) {
+        }
+    }
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -174,7 +174,12 @@ public class DataSources {
         //we use a custom cache for two reasons:
         //fast thread local cache should be faster
         //and it prevents a thread local leak
-        dataSourceConfiguration.connectionPoolConfiguration().connectionCache(new QuarkusConnectionCache());
+        try {
+            Class.forName("io.netty.util.concurrent.FastThreadLocal", true, Thread.currentThread().getContextClassLoader());
+            dataSourceConfiguration.connectionPoolConfiguration().connectionCache(new QuarkusNettyConnectionCache());
+        } catch (ClassNotFoundException e) {
+            dataSourceConfiguration.connectionPoolConfiguration().connectionCache(new QuarkusSimpleConnectionCache());
+        }
 
         agroalConnectionConfigurer.setExceptionSorter(resolvedDbKind, dataSourceConfiguration);
 

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusNettyConnectionCache.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusNettyConnectionCache.java
@@ -1,0 +1,41 @@
+package io.quarkus.agroal.runtime;
+
+import org.jboss.threads.JBossThread;
+
+import io.agroal.api.cache.Acquirable;
+import io.agroal.api.cache.ConnectionCache;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+class QuarkusNettyConnectionCache implements ConnectionCache {
+
+    volatile FastThreadLocal<Acquirable> connectionCache = new FastThreadLocal<>();
+
+    @Override
+    public Acquirable get() {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+            //we only want to cache on threads that we control the lifecycle
+            //which are the vert.x and potentially jboss threads
+            //JBossThread still works with FastThreadLocal, it is just slower, and for most apps
+            //this will not be used anyway, as we use VertThread pretty much everywhere if
+            //Vert.x is present
+            Acquirable acquirable = connectionCache.get();
+            return acquirable != null && acquirable.acquire() ? acquirable : null;
+        }
+        return null;
+    }
+
+    @Override
+    public void put(Acquirable acquirable) {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+            connectionCache.set(acquirable);
+        }
+    }
+
+    @Override
+    public void reset() {
+        connectionCache = new FastThreadLocal<>();
+    }
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusSimpleConnectionCache.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/QuarkusSimpleConnectionCache.java
@@ -4,17 +4,15 @@ import org.jboss.threads.JBossThread;
 
 import io.agroal.api.cache.Acquirable;
 import io.agroal.api.cache.ConnectionCache;
-import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.concurrent.FastThreadLocalThread;
 
-class QuarkusConnectionCache implements ConnectionCache {
+class QuarkusSimpleConnectionCache implements ConnectionCache {
 
-    volatile FastThreadLocal<Acquirable> connectionCache = new FastThreadLocal<>();
+    volatile ThreadLocal<Acquirable> connectionCache = new ThreadLocal<>();
 
     @Override
     public Acquirable get() {
         Thread thread = Thread.currentThread();
-        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+        if (thread instanceof JBossThread) {
             //we only want to cache on threads that we control the lifecycle
             //which are the vert.x and potentially jboss threads
             //JBossThread still works with FastThreadLocal, it is just slower, and for most apps
@@ -29,13 +27,13 @@ class QuarkusConnectionCache implements ConnectionCache {
     @Override
     public void put(Acquirable acquirable) {
         Thread thread = Thread.currentThread();
-        if (thread instanceof FastThreadLocalThread || thread instanceof JBossThread) {
+        if (thread instanceof JBossThread) {
             connectionCache.set(acquirable);
         }
     }
 
     @Override
     public void reset() {
-        connectionCache = new FastThreadLocal<>();
+        connectionCache = new ThreadLocal<>();
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
@@ -10,14 +10,17 @@ public class ConfiguredClassLoading implements Serializable {
 
     public final Set<AppArtifactKey> parentFirstArtifacts;
     public final Set<AppArtifactKey> reloadableArtifacts;
+    public final Set<AppArtifactKey> removedArtifacts;
     public final Map<AppArtifactKey, List<String>> removedResources;
     public final boolean flatTestClassPath;
 
     public ConfiguredClassLoading(Set<AppArtifactKey> parentFirstArtifacts, Set<AppArtifactKey> reloadableArtifacts,
+            Set<AppArtifactKey> removedArtifacts,
             Map<AppArtifactKey, List<String>> removedResources, boolean flatTestClassPath) {
         this.parentFirstArtifacts = parentFirstArtifacts;
         this.reloadableArtifacts = reloadableArtifacts;
         this.removedResources = removedResources;
         this.flatTestClassPath = flatTestClassPath;
+        this.removedArtifacts = removedArtifacts;
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -202,7 +202,11 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 if (configuredClassLoading.reloadableArtifacts.contains(i.getArtifact().getKey())) {
                     continue;
                 }
-                processCpElement(i.getArtifact(), element -> addCpElement(builder, i.getArtifact(), element));
+                if (configuredClassLoading.removedArtifacts.contains(i.getArtifact().getKey())) {
+                    processCpElement(i.getArtifact(), builder::addBannedElement);
+                } else {
+                    processCpElement(i.getArtifact(), element -> addCpElement(builder, i.getArtifact(), element));
+                }
             }
 
             for (Path i : quarkusBootstrap.getAdditionalDeploymentArchives()) {
@@ -280,7 +284,12 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 if (configuredClassLoading.reloadableArtifacts.contains(dependency.getArtifact().getKey())) {
                     continue;
                 }
-                processCpElement(dependency.getArtifact(), element -> addCpElement(builder, dependency.getArtifact(), element));
+                if (configuredClassLoading.removedArtifacts.contains(dependency.getArtifact().getKey())) {
+                    processCpElement(dependency.getArtifact(), builder::addBannedElement);
+                } else {
+                    processCpElement(dependency.getArtifact(),
+                            element -> addCpElement(builder, dependency.getArtifact(), element));
+                }
             }
 
             baseRuntimeClassLoader = builder.build();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -188,17 +188,21 @@ public class QuarkusBootstrap implements Serializable {
                             p.getProperty(selectKey("quarkus.class-loading.parent-first-artifacts", p, mode)));
                     Set<AppArtifactKey> liveReloadable = toArtifactSet(
                             p.getProperty(selectKey("quarkus.class-loading.reloadable-artifacts", p, mode)));
+                    Set<AppArtifactKey> removedArtifacts = toArtifactSet(
+                            p.getProperty(selectKey("quarkus.class-loading.removed-artifacts", p, mode)));
                     boolean flatClassPath = Boolean.parseBoolean(
                             p.getProperty(selectKey("quarkus.test.flat-class-path", p, mode)));
                     Map<AppArtifactKey, List<String>> removedResources = toArtifactMapList(
                             "quarkus.class-loading.removed-resources.", p, mode);
-                    return new ConfiguredClassLoading(parentFirst, liveReloadable, removedResources, flatClassPath);
+                    return new ConfiguredClassLoading(parentFirst, liveReloadable, removedArtifacts, removedResources,
+                            flatClassPath);
                 } catch (IOException e) {
                     throw new RuntimeException("Failed to load bootstrap classloading config from application.properties", e);
                 }
             }
         }
-        return new ConfiguredClassLoading(Collections.emptySet(), Collections.emptySet(), Collections.emptyMap(), false);
+        return new ConfiguredClassLoading(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+                Collections.emptyMap(), false);
     }
 
     private static Map<AppArtifactKey, List<String>> toArtifactMapList(String baseConfigKey, Properties properties, Mode mode) {


### PR DESCRIPTION
This also include some ClassLoader enhancements that allow us to exclude dependencies in unit tests, so we don't have to create a whole new module just to test this.


Fixes #19247