### PR TITLE
Improve additional build args documentation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -15,7 +15,8 @@ import io.quarkus.runtime.configuration.TrimmedStringConverter;
 public class NativeConfig {
 
     /**
-     * Additional arguments to pass to the build process
+     * Comma-separated, additional arguments to pass to the build process.
+     * If an argument includes the {@code ,} symbol, it needs to be escaped, e.g. {@code \\,}
      */
     @ConfigItem
     public Optional<List<String>> additionalBuildArgs;


### PR DESCRIPTION
This information is already included in the tips page (added by @geoand), but I was expecting to find it as part of the configuration property documentation itself. Hence I'm sending this PR to improve this:

* Note that additional arguments are comma-separated.
* Also, provide a tip on how to pass comma character within a single argument.