### PR TITLE
Make separate schema compiling really work

### DIFF
--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroSchemaCodeGenProvider.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroSchemaCodeGenProvider.java
@@ -46,7 +46,7 @@ public class AvroSchemaCodeGenProvider extends AvroCodeGenProviderBase implement
         // allow them to share a single schema so reuse and sharing of schema
         // is possible.
         try {
-            if (options.imports == null) {
+            if (options.imports == AvroOptions.EMPTY) {
                 schema = new Schema.Parser().parse(file);
             } else {
                 schema = schemaParser.parse(file);


### PR DESCRIPTION
This fix is obvious:

https://github.com/quarkusio/quarkus/blob/main/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java#L148

```java
this.imports = "".equals(imports) ? EMPTY : imports.split(",");
```

`options.imports` is `AvroOptions.EMPTY` by default, not `null`.