### PR TITLE
Scheduler docs - clarify the "concurrent execution strategy"

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -201,6 +201,8 @@ void nonConcurrent() {
 
 TIP: A CDI event of type `io.quarkus.scheduler.SkippedExecution` is fired when an execution of a scheduled method is skipped.
 
+NOTE: Note that only executions within the same application instance are considered. This feature is not intended to work across the cluster.
+
 [[conditional_execution]]
 === Conditional Execution
 

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -140,7 +140,10 @@ public @interface Scheduled {
     }
 
     /**
-     * Represents a strategy to handle concurrent execution of a scheduled method
+     * Represents a strategy to handle concurrent execution of a scheduled method.
+     * <p>
+     * Note that this strategy only considers executions within the same application instance. It's not intended to work
+     * across the cluster.
      */
     enum ConcurrentExecution {
 


### PR DESCRIPTION
- make it clear that it's not designed to work across the cluster
- resolves #15800