### PR TITLE
Add build reporting extension and include report into uploaded archives

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -174,6 +174,14 @@ jobs:
       - name: Delete Local Artifacts From Cache
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus
+      - name: Upload build reports (if build failed)
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
+          path: |
+            target/build-report.json
+          retention-days: 2
 
   calculate-test-jobs:
     name: Calculate Test Jobs
@@ -306,12 +314,14 @@ jobs:
         with:
           name: test-reports-jvm${{matrix.java.name}}
           path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-JVM Tests - JDK ${{matrix.java.name}}"
-          path: "**/target/*-reports/TEST-*.xml"
+          name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
           retention-days: 2
 
   maven-tests:
@@ -365,12 +375,14 @@ jobs:
         with:
           name: test-reports-maven-java${{matrix.java.name}}
           path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-Maven Tests - JDK ${{matrix.java.name}}"
-          path: "**/target/*-reports/TEST-*.xml"
+          name: "build-reports-Maven Tests - JDK ${{matrix.java.name}}"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
           retention-days: 2
 
   gradle-tests:
@@ -421,12 +433,14 @@ jobs:
         shell: bash
         # Important: keep -pl ... in sync with "Calculate run flags"!
         run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl integration-tests/gradle
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-Gradle Tests - JDK ${{matrix.java.name}}"
-          path: "**/build/test-results/test/TEST-*.xml"
+          name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
+          path: |
+            **/build/test-results/test/TEST-*.xml
+            target/build-report.json
           retention-days: 2
 
   devtools-tests:
@@ -478,12 +492,14 @@ jobs:
         with:
           name: test-reports-devtools-java${{matrix.java.name}}
           path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-Devtools Tests - JDK ${{matrix.java.name}}"
-          path: "**/target/*-reports/TEST-*.xml"
+          name: "build-reports-Devtools Tests - JDK ${{matrix.java.name}}"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
           retention-days: 2
 
   tcks-test:
@@ -534,12 +550,14 @@ jobs:
         with:
           name: test-reports-tcks
           path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-MicroProfile TCKs Tests"
-          path: "**/target/*-reports/TEST-*.xml"
+          name: "build-reports-MicroProfile TCKs Tests"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
           retention-days: 2
 
   native-tests:
@@ -610,10 +628,12 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}
           path: 'test-reports.tgz'
-      - name: Upload Surefire reports (if build failed)
+      - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v2
         if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-Native Tests - ${{matrix.category}}"
-          path: "**/target/*-reports/TEST-*.xml"
+          name: "build-reports-Native Tests - ${{matrix.category}}"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
           retention-days: 2

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,13 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <extensions>
+            <extension>
+                <groupId>io.quarkus.bot</groupId>
+                <artifactId>build-reporting-maven-extension</artifactId>
+                <version>1.0.1</version>
+            </extension>
+        </extensions>
     </build>
 
     <profiles>

--- a/update-extension-dependencies.sh
+++ b/update-extension-dependencies.sh
@@ -49,7 +49,7 @@ echo ''
 # get all "artifact-id" values from the generated json file
 # pipefail is switched off briefly so that a better error can be logged when nothing is found
 set +o pipefail
-ARTIFACT_IDS=$(cd "${PRG_PATH}" && grep '^    "artifact"' devtools/bom-descriptor-json/target/*.json | grep -Eo 'quarkus-[a-z0-9-]+' | sort)
+ARTIFACT_IDS=$(cd "${PRG_PATH}" && grep '^    "artifact"' devtools/bom-descriptor-json/target/quarkus-bom-quarkus-platform-descriptor-*.json | grep -Eo 'quarkus-[a-z0-9-]+' | sort)
 set -o pipefail
 if [ -z "${ARTIFACT_IDS}" ]
 then


### PR DESCRIPTION
The bot has been updated to support the new name. It doesn't consume the
file yet but should soon.

@famod this is part of the work to consume more information from the Maven build. The extension has been pushed here: https://github.com/quarkusio/build-report-maven-extension .