### PR TITLE
Add jandex-maven-plugin usage to gRPC Getting Started Guide

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -33,6 +33,9 @@
         <version.exec.plugin>3.0.0</version.exec.plugin>
         <failsafe-plugin.version>${version.surefire.plugin}</failsafe-plugin.version>
 
+        <!-- jandex maven plugin version -->
+        <jandex-maven-plugin.version>1.1.0</jandex-maven-plugin.version>
+
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
@@ -580,7 +583,7 @@
                 <plugin>
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
-                    <version>1.1.0</version>
+                    <version>${jandex-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2769,6 +2769,8 @@
                         <gradle-version>${gradle-wrapper.version}</gradle-version>
                         <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
 
+                        <jandex-maven-plugin-version>${jandex-maven-plugin.version}</jandex-maven-plugin-version>
+
                         <grpc-version>${grpc.version}</grpc-version>
                         <protoc-version>${protoc.version}</protoc-version>
                         <elasticsearch-version>${elasticsearch-server.version}</elasticsearch-version>

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -46,14 +46,14 @@ NOTE: Quarkus extensions may declare additional discovery rules. For example, `@
 A dependency with a Jandex index is automatically scanned for beans.
 To generate the index just add the following to your `pom.xml`:
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <build>
   <plugins>
     <plugin>
       <groupId>org.jboss.jandex</groupId>
       <artifactId>jandex-maven-plugin</artifactId>
-      <version>1.1.0</version>
+      <version>{jandex-maven-plugin-version}</version>
       <executions>
         <execution>
           <id>make-index</id>

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -395,15 +395,14 @@ IMPORTANT: When using `protobuf-maven-plugin`, instead of the `quarkus-maven-plu
 When gRPC classes - the classes generated from `proto` files - are in a dependency of the application, then the dependency needs a Jandex index.
 The `jandex-maven-plugin` can be used to create a Jandex index. More information on this topic can be found in the link:cdi-reference#bean_discovery[Bean Discovery] section of the CDI guide.
 
-
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <build>
     <plugins>
         <plugin>
             <groupId>org.jboss.jandex</groupId>
             <artifactId>jandex-maven-plugin</artifactId>
-            <version>1.1.0</version>
+            <version>{jandex-maven-plugin-version}</version>
             <executions>
                 <execution>
                 <id>make-index</id>

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -388,3 +388,31 @@ That's why we use the `os-maven-plugin` to target the executable compatible with
 NOTE: This configuration instructs the `protobuf-maven-plugin` to generate the default gRPC classes and classes using Mutiny to fit with the Quarkus development experience.
 
 IMPORTANT: When using `protobuf-maven-plugin`, instead of the `quarkus-maven-plugin`, every time you update the `proto` files, you need to re-generate the classes (using `mvn compile`).
+
+
+== gRPC classes from dependencies
+
+When gRPC classes - the classes generated from `proto` files - are in a dependency of the application, then the dependency needs a Jandex index.
+The `jandex-maven-plugin` can be used to create a Jandex index. More information on this topic can be found in the link:cdi-reference#bean_discovery[Bean Discovery] section of the CDI guide.
+
+
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.jboss.jandex</groupId>
+            <artifactId>jandex-maven-plugin</artifactId>
+            <version>1.1.0</version>
+            <executions>
+                <execution>
+                <id>make-index</id>
+                <goals>
+                    <goal>jandex</goal>
+                </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+----

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -545,14 +545,14 @@ By default, Quarkus will not discover CDI beans inside another module.
 The best way to enable CDI bean discovery for a module in a multi-module project would be to include the `jandex-maven-plugin`,
 unless it is the main application module already configured with the quarkus-maven-plugin, in which case it will indexed automatically.
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <build>
   <plugins>
     <plugin>
       <groupId>org.jboss.jandex</groupId>
       <artifactId>jandex-maven-plugin</artifactId>
-      <version>1.1.0</version>
+      <version>{jandex-maven-plugin-version}</version>
       <executions>
         <execution>
           <id>make-index</id>

--- a/independent-projects/tools/artifact-api/pom.xml
+++ b/independent-projects/tools/artifact-api/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -55,6 +55,7 @@
         <maven-model-helper.version>18</maven-model-helper.version>
         <commons-io.version>2.11.0</commons-io.version>
         <smallrye-common.version>1.6.0</smallrye-common.version>
+        <jandex-maven-plugin.version>1.1.0</jandex-maven-plugin.version>
     </properties>
     <modules>
         <module>artifact-api</module>

--- a/independent-projects/tools/registry-client/pom.xml
+++ b/independent-projects/tools/registry-client/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -88,7 +88,7 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
People seem to be running into
https://github.com/quarkusio/quarkus/issues/15057 (including myself)
because a Jandex Index is missing, thus we should update the gRPC
Getting Started Guide and mention this.