### PR TITLE
Make sure super-configuration are used for dependency resolution

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -38,7 +38,7 @@ public class DependencyUtils {
         configurationCopy.getDependencies().addAll(boms);
 
         for (Configuration toDuplicate : toDuplicates) {
-            for (Dependency dependency : toDuplicate.getDependencies()) {
+            for (Dependency dependency : toDuplicate.getAllDependencies()) {
                 if (includedBuild(project, dependency.getName()) != null) {
                     continue;
                 }

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+group = 'com.quarkus.demo'
+version = '1.0'
+
+repositories {
+    mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+
+    implementation 'io.quarkus:quarkus-resteasy'
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+
+    implementation 'org.apache.commons:commons-collections4:4.4'
+    testImplementation 'org.apache.commons:commons-collections4::tests'
+}
+

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'quarkus-configuration-inheritance'
+
+

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,17 @@
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyResolutionTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyResolutionTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+public class DependencyResolutionTest extends QuarkusGradleWrapperTestBase {
+    @Test
+    public void shouldResolveDependencyVersionFromSuperConfigurationProject()
+            throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("configuration-inheritance-project");
+
+        final BuildResult result = runGradleWrapper(projectDir, "clean", "quarkusBuild");
+
+        assertThat(result.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+}


### PR DESCRIPTION
For conditional dependency resolution, we create/copy new configuration based on existing configuration (implementation, testImplementation, ...)

When duplicating configuration we are not loading all dependency of the configuration (a configuration can inherit from an other one). This can lead to resolution error due to missing dependency. This make sure load all dependency from the configuration when duplicating it. 

close #19386