### PR TITLE
Normalize the quarkus.http.root-path at config level

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/UriNormalizationUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/UriNormalizationUtil.java
@@ -91,14 +91,18 @@ public class UriNormalizationUtil {
      * </ul>
      *
      * @param base URI to resolve relative paths. Use {@link #toURI(String, boolean)} to construct this parameter.
-     * 
+     *
      * @param segment Relative or absolute path
      * @param trailingSlash true if resulting URI must end with a '/'
      * @throws IllegalArgumentException if the path contains invalid characters or path segments.
      */
     public static URI normalizeWithBase(URI base, String segment, boolean trailingSlash) {
         if (segment == null || segment.trim().isEmpty()) {
-            return base;
+            if ("/".equals(base.getPath())) {
+                return base;
+            }
+            // otherwise, make sure trailingSlash is honored
+            return toURI(base.getPath(), trailingSlash);
         }
         URI segmentUri = toURI(segment, trailingSlash);
         URI resolvedUri = base.resolve(segmentUri);

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/NormalizeRootHttpPathConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/NormalizeRootHttpPathConverter.java
@@ -1,0 +1,40 @@
+package io.quarkus.runtime.configuration;
+
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * A converter to normalize paths that are considered root of something.
+ * <p>
+ * Any path coming out of this converter will have a leading and ending '/'.
+ * <p>
+ * Do NOT use this converter for paths that could be relative.
+ */
+@Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+public class NormalizeRootHttpPathConverter implements Converter<String> {
+
+    private static final String SLASH = "/";
+
+    @Override
+    public String convert(String value) throws IllegalArgumentException, NullPointerException {
+        if (value == null) {
+            return SLASH;
+        }
+
+        value = value.trim();
+        if (SLASH.equals(value)) {
+            return value;
+        }
+        if (!value.startsWith(SLASH)) {
+            value = SLASH + value;
+        }
+        if (!value.endsWith(SLASH)) {
+            value = value + SLASH;
+        }
+
+        return value;
+    }
+}

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyDeploymentBuildItem.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyDeploymentBuildItem.java
@@ -5,12 +5,12 @@ import org.jboss.resteasy.spi.ResteasyDeployment;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class ResteasyDeploymentBuildItem extends SimpleBuildItem {
-    private ResteasyDeployment deployment;
     private String rootPath;
+    private ResteasyDeployment deployment;
 
     public ResteasyDeploymentBuildItem(String rootPath, ResteasyDeployment deployment) {
+        this.rootPath = rootPath.startsWith("/") ? rootPath : "/" + rootPath;
         this.deployment = deployment;
-        this.rootPath = rootPath;
     }
 
     public ResteasyDeployment getDeployment() {

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -77,6 +77,8 @@ import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodParamA
 import io.quarkus.resteasy.server.common.spi.AllowedJaxRsAnnotationPrefixBuildItem;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.NormalizeRootHttpPathConverter;
 
 /**
  * Processor that builds the RESTEasy server configuration.
@@ -135,9 +137,17 @@ public class ResteasyServerCommonProcessor {
 
         /**
          * Set this to override the default path for JAX-RS resources if there are no
-         * annotated application classes.
+         * annotated application classes. This path is specified with a leading {@literal /}, but is resolved relative
+         * to {@literal quarkus.http.root-path}.
+         * <ul>
+         * <li>If {@literal quarkus.http.root-path=/} and {@code quarkus.resteasy.path=/bar}, the JAX-RS resource path will be
+         * {@literal /bar}</li>
+         * <li>If {@literal quarkus.http.root-path=/foo} and {@code quarkus.resteasy.path=/bar}, the JAX-RS resource path will
+         * be {@literal /foo/bar}</li>
+         * </ul>
          */
         @ConfigItem(defaultValue = "/")
+        @ConvertWith(NormalizeRootHttpPathConverter.class)
         String path;
 
         /**

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerConfigBuildItem.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerConfigBuildItem.java
@@ -21,7 +21,7 @@ public final class ResteasyServerConfigBuildItem extends SimpleBuildItem {
      */
     public ResteasyServerConfigBuildItem(String rootPath, String path, Map<String, String> initParameters) {
         this.rootPath = rootPath;
-        this.path = path;
+        this.path = path.startsWith("/") ? path : "/" + path;
         this.initParameters = initParameters;
     }
 

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
@@ -53,9 +53,8 @@ public class ResteasyServletProcessor {
             BuildProducer<io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig,
             HttpRootPathBuildItem httpRootPathBuildItem) {
         if (resteasyServerConfig.isPresent()) {
-            String rp = resteasyServerConfig.get().getRootPath();
-            String rootPath = httpRootPathBuildItem.resolvePath(rp.startsWith("/") ? rp.substring(1) : rp);
-            String defaultPath = httpRootPathBuildItem.resolvePath(resteasyServerConfig.get().getPath());
+            String rootPath = httpRootPathBuildItem.relativePath(resteasyServerConfig.get().getRootPath());
+            String defaultPath = resteasyServerConfig.get().getPath();
 
             deprecatedResteasyJaxrsConfig.produce(new ResteasyJaxrsConfigBuildItem(defaultPath));
             resteasyJaxrsConfig

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -23,9 +23,9 @@ import io.quarkus.resteasy.runtime.standalone.ResteasyStandaloneRecorder;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.DefaultRouteBuildItem;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 import io.vertx.core.Handler;
@@ -50,32 +50,17 @@ public class ResteasyStandaloneBuildStep {
             ResteasyDeploymentBuildItem deployment,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             ResteasyInjectionReadyBuildItem resteasyInjectionReady,
-            HttpBuildTimeConfig httpConfig,
+            HttpRootPathBuildItem httpRootPathBuildItem,
             BuildProducer<ResteasyStandaloneBuildItem> standalone) throws Exception {
         if (capabilities.isPresent(Capability.SERVLET)) {
             return;
         }
 
-        String deploymentRootPath = null;
-        // The context path + the resources path
-        String rootPath = httpConfig.rootPath;
-
         if (deployment != null) {
-            deploymentRootPath = deployment.getRootPath();
-            if (rootPath.endsWith("/")) {
-                if (deploymentRootPath.startsWith("/")) {
-                    rootPath += deploymentRootPath.substring(1);
-                } else {
-                    rootPath += deploymentRootPath;
-                }
-            } else if (!deploymentRootPath.equals("/")) {
-                if (!deploymentRootPath.startsWith("/")) {
-                    rootPath += "/";
-                }
-                rootPath += deploymentRootPath;
-            }
-            recorder.staticInit(deployment.getDeployment(), rootPath);
-            standalone.produce(new ResteasyStandaloneBuildItem(deploymentRootPath));
+            // the deployment path is always relative to the HTTP root path
+            recorder.staticInit(deployment.getDeployment(),
+                    httpRootPathBuildItem.relativePath(deployment.getRootPath()));
+            standalone.produce(new ResteasyStandaloneBuildItem(deployment.getRootPath()));
         }
     }
 

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/ServletConfig.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/ServletConfig.java
@@ -1,22 +1,37 @@
 package io.quarkus.undertow.deployment;
 
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+
 import java.util.Optional;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.ConvertWith;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class ServletConfig {
 
     /**
-     * The context path to serve all Servlet context from. This will also affect any resources
-     * that run as a Servlet, e.g. JAX-RS.
-     *
-     * Note that this is relative to the HTTP root path set in quarkus.http.root-path, so if the context path
-     * is /bar and the http root is /foo then the actual Servlet path will be /foo/bar.
+     * The context path for Servlet content. This will determine the path used to
+     * resolve all Servlet-based resources, including JAX-RS resources - when using the Undertow extension in conjunction with
+     * RESTEasy.
+     * <p>
+     * This path is specified with a leading {@literal /}, but is resolved relative
+     * to {@literal quarkus.http.root-path}.
+     * <ul>
+     * <li>If {@literal quarkus.http.root-path=/} and {@code quarkus.servlet.context-path=/bar}, the servlet path will be
+     * {@literal /bar}</li>
+     * <li>If {@literal quarkus.http.root-path=/foo} and {@code quarkus.servlet.context-path=/bar}, the servlet path will be
+     * {@literal /foo/bar}</li>
+     * </ul>
      */
     @ConfigItem
+    @ConvertWith(ContextPathConverter.class)
     Optional<String> contextPath;
 
     /**
@@ -24,5 +39,34 @@ public class ServletConfig {
      */
     @ConfigItem(defaultValue = "UTF-8")
     public String defaultCharset;
+
+    /**
+     * This converter adds a '/' at the beginning of the context path but does not add one at the end, given we want to support
+     * binding to a context without an ending '/'.
+     * <p>
+     * See ContextPathTestCase for an example.
+     */
+    @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+    public static class ContextPathConverter implements Converter<String> {
+
+        private static final String SLASH = "/";
+
+        @Override
+        public String convert(String value) throws IllegalArgumentException, NullPointerException {
+            if (value == null) {
+                return SLASH;
+            }
+
+            value = value.trim();
+            if (SLASH.equals(value)) {
+                return value;
+            }
+            if (!value.startsWith(SLASH)) {
+                value = SLASH + value;
+            }
+
+            return value;
+        }
+    }
 
 }

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -116,6 +116,7 @@ import io.quarkus.undertow.runtime.ServletSecurityInfoSubstitution;
 import io.quarkus.undertow.runtime.UndertowDeploymentRecorder;
 import io.quarkus.undertow.runtime.UndertowHandlersConfServletExtension;
 import io.quarkus.vertx.http.deployment.DefaultRouteBuildItem;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
@@ -319,11 +320,7 @@ public class UndertowBuildStep {
             WebMetadataBuildItem webMetadataBuildItem) {
         String contextPath;
         if (servletConfig.contextPath.isPresent()) {
-            if (!servletConfig.contextPath.get().startsWith("/")) {
-                contextPath = "/" + servletConfig.contextPath;
-            } else {
-                contextPath = servletConfig.contextPath.get();
-            }
+            contextPath = servletConfig.contextPath.get();
         } else if (webMetadataBuildItem.getWebMetaData().getDefaultContextPath() != null) {
             contextPath = webMetadataBuildItem.getWebMetaData().getDefaultContextPath();
         } else {
@@ -351,6 +348,7 @@ public class UndertowBuildStep {
             ShutdownContextBuildItem shutdownContext,
             KnownPathsBuildItem knownPaths,
             HttpBuildTimeConfig httpBuildTimeConfig,
+            HttpRootPathBuildItem httpRootPath,
             ServletConfig servletConfig) throws Exception {
 
         ObjectSubstitutionBuildItem.Holder holder = new ObjectSubstitutionBuildItem.Holder(ServletSecurityInfo.class,
@@ -365,7 +363,7 @@ public class UndertowBuildStep {
         String contextPath = servletContextPathBuildItem.getServletContextPath();
         RuntimeValue<DeploymentInfo> deployment = recorder.createDeployment("test", knownPaths.knownFiles,
                 knownPaths.knownDirectories,
-                launchMode.getLaunchMode(), shutdownContext, contextPath, httpBuildTimeConfig.rootPath,
+                launchMode.getLaunchMode(), shutdownContext, httpRootPath.relativePath(contextPath),
                 servletConfig.defaultCharset, webMetaData.getRequestCharacterEncoding(),
                 webMetaData.getResponseCharacterEncoding(), httpBuildTimeConfig.auth.proactive,
                 webMetaData.getWelcomeFileList() != null ? webMetaData.getWelcomeFileList().getWelcomeFiles() : null);

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -156,18 +156,9 @@ public class UndertowDeploymentRecorder {
     }
 
     public RuntimeValue<DeploymentInfo> createDeployment(String name, Set<String> knownFile, Set<String> knownDirectories,
-            LaunchMode launchMode, ShutdownContext context, String contextPath, String httpRootPath, String defaultCharset,
+            LaunchMode launchMode, ShutdownContext context, String mountPoint, String defaultCharset,
             String requestCharacterEncoding, String responseCharacterEncoding, boolean proactiveAuth,
             List<String> welcomeFiles) {
-        String realMountPoint;
-        if (contextPath.equals("/")) {
-            realMountPoint = httpRootPath;
-        } else if (httpRootPath.equals("/")) {
-            realMountPoint = contextPath;
-        } else {
-            realMountPoint = httpRootPath + contextPath;
-        }
-
         DeploymentInfo d = new DeploymentInfo();
         d.setDefaultRequestEncoding(requestCharacterEncoding);
         d.setDefaultResponseEncoding(responseCharacterEncoding);
@@ -175,7 +166,7 @@ public class UndertowDeploymentRecorder {
         d.setSessionIdGenerator(new QuarkusSessionIdGenerator());
         d.setClassLoader(getClass().getClassLoader());
         d.setDeploymentName(name);
-        d.setContextPath(realMountPoint);
+        d.setContextPath(mountPoint);
         d.setEagerFilterInit(true);
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
@@ -66,6 +66,33 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
         return UriNormalizationUtil.normalizeWithBase(rootPath, path, false).getPath();
     }
 
+    /**
+     * Resolve path that is always relative into an absolute path.
+     * Whether the path is relative or absolute, it will be resolved against `quarkus.http.root-path`,
+     * by removing the '/' in the latter case.
+     * <p>
+     * Given {@literal quarkus.http.root-path=/}
+     * <ul>
+     * <li>{@code relativePath("foo")} will return {@literal /foo}</li>
+     * <li>{@code relativePath("/foo")} will return {@literal /foo}</li>
+     * </ul>
+     * Given {@literal quarkus.http.root-path=/app}
+     * <ul>
+     * <li>{@code relativePath("foo")} will return {@literal /app/foo}</li>
+     * <li>{@code relativePath("/foo")} will return {@literal /app/foo}</li>
+     * </ul>
+     * <p>
+     * The returned path will not end with a slash.
+     *
+     * @param path Path to be resolved to an absolute path.
+     * @return An absolute path not ending with a slash
+     * @see UriNormalizationUtil#normalizeWithBase(URI, String, boolean)
+     */
+    public String relativePath(String path) {
+        String relativePath = path.startsWith("/") ? path.substring(1) : path;
+        return UriNormalizationUtil.normalizeWithBase(rootPath, relativePath, false).getPath();
+    }
+
     public HttpRootPathBuildItem.Builder routeBuilder() {
         return new HttpRootPathBuildItem.Builder(this);
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -198,6 +198,7 @@ class VertxHttpProcessor {
             LaunchModeBuildItem launchMode,
             List<DefaultRouteBuildItem> defaultRoutes, List<FilterBuildItem> filters,
             VertxWebRouterBuildItem httpRouteRouter,
+            HttpRootPathBuildItem httpRootPathBuildItem,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             HttpBuildTimeConfig httpBuildTimeConfig, HttpConfiguration httpConfiguration,
             List<RequireBodyHandlerBuildItem> requireBodyHandlerBuildItems,
@@ -256,7 +257,8 @@ class VertxHttpProcessor {
 
         recorder.finalizeRouter(beanContainer.getValue(),
                 defaultRoute.map(DefaultRouteBuildItem::getRoute).orElse(null),
-                listOfFilters, vertx.getVertx(), lrc, mainRouter, httpRouteRouter.getHttpRouter(), httpBuildTimeConfig.rootPath,
+                listOfFilters, vertx.getVertx(), lrc, mainRouter, httpRouteRouter.getHttpRouter(),
+                httpRootPathBuildItem.getRootPath(),
                 launchMode.getLaunchMode(),
                 !requireBodyHandlerBuildItems.isEmpty(), bodyHandler, httpConfiguration, gracefulShutdownFilter,
                 shutdownConfig, executorBuildItem.getExecutorProxy());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItemTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItemTest.java
@@ -18,7 +18,7 @@ public class HttpRootPathBuildItemTest {
     void testResolvePathWithSlashApp() {
         HttpRootPathBuildItem buildItem = new HttpRootPathBuildItem("/app");
 
-        Assertions.assertEquals("/app/", buildItem.resolvePath(""));
+        Assertions.assertEquals("/app", buildItem.resolvePath(""));
         Assertions.assertEquals("/app/foo", buildItem.resolvePath("foo"));
         Assertions.assertEquals("/foo", buildItem.resolvePath("/foo"));
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -5,6 +5,8 @@ import java.time.Duration;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.NormalizeRootHttpPathConverter;
 import io.vertx.core.http.ClientAuth;
 
 @ConfigRoot(name = "http", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -14,6 +16,7 @@ public class HttpBuildTimeConfig {
      * The HTTP root path. All web content will be served relative to this root path.
      */
     @ConfigItem(defaultValue = "/")
+    @ConvertWith(NormalizeRootHttpPathConverter.class)
     public String rootPath;
 
     public AuthConfig auth;
@@ -43,7 +46,7 @@ public class HttpBuildTimeConfig {
      * Non-application endpoints will be served from the specified path.
      * * `${quarkus.http.root-path}` -> Setting this path to the same value as HTTP root path disables
      * this root path. All extension-provided endpoints will be served from `${quarkus.http.root-path}`.
-     * 
+     *
      * @asciidoclet
      */
     @ConfigItem(defaultValue = "q")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
@@ -56,7 +56,9 @@ public class StaticResourcesRecorder {
             StaticHandler staticHandler = StaticHandler.create(META_INF_RESOURCES).setDefaultContentEncoding("UTF-8");
             handlers.add(ctx -> {
                 String rel = ctx.mountPoint() == null ? ctx.normalisedPath()
-                        : ctx.normalisedPath().substring(ctx.mountPoint().length());
+                        : ctx.normalisedPath().substring(
+                                // let's be extra careful here in case Vert.x normalizes the mount points at some point
+                                ctx.mountPoint().endsWith("/") ? ctx.mountPoint().length() - 1 : ctx.mountPoint().length());
                 if (knownPaths.contains(rel)) {
                     staticHandler.handle(ctx);
                 } else {


### PR DESCRIPTION
Make sure the quarkus.http.root-path always starts and ends with a '/'
so that we don't have any risk of having logic working with '/test' and
not with '/test/'.

Fixes #19492