### PR TITLE
Doc edit: config-mapping mocking docs need @InjectMock

### DIFF
--- a/docs/src/main/asciidoc/config-mappings.adoc
+++ b/docs/src/main/asciidoc/config-mappings.adoc
@@ -450,7 +450,7 @@ The `Server` can be injected as a mock into a Quarkus test class with `@InjectMo
 ----
 @QuarkusTest
 class ServerMockTest {
-    @Inject
+    @InjectMock
     Server server;
 
     @Test


### PR DESCRIPTION
In the mocking section it says that the `Server` can be injected as a mock into a Quarkus test class with `@InjectMock`, yet the following code snippet just shows `@Inject`.