### PR TITLE
Use Maven plugin's groupId and version as the base for the target platform groupId and version

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -101,10 +100,7 @@ public class CreateJBangMojo extends AbstractMojo {
         final MessageWriter log = new MojoMessageWriter(getLog());
         ExtensionCatalog catalog;
         try {
-            catalog = CreateProjectMojo.resolveExtensionsCatalog(
-                    StringUtils.defaultIfBlank(bomGroupId, null),
-                    StringUtils.defaultIfBlank(bomArtifactId, null),
-                    StringUtils.defaultIfBlank(bomVersion, null),
+            catalog = CreateProjectMojo.resolveExtensionsCatalog(this, bomGroupId, bomArtifactId, bomVersion,
                     QuarkusProjectHelper.getCatalogResolver(mvn, log), mvn, log);
         } catch (RegistryResolutionException e) {
             throw new MojoExecutionException("Failed to resolve Quarkus extension catalog", e);

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -9,17 +9,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -48,7 +50,8 @@ import io.quarkus.platform.tools.maven.MojoMessageWriter;
 import io.quarkus.registry.ExtensionCatalogResolver;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
-import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.config.RegistriesConfigLocator;
+import io.quarkus.registry.config.RegistryConfig;
 
 /**
  * This goal helps in setting up Quarkus Maven project with quarkus-maven-plugin, with sensible defaults
@@ -214,14 +217,12 @@ public class CreateProjectMojo extends AbstractMojo {
                     ? QuarkusProjectHelper.getCatalogResolver(mvn, log)
                     : ExtensionCatalogResolver.empty();
         } catch (RegistryResolutionException e) {
-            throw new MojoExecutionException("Failed to initialize Quarkus extension catalog resolver", e);
+            // fall back to the default platform
+            catalogResolver = ExtensionCatalogResolver.empty();
         }
 
-        final ExtensionCatalog catalog = resolveExtensionsCatalog(
-                StringUtils.defaultIfBlank(bomGroupId, null),
-                StringUtils.defaultIfBlank(bomArtifactId, null),
-                StringUtils.defaultIfBlank(bomVersion, null),
-                catalogResolver, mvn, log);
+        final ExtensionCatalog catalog = resolveExtensionsCatalog(this, bomGroupId, bomArtifactId, bomVersion, catalogResolver,
+                mvn, log);
 
         File projectRoot = outputDirectory;
         File pom = project != null ? project.getFile() : null;
@@ -325,35 +326,63 @@ public class CreateProjectMojo extends AbstractMojo {
         }
     }
 
-    static ExtensionCatalog resolveExtensionsCatalog(String groupId, String artifactId, String version,
+    static ExtensionCatalog resolveExtensionsCatalog(AbstractMojo mojo, String groupId, String artifactId, String version,
             ExtensionCatalogResolver catalogResolver, MavenArtifactResolver artifactResolver, MessageWriter log)
             throws MojoExecutionException {
 
         if (!catalogResolver.hasRegistries()) {
-            // TODO: this should normally result in an error, however for the time being
-            // until we get the registry service up and running this will allow
-            // a fall back to the legacy way of resolving the default platform catalog directly
-            return ToolsUtils.resolvePlatformDescriptorDirectly(groupId, artifactId,
-                    version == null ? CreateUtils.resolvePluginInfo(CreateUtils.class).getVersion() : version, artifactResolver,
-                    log);
+            groupId = getPlatformGroupId(mojo, groupId);
+            artifactId = getPlatformArtifactId(artifactId);
+            version = getPlatformVersion(mojo, version);
+            final StringBuilder buf = new StringBuilder();
+            buf.append("The extension catalog will be narrowed to the ").append(groupId).append(":").append(artifactId)
+                    .append(":").append(version).append(" platform release.");
+            buf.append(
+                    " To enable the complete Quarkiverse extension catalog along with the latest recommended platform releases, please, make sure ");
+            if (QuarkusProjectHelper.isRegistryClientEnabled()) {
+                buf.append("the following registries are accessible from your environment: ");
+                final Iterator<RegistryConfig> iterator = RegistriesConfigLocator.resolveConfig().getRegistries().iterator();
+                int i = 0;
+                while (iterator.hasNext()) {
+                    final RegistryConfig r = iterator.next();
+                    if (r.isEnabled()) {
+                        if (i++ > 0) {
+                            buf.append(", ");
+                        }
+                        buf.append(r.getId());
+                    }
+                }
+
+            } else {
+                buf.append("the extension registry client is enabled.");
+            }
+            log.warn(buf.toString());
+            return ToolsUtils.resolvePlatformDescriptorDirectly(groupId, artifactId, version, artifactResolver, log);
         }
 
+        final ExtensionCatalog catalog;
         try {
-            if (groupId == null && artifactId == null && version == null) {
-                return catalogResolver.resolveExtensionCatalog();
-            }
-            final PlatformCatalog platformsCatalog = catalogResolver.resolvePlatformCatalog();
-            if (platformsCatalog == null) {
-                throw new MojoExecutionException(
-                        "No platforms are available. Please make sure your .quarkus/config.yaml configuration includes proper extensions registry configuration");
-            }
-            final ArtifactCoords matchedBom = QuarkusProjectMojoBase.getSingleMatchingBom(groupId, artifactId, version,
-                    platformsCatalog);
-            return catalogResolver
-                    .resolveExtensionCatalog(matchedBom == null ? Collections.emptyList() : Arrays.asList(matchedBom));
+            catalog = isBlank(groupId) && isBlank(artifactId) && isBlank(version)
+                    ? catalogResolver.resolveExtensionCatalog()
+                    : catalogResolver.resolveExtensionCatalog(Collections.singletonList(
+                            new ArtifactCoords(getPlatformGroupId(mojo, groupId), getPlatformArtifactId(artifactId), "pom",
+                                    getPlatformVersion(mojo, version))));
         } catch (RegistryResolutionException e) {
             throw new MojoExecutionException("Failed to resolve the extensions catalog", e);
         }
+
+        if (catalog == null) {
+            final StringBuilder buf = new StringBuilder();
+            buf.append(
+                    "The Quarkus registry client failed to resolve the extension catalog. Please make sure the following registries are accessible from your environment: ");
+            final Iterator<RegistryConfig> r = catalogResolver.getConfig().getRegistries().iterator();
+            buf.append(r.next().getId());
+            while (r.hasNext()) {
+                buf.append(", ").append(r.next().getId());
+            }
+            throw new MojoExecutionException(buf.toString());
+        }
+        return catalog;
     }
 
     private void askTheUserForMissingValues() throws MojoExecutionException {
@@ -361,43 +390,43 @@ public class CreateProjectMojo extends AbstractMojo {
         // If the user has disabled the interactive mode or if the user has specified the artifactId, disable the
         // user interactions.
         if (!session.getRequest().isInteractiveMode() || shouldUseDefaults()) {
-            if (StringUtils.isBlank(projectArtifactId)) {
+            if (isBlank(projectArtifactId)) {
                 // we need to set it for the project directory
                 projectArtifactId = DEFAULT_ARTIFACT_ID;
             }
-            if (StringUtils.isBlank(projectGroupId)) {
+            if (isBlank(projectGroupId)) {
                 projectGroupId = DEFAULT_GROUP_ID;
             }
-            if (StringUtils.isBlank(projectVersion)) {
+            if (isBlank(projectVersion)) {
                 projectVersion = DEFAULT_VERSION;
             }
             return;
         }
 
         try {
-            if (StringUtils.isBlank(projectGroupId)) {
+            if (isBlank(projectGroupId)) {
                 projectGroupId = prompter.promptWithDefaultValue("Set the project groupId",
                         DEFAULT_GROUP_ID);
             }
 
-            if (StringUtils.isBlank(projectArtifactId)) {
+            if (isBlank(projectArtifactId)) {
                 projectArtifactId = prompter.promptWithDefaultValue("Set the project artifactId",
                         DEFAULT_ARTIFACT_ID);
             }
 
-            if (StringUtils.isBlank(projectVersion)) {
+            if (isBlank(projectVersion)) {
                 projectVersion = prompter.promptWithDefaultValue("Set the project version",
                         DEFAULT_VERSION);
             }
 
-            if (!noCode && StringUtils.isBlank(example)) {
+            if (!noCode && isBlank(example)) {
                 if (extensions.isEmpty()) {
                     extensions = Arrays
                             .stream(prompter
                                     .promptWithDefaultValue("What extensions do you wish to add (comma separated list)",
                                             DEFAULT_EXTENSIONS)
                                     .split(","))
-                            .map(String::trim).filter(StringUtils::isNotEmpty).collect(Collectors.toSet());
+                            .map(String::trim).filter(Predicate.not(String::isEmpty)).collect(Collectors.toSet());
                 }
                 String answer = prompter.promptWithDefaultValue(
                         "Would you like some code to start (yes), or just an empty Quarkus project (no)", "yes");
@@ -419,7 +448,7 @@ public class CreateProjectMojo extends AbstractMojo {
             className = sourceType.stripExtensionFrom(className);
 
             int idx = className.lastIndexOf('.');
-            if (idx >= 0 && StringUtils.isBlank(packageName)) {
+            if (idx >= 0 && isBlank(packageName)) {
                 // if it's a full qualified class name, we use the package name part (only if the packageName wasn't already defined)
                 packageName = className.substring(0, idx);
 
@@ -427,7 +456,7 @@ public class CreateProjectMojo extends AbstractMojo {
                 className = className.substring(idx + 1);
             }
 
-            if (StringUtils.isBlank(path)) {
+            if (isBlank(path)) {
                 path = "/hello";
             } else if (!path.startsWith("/")) {
                 path = "/" + path;
@@ -452,5 +481,33 @@ public class CreateProjectMojo extends AbstractMojo {
                         .reset().toString());
         getLog().info("========================================================================================");
         getLog().info("");
+    }
+
+    public static String getPlatformVersion(AbstractMojo mojo, String version) {
+        return isBlank(version) ? getPluginVersion(mojo) : version;
+    }
+
+    public static String getPlatformArtifactId(String artifactId) {
+        return isBlank(artifactId) ? "quarkus-bom" : artifactId;
+    }
+
+    public static String getPlatformGroupId(AbstractMojo mojo, String groupId) {
+        return isBlank(groupId) ? getPluginGroupId(mojo) : groupId;
+    }
+
+    private static String getPluginGroupId(AbstractMojo mojo) {
+        return getPluginDescriptor(mojo).getGroupId();
+    }
+
+    private static String getPluginVersion(AbstractMojo mojo) {
+        return getPluginDescriptor(mojo).getVersion();
+    }
+
+    private static PluginDescriptor getPluginDescriptor(AbstractMojo mojo) {
+        return (PluginDescriptor) mojo.getPluginContext().get("pluginDescriptor");
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
     }
 }

--- a/docs/src/main/asciidoc/amazon-dynamodb.adoc
+++ b/docs/src/main/asciidoc/amazon-dynamodb.adoc
@@ -100,7 +100,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-dynamodb-quickstart \
     -DclassName="org.acme.dynamodb.FruitResource" \

--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -92,7 +92,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-kms-quickstart \
     -DclassName="org.acme.kms.QuarkusKmsSyncResource" \

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -82,7 +82,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-s3-quickstart \
     -DclassName="org.acme.s3.S3SyncClientResource" \

--- a/docs/src/main/asciidoc/amazon-ses.adoc
+++ b/docs/src/main/asciidoc/amazon-ses.adoc
@@ -101,7 +101,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-ses-quickstart \
     -DclassName="org.acme.ses.QuarkusSesSyncResource" \

--- a/docs/src/main/asciidoc/amazon-sns.adoc
+++ b/docs/src/main/asciidoc/amazon-sns.adoc
@@ -89,7 +89,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-sns-quickstart \
     -DclassName="org.acme.sns.QuarksCannonSyncResource" \

--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -90,7 +90,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-sqs-quickstart \
     -DclassName="org.acme.sqs.QuarksCannonSyncResource" \

--- a/docs/src/main/asciidoc/amazon-ssm.adoc
+++ b/docs/src/main/asciidoc/amazon-ssm.adoc
@@ -71,7 +71,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amazon-ssm-quickstart \
     -DclassName="org.acme.ssm.QuarkusSsmSyncResource" \

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -62,7 +62,7 @@ To create the _producer_ project, in a terminal run:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amqp-quickstart-producer \
     -DnoCode=true \
@@ -78,7 +78,7 @@ To create the _processor_ project, from the same directory, run:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amqp-quickstart-processor \
     -DnoCode=true \

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -98,11 +98,11 @@ It will try to auto-detect its options:
 * in other cases it will use the 'Standalone' extension layout and defaults.
 * we may introduce other layout types in the future.
 
-TIP: You may call it without any parameter to use the interactive mode: `mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N`
+TIP: You may call it without any parameter to use the interactive mode: `mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create-extension -N`
 
 [source,shell,subs=attributes+]
 ----
-$ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
+$ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
     -DgroupId=org.acme \ #<1>
     -DextensionId=greeting-extension \  #<2>
     -DwithoutTests #<3>
@@ -716,7 +716,7 @@ mvn clean install
 Then from another directory, use our tooling to create a new `greeting-app` Quarkus application with your new extension:
 [source,bash, subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
      -DprojectGroupId=org.acme \
      -DprojectArtifactId=greeting-app \
      -Dextensions="org.acme:greeting-extension:1.0.0-SNAPSHOT" \

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -44,7 +44,7 @@ First, we need to create a new Quarkus project using Maven with the following co
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=cache-quickstart \
     -DclassName="org.acme.cache.WeatherForecastResource" \

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -25,7 +25,7 @@ Create an application with the `quarkus-logging-gelf` extension. You can use the
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=gelf-logging \
     -DclassName="org.acme.quickstart.GelfLoggingResource" \

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -39,7 +39,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=config-quickstart \
     -DclassName="org.acme.config.GreetingResource" \

--- a/docs/src/main/asciidoc/consul-config.adoc
+++ b/docs/src/main/asciidoc/consul-config.adoc
@@ -48,7 +48,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=consul-config-quickstart \
     -DclassName="org.acme.consul.config.GreetingResource" \

--- a/docs/src/main/asciidoc/deploying-to-heroku.adoc
+++ b/docs/src/main/asciidoc/deploying-to-heroku.adoc
@@ -54,7 +54,7 @@ Or, just generate a fresh project:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=code-with-quarkus-on-heroku \
     -DclassName="org.acme.getting.started.GreetingResource" \

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -29,7 +29,7 @@ Let's create a new project that contains both the Kubernetes and Jib extensions:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kubernetes-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -27,7 +27,7 @@ First, we need a new project that contains the OpenShift extension. This can be 
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=openshift-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -51,7 +51,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=elasticsearch-quickstart \
     -DclassName="org.acme.elasticsearch.FruitResource" \

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -44,7 +44,7 @@ You can use the following Maven command to create it:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=funqy-google-cloud-functions \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -44,7 +44,7 @@ You can use the following Maven command to create it:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=google-cloud-functions-http \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -42,7 +42,7 @@ You can use the following Maven command to create it:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=google-cloud-functions \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -77,7 +77,7 @@ For Linux & MacOS users
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=getting-started \
     -DclassName="org.acme.getting.started.GreetingResource" \
@@ -91,14 +91,14 @@ For Windows users
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create -DprojectGroupId=org.acme -DprojectArtifactId=getting-started -DclassName="org.acme.getting.started.GreetingResource" -Dpath="/hello"
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create -DprojectGroupId=org.acme -DprojectArtifactId=getting-started -DclassName="org.acme.getting.started.GreetingResource" -Dpath="/hello"
 ----
 
 - If using Powershell , wrap `-D` parameters in double quotes
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create "-DprojectGroupId=org.acme" "-DprojectArtifactId=getting-started" "-DclassName=org.acme.getting.started.GreetingResource" "-Dpath=/hello"
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create "-DprojectGroupId=org.acme" "-DprojectArtifactId=getting-started" "-DclassName=org.acme.getting.started.GreetingResource" "-Dpath=/hello"
 ----
 
 It generates the following in  `./getting-started`:

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -19,7 +19,7 @@ The easiest way to scaffold a Gradle project, is currently to use the Quarkus Ma
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=my-groupId \
     -DprojectArtifactId=my-artifactId \
     -DprojectVersion=my-version \
@@ -28,7 +28,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DbuildTool=gradle
 ----
 
-NOTE: If you just launch `mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create` the Maven plugin asks
+NOTE: If you just launch `mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create` the Maven plugin asks
 for user inputs. You can disable (and use default values) this interactive mode by passing `-B` to the Maven command.
 
 [NOTE]

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -49,7 +49,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=hibernate-search-orm-elasticsearch-quickstart \
     -DclassName="org.acme.hibernate.search.elasticsearch.LibraryResource" \

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -59,7 +59,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
     -DclassName="org.acme.jms.PriceResource" \
@@ -362,7 +362,7 @@ Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
     -DclassName="org.acme.jms.PriceResource" \

--- a/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
@@ -55,7 +55,7 @@ To create the _producer_ project, in a terminal run:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-quickstart-producer \
     -DnoCode=true \
@@ -71,7 +71,7 @@ To create the _processor_ project, from the same directory, run:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-quickstart-processor \
     -DnoCode=true \

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -53,7 +53,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-avro-schema-quickstart \
     -DclassName="org.acme.kafka.MovieResource" \

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -84,7 +84,7 @@ Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-streams-quickstart-producer \
     -Dextensions="kafka" \
@@ -236,7 +236,7 @@ Create another project like so:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-streams-quickstart-aggregator \
     -Dextensions="resteasy,kafka-streams,resteasy-jackson" \

--- a/docs/src/main/asciidoc/kogito-dmn.adoc
+++ b/docs/src/main/asciidoc/kogito-dmn.adoc
@@ -75,7 +75,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-dmn-quickstart \
     -Dextensions="dmn" \

--- a/docs/src/main/asciidoc/kogito-drl.adoc
+++ b/docs/src/main/asciidoc/kogito-drl.adoc
@@ -56,7 +56,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-drl-quickstart \
     -Dextensions="kogito-quarkus-rules" \

--- a/docs/src/main/asciidoc/kogito-pmml.adoc
+++ b/docs/src/main/asciidoc/kogito-pmml.adoc
@@ -59,7 +59,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-pmml-quickstart \
     -Dextensions="kogito" \

--- a/docs/src/main/asciidoc/kogito.adoc
+++ b/docs/src/main/asciidoc/kogito.adoc
@@ -85,7 +85,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-quickstart \
     -Dextensions="kogito" \

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -31,7 +31,7 @@ First, we need a new Kotlin project. This can be done using the following comman
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-kotlin-quickstart \
     -DclassName="org.acme.rest.GreetingResource" \

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -39,7 +39,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=lifecycle-quickstart \
     -DclassName="org.acme.lifecycle.GreetingResource" \

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -14,14 +14,14 @@ With Maven, you can scaffold a new project with:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=my-groupId \
     -DprojectArtifactId=my-artifactId \
     -DprojectVersion=my-version \
     -DclassName="org.my.group.MyResource"
 ----
 
-NOTE: If you just launch `mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create` the Maven plugin asks
+NOTE: If you just launch `mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create` the Maven plugin asks
 for user inputs. You can disable (and use default values) this interactive mode by passing `-B` to the Maven command.
 
 The following table lists the attributes you can pass to the `create` command:

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -62,7 +62,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=micrometer-quickstart \
     -DclassName="org.acme.micrometer.ExampleResource" \

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -65,7 +65,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=mongodb-panache-quickstart \
     -DclassName="org.acme.mongodb.panache.PersonResource" \

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -43,7 +43,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=mongodb-quickstart \
     -DclassName="org.acme.mongodb.FruitResource" \

--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -124,7 +124,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=neo4j-quickstart \
     -DclassName="org.acme.datasource.GreetingResource" \

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -39,7 +39,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=openapi-swaggerui-quickstart \
     -DclassName="org.acme.openapi.swaggerui.FruitResource" \

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -41,7 +41,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=opentelemetry-quickstart \
     -DclassName="org.acme.opentelemetry.TracedResource" \

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -41,7 +41,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=opentracing-quickstart \
     -DclassName="org.acme.opentracing.TracedResource" \

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -67,7 +67,7 @@ Alternatively, generate it from the command line with Maven:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=optaplanner-quickstart \
     -Dextensions="resteasy,resteasy-jackson,optaplanner-quarkus,optaplanner-quarkus-jackson" \

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -44,7 +44,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=quartz-quickstart \
     -DclassName="org.acme.quartz.TaskResource" \

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -27,7 +27,7 @@ If you are creating a new project, set the `extensions` parameter are follows:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-quickstart \
     -Dextensions="vertx,resteasy-mutiny" \
@@ -292,7 +292,7 @@ First create a new project using:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-http-quickstart \
     -Dextensions="vertx" \

--- a/docs/src/main/asciidoc/reactive-messaging-http.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging-http.adoc
@@ -44,7 +44,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=reactive-messaging-http-quickstart \
     -Dextensions="reactive-messaging-http" \

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -65,7 +65,7 @@ If you are creating a new project, set the `extensions` parameter as follows:
 
 [source,bash, subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=reactive-pg-client-quickstart \
     -DclassName="org.acme.vertx.FruitResource" \

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -45,7 +45,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=redis-quickstart \
     -Dextensions="redis-client,resteasy-jackson,resteasy-mutiny" \

--- a/docs/src/main/asciidoc/rest-client-multipart.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart.adoc
@@ -37,7 +37,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-client-multipart-quickstart \
     -DclassName="org.acme.rest.client.multipart.MultipartClientResource" \

--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -37,7 +37,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-client-reactive-quickstart \
     -DclassName="org.acme.rest.client.CountriesResource" \

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -36,7 +36,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-client-quickstart \
     -DclassName="org.acme.rest.client.CountriesResource" \

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -43,7 +43,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-json-quickstart \
     -DclassName="org.acme.rest.json.FruitResource" \
@@ -72,7 +72,7 @@ Quarkus also supports http://json-b.net/[JSON-B] so, if you prefer JSON-B over J
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-json-quickstart \
     -DclassName="org.acme.rest.json.FruitResource" \

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -43,7 +43,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=scheduler-quickstart \
     -DclassName="org.acme.scheduler.CountResource" \

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -46,7 +46,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-jdbc-quickstart \
     -Dextensions="elytron-security-jdbc,jdbc-postgresql,resteasy" \

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -47,7 +47,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-jpa-quickstart \
     -Dextensions="security-jpa,jdbc-postgresql,resteasy,hibernate-orm-panache" \

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -31,7 +31,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-jwt-quickstart \
     -DclassName="org.acme.security.jwt.TokenSecuredResource" \

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -70,7 +70,7 @@ Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-keycloak-authorization-quickstart \
     -Dextensions="oidc,keycloak-authorization,resteasy-jackson" \

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -46,7 +46,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-ldap-quickstart \
     -Dextensions="elytron-security-ldap,resteasy" \

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -37,7 +37,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-oauth2-quickstart \
     -DclassName="org.acme.security.oauth2.TokenSecuredResource" \

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -50,7 +50,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-multi-tenancy-quickstart \
     -Dextensions="oidc,resteasy-jackson" \

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -50,7 +50,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-web-authentication-quickstart \
     -Dextensions="resteasy,oidc" \

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -59,7 +59,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-quickstart \
     -Dextensions="resteasy,oidc,resteasy-jackson" \

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -48,7 +48,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-fault-tolerance-quickstart \
     -DclassName="org.acme.microprofile.faulttolerance.CoffeeResource" \

--- a/docs/src/main/asciidoc/smallrye-graphql-client.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql-client.adoc
@@ -66,7 +66,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-graphql-client-quickstart \
     -DclassName="org.acme.microprofile.graphql.client.StarWarsResource" \

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -67,7 +67,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-graphql-quickstart \
     -DclassName="org.acme.microprofile.graphql.FilmResource" \

--- a/docs/src/main/asciidoc/smallrye-health.adoc
+++ b/docs/src/main/asciidoc/smallrye-health.adoc
@@ -47,7 +47,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-health-quickstart \
     -Dextensions="smallrye-health"

--- a/docs/src/main/asciidoc/smallrye-metrics.adoc
+++ b/docs/src/main/asciidoc/smallrye-metrics.adoc
@@ -53,7 +53,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-metrics-quickstart \
     -DclassName="org.acme.microprofile.metrics.PrimeNumberResource" \

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -34,7 +34,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-boot-properties-quickstart \
     -DclassName="org.acme.spring.boot.properties.GreetingResource" \

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -28,7 +28,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-cache-quickstart \
     -DclassName="org.acme.spring.cache.GreeterResource" \

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -34,7 +34,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-cloud-config-quickstart \
     -DclassName="org.acme.spring.cloud.config.client.GreetingResource" \

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -34,7 +34,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-data-jpa-quickstart \
     -DclassName="org.acme.spring.data.jpa.FruitResource" \

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -38,7 +38,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-data-rest-quickstart \
     -Dextensions="spring-data-rest,resteasy-jackson,quarkus-jdbc-postgresql" \

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -36,7 +36,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-di-quickstart \
     -DclassName="org.acme.spring.di.GreeterResource" \

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -37,7 +37,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-scheduler-quickstart \
     -DclassName="org.acme.spring.scheduler.CountResource" \

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -37,7 +37,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-security-quickstart \
     -DclassName="org.acme.spring.security.GreetingController" \

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -36,7 +36,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spring-web-quickstart \
     -DclassName="org.acme.spring.web.GreetingController" \

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -56,7 +56,7 @@ Let's start from an empty application created with the Quarkus Maven plugin:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=tests-with-coverage-quickstart
 cd tests-with-coverage-quickstart

--- a/docs/src/main/asciidoc/tika.adoc
+++ b/docs/src/main/asciidoc/tika.adoc
@@ -56,7 +56,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme.example \
     -DprojectArtifactId=tika-quickstart \
     -DclassName="org.acme.tika.TikaParserResource" \

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -44,7 +44,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=validation-quickstart \
     -DclassName="org.acme.validation.BookResource" \

--- a/docs/src/main/asciidoc/vault-transit.adoc
+++ b/docs/src/main/asciidoc/vault-transit.adoc
@@ -146,7 +146,7 @@ First, let's create a simple Quarkus application with Vault and Jackson extensio
 
 [source,bash, subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vault-transit-quickstart \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -241,7 +241,7 @@ a-private-key    123456
 
 [source,bash, subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vault-quickstart \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -41,7 +41,7 @@ First, we need a new project. Create a new project with the following command:
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=websockets-quickstart \
     -Dextensions="websockets" \

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -381,7 +381,7 @@ Your extension project should be setup as a multi-module project with two submod
 
 2. A runtime submodule that contains the runtime behavior that will provide the extension behavior in the native executable or runtime JVM.
 
-TIP: You may want to use the `create-extension` mojo of `io.quarkus:quarkus-maven-plugin` to create these Maven modules - see the next section.
+TIP: You may want to use the `create-extension` mojo of `io.quarkus.platform:quarkus-maven-plugin` to create these Maven modules - see the next section.
 
 Your runtime artifact should depend on `io.quarkus:quarkus-core`, and possibly the runtime artifacts of other Quarkus
 modules if you want to use functionality provided by them.
@@ -484,7 +484,7 @@ It will try to auto-detect its options:
 * in other cases it will use the 'Standalone' extension layout and defaults.
 * we may introduce other layout types in the future.
 
-TIP: You may not specify any parameter to use the interactive mode: `mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N`
+TIP: You may not specify any parameter to use the interactive mode: `mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create-extension -N`
 
 As and example, let's add a new extension called `my-ext` to the Quarkus source tree:
 
@@ -492,7 +492,7 @@ As and example, let's add a new extension called `my-ext` to the Quarkus source 
 ----
 git clone https://github.com/quarkusio/quarkus.git
 cd quarkus
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
     -DextensionId=my-ext \
     -Dname="My Extension"
 ----
@@ -2215,7 +2215,7 @@ using the Quarkus maven plugin as shown in this example taken from the link:rest
 
 [source,bash,subs=attributes+]
 ----
-mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=rest-json \
     -DclassName="org.acme.rest.json.FruitResource" \

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -59,7 +59,6 @@ public class ExtensionCatalogResolver {
     public class Builder {
 
         private MavenArtifactResolver artifactResolver;
-        private RegistriesConfig config;
         private boolean built;
 
         private RegistryClientFactory defaultClientFactory;
@@ -230,7 +229,12 @@ public class ExtensionCatalogResolver {
     }
 
     private MessageWriter log;
+    private RegistriesConfig config;
     private List<RegistryExtensionResolver> registries;
+
+    public RegistriesConfig getConfig() {
+        return config;
+    }
 
     public boolean hasRegistries() {
         return !registries.isEmpty();


### PR DESCRIPTION
Fixes #19250, #19558, #19612

In case the `quarkus-maven-plugin` is used to create a project and the registry client is disabled or a configured registry isn't available, fallback to the default platform release, unless the desired platform groupId, artifactId and version were provided by the user. The default platform groupId and version are matching those of the `quarkus-maven-plugin` and the default platform artifactId is `quarkus-bom`.

For example if a registry isn't available

`mvn io.quarkus.platform:quarkus-maven-plugin:999-SNAPSHOT:create` will create a project using `io.quarkus.platform:quarkus-bom:999-SNAPSHOT`.

`mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create` will create a project using `io.quarkus:quarkus-bom:999-SNAPSHOT`.

A warning would look something like this:
````
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[INFO] Refreshing the local extension catalog cache of registry.quarkus.io
Downloading from aliyunmaven: https://maven.aliyun.com/repository/public/io/quarkus/registry/quarkus-registry-descriptor/1.0-SNAPSHOT/maven-metadata.xml
Downloading from aliyunmaven: https://maven.aliyun.com/repository/public/io/quarkus/registry/quarkus-registry-descriptor/1.0-SNAPSHOT/quarkus-registry-descriptor-1.0-SNAPSHOT.json
[WARNING] The extension catalog will be narrowed to the io.quarkus:quarkus-bom:999-SNAPSHOT platform release. To enable the complete Quarkiverse extension catalog along with the latest recommended platform releases, please, make sure the following registries are accissible from your environment: registry.quarkus.io
Set the project groupId [org.acme]:
````