### PR TITLE
Update DevServices for Keycloak to support Keycloak-X

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -27,16 +27,12 @@ Start your application without configuring `quarkus.oidc` properties in `applica
 ----
 $ mvn quarkus:dev
 
-2021-06-04 16:22:47,175 INFO  [🐳 .io/keycloak/keycloak:14.0.0]] (build-38) Creating container for image: quay.io/keycloak/keycloak:14.0.0
-2021-06-04 16:22:47,243 INFO  [🐳 .io/keycloak/keycloak:14.0.0]] (build-38) Starting container with ID: 6469f6db9cec2c855fcc6c8db4273944cc9d69e8f6803a0b47eb2d5b8f5b94fd
-2021-06-04 16:22:47,629 INFO  [🐳 .io/keycloak/keycloak:14.0.0]] (build-38) Container quay.io/keycloak/keycloak:14.0.0 is starting: 6469f6db9cec2c855fcc6c8db4273944cc9d69e8f6803a0b47eb2d5b8f5b94fd
-2021-06-04 16:22:47,643 INFO  [org.tes.con.wai.str.HttpWaitStrategy] (build-38) /elastic_lovelace: Waiting for 60 seconds for URL: http://localhost:32812/auth (where port 32812 maps to container port 8080)
-2021-06-04 16:23:07,665 INFO  [🐳 .io/keycloak/keycloak:14.0.0]] (build-38) Container quay.io/keycloak/keycloak:14.0.0 started in PT5.500489S
-2021-06-04 16:23:07,666 INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (build-38) Dev Services for Keycloak started.
-...
+KeyCloak Dev Services Starting:
+2021-11-02 17:14:24,864 INFO  [org.tes.con.wai.str.HttpWaitStrategy] (build-10) /unruffled_agnesi: Waiting for 60 seconds for URL: http://localhost:32781/auth (where port 32781 maps to container port 8080)
+2021-11-02 17:14:44,170 INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (build-10) Dev Services for Keycloak started.
 ----
 
-The `quay.io/keycloak/keycloak:14.0.0` Keycloak image is used by default to start a container. `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image used.
+The `quay.io/keycloak/keycloak:15.0.2` image which contains a `Keycloak` distribution powered by `WildFly` is currently used to start a container by default. See the <<keycloak-initialization, Keycloak Initialization>> section for more details about the image selection.
 
 Note that by default, `Dev Services for Keycloak` will not start a new container if it finds a container with a `quarkus-dev-service-keycloak` label and connect to it if this label's value matches the value of the `quarkus.keycloak.devservices.service-name` property (default value is `quarkus`). In such cases you will see a slighty different output:
 
@@ -159,9 +155,13 @@ You can run the tests against a Keycloak container started in a test mode in a l
 It is also recommended to run the integration tests against Keycloak using `Dev Services for Keycloak`.
 Please see link:security-openid-connect#integration-testing-keycloak-devservices[Testing OpenId Connect Service Applications with Dev Services] and link:security-openid-connect-web-authentication#integration-testing-keycloak-devservices[Testing OpenId Connect WebApp Applications with Dev Services] for more information.
 
+[[keycloak-initialization]]
 === Keycloak Initialization
 
-You do not need to configure `quarkus-oidc-keycloak` to start developing your Quarkus Keycloak `OIDC` applications with the only exception being that `quarkus.oidc.application-type=web-app` has to be set in `application.properties` to give the `Keycloak` page a hint it needs to show an option to `Sign In To Service`.
+The `quay.io/keycloak/keycloak:15.0.2` image which contains a `Keycloak` distribution powered by `WildFly` is currently used to start a container by default.
+`quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak-x:15.0.2` to use a `Keycloak-X` distribution powered by `Quarkus`. `Dev Services for Keycloak` will use a Keycloak-X based image by default soon.
+
+`Dev Services for Keycloak` will initialize a launched Keycloak server next.
 
 By default, the `quarkus`, `quarkus-app` client with a `secret` password, `alice` and `bob` users (with the passwords matching the names), and `user` and `admin` roles are created, with `alice` given both `admin` and `user` roles and `bob` - the `user` role. 
 
