### PR TITLE
Redis Dev Services - Print connection url

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
@@ -94,6 +94,7 @@ public class DevServicesRedisProcessor {
             currentCloseables.add(startResult.closeable);
             String configKey = getConfigPrefix(connectionName) + RedisConfig.HOSTS_CONFIG_NAME;
             devConfigProducer.produce(new DevServicesConfigResultBuildItem(configKey, startResult.url));
+            log.infof("The %s redis server is ready to accept connections on %s", connectionName, startResult.url);
         }
 
         closeables = currentCloseables;


### PR DESCRIPTION
Print the Redis url connection once the instance is started.
Fix #19397﻿
