### PR TITLE
ADR: Enable github discussions to enable broader community

### DIFF
--- a/adr/0001-community-discussions.adoc
+++ b/adr/0001-community-discussions.adoc
@@ -1,0 +1,75 @@
+= Setup Quarkus Github Discussions to enable the broader Community
+
+* Status: proposed
+* Date: 2021-06-26
+
+== Context and Problem Statement
+
+Quarkus community is growing and until now we've catered very well for core contributors and initial early consumers. 
+
+We have multiple communication channels: https://github.com/quarkusio/quarkus[issues], https://groups.google.com/g/quarkus-dev?pli=1[quarkus-dev mailing list], https://quarkusio.zulipchat.com[zulip], https://stackoverflow.com/questions/tagged/quarkus[stackoverflow]
+
+Isues are great for bugs/feature work. Mailing list for design conversations between developers, chat for watercooler style discussions and stackoverflow for user questions.
+
+This setup has issues though, some are:
+
+- zulip chat is used for a lot of users questions but none of that is easily searchable/discoverable so it is very synchronous,
+- people reported that they don't feel okey posting on quarkus-dev or zulips as it is seems focused on dev work and not so much about community events, jobs, conferences, etc.
+- its hard to monitor as contributor who wants to help answer/ask questions.
+- Users reported they do not have access to Zulip chat due to corporate or company policies/proxies. They do have access to GitHub.
+
+How can we improve this situaton and enable the broader community to more easily ask questions and find answers - without it all be relying on just a few Quarkus core contributors?
+
+== Scenarios (optional)
+
+User wants to locate a answer to a question - zulip chats does not show up in google search; stackoverflow might but might not have an answer.
+
+Contributor want to arrange or attend an event around Quarkus - where do he post/look for info on that ?
+
+Contributor/committer are trying to follow new questions and issues - what does he need to track to do that ? today it is a lot and it is all different notification sytems and mainly its a big "firehose" with no good ability to filter out what you don't need. 
+
+User looking for a job involving Quarkus - where do he go look ?
+
+
+////
+ as well as a lot of social platform presence https://twitter.com/quarkusio/[twitter], https://www.facebook.com/quarkusio/[facebook], https://www.linkedin.com/groups/13789086/[linkedin], https://www.youtube.com/quarkusio[youtube] and https://www.linkedin.com/groups/13789086/[reddit].
+////
+
+== Considered options
+
+=== quarkusio-community mailing list
+Not proposed since it is just another waterhose of info with no good ability to ignore/consume as needed/wanted.
+
+=== enable discussions on github.com/quarkusio/quarkus-insights
+Considered as quarkus insights is an existing "community" and let us have separate permissons for moderators/triage but some suggested it might be hard to find.
+
+=== enable discussions on github.com/quarkusio/community
+Downside is that labels etc. would need to be kept in sync and that searches in github.com/quarkusio would not show up community/discussions.
+It could show up if searched on github.com/quarkus level though.
+Could be considered as allow us to have separate permissions for moderator/triagers separate from commit access - need to check if https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization[github docs] on permissions levels work for us.
+
+== Decision
+
+Enable GitHub discussions feature on `quarkusio/quarkusio` with the following initial categories:
+
+- Announcements (post only by admins)
+- Introductions (posts by anyone, optional place introduce yourself)
+- Comunity (post by anyone, general discussions)
+- Q&A (post by anyone, Q&A mode enabled)
+- Quarkus Insights Episodes (show notes and offline comments)
+- Events (Setup and announce of interest or other events)
+- Jobs and Opportunities (post by anyone)
+
+Add discussions triage to Quarkus Bot to add a comment/label based on triage rules using `https://docs.github.com/en/graphql/reference/mutations#addlabelstolabelable[addlabelstolabelable]`.
+
+== Consequences
+
+With this the conversation(s) in Quarkus community is no longer only about development on quarkus-dev mailing list nor just by Quarkus core contributors. That should enable broader participation and let Quarkus community grow beyond just "the code".
+
+We do add a Q/A section to this as complementary for Zulip Users and Stackoverflow. Belief is that if we don't it will just naturally happen that people will do it thus best from start have a place to put that. Over time we hopefully shuold see Zulip #users be less active as Zulip chats are non searchable and requires a login to read this is a plus.
+
+Downsides: "Another notification sinkhole"; yes - it is another additional location to keep an eye on but since this is hosted at Github you can use the unified notifcation mechanism and system; especially you can just subscribe or unsubcribe based on  what is best for the invidiual community member. We remedy this by enabling triaging via Quarksu Bot that we can improve over time. Something we can't do with any of the other systems (zulip/stackoverflow).
+
+"Stackoverflow competition"; yes - this will be "competing" with Stackoverflow. This is not trying to "battle" with SO. StackOverflow does work for the casual quarkus user but its quite a manual process to participate as a contributor. What is worse is Zulip #user chats which has high traffic, lots of answers but close to zero discoverability/searching. Quarkus community can better serve each other by being able to have a focused and dedicated area to have a more free Q/A section to replace login-only Zimbra #users and Stackoverflow stays as is and something to keep an eye on.
+
+


### PR DESCRIPTION
This proposal is one I wrote up a while back on how to use github discussions to enable 
broader quarkus community participation. 

We might consider outphasing stackoverflow and add a QA section but for now i'm not proposing 
that but I'm starting to think if we open github discussions thats what users will want to do.

Thus maybe add two categories:

Using Quarkus 
Writing Extensions