### PR TITLE
Queue the log messages if the queue compaction leads to new space

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
@@ -95,7 +95,6 @@ public class QuarkusDelayedHandler extends ExtHandler {
                             //still too full, nothing we can do
                             return;
                         }
-                        return;
                     }
                     // Determine if we need to calculate the caller information before we queue the record
                     if (isCallerCalculationRequired()) {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/19381

As rightly noticed and debugged by the reporter in the linked issue, the `QuarkusDelayedHandler` has a `return` statement which prevents the log message(s) from being queued after a queue compaction has made available new space. This commit fixes that issue.