### PR TITLE
Fix code location in the multi-stage build examples

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -513,19 +513,19 @@ Sample Dockerfile for building with Maven:
 ----
 ## Stage 1 : build with maven builder image with native capabilities
 FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
-COPY pom.xml /project/
-COPY mvnw /project/mvnw
-COPY .mvn /project/.mvn
+COPY pom.xml /code/
+COPY mvnw /code/mvnw
+COPY .mvn /code/.mvn
 USER quarkus
-WORKDIR /project
+WORKDIR /code
 RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline
-COPY src /project/src
+COPY src /code/src
 RUN ./mvnw package -Pnative
 
 ## Stage 2 : create the docker final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
-COPY --from=build /project/target/*-runner /work/application
+COPY --from=build /code/target/*-runner /work/application
 
 # set up permissions for user `1001`
 RUN chmod 775 /work /work/application \
@@ -551,20 +551,20 @@ Sample Dockerfile for building with Gradle:
 ----
 ## Stage 1 : build with maven builder image with native capabilities
 FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
-COPY gradlew /project/gradlew
-COPY gradle /project/gradle
-COPY build.gradle /project/
-COPY settings.gradle /project/
-COPY gradle.properties /project/
+COPY gradlew /code/gradlew
+COPY gradle /code/gradle
+COPY build.gradle /code/
+COPY settings.gradle /code/
+COPY gradle.properties /code/
 USER quarkus
-WORKDIR /project
-COPY src /project/src
-RUN gradle -b /project/build.gradle buildNative
+WORKDIR /code
+COPY src /code/src
+RUN gradle -b /code/build.gradle buildNative
 
 ## Stage 2 : create the docker final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
-COPY --from=build /project/build/*-runner /work/application
+COPY --from=build /code/build/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
Do not use `/project` as it's a volume declared by the base image, and content get erased between the two stages. 
It works on Mac for an unknown reason, but fails on Linux. 
See https://github.com/quarkusio/quarkus-images/issues/164﻿.
