### PR TITLE
gRPC: support per service interceptors

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -243,11 +243,14 @@ quarkus.grpc.server.ssl.client-auth=REQUIRED
 
 == Server Interceptors
 
-You can implement a gRPC server interceptor by implementing an `@ApplicationScoped` bean implementing `io.grpc.ServerInterceptor`:
+gRPC server interceptors let you perform logic, such as authentication, before your service is invoked.
+
+You can implement a gRPC server interceptor by creating an `@ApplicationScoped` bean implementing `io.grpc.ServerInterceptor`:
 
 [source, java]
 ----
 @ApplicationScoped
+// add @GlobalInterceptor for interceptors meant to be invoked for every service
 public class MyInterceptor implements ServerInterceptor {
 
     @Override
@@ -260,7 +263,22 @@ public class MyInterceptor implements ServerInterceptor {
 
 TIP: Check the https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerInterceptor.html[ServerInterceptor JavaDoc] to properly implement your interceptor.
 
-When you have multiple server interceptors, you can order them by implementing the `javax.enterprise.inject.spi.Prioritized` interface:
+To apply an interceptor to all exposed services, annotate it with `@io.quarkus.grpc.GlobalInterceptor`.
+To apply an interceptor to a single service, register it on the service with `@io.quarkus.grpc.RegisterInterceptor`:
+[source, java]
+----
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.RegisterInterceptor;
+
+@GrpcService
+@RegisterInterceptor(MyInterceptor.class)
+public class StreamingService implements Streaming {
+    // ...
+}
+----
+
+When you have multiple server interceptors, you can order them by implementing the `javax.enterprise.inject.spi.Prioritized` interface. Please note that all the global interceptors are invoked before the service-specific
+interceptors.
 
 [source, java]
 ----

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/AdditionalGlobalInterceptorBuildItem.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/AdditionalGlobalInterceptorBuildItem.java
@@ -1,0 +1,15 @@
+package io.quarkus.grpc.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AdditionalGlobalInterceptorBuildItem extends MultiBuildItem {
+    private final String interceptorClass;
+
+    public AdditionalGlobalInterceptorBuildItem(String interceptorClass) {
+        this.interceptorClass = interceptorClass;
+    }
+
+    public String interceptorClass() {
+        return interceptorClass;
+    }
+}

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/DelegatingGrpcBeanBuildItem.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/DelegatingGrpcBeanBuildItem.java
@@ -1,0 +1,15 @@
+package io.quarkus.grpc.deployment;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+final class DelegatingGrpcBeanBuildItem extends MultiBuildItem {
+    final ClassInfo generatedBean;
+    final ClassInfo userDefinedBean;
+
+    DelegatingGrpcBeanBuildItem(ClassInfo generatedBean, ClassInfo userDefinedBean) {
+        this.generatedBean = generatedBean;
+        this.userDefinedBean = userDefinedBean;
+    }
+}

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
@@ -6,11 +6,15 @@ import org.jboss.jandex.DotName;
 
 import io.grpc.BindableService;
 import io.grpc.Channel;
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.AbstractBlockingStub;
 import io.grpc.stub.AbstractStub;
 import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.grpc.GlobalInterceptor;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.RegisterInterceptor;
+import io.quarkus.grpc.RegisterInterceptors;
 import io.quarkus.grpc.runtime.MutinyBean;
 import io.quarkus.grpc.runtime.MutinyClient;
 import io.quarkus.grpc.runtime.MutinyGrpc;
@@ -37,6 +41,11 @@ public class GrpcDotNames {
     public static final DotName MUTINY_CLIENT = DotName.createSimple(MutinyClient.class.getName());
     public static final DotName MUTINY_BEAN = DotName.createSimple(MutinyBean.class.getName());
     public static final DotName MUTINY_SERVICE = DotName.createSimple(MutinyService.class.getName());
+
+    public static final DotName GLOBAL_INTERCEPTOR = DotName.createSimple(GlobalInterceptor.class.getName());
+    public static final DotName REGISTER_INTERCEPTOR = DotName.createSimple(RegisterInterceptor.class.getName());
+    public static final DotName REGISTER_INTERCEPTORS = DotName.createSimple(RegisterInterceptors.class.getName());
+    public static final DotName SERVER_INTERCEPTOR = DotName.createSimple(ServerInterceptor.class.getName());
 
     static final MethodDescriptor CREATE_CHANNEL_METHOD = MethodDescriptor.ofMethod(Channels.class, "createChannel",
             Channel.class, String.class);

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/devmode/DevModeTestInterceptor.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/devmode/DevModeTestInterceptor.java
@@ -7,8 +7,10 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import io.quarkus.grpc.GlobalInterceptor;
 
 @ApplicationScoped
+@GlobalInterceptor
 public class DevModeTestInterceptor implements ServerInterceptor {
 
     private volatile String lastStatus = "initial";
@@ -17,7 +19,7 @@ public class DevModeTestInterceptor implements ServerInterceptor {
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> serverCall,
             Metadata metadata, ServerCallHandler<ReqT, RespT> serverCallHandler) {
         return serverCallHandler
-                .startCall(new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(serverCall) {
+                .startCall(new ForwardingServerCall.SimpleForwardingServerCall<>(serverCall) {
                     @Override
                     protected ServerCall<ReqT, RespT> delegate() {
                         lastStatus = getStatus();

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/GlobalAndServiceInterceptorsTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/GlobalAndServiceInterceptorsTest.java
@@ -1,0 +1,178 @@
+package io.quarkus.grpc.server.interceptors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.examples.goodbyeworld.Farewell;
+import io.grpc.examples.goodbyeworld.FarewellGrpc;
+import io.grpc.examples.goodbyeworld.GoodbyeReply;
+import io.grpc.examples.goodbyeworld.GoodbyeRequest;
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.GreeterBean;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld3.Greeter3;
+import io.grpc.examples.helloworld3.Greeter3Grpc;
+import io.grpc.examples.helloworld3.HelloReply3;
+import io.grpc.examples.helloworld3.HelloRequest3;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.RegisterInterceptor;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class GlobalAndServiceInterceptorsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addPackage(Greeter3Grpc.class.getPackage())
+                    .addPackage(FarewellGrpc.class.getPackage())
+                    .addClasses(MyFirstInterceptor.class, GreeterBean.class, HelloRequest.class));
+
+    protected ManagedChannel channel;
+
+    @GrpcClient
+    Greeter greeter;
+
+    @GrpcClient
+    Greeter3 greeter3;
+
+    @GrpcClient
+    Farewell farewell;
+
+    @BeforeEach
+    void cleanUp() {
+        config.getLogRecords();
+        GlobalInterceptor.invoked = false;
+        ServiceBInterceptor.invoked = false;
+        FarewellInterceptor.invoked = false;
+    }
+
+    @Test
+    void shouldInvokeGlobalInterceptorAndNotInvokedUnregisteredLocal() {
+        Uni<HelloReply> result = greeter.sayHello(HelloRequest.newBuilder().setName("ServiceA").build());
+
+        HelloReply helloReply = result.await().atMost(Duration.ofSeconds(5));
+        assertThat(helloReply.getMessage()).isEqualTo("Hello, ServiceA");
+
+        assertThat(GlobalInterceptor.invoked).isTrue();
+        assertThat(ServiceBInterceptor.invoked).isFalse();
+        assertThat(FarewellInterceptor.invoked).isFalse();
+    }
+
+    @Test
+    void shouldInvokeGlobalInterceptorAndInvokedRegisteredLocal() {
+        Uni<HelloReply3> result = greeter3.sayHello(HelloRequest3.newBuilder().setName("ServiceB").build());
+
+        HelloReply3 helloReply = result.await().atMost(Duration.ofSeconds(5));
+        assertThat(helloReply.getMessage()).isEqualTo("Hello3, ServiceB");
+
+        assertThat(GlobalInterceptor.invoked).isTrue();
+        assertThat(ServiceBInterceptor.invoked).isTrue();
+        assertThat(FarewellInterceptor.invoked).isFalse();
+    }
+
+    @Test
+    void shouldInvokeGlobalInterceptorAndInvokedRegisteredLocalOnGrpcStub() {
+        Uni<GoodbyeReply> result = farewell.sayGoodbye(GoodbyeRequest.newBuilder().setName("Farewell").build());
+
+        GoodbyeReply goodbyeReply = result.await().atMost(Duration.ofSeconds(5));
+        assertThat(goodbyeReply.getMessage()).isEqualTo("Goodbye, Farewell");
+
+        assertThat(GlobalInterceptor.invoked).isTrue();
+        assertThat(ServiceBInterceptor.invoked).isFalse();
+        assertThat(FarewellInterceptor.invoked).isTrue();
+    }
+
+    @GrpcService
+    public static class ServiceA implements Greeter {
+        @Override
+        public Uni<HelloReply> sayHello(HelloRequest request) {
+            return Uni.createFrom().item(HelloReply.newBuilder().setMessage("Hello, " + request.getName()).build());
+        }
+    }
+
+    @GrpcService
+    @RegisterInterceptor(ServiceBInterceptor.class)
+    public static class ServiceB implements Greeter3 {
+        @Override
+        public Uni<HelloReply3> sayHello(HelloRequest3 request) {
+            return Uni.createFrom().item(HelloReply3.newBuilder().setMessage("Hello3, " + request.getName()).build());
+        }
+    }
+
+    @io.quarkus.grpc.GlobalInterceptor
+    @ApplicationScoped
+    public static class GlobalInterceptor implements ServerInterceptor {
+        static boolean invoked;
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+            invoked = true;
+            return next.startCall(call, headers);
+        }
+    }
+
+    @GrpcService
+    @RegisterInterceptor(FarewellInterceptor.class)
+    public static class FarewellService extends FarewellGrpc.FarewellImplBase {
+        @Override
+        public void sayGoodbye(GoodbyeRequest request, StreamObserver<GoodbyeReply> responseObserver) {
+            responseObserver.onNext(GoodbyeReply.newBuilder().setMessage("Goodbye, " + request.getName()).build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @ApplicationScoped
+    public static class ServiceBInterceptor implements ServerInterceptor {
+        static boolean invoked;
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+            invoked = true;
+            return next.startCall(call, headers);
+        }
+    }
+
+    @ApplicationScoped
+    public static class FarewellInterceptor implements ServerInterceptor {
+        static boolean invoked;
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+            invoked = true;
+            return next.startCall(call, headers);
+        }
+    }
+
+    @ApplicationScoped
+    public static class UnusedInterceptor implements ServerInterceptor {
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+            throw new IllegalStateException("Interceptor that should not be called was invoked");
+        }
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/MyFirstInterceptor.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/MyFirstInterceptor.java
@@ -9,8 +9,10 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.quarkus.grpc.GlobalInterceptor;
 
 @ApplicationScoped
+@GlobalInterceptor
 public class MyFirstInterceptor implements ServerInterceptor, Prioritized {
 
     private volatile long callTime;

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/MySecondInterceptor.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/MySecondInterceptor.java
@@ -9,8 +9,10 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.quarkus.grpc.GlobalInterceptor;
 
 @ApplicationScoped
+@GlobalInterceptor
 public class MySecondInterceptor implements ServerInterceptor, Prioritized {
 
     private volatile long callTime;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/GlobalInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/GlobalInterceptor.java
@@ -1,0 +1,19 @@
+package io.quarkus.grpc;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes a ServerInterceptor that should be registered for all gRPC services
+ *
+ * @see RegisterInterceptor
+ */
+@Target({ FIELD, PARAMETER, TYPE })
+@Retention(RUNTIME)
+public @interface GlobalInterceptor {
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/RegisterInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/RegisterInterceptor.java
@@ -1,0 +1,22 @@
+package io.quarkus.grpc;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.grpc.ServerInterceptor;
+
+/**
+ * Registers a {@link ServerInterceptor} for a particular gRPC service.
+ *
+ * @see GlobalInterceptor
+ */
+@Target({ FIELD, PARAMETER, TYPE })
+@Retention(RUNTIME)
+public @interface RegisterInterceptor {
+    Class<? extends ServerInterceptor> value();
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/RegisterInterceptors.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/RegisterInterceptors.java
@@ -1,0 +1,14 @@
+package io.quarkus.grpc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RegisterInterceptors {
+    RegisterInterceptor[] value();
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcContainer.java
@@ -1,53 +1,95 @@
 package io.quarkus.grpc.runtime;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Prioritized;
 import javax.inject.Inject;
 
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.grpc.GrpcService;
 
 @ApplicationScoped
 public class GrpcContainer {
+
+    private static final Comparator<ServerInterceptor> INTERCEPTOR_COMPARATOR = new Comparator<>() {
+        @Override
+        public int compare(ServerInterceptor si1, ServerInterceptor si2) {
+            int p1 = 0;
+            int p2 = 0;
+            if (si1 instanceof Prioritized) {
+                p1 = ((Prioritized) si1).getPriority();
+            }
+            if (si2 instanceof Prioritized) {
+                p2 = ((Prioritized) si2).getPriority();
+            }
+            if (si1.equals(si2)) {
+                return 0;
+            }
+            return Integer.compare(p1, p2);
+        }
+    };
 
     @Inject
     @GrpcService
     Instance<BindableService> services;
 
     @Inject
-    @Any
     Instance<ServerInterceptor> interceptors;
 
-    List<ServerInterceptor> getSortedInterceptors() {
+    @Inject
+    InterceptorStorage perServiceInterceptors;
+
+    List<ServerInterceptor> getSortedPerServiceInterceptors(String serviceClassName) {
+        Set<Class<? extends ServerInterceptor>> interceptorClasses = perServiceInterceptors.getInterceptors(serviceClassName);
+        if (interceptorClasses == null || interceptorClasses.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ServerInterceptor> interceptors = new ArrayList<>();
+
+        for (Class<? extends ServerInterceptor> interceptorClass : interceptorClasses) {
+            InstanceHandle<? extends ServerInterceptor> interceptorInstance = Arc.container().instance(interceptorClass);
+            ServerInterceptor serverInterceptor = interceptorInstance.get();
+            if (serverInterceptor == null) {
+                throw new IllegalArgumentException("Server interceptor class " + interceptorClass + " is not a CDI bean. " +
+                        "Only CDI beans can be used as gRPC server interceptors. Add one of the scope-defining annotations" +
+                        " (@Singleton, @ApplicationScoped, @RequestScoped) on the interceptor class.");
+            }
+            interceptors.add(serverInterceptor);
+        }
+        interceptors.sort(INTERCEPTOR_COMPARATOR);
+
+        return interceptors;
+    }
+
+    List<ServerInterceptor> getSortedGlobalInterceptors() {
         if (interceptors.isUnsatisfied()) {
             return Collections.emptyList();
         }
 
-        return interceptors.stream().sorted(new Comparator<>() { // NOSONAR
-            @Override
-            public int compare(ServerInterceptor si1, ServerInterceptor si2) {
-                int p1 = 0;
-                int p2 = 0;
-                if (si1 instanceof Prioritized) {
-                    p1 = ((Prioritized) si1).getPriority();
-                }
-                if (si2 instanceof Prioritized) {
-                    p2 = ((Prioritized) si2).getPriority();
-                }
-                if (si1.equals(si2)) {
-                    return 0;
-                }
-                return Integer.compare(p1, p2);
+        Set<Class<? extends ServerInterceptor>> globalInterceptors = perServiceInterceptors.getGlobalInterceptors();
+        List<ServerInterceptor> interceptors = new ArrayList<>();
+        for (Class<? extends ServerInterceptor> interceptorClass : globalInterceptors) {
+            InstanceHandle<? extends ServerInterceptor> interceptorInstance = Arc.container().instance(interceptorClass);
+            ServerInterceptor serverInterceptor = interceptorInstance.get();
+            if (serverInterceptor == null) {
+                throw new IllegalArgumentException("Server interceptor class " + interceptorClass + " is not a CDI bean. " +
+                        "Only CDI beans can be used as gRPC server interceptors. Add one of the scope-defining annotations" +
+                        " (@Singleton, @ApplicationScoped, @RequestScoped) on the interceptor class.");
             }
-        }).collect(Collectors.toList());
+            interceptors.add(serverInterceptor);
+        }
+        interceptors.sort(INTERCEPTOR_COMPARATOR);
+        return interceptors;
     }
 
     public Instance<BindableService> getServices() {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -286,7 +286,7 @@ public class GrpcServerRecorder {
         List<ServerServiceDefinition> servicesWithInterceptors = new ArrayList<>();
         CompressionInterceptor compressionInterceptor = prepareCompressionInterceptor(configuration);
         for (GrpcServiceDefinition service : services) {
-            servicesWithInterceptors.add(serviceWithInterceptors(vertx, compressionInterceptor, service, true));
+            servicesWithInterceptors.add(serviceWithInterceptors(vertx, grpcContainer, compressionInterceptor, service, true));
         }
 
         for (ServerServiceDefinition serviceWithInterceptors : servicesWithInterceptors) {
@@ -298,7 +298,7 @@ public class GrpcServerRecorder {
 
         initHealthStorage();
 
-        GrpcServerReloader.reinitialize(servicesWithInterceptors, methods, grpcContainer.getSortedInterceptors());
+        GrpcServerReloader.reinitialize(servicesWithInterceptors, methods, grpcContainer.getSortedGlobalInterceptors());
 
         shutdown.addShutdownTask(
                 new Runnable() { // NOSONAR
@@ -357,7 +357,8 @@ public class GrpcServerRecorder {
 
         for (GrpcServiceDefinition service : toBeRegistered) {
             builder.addService(
-                    serviceWithInterceptors(vertx, compressionInterceptor, service, launchMode == LaunchMode.DEVELOPMENT));
+                    serviceWithInterceptors(vertx, grpcContainer, compressionInterceptor, service,
+                            launchMode == LaunchMode.DEVELOPMENT));
             LOGGER.debugf("Registered gRPC service '%s'", service.definition.getServiceDescriptor().getName());
             definitions.add(service.definition);
         }
@@ -367,7 +368,7 @@ public class GrpcServerRecorder {
             builder.addService(new ReflectionService(definitions));
         }
 
-        for (ServerInterceptor serverInterceptor : grpcContainer.getSortedInterceptors()) {
+        for (ServerInterceptor serverInterceptor : grpcContainer.getSortedGlobalInterceptors()) {
             builder.intercept(serverInterceptor);
         }
 
@@ -413,12 +414,15 @@ public class GrpcServerRecorder {
         return compressionInterceptor;
     }
 
-    private ServerServiceDefinition serviceWithInterceptors(Vertx vertx, CompressionInterceptor compressionInterceptor,
-            GrpcServiceDefinition service, boolean devMode) {
+    private ServerServiceDefinition serviceWithInterceptors(Vertx vertx, GrpcContainer grpcContainer,
+            CompressionInterceptor compressionInterceptor, GrpcServiceDefinition service, boolean devMode) {
         List<ServerInterceptor> interceptors = new ArrayList<>();
         if (compressionInterceptor != null) {
             interceptors.add(compressionInterceptor);
         }
+
+        interceptors.addAll(grpcContainer.getSortedPerServiceInterceptors(service.getImplementationClassName()));
+
         // We only register the blocking interceptor if needed by at least one method of the service.
         if (!blockingMethodsPerService.isEmpty()) {
             List<String> list = blockingMethodsPerService.get(service.getImplementationClassName());

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/InterceptorStorage.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/InterceptorStorage.java
@@ -1,0 +1,33 @@
+package io.quarkus.grpc.runtime;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import io.grpc.ServerInterceptor;
+
+public abstract class InterceptorStorage {
+    private final Map<String, Set<Class<? extends ServerInterceptor>>> perServiceInterceptors = new HashMap<>();
+    private final Set<Class<? extends ServerInterceptor>> globalInterceptors = new HashSet<>();
+
+    public Set<Class<? extends ServerInterceptor>> getInterceptors(String serviceClassName) {
+        return perServiceInterceptors.get(serviceClassName);
+    }
+
+    public Set<Class<? extends ServerInterceptor>> getGlobalInterceptors() {
+        return globalInterceptors;
+    }
+
+    @SuppressWarnings("unused") // used by generated code
+    public void addGlobalInterceptor(Class<? extends ServerInterceptor> interceptor) {
+        globalInterceptors.add(interceptor);
+    }
+
+    @SuppressWarnings("unused") // used by generated code
+    public void addInterceptor(String serviceClassName, Class<? extends ServerInterceptor> interceptor) {
+        Set<Class<? extends ServerInterceptor>> interceptors = perServiceInterceptors.computeIfAbsent(serviceClassName,
+                c -> new HashSet<>());
+        interceptors.add(interceptor);
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/metrics/GrpcMetricsServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/metrics/GrpcMetricsServerInterceptor.java
@@ -7,8 +7,10 @@ import javax.interceptor.Interceptor.Priority;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
+import io.quarkus.grpc.GlobalInterceptor;
 
 @Singleton
+@GlobalInterceptor
 public class GrpcMetricsServerInterceptor extends MetricCollectingServerInterceptor implements Prioritized {
 
     @Inject

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
@@ -13,10 +13,12 @@ import io.grpc.ServerInterceptor;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.grpc.GlobalInterceptor;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 
 @ApplicationScoped
+@GlobalInterceptor
 public class GrpcRequestContextGrpcInterceptor implements ServerInterceptor, Prioritized {
     private static final Logger log = Logger.getLogger(GrpcRequestContextGrpcInterceptor.class.getName());
 

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -376,7 +376,7 @@ class RestClientReactiveProcessor {
 
                     // METHODS:
                     for (MethodInfo method : restMethods) {
-                        // for each method method that corresponds to making a rest call, create a method like:
+                        // for each method that corresponds to making a rest call, create a method like:
                         // public JsonArray get() {
                         //      return ((InterfaceClass)this.getDelegate()).get();
                         // }

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HeaderServerInterceptor.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HeaderServerInterceptor.java
@@ -11,11 +11,13 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import io.quarkus.grpc.GlobalInterceptor;
 
 /**
  * A interceptor to handle server header.
  */
 @ApplicationScoped
+@GlobalInterceptor
 public class HeaderServerInterceptor implements ServerInterceptor {
 
     private static final Logger logger = Logger.getLogger(HeaderServerInterceptor.class.getName());
@@ -30,7 +32,7 @@ public class HeaderServerInterceptor implements ServerInterceptor {
             final Metadata requestHeaders,
             ServerCallHandler<I, O> next) {
         logger.info("header received from client:" + requestHeaders);
-        return next.startCall(new ForwardingServerCall.SimpleForwardingServerCall<I, O>(call) {
+        return next.startCall(new ForwardingServerCall.SimpleForwardingServerCall<>(call) {
             @Override
             public void sendHeaders(Metadata responseHeaders) {
                 responseHeaders.put(CUSTOM_HEADER_KEY, "customRespondValue");

--- a/integration-tests/grpc-plain-text-mutiny/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/integration-tests/grpc-plain-text-mutiny/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -6,9 +6,11 @@ import examples.HelloReply;
 import examples.HelloRequest;
 import examples.MutinyGreeterGrpc;
 import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.RegisterInterceptor;
 import io.smallrye.mutiny.Uni;
 
 @GrpcService
+@RegisterInterceptor(IncomingInterceptor.class)
 public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
 
     AtomicInteger counter = new AtomicInteger();


### PR DESCRIPTION
fixes #19229

This is a breaking change. With it, global gRPC interceptors have to be annotated with `@GlobalInterceptor`. 
Without it, every CDI bean implementing `ServerInterceptor` was a global interceptor.