### PR TITLE
Hibernate ORM DevUI - show DDL scripts collapsed by default

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-templates/persistence-units.html
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-templates/persistence-units.html
@@ -3,8 +3,17 @@
 .ddl-script {
     padding: 5px;
 }
+.hidden {
+    display: none;
+}
 th .badge {
     font-size: 100%;
+}
+a.script-heading {
+    display: block;
+    float:left;
+    width: 90%;
+    text-decoration: none;
 }
 {/style}
 {#title}Persistence Units{/title}
@@ -22,32 +31,38 @@ th .badge {
     </thead>
     <thead class="thead-light">
     <tr>
-        <th scope="col">Create Script</th>
+        <th scope="col">
+            <a href="#" onclick="toggleExpanded(this, 'td-create-script-{count}'); return false;" class="script-heading">
+                <span class="fa fa-chevron-right icon"></span>
+                <span>Create Script</span>
+            </a>
+            <a href="#" onclick="copyToClipboard('create-script-{count}'); return false;" class="float-right badge">
+                <span class="fa fa-clipboard"></span> Copy</a>
+        </th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td>
+        <td id="td-create-script-{count}" class="hidden">
             <pre id="create-script-{count}" class="ddl-script">{info:persistence.createDDLs.get(unit)}</pre>
-            <p class="float-right">
-                <a href="#" onclick="copyToClipboard('create-script-{count}'); return false;">
-                    <i class="fa fa-clipboard"></i><span class="badge">Copy</span></a>
-            </p>
         </td>
     </tr>
     <thead class="thead-light">
     <tr>
-        <th scope="col">Drop Script</th>
+        <th scope="col">
+            <a href="#" onclick="toggleExpanded(this, 'td-drop-script-{count}'); return false;" class="script-heading">
+                <span class="fa fa-chevron-right icon"></span>
+                <span>Drop Script</span>
+            </a>
+            <a href="#" onclick="copyToClipboard('drop-script-{count}'); return false;" class="float-right badge">
+                <span class="fa fa-clipboard"></span> Copy</a>
+        </th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td>
+        <td id="td-drop-script-{count}" class="hidden">
             <pre id="drop-script-{count}" class="ddl-script">{info:persistence.dropDDLs.get(unit)}</pre>
-            <p class="float-right">
-                <a href="#" onclick="copyToClipboard('drop-script-{count}'); return false;">
-                    <i class="fa fa-clipboard"></i><span class="badge">Copy</span></a>
-            </p>
         </td>
     </tr>
     </tbody>
@@ -58,15 +73,32 @@ th .badge {
 <script>
 <!--
 function copyToClipboard(elementId) {
-    var element = document.getElementById(elementId);
-    var range = document.createRange();
-    range.setStartBefore(element.firstChild);
-    range.setEndAfter(element.lastChild);
-    var selection = window.getSelection();
-    selection.removeAllRanges();
-    selection.addRange(range);
-    document.execCommand('copy');
-    selection.removeAllRanges();
+    var text = document.getElementById(elementId).textContent;
+    var listener = function(ev) {
+	    ev.clipboardData.setData("text/plain", text);
+	    ev.preventDefault();
+    };
+    document.addEventListener("copy", listener);
+    document.execCommand("copy");
+    document.removeEventListener("copy", listener);
+}
+
+function toggleExpanded(link, expandableElementId) {
+    var expandedClass = 'fa-chevron-down';
+    var collapsedClass = 'fa-chevron-right';
+
+    var icon = link.getElementsByClassName('icon')[0];
+
+    var element = document.getElementById(expandableElementId);
+    if (element.classList.contains('hidden')) {
+        element.classList.remove('hidden');
+        icon.classList.remove(collapsedClass);
+        icon.classList.add(expandedClass);
+    } else {
+        element.classList.add('hidden');
+        icon.classList.add(collapsedClass);
+        icon.classList.remove(expandedClass);
+    }
 }
 //-->
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleInfoSupplierTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleInfoSupplierTestCase.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.runtime.devconsole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class HibernateOrmDevConsoleInfoSupplierTestCase {
+
+    @Test
+    public void puNameComparatorTest() {
+        List<String> names = new ArrayList<>();
+        names.add("gamma");
+        names.add("alpha");
+        names.add("<default>");
+        names.add("beta");
+        names.sort(new HibernateOrmDevConsoleInfoSupplier.PersistenceUnitNameComparator());
+
+        assertThat(names.get(0)).isEqualTo("<default>");
+        assertThat(names.get(1)).isEqualTo("alpha");
+        assertThat(names.get(2)).isEqualTo("beta");
+        assertThat(names.get(3)).isEqualTo("gamma");
+    }
+}


### PR DESCRIPTION
This makes the DDL scripts in the Hibernate ORM DevUI pages collapsed by default. User can click on the heading to display the scripts. This should make the page more readable when working with large schemas.

Also changes the order of persistence units to show the < default > PU first.

![Screenshot from 2021-08-12 10-55-56](https://user-images.githubusercontent.com/353221/129170066-7c61e909-4040-4a9e-8d91-e4582b83a1cb.png)

Cc @gsmet 