### PR TITLE
Ability to configure the registry URL from an env var

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
@@ -270,7 +270,18 @@ public class RegistriesConfigLocator {
 
                 if (isEnvVarOption(var.getKey(), envvarPrefix, "UPDATE_POLICY")) {
                     registry.setUpdatePolicy(var.getValue());
-                    break;
+                } else if (isEnvVarOption(var.getKey(), envvarPrefix, "REPO_URL")) {
+                    JsonRegistryMavenConfig maven = (JsonRegistryMavenConfig) registry.getMaven();
+                    if (maven == null) {
+                        maven = new JsonRegistryMavenConfig();
+                        registry.setMaven(maven);
+                    }
+                    JsonRegistryMavenRepoConfig repository = (JsonRegistryMavenRepoConfig) maven.getRepository();
+                    if (repository == null) {
+                        repository = new JsonRegistryMavenRepoConfig();
+                        maven.setRepository(repository);
+                    }
+                    repository.setUrl(var.getValue());
                 }
             }
         }


### PR DESCRIPTION
This change allows to configure a registry's Maven repo URL in an environment variable. E.g.
````
QUARKUS_REGISTRIES=registry.acme.org,registry.other.io
QUARKUS_REGISTRY_REGISTRY_OTHER_IO_REPO_URL=https://custom.registry.net/mvn
````