### PR TITLE
Filter out duplicate JMX registration message

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.smallrye.reactivemessaging.kafka.ReactiveMessagingKafkaConfig;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 
@@ -47,6 +48,16 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                         .constructors(true)
                         .finalFieldsWritable(true)
                         .build());
+    }
+
+    @BuildStep
+    public void ignoreDuplicateJmxRegistrationInDevAndTestModes(LaunchModeBuildItem launchMode,
+            BuildProducer<LogCleanupFilterBuildItem> log) {
+        if (launchMode.getLaunchMode().isDevOrTest()) {
+            log.produce(new LogCleanupFilterBuildItem(
+                    "org.apache.kafka.common.utils.AppInfoParser",
+                    "Error registering AppInfo mbean"));
+        }
     }
 
     /**


### PR DESCRIPTION
Filter out duplicate registration messages when the Kafka client tries to register a producer/consumer/admin with an already used id. This is done in the Kafka connector extension as it's likely going to happen with the connector which use the channel name as id. When using the bare Kafka client, the user must set the id. The filter is only applied in dev and test modes.

Fix #19045.