### PR TITLE
Properly deprecate quarkus.resteasy.metrics.enabled

### DIFF
--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -147,11 +147,12 @@ public class ResteasyServerCommonProcessor {
          * See <a href=
          * "https://github.com/eclipse/microprofile-metrics/blob/2.3.x/spec/src/main/asciidoc/required-metrics.adoc#optional-rest">MicroProfile
          * Metrics: Optional REST metrics</a>.
-         * <p>
-         * Deprecated. Use {@code quarkus.smallrye-metrics.jaxrs.enabled}.
+         *
+         * @deprecated Use {@code quarkus.smallrye-metrics.jaxrs.enabled} instead.
          */
-        @ConfigItem(name = "metrics.enabled", defaultValue = "false")
-        public boolean metricsEnabled;
+        @Deprecated(forRemoval = true)
+        @ConfigItem(name = "metrics.enabled")
+        public Optional<Boolean> metricsEnabled;
 
         /**
          * Ignore all explicit JAX-RS {@link Application} classes.

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
@@ -32,7 +32,7 @@ public class JaxRsMetricsProcessor {
         SmallRyeMetricsProcessor.SmallRyeMetricsConfig smConfig;
 
         public boolean getAsBoolean() {
-            boolean resteasyConfigEnabled = ConfigProvider.getConfig().getOptionalValue(RESTEASY_CONFIG_PROPERTY, boolean.class)
+            boolean resteasyConfigEnabled = ConfigProvider.getConfig().getOptionalValue(RESTEASY_CONFIG_PROPERTY, Boolean.class)
                     .orElse(false);
             return smConfig.extensionsEnabled && (smConfig.jaxrsEnabled || resteasyConfigEnabled);
         }
@@ -73,7 +73,7 @@ public class JaxRsMetricsProcessor {
     }
 
     private void warnIfDeprecatedResteasyPropertiesPresent() {
-        if (ConfigProvider.getConfig().getOptionalValue(RESTEASY_CONFIG_PROPERTY, boolean.class).isPresent()) {
+        if (ConfigProvider.getConfig().getOptionalValue(RESTEASY_CONFIG_PROPERTY, Boolean.class).isPresent()) {
             SmallRyeMetricsProcessor.LOGGER.warn(
                     "`quarkus.resteasy.metrics.enabled` is deprecated and will be removed in a future version. "
                             + "Use `quarkus.smallrye-metrics.jaxrs.enabled` to enable metrics for REST endpoints "


### PR DESCRIPTION
Fix #19480