### PR TITLE
Add a config file to the config dir by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalRuntimeConfigFileBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalRuntimeConfigFileBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that represents an additional config file that will be automatically created in the
+ * fast-jar config directory.
+ */
+public final class AdditionalRuntimeConfigFileBuildItem extends MultiBuildItem {
+
+    private final String fileName;
+    private final String defaultContents;
+
+    public AdditionalRuntimeConfigFileBuildItem(String fileName, String defaultContents) {
+        this.fileName = fileName;
+        this.defaultContents = defaultContents;
+    }
+
+    public String getDefaultContents() {
+        return defaultContents;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalBootstrapConfigSourceProviderBuildItem;
+import io.quarkus.deployment.builditem.AdditionalRuntimeConfigFileBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigSourceProviderBuildItem;
@@ -39,5 +40,10 @@ public final class ConfigYamlProcessor {
         String activeProfile = ProfileManager.getActiveProfile();
         items.produce(new HotDeploymentWatchedFileBuildItem(String.format("application-%s.yml", activeProfile)));
         items.produce(new HotDeploymentWatchedFileBuildItem(String.format("application-%s.yaml", activeProfile)));
+    }
+
+    @BuildStep
+    AdditionalRuntimeConfigFileBuildItem configFileBuildItem() {
+        return new AdditionalRuntimeConfigFileBuildItem("application.yaml", "#empty config file");
     }
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -422,6 +422,7 @@ public class JibProcessor {
 
             jibContainerBuilder
                     .addLayer(Collections.singletonList(componentsPath.resolve(JarResultBuildStep.APP)), workDirInContainer)
+                    .addLayer(Collections.singletonList(componentsPath.resolve(JarResultBuildStep.CONFIG)), workDirInContainer)
                     .addLayer(Collections.singletonList(componentsPath.resolve(JarResultBuildStep.QUARKUS)), workDirInContainer)
                     .setWorkingDirectory(workDirInContainer)
                     .setEntrypoint(entrypoint)

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
@@ -10,6 +10,7 @@ ARG RUN_JAVA_VERSION={dockerfile.jvm.run-java-version}
 COPY --chown=1001 {buildtool.build-dir}/quarkus-app/lib/ /deployments/lib/
 COPY --chown=1001 {buildtool.build-dir}/quarkus-app/*.jar /deployments/
 COPY --chown=1001 {buildtool.build-dir}/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 {buildtool.build-dir}/quarkus-app/config/ /deployments/config/
 COPY --chown=1001 {buildtool.build-dir}/quarkus-app/quarkus/ /deployments/quarkus/
     {/copy}
 {/include}


### PR DESCRIPTION
This file is already supported, but adding an empty one by default
should make it more obvious that you can use this to configure the
application.