### PR TITLE
RR routing fixes

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
@@ -65,25 +65,9 @@ public class PathMatcher<T> implements Dumpable {
             } else if (pathLength < length) {
                 char c = path.charAt(pathLength);
                 if (c == '/') {
-                    //todo: matches that end with / are a bit weird, maybe this is not the best matching algo
-                    SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength + 1);
-                    if (next != null && next.getKey().endsWith("/")) {
-                        return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
-                    }
-                    next = paths.get(path, pathLength);
+                    SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength);
                     if (next != null) {
                         return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
-                    }
-                }
-                // it's also possible that we're looking up /foo/bar/gee and have a current path of /foo/bar/ which
-                // is an acceptable prefix
-                if (pathLength > 0) {
-                    c = path.charAt(pathLength - 1);
-                    if (c == '/') {
-                        SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength);
-                        if (next != null) {
-                            return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
-                        }
                     }
                 }
             }
@@ -111,6 +95,8 @@ public class PathMatcher<T> implements Dumpable {
         if (PathMatcher.STRING_PATH_SEPARATOR.equals(path)) {
             this.defaultHandler = handler;
             return this;
+        } else if (path.endsWith(STRING_PATH_SEPARATOR)) {
+            throw new RuntimeException("Prefix path cannot end with /");
         }
 
         paths.put(path, handler);

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/GeneralResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/GeneralResource.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GeneralResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("{id}")
+    public String hello(@PathParam("id") String id) {
+        return "general:" + id;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/SpecificResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/SpecificResource.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello/{id}/bar")
+public class SpecificResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello(@PathParam("id") String id) {
+        return "specific:" + id;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/StemMatchTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/StemMatchTest.java
@@ -1,0 +1,39 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.function.Supplier;
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class StemMatchTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(SpecificResource.class, GeneralResource.class);
+                }
+            });
+
+    @Test
+    public void testPathMatchSpecifics() {
+        given()
+                .when().get("/hello/foo")
+                .then()
+                .statusCode(200)
+                .body(is("general:foo"));
+        given()
+                .when().get("/hello/foo/bar")
+                .then()
+                .statusCode(200)
+                .body(is("specific:foo"));
+    }
+
+}


### PR DESCRIPTION
Class level /hello and /hello/{foo}/bar would not match properly, as the /hello/ was
considered mode specific than the unprefixed /hello

Fixes #18542
Fixes #19299