### PR TITLE
Register classes referenced in Picocli annotations for reflection

### DIFF
--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/CustomDefaultValueProvider.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/CustomDefaultValueProvider.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.picocli;
+
+import picocli.CommandLine.IDefaultValueProvider;
+import picocli.CommandLine.Model.ArgSpec;
+
+public class CustomDefaultValueProvider implements IDefaultValueProvider {
+
+    @Override
+    public String defaultValue(ArgSpec argSpec) throws Exception {
+        return "false";
+    }
+}

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/DefaultValueProviderCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/DefaultValueProviderCommand.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.picocli;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "defaultvalueprovider", mixinStandardHelpOptions = true, defaultValueProvider = CustomDefaultValueProvider.class)
+public class DefaultValueProviderCommand implements Runnable {
+
+    @Override
+    public void run() {
+    }
+
+}

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TestResource.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TestResource.java
@@ -41,6 +41,7 @@ public class TestResource {
         testUnmatched();
         testI18s();
         testCompletionReflection();
+        testDefaultValueProvider();
         return "OK";
     }
 
@@ -114,5 +115,10 @@ public class TestResource {
     private void testCompletionReflection() {
         CommandLine completionReflectionCommand = new CommandLine(CompletionReflectionCommand.class, factory);
         completionReflectionCommand.execute("one");
+    }
+
+    private void testDefaultValueProvider() {
+        CommandLine cmd = new CommandLine(DefaultValueProviderCommand.class, factory);
+        Assertions.assertThat(cmd.execute()).isZero();
     }
 }


### PR DESCRIPTION
Let's do it in a generic way, given there are a lot of them.

Fixes #19289

The way I did it should be more future proof, I think. One difference is that the `IVersionProvider` classes are not registered as proxies anymore but I don't think it was really necessary and it was just an artifact of the implementation. Let me know if it was done on purpose.