### PR TITLE
Avoid exception wrapping when native image build error

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -249,6 +249,8 @@ public class NativeImageBuildStep {
                             graalVMVersion.version.toString(),
                             graalVMVersion.javaFeatureVersion,
                             graalVMVersion.distribution.name()));
+        } catch (ImageGenerationFailureException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Failed to build native image", e);
         } finally {
@@ -377,16 +379,16 @@ public class NativeImageBuildStep {
     private RuntimeException imageGenerationFailed(int exitValue, boolean isContainerBuild) {
         if (exitValue == OOM_ERROR_VALUE) {
             if (isContainerBuild && !SystemUtils.IS_OS_LINUX) {
-                return new RuntimeException("Image generation failed. Exit code was " + exitValue
+                return new ImageGenerationFailureException("Image generation failed. Exit code was " + exitValue
                         + " which indicates an out of memory error. The most likely cause is Docker not being given enough memory. Also consider increasing the Xmx value for native image generation by setting the \""
                         + QUARKUS_XMX_PROPERTY + "\" property");
             } else {
-                return new RuntimeException("Image generation failed. Exit code was " + exitValue
+                return new ImageGenerationFailureException("Image generation failed. Exit code was " + exitValue
                         + " which indicates an out of memory error. Consider increasing the Xmx value for native image generation by setting the \""
                         + QUARKUS_XMX_PROPERTY + "\" property");
             }
         } else {
-            return new RuntimeException("Image generation failed. Exit code: " + exitValue);
+            return new ImageGenerationFailureException("Image generation failed. Exit code: " + exitValue);
         }
     }
 
@@ -849,6 +851,13 @@ public class NativeImageBuildStep {
                     }
                 }
             }
+        }
+    }
+
+    private static class ImageGenerationFailureException extends RuntimeException {
+
+        private ImageGenerationFailureException(String message) {
+            super(message);
         }
     }
 }


### PR DESCRIPTION
@stuartwdouglas this was part of a larger work to get the errors of the native image build injected into the exception so I could grab them with the bot.

Unfortunately, when I'm not using inherit IO to be able to get the output, the output is all garbled. It seems our existing infra doesn't support disabling IO inheritance very well. Not sure if it's the `ErrorReplacingProcessReader` competing with the ones of `ProcessUtil` or if it's something more involved.

I wasn't too sure also if it would work well with Gradle to not inherit the IO.

I'll see if I can put more time into it but it you have ideas, I'm all ears.