### PR TITLE
OpenAPI: Added AutoTag and Response for Auto Security Requirement

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -65,6 +65,12 @@ public final class SmallRyeOpenApiConfig {
     public boolean autoAddSecurityRequirement;
 
     /**
+     * This will automatically add tags to operations based on the Java class name.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean autoAddTags;
+
+    /**
      * Add a scheme value to the Basic HTTP Security Scheme
      */
     @ConfigItem(defaultValue = "basic")

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoRolesAllowedFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoRolesAllowedFilter.java
@@ -1,0 +1,120 @@
+package io.quarkus.smallrye.openapi.deployment.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.jboss.logging.Logger;
+
+import io.smallrye.openapi.api.models.OperationImpl;
+import io.smallrye.openapi.api.models.responses.APIResponseImpl;
+import io.smallrye.openapi.api.models.security.SecurityRequirementImpl;
+
+/**
+ * Automatically add security requirement to RolesAllowed methods
+ */
+public class AutoRolesAllowedFilter implements OASFilter {
+    private static final Logger log = Logger.getLogger(AutoRolesAllowedFilter.class);
+
+    private Map<String, List<String>> methodReferences;
+    private String defaultSecuritySchemeName;
+
+    public AutoRolesAllowedFilter() {
+
+    }
+
+    public AutoRolesAllowedFilter(String defaultSecuritySchemeName, Map<String, List<String>> methodReferences) {
+        this.defaultSecuritySchemeName = defaultSecuritySchemeName;
+        this.methodReferences = methodReferences;
+    }
+
+    public Map<String, List<String>> getMethodReferences() {
+        return methodReferences;
+    }
+
+    public void setMethodReferences(Map<String, List<String>> methodReferences) {
+        this.methodReferences = methodReferences;
+    }
+
+    public String getDefaultSecuritySchemeName() {
+        return defaultSecuritySchemeName;
+    }
+
+    public void setDefaultSecuritySchemeName(String defaultSecuritySchemeName) {
+        this.defaultSecuritySchemeName = defaultSecuritySchemeName;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+
+        if (!methodReferences.isEmpty()) {
+            String securitySchemeName = getSecuritySchemeName(openAPI);
+            Paths paths = openAPI.getPaths();
+            if (paths != null) {
+                Map<String, PathItem> pathItems = paths.getPathItems();
+                if (pathItems != null && !pathItems.isEmpty()) {
+                    Set<Map.Entry<String, PathItem>> pathItemsEntries = pathItems.entrySet();
+                    for (Map.Entry<String, PathItem> pathItem : pathItemsEntries) {
+                        Map<PathItem.HttpMethod, Operation> operations = pathItem.getValue().getOperations();
+                        if (operations != null && !operations.isEmpty()) {
+
+                            for (Operation operation : operations.values()) {
+
+                                OperationImpl operationImpl = (OperationImpl) operation;
+
+                                if (methodReferences.keySet().contains(operationImpl.getMethodRef())) {
+                                    SecurityRequirement securityRequirement = new SecurityRequirementImpl();
+                                    List<String> roles = methodReferences.get(operationImpl.getMethodRef());
+                                    securityRequirement = securityRequirement.addScheme(securitySchemeName, roles);
+                                    operation = operation.addSecurityRequirement(securityRequirement);
+                                    APIResponses responses = operation.getResponses();
+                                    for (APIResponseImpl response : getSecurityResponses()) {
+                                        responses.addAPIResponse(response.getResponseCode(), response);
+                                    }
+                                    operation = operation.responses(responses);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private String getSecuritySchemeName(OpenAPI openAPI) {
+
+        // Might be set in annotations
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null
+                && !openAPI.getComponents().getSecuritySchemes().isEmpty()) {
+            Map<String, SecurityScheme> securitySchemes = openAPI.getComponents().getSecuritySchemes();
+            return securitySchemes.keySet().iterator().next();
+        }
+        return defaultSecuritySchemeName;
+    }
+
+    private List<APIResponseImpl> getSecurityResponses() {
+        List<APIResponseImpl> responses = new ArrayList<>();
+
+        APIResponseImpl notAuthorized = new APIResponseImpl();
+        notAuthorized.setDescription("Not Authorized");
+        notAuthorized.setResponseCode("401");
+        responses.add(notAuthorized);
+
+        APIResponseImpl forbidden = new APIResponseImpl();
+        forbidden.setDescription("Not Allowed");
+        forbidden.setResponseCode("403");
+        responses.add(forbidden);
+
+        return responses;
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoTagFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoTagFilter.java
@@ -1,0 +1,75 @@
+package io.quarkus.smallrye.openapi.deployment.filter;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.jboss.logging.Logger;
+
+import io.smallrye.openapi.api.models.OperationImpl;
+
+/**
+ * Automatically tag operations based on the class name.
+ */
+public class AutoTagFilter implements OASFilter {
+    private static final Logger log = Logger.getLogger(AutoTagFilter.class);
+
+    private Map<String, String> classNameMap;
+
+    public AutoTagFilter() {
+
+    }
+
+    public AutoTagFilter(Map<String, String> classNameMap) {
+        this.classNameMap = classNameMap;
+    }
+
+    public Map<String, String> getClassNameMap() {
+        return classNameMap;
+    }
+
+    public void setClassNameMap(Map<String, String> classNameMap) {
+        this.classNameMap = classNameMap;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        if (!classNameMap.isEmpty()) {
+            Paths paths = openAPI.getPaths();
+            if (paths != null) {
+                Map<String, PathItem> pathItems = paths.getPathItems();
+                if (pathItems != null && !pathItems.isEmpty()) {
+                    Set<Map.Entry<String, PathItem>> pathItemsEntries = pathItems.entrySet();
+                    for (Map.Entry<String, PathItem> pathItem : pathItemsEntries) {
+                        Map<PathItem.HttpMethod, Operation> operations = pathItem.getValue().getOperations();
+                        if (operations != null && !operations.isEmpty()) {
+                            for (Operation operation : operations.values()) {
+                                if (operation.getTags() == null || operation.getTags().isEmpty()) {
+                                    // Auto add a tag
+                                    OperationImpl operationImpl = (OperationImpl) operation;
+                                    String methodRef = operationImpl.getMethodRef();
+                                    if (classNameMap.containsKey(methodRef)) {
+                                        operation.addTag(splitCamelCase(classNameMap.get(methodRef)));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private String splitCamelCase(String s) {
+        return s.replaceAll(
+                String.format("%s|%s|%s",
+                        "(?<=[A-Z])(?=[A-Z][a-z])",
+                        "(?<=[^A-Z])(?=[A-Z])",
+                        "(?<=[A-Za-z])(?=[^A-Za-z])"),
+                " ");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilter.java
@@ -1,38 +1,28 @@
-package io.quarkus.smallrye.openapi.deployment.security;
+package io.quarkus.smallrye.openapi.deployment.filter;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
-import org.eclipse.microprofile.openapi.models.Operation;
-import org.eclipse.microprofile.openapi.models.PathItem;
-import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
 import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
-import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 import org.jboss.logging.Logger;
 
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
-import io.smallrye.openapi.api.models.OperationImpl;
-import io.smallrye.openapi.api.models.security.SecurityRequirementImpl;
 
 /**
  * Add Basic Security via Config
  */
 public class SecurityConfigFilter implements OASFilter {
-    private static final Logger log = Logger.getLogger("io.quarkus.smallrye.openapi");
+    private static final Logger log = Logger.getLogger(SecurityConfigFilter.class);
 
     private final SmallRyeOpenApiConfig config;
-    private final Map<String, List<String>> methodReferences;
 
-    public SecurityConfigFilter(SmallRyeOpenApiConfig config, Map<String, List<String>> methodReferences) {
+    public SecurityConfigFilter(SmallRyeOpenApiConfig config) {
         this.config = config;
-        this.methodReferences = methodReferences;
     }
 
     @Override
@@ -81,7 +71,7 @@ public class SecurityConfigFilter implements OASFilter {
                         oAuthFlow.authorizationUrl(config.oauth2ImplicitAuthorizationUrl.get());
                     }
                     if (config.oauth2ImplicitRefreshUrl.isPresent()) {
-                        oAuthFlow.authorizationUrl(config.oauth2ImplicitRefreshUrl.get());
+                        oAuthFlow.refreshUrl(config.oauth2ImplicitRefreshUrl.get());
                     }
                     if (config.oauth2ImplicitTokenUrl.isPresent()) {
                         oAuthFlow.tokenUrl(config.oauth2ImplicitTokenUrl.get());
@@ -101,32 +91,6 @@ public class SecurityConfigFilter implements OASFilter {
             if (securitySchemes.size() > 1) {
                 log.warn("Detected multiple Security Schemes, only one scheme is supported at the moment "
                         + securitySchemes.keySet().toString());
-            }
-
-            // Also add Security requirement for all methods annotated with Roles allowed
-            if (config.autoAddSecurityRequirement && !securitySchemes.isEmpty() && !methodReferences.isEmpty()) {
-                Paths paths = openAPI.getPaths();
-                if (paths != null) {
-                    Map<String, PathItem> pathItems = paths.getPathItems();
-                    if (pathItems != null && !pathItems.isEmpty()) {
-                        Set<Map.Entry<String, PathItem>> pathItemsEntries = pathItems.entrySet();
-                        for (Map.Entry<String, PathItem> pathItem : pathItemsEntries) {
-                            Map<PathItem.HttpMethod, Operation> operations = pathItem.getValue().getOperations();
-                            if (operations != null && !operations.isEmpty()) {
-                                for (Operation operation : operations.values()) {
-                                    OperationImpl operationImpl = (OperationImpl) operation;
-                                    if (methodReferences.keySet().contains(operationImpl.getMethodRef())) {
-                                        SecurityRequirement securityRequirement = new SecurityRequirementImpl();
-                                        List<String> roles = methodReferences.get(operationImpl.getMethodRef());
-                                        String name = securitySchemes.keySet().iterator().next();
-                                        securityRequirement = securityRequirement.addScheme(name, roles);
-                                        operation = operation.addSecurityRequirement(securityRequirement);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoTagTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoTagTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoTagTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResourceWithNoTag.class));
+
+    @Test
+    public void testAutoSecurityRequirement() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("paths.'/resource/annotated'.get.tags", Matchers.hasItem("From Annotation"))
+                .and()
+                .body("paths.'/resource/auto'.get.tags", Matchers.hasItem("Open Api Resource With No Tag"))
+                .and()
+                .body("paths.'/resource/auto'.post.tags", Matchers.hasItem("Open Api Resource With No Tag"));
+
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceWithNoTag.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceWithNoTag.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/resource")
+public class OpenApiResourceWithNoTag {
+
+    @GET
+    @Path("/auto")
+    public String auto() {
+        return "by auto tag";
+    }
+
+    @POST
+    @Path("/auto")
+    public String autopost() {
+        return "by auto tag";
+    }
+
+    @GET
+    @Path("/annotated")
+    @Tag(name = "From Annotation")
+    public String annotated() {
+        return "by annotation";
+    }
+
+}

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -25,6 +25,7 @@
                         <test.url>http://localhost:8081</test.url>
                         <!-- Change metrics endpoint to be /metrics -->
                         <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
+                        <quarkus.smallrye-openapi.auto-add-tags>false</quarkus.smallrye-openapi.auto-add-tags>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->


### PR DESCRIPTION
This PR adds a AutoTag filter that will tag an operation with the class name. (if it's not explicitly tagged in annotations) 
It also refactors the Auto Roles Allowed filter into it's own filer (from the SecurityConfig Filter) so it can apply even if security in not added with config.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>