### PR TITLE
Make gradle-tooling-api optional to remove a myriad of warnings in CI

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -33,6 +33,11 @@
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
+            <!--
+                 This will be bundled via shade-plugin (see further down), so don't propagate it.
+                 Note: "provided" scope doesn't work that well with shade-plugin.
+            -->
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
Removes 200+ warnings like the following from CI intial build (and maybe others):
```
2021-08-13T15:12:41.9836906Z [INFO] --- quarkus-bootstrap-maven-plugin:999-SNAPSHOT:extension-descriptor (generate-extension-descriptor) @ quarkus-apicurio-registry-avro ---
2021-08-13T15:12:42.0647038Z [WARNING] Failed to resolve org.gradle:gradle-tooling-api:jar:6.8.3
```
https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/gradle-tooling-api.20warnings