### PR TITLE
Make the build time defaults a higher priority

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -382,8 +382,10 @@ public final class RunTimeConfigurationGenerator {
             // the build time config source field, to feed into the run time config
             cc.getFieldCreator(C_BUILD_TIME_CONFIG_SOURCE)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
+            //in-app application.yaml is 255, file-system application.properties is 260, this needs to be between them
+            //really it could be higher to stop build time config being overridden, but then the warning would not work
             final ResultHandle buildTimeConfigSource = clinit.newInstance(PCS_NEW, buildTimeValues,
-                    clinit.load("Build time config"), clinit.load(100));
+                    clinit.load("Build time config"), clinit.load(256));
             clinit.writeStaticField(C_BUILD_TIME_CONFIG_SOURCE, buildTimeConfigSource);
 
             // the build time run time visible default values config source
@@ -567,7 +569,7 @@ public final class RunTimeConfigurationGenerator {
                 }
             }
             final ResultHandle specifiedRunTimeSource = clinit.newInstance(PCS_NEW, specifiedRunTimeValues,
-                    clinit.load("Specified default values"), clinit.load(Integer.MIN_VALUE + 100));
+                    clinit.load("Specified default values"), clinit.load(256)); //in-app application.yaml is 255, file-system application.properties is 260, this needs to be between them
             cc.getFieldCreator(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE)
                     .setModifiers(Opcodes.ACC_STATIC | (devMode ? Opcodes.ACC_VOLATILE : Opcodes.ACC_FINAL));
             clinit.writeStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE, specifiedRunTimeSource);

--- a/core/test-extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -332,7 +332,7 @@ public class ConfiguredBeanTest {
             }
         }
         assertNotNull(defaultValues);
-        assertEquals(Integer.MIN_VALUE + 100, defaultValues.getOrdinal());
+        assertEquals(256, defaultValues.getOrdinal());
 
         // Should be the first
         ConfigSource applicationProperties = config.getConfigSources().iterator().next();

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -86,12 +86,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -152,11 +146,9 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
             <build>
                 <plugins>
+                    <!-- Note that this URL is set in io.quarkus.it.jpa.postgresql.OverrideJdbcUrlBuildTimeConfigSource -->
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>

--- a/integration-tests/jpa-postgresql/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.datasource.username=hibernate_orm_test
 quarkus.datasource.password=hibernate_orm_test
+#postgres.url comes from io.quarkus.it.jpa.postgresql.OverrideJdbcUrlBuildTimeConfigSource
 quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/OverrideJdbcUrlBuildTimeConfigSource.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/OverrideJdbcUrlBuildTimeConfigSource.java
@@ -19,7 +19,7 @@ public class OverrideJdbcUrlBuildTimeConfigSource extends MapBackedConfigSource 
 
     @Override
     public String getValue(final String propertyName) {
-        if (!propertyName.equals("quarkus.datasource.jdbc.url")) {
+        if (!propertyName.equals("postgres.url")) {
             return super.getValue(propertyName);
         }
 
@@ -31,10 +31,10 @@ public class OverrideJdbcUrlBuildTimeConfigSource extends MapBackedConfigSource 
             }
         }
 
-        if (isBuildTime) {
-            return "${postgres.url}";
+        if (!isBuildTime) {
+            return "jdbc:postgresql://localhost:5431/hibernate_orm_test";
+        } else {
+            return null;
         }
-
-        return super.getValue(propertyName);
     }
 }

--- a/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/UserConfigSourceProvider.java
+++ b/integration-tests/smallrye-config/src/main/java/io/quarkus/it/smallrye/config/UserConfigSourceProvider.java
@@ -10,8 +10,12 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 public class UserConfigSourceProvider implements ConfigSourceProvider {
     @Override
     public Iterable<ConfigSource> getConfigSources(final ClassLoader forClassLoader) {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("user.config.provider.prop", "1234");
-        return Collections.singleton(new UserConfigSource(properties));
+        if (forClassLoader.toString().contains("Runtime")) {
+            final Map<String, String> properties = new HashMap<>();
+            properties.put("user.config.provider.prop", "1234");
+            return Collections.singleton(new UserConfigSource(properties));
+        } else {
+            return Collections.emptyList();
+        }
     }
 }


### PR DESCRIPTION
This means that if you set a value using a system property when building
the application it will now override the application.properties that is
packaged in the application (but not an external application.properties
on the file system).

Otherwise the behaviour is very confusing, with build time config values
only taking effect if they are not overriding a property in
application.properties.