### PR TITLE
Add Surefire test results for Gradle integration tests

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -440,6 +440,7 @@ jobs:
           name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
           path: |
             **/build/test-results/test/TEST-*.xml
+            **/target/*-reports/TEST-*.xml
             target/build-report.json
           retention-days: 2
 
@@ -635,5 +636,6 @@ jobs:
           name: "build-reports-Native Tests - ${{matrix.category}}"
           path: |
             **/target/*-reports/TEST-*.xml
+            **/build/test-results/test/TEST-*.xml
             target/build-report.json
           retention-days: 2


### PR DESCRIPTION
Also add Gradle tests results for native tests as we also run some
native tests for Gradle.

@glefloch it should add the missing info to the build report.