@@ -177,9 +177,11 @@ Also the Keycloak page offers an option to `Sign In To Keycloak To Configure Rea
 
 image::dev-ui-keycloak-admin.png[alt=Dev UI OpenId Connect Keycloak Page - Keycloak Admin,role="center"]
 
-Sign in to Keycloak as `admin:admin` in order to further customize the realm properties or create a new realm, export the realm and have Keycloak initialized with the custom realm after a restart.
+Sign in to Keycloak as `admin:admin` in order to further customize the realm properties, create or import a new realm, export the realm.
 
-Note that even if you initialize Keycloak from a realm file, it is still needed to set the `quarkus.keycloak.devservices.realm-name` property for `quarkus.oidc.auth-server-url` to be calculated correctly. Setting the `quarkus.keycloak.devservices.users` property is needed if a `password` grant is used to acquire the tokens to test the OIDC `service` applications.
+Note that at the moment, if you use a `Keycloak-X` image then auto-importing a custom realm file does not work - for now use a `Keycloak Admin` Dev UI option to import a custom realm if required. In this case you may also want to set `quarkus.keycloak.devservices.create-realm=false` for `Dev Services for Keycloak` to avoid creating a default realm.
+
+Note that even if you initialize Keycloak from a realm file, it is still needed to set `quarkus.keycloak.devservices.users` property if a `password` grant is used to acquire the tokens to test the OIDC `service` applications.
 
 == Disable Dev Services for Keycloak
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -24,9 +24,30 @@ public class DevServicesConfig {
 
     /**
      * The container image name to use, for container based DevServices providers.
+     *
+     * Image with a WildFly based Keycloak distribution is used by default.
+     * Image with a Quarkus based Keycloak-X distribution can be selected instead, for example:
+     * 'quay.io/keycloak/keycloak-x:15.0.2'.
+     * <p>
+     * Note Keycloak-X and Keycloak images are initialized differently.
+     * By default, Dev Services for Keycloak will assume it is a Keycloak-X image if the image name contains a 'keycloak-x'
+     * string.
+     * Set 'quarkus.devservices.keycloak.keycloak-x-image' to override this check.
      */
     @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:15.0.2")
     public String imageName;
+
+    /**
+     * If Keycloak-X image is used.
+     *
+     * By default, Dev Services for Keycloak will assume a Keycloak-X image is used if the image name contains a 'keycloak-x'
+     * string.
+     * Set 'quarkus.devservices.keycloak.keycloak-x-image' to override this check which may be necessary if you build custom
+     * Keycloak-X or Keycloak images.
+     * You do not need to set this property if the default check works.
+     */
+    @ConfigItem
+    public Optional<Boolean> keycloakXImage;
 
     /**
      * Indicates if the Keycloak container managed by Quarkus Dev Services is shared.

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -81,15 +81,25 @@ public class KeycloakDevServicesProcessor {
     private static final String KEYCLOAK_REALM_KEY = "keycloak.realm";
 
     private static final int KEYCLOAK_PORT = 8080;
-    private static final String JAVA_OPTS = "JAVA_OPTS";
-    private static final String KEYCLOAK_DOCKER_REALM_PATH = "/tmp/realm.json";
-    private static final String KEYCLOAK_USER_PROP = "KEYCLOAK_USER";
-    private static final String KEYCLOAK_PASSWORD_PROP = "KEYCLOAK_PASSWORD";
-    private static final String KEYCLOAK_VENDOR_PROP = "DB_VENDOR";
-    private static final String KEYCLOAK_IMPORT_PROP = "KEYCLOAK_IMPORT";
+
+    private static final String KEYCLOAK_X_IMAGE_NAME = "keycloak-x";
+
     private static final String KEYCLOAK_ADMIN_USER = "admin";
     private static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
-    private static final String KEYCLOAK_DB_VENDOR = "H2";
+
+    // Properties recognized by Wildfly-powered Keycloak
+    private static final String KEYCLOAK_WILDFLY_USER_PROP = "KEYCLOAK_USER";
+    private static final String KEYCLOAK_WILDFLY_PASSWORD_PROP = "KEYCLOAK_PASSWORD";
+    private static final String KEYCLOAK_WILDFLY_IMPORT_PROP = "KEYCLOAK_IMPORT";
+    private static final String KEYCLOAK_WILDFLY_DB_VENDOR = "H2";
+    private static final String KEYCLOAK_WILDFLY_VENDOR_PROP = "DB_VENDOR";
+
+    // Properties recognized by Quarkus-powered Keycloak
+    private static final String KEYCLOAK_QUARKUS_ADMIN_PROP = "KEYCLOAK_ADMIN";
+    private static final String KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP = "KEYCLOAK_ADMIN_PASSWORD";
+
+    private static final String JAVA_OPTS = "JAVA_OPTS";
+    private static final String KEYCLOAK_DOCKER_REALM_PATH = "/tmp/realm.json";
     private static final String OIDC_USERS = "oidc.users";
 
     /**
@@ -198,7 +208,7 @@ public class KeycloakDevServicesProcessor {
                 closeBuildItem.addCloseTask(closeTask, true);
             }
 
-            capturedKeycloakUrl = startResult.url + "/auth";
+            capturedKeycloakUrl = startResult.url + (startResult.keycloakX ? "" : "/auth");
             if (vertxInstance == null) {
                 vertxInstance = Vertx.vertx();
             }
@@ -211,11 +221,11 @@ public class KeycloakDevServicesProcessor {
         LOG.info("Dev Services for Keycloak started.");
 
         return prepareConfiguration(capturedDevServicesConfiguration.createRealm && startResult.createDefaultRealm,
-                startResult.realmNameToUse, devServices, startResult.shared);
+                startResult.realmNameToUse, devServices);
     }
 
     private KeycloakDevServicesConfigBuildItem prepareConfiguration(boolean createRealm, String realmNameToUse,
-            BuildProducer<DevServicesConfigResultBuildItem> devServices, boolean shared) {
+            BuildProducer<DevServicesConfigResultBuildItem> devServices) {
         final String realmName = realmNameToUse != null ? realmNameToUse : getDefaultRealmName();
         final String authServerUrl = capturedKeycloakUrl + "/realms/" + realmName;
 
@@ -275,10 +285,11 @@ public class KeycloakDevServicesProcessor {
                 capturedDevServicesConfiguration.shared,
                 LaunchMode.current());
 
+        String imageName = capturedDevServicesConfiguration.imageName;
+        DockerImageName dockerImageName = DockerImageName.parse(imageName).asCompatibleSubstituteFor(imageName);
+
         final Supplier<StartResult> defaultKeycloakContainerSupplier = () -> {
-            String imageName = capturedDevServicesConfiguration.imageName;
-            DockerImageName dockerImageName = DockerImageName.parse(imageName)
-                    .asCompatibleSubstituteFor(imageName);
+
             QuarkusOidcContainer oidcContainer = new QuarkusOidcContainer(dockerImageName,
                     capturedDevServicesConfiguration.port,
                     useSharedContainer,
@@ -303,13 +314,20 @@ public class KeycloakDevServicesProcessor {
                             LOG.info("Dev Services for Keycloak shut down.");
                         }
                     },
+                    oidcContainer.keycloakX,
                     false);
         };
 
         return maybeContainerAddress
                 .map(containerAddress -> new StartResult(getSharedContainerUrl(containerAddress), false,
-                        null, null, true))
+                        null, null, isKeycloakX(dockerImageName), true))
                 .orElseGet(defaultKeycloakContainerSupplier);
+    }
+
+    private static boolean isKeycloakX(DockerImageName dockerImageName) {
+        return capturedDevServicesConfiguration.keycloakXImage.isPresent()
+                ? capturedDevServicesConfiguration.keycloakXImage.get()
+                : dockerImageName.getUnversionedPart().contains(KEYCLOAK_X_IMAGE_NAME);
     }
 
     private String getSharedContainerUrl(ContainerAddress containerAddress) {
@@ -322,13 +340,16 @@ public class KeycloakDevServicesProcessor {
         private final boolean createDefaultRealm;
         private String realmNameToUse;
         private final Closeable closeable;
+        private final boolean keycloakX;
         private final boolean shared;
 
-        public StartResult(String url, boolean createDefaultRealm, String realmNameToUse, Closeable closeable, boolean shared) {
+        public StartResult(String url, boolean createDefaultRealm, String realmNameToUse, Closeable closeable,
+                boolean keycloakX, boolean shared) {
             this.url = url;
             this.createDefaultRealm = createDefaultRealm;
             this.realmNameToUse = realmNameToUse;
             this.closeable = closeable;
+            this.keycloakX = keycloakX;
             this.shared = shared;
         }
     }
@@ -344,6 +365,7 @@ public class KeycloakDevServicesProcessor {
         private boolean realmFileExists;
         private String hostName = null;
         private String realmNameToUse;
+        private boolean keycloakX;
 
         public QuarkusOidcContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
                 Optional<String> configuredRealmName, Optional<String> realmPath, String containerLabelValue,
@@ -356,6 +378,7 @@ public class KeycloakDevServicesProcessor {
             this.containerLabelValue = containerLabelValue;
             this.sharedContainer = sharedContainer;
             this.javaOpts = javaOpts;
+            this.keycloakX = isKeycloakX(dockerImageName);
         }
 
         @Override
@@ -380,36 +403,55 @@ public class KeycloakDevServicesProcessor {
                 withLabel(DEV_SERVICE_LABEL, containerLabelValue);
             }
 
-            addEnv(KEYCLOAK_USER_PROP, KEYCLOAK_ADMIN_USER);
-            addEnv(KEYCLOAK_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
-            addEnv(KEYCLOAK_VENDOR_PROP, KEYCLOAK_DB_VENDOR);
             if (javaOpts.isPresent()) {
                 addEnv(JAVA_OPTS, javaOpts.get());
             }
 
+            if (keycloakX) {
+                addEnv(KEYCLOAK_QUARKUS_ADMIN_PROP, KEYCLOAK_ADMIN_USER);
+                addEnv(KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
+                withCommand("--http-enabled=true");
+            } else {
+                addEnv(KEYCLOAK_WILDFLY_USER_PROP, KEYCLOAK_ADMIN_USER);
+                addEnv(KEYCLOAK_WILDFLY_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
+                addEnv(KEYCLOAK_WILDFLY_VENDOR_PROP, KEYCLOAK_WILDFLY_DB_VENDOR);
+            }
+
             if (realmPath.isPresent()) {
-                URL realmPathUrl = null;
-                if ((realmPathUrl = Thread.currentThread().getContextClassLoader().getResource(realmPath.get())) != null) {
-                    realmFileExists = true;
-                    realmNameToUse = configuredRealmName.isPresent() ? null
-                            : getRealmNameFromRealmFile(realmPathUrl, realmPath.get());
-                    withClasspathResourceMapping(realmPath.get(), KEYCLOAK_DOCKER_REALM_PATH, BindMode.READ_ONLY);
-                    addEnv(KEYCLOAK_IMPORT_PROP, KEYCLOAK_DOCKER_REALM_PATH);
+                if (keycloakX) {
+                    LOG.infof("Auto-importing the realm file %s to Keycloak-X is currently not supported."
+                            + " Please select a DevUI 'Keycloak Admin' option, login to Keycloak as 'admin:admin'"
+                            + " and import this realm file", realmPath.get());
                 } else {
-                    Path filePath = Paths.get(realmPath.get());
-                    if (Files.exists(filePath)) {
+                    URL realmPathUrl = null;
+                    if ((realmPathUrl = Thread.currentThread().getContextClassLoader().getResource(realmPath.get())) != null) {
                         realmFileExists = true;
                         realmNameToUse = configuredRealmName.isPresent() ? null
-                                : getRealmNameFromRealmFile(filePath.toUri(), realmPath.get());
-                        withFileSystemBind(realmPath.get(), KEYCLOAK_DOCKER_REALM_PATH, BindMode.READ_ONLY);
-                        addEnv(KEYCLOAK_IMPORT_PROP, KEYCLOAK_DOCKER_REALM_PATH);
+                                : getRealmNameFromRealmFile(realmPathUrl, realmPath.get());
+                        withClasspathResourceMapping(realmPath.get(), KEYCLOAK_DOCKER_REALM_PATH, BindMode.READ_ONLY);
                     } else {
-                        LOG.debugf("Realm %s resource is not available", realmPath.get());
+                        Path filePath = Paths.get(realmPath.get());
+                        if (Files.exists(filePath)) {
+                            realmFileExists = true;
+                            realmNameToUse = configuredRealmName.isPresent() ? null
+                                    : getRealmNameFromRealmFile(filePath.toUri(), realmPath.get());
+                        } else {
+                            LOG.debugf("Realm %s resource is not available", realmPath.get());
+                        }
                     }
                 }
             }
+            if (realmFileExists) {
+                if (keycloakX) {
+                    //It does not work with HTTP at the moment
+                    //withCommand("import --file=" + KEYCLOAK_DOCKER_REALM_PATH);
+                } else {
+                    addEnv(KEYCLOAK_WILDFLY_IMPORT_PROP, KEYCLOAK_DOCKER_REALM_PATH);
+                }
+            }
 
-            super.setWaitStrategy(Wait.forHttp("/auth").forPort(KEYCLOAK_PORT));
+            LOG.infof("Using %s powered Keycloak distribution", keycloakX ? "Quarkus" : "WildFly");
+            super.setWaitStrategy(Wait.forHttp(keycloakX ? "/" : "/auth").forPort(KEYCLOAK_PORT));
         }
 
         private String getRealmNameFromRealmFile(URI uri, String realmPath) {


### PR DESCRIPTION
Fixes #19141

Importing the custom realm files does not work, see also https://keycloak.discourse.group/t/keycloak-x-distribution-import-configuration-issue/8583.

Some properties and endpoint addresses have changed - the final PR would support both WildFly and Quarkus based distributions, there will be some extra property like `quarkus.keycloak.devservices.image-distribution=quarkus` (or `wildfly`) for the dev services processor to set the properties correctly.

CC @pedroigor @stuartwdouglas @phillip-kruger 