### PR TITLE
Update Netty to 4.1.67

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -131,7 +131,7 @@
         <infinispan.version>12.1.7.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <netty.version>4.1.65.Final</netty.version>
+        <netty.version>4.1.67.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.2.Final</jboss-logging.version>
         <mutiny.version>1.0.0</mutiny.version>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -53,6 +53,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/HttpContentCompressorSubstitutions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/HttpContentCompressorSubstitutions.java
@@ -1,0 +1,115 @@
+package io.quarkus.vertx.http.runtime.graal;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.X_DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.X_GZIP;
+
+import java.util.function.BooleanSupplier;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.http2.CompressorHttp2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Exception;
+
+public class HttpContentCompressorSubstitutions {
+
+    @TargetClass(className = "io.netty.handler.codec.compression.ZstdEncoder", onlyWith = IsZstdAbsent.class)
+    public static final class ZstdEncoderFactorySubstitution {
+
+        @Substitute
+        protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, ByteBuf msg, boolean preferDirect) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Substitute
+        protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) {
+
+        }
+
+        @Substitute
+        public void flush(final ChannelHandlerContext ctx) {
+
+        }
+    }
+
+    @TargetClass(className = "io.netty.handler.codec.compression.BrotliEncoder", onlyWith = IsBrotliAbsent.class)
+    public static final class BrEncoderFactorySubstitution {
+
+        @Substitute
+        protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, ByteBuf msg, boolean preferDirect) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Substitute
+        protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) {
+
+        }
+    }
+
+    @TargetClass(CompressorHttp2ConnectionEncoder.class)
+    public static final class CompressorHttp2ConnectionSubstitute {
+
+        @Substitute
+        protected EmbeddedChannel newContentCompressor(ChannelHandlerContext ctx, CharSequence contentEncoding)
+                throws Http2Exception {
+            if (GZIP.contentEqualsIgnoreCase(contentEncoding) || X_GZIP.contentEqualsIgnoreCase(contentEncoding)) {
+                return newCompressionChannel(ctx, ZlibWrapper.GZIP);
+            }
+            if (DEFLATE.contentEqualsIgnoreCase(contentEncoding) || X_DEFLATE.contentEqualsIgnoreCase(contentEncoding)) {
+                return newCompressionChannel(ctx, ZlibWrapper.ZLIB);
+            }
+            // 'identity' or unsupported
+            return null;
+        }
+
+        @Alias
+        private EmbeddedChannel newCompressionChannel(final ChannelHandlerContext ctx, ZlibWrapper wrapper) {
+            return null;
+        }
+    }
+
+    public static class IsZstdAbsent implements BooleanSupplier {
+
+        private boolean zstdAbsent;
+
+        public IsZstdAbsent() {
+            try {
+                Class.forName("com.github.luben.zstd.Zstd");
+                zstdAbsent = false;
+            } catch (ClassNotFoundException e) {
+                zstdAbsent = true;
+            }
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return zstdAbsent;
+        }
+    }
+
+    public static class IsBrotliAbsent implements BooleanSupplier {
+
+        private boolean brotliAbsent;
+
+        public IsBrotliAbsent() {
+            try {
+                Class.forName("com.aayushatharva.brotli4j.encoder.Encoder");
+                brotliAbsent = false;
+            } catch (ClassNotFoundException e) {
+                brotliAbsent = true;
+            }
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return brotliAbsent;
+        }
+    }
+}


### PR DESCRIPTION
Update Netty version to 4.1.67.

Unlike previous Netty update, this one is motivated by https://github.com/quarkusio/quarkus/issues/18469.﻿
