### PR TITLE
Move to JLine 3.x to avoid Jansi 1.x dependency/usage

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -503,6 +503,10 @@
                                             <exclude>org.jboss.resteasy:resteasy-context-propagation</exclude>
                                             <exclude>com.google.android:annotations</exclude>
                                             <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
+                                            <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                            to prevent version compatibility issues with the
+                                            Jansi library shipped in Maven -->
+                                            <exclude>jline:jline</exclude>
                                         </excludes>
                                         <includes>
                                             <!-- this is for REST Assured -->

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
@@ -1,8 +1,6 @@
 package io.quarkus.maven.components;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 import org.codehaus.plexus.component.annotations.Component;
 
@@ -17,7 +15,4 @@ public class Prompter extends io.quarkus.devtools.utils.Prompter {
         super();
     }
 
-    public Prompter(InputStream in, OutputStream out) throws IOException {
-        super(in, out);
-    }
 }

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -245,6 +245,10 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                            to prevent version compatibility issues with the
+                                            Jansi library shipped in Maven -->
+                                            <exclude>jline:jline</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -123,6 +123,10 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                            to prevent version compatibility issues with the
+                                            Jansi library shipped in Maven -->
+                                            <exclude>jline:jline</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -173,6 +173,10 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                            to prevent version compatibility issues with the
+                                            Jansi library shipped in Maven -->
+                                            <exclude>jline:jline</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -364,6 +364,10 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                            to prevent version compatibility issues with the
+                                            Jansi library shipped in Maven -->
+                                            <exclude>jline:jline</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <!-- user prompt -->
         <dependency>
-            <groupId>jline</groupId>
+            <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>
         <dependency>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/Prompter.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/Prompter.java
@@ -1,11 +1,12 @@
 package io.quarkus.devtools.utils;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Objects;
-import jline.console.ConsoleReader;
 import org.apache.commons.lang3.StringUtils;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 
 /**
  * Prompt implementation.
@@ -14,22 +15,15 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class Prompter {
 
-    private final ConsoleReader console;
+    private final LineReader lineReader;
 
     public Prompter() throws IOException {
-        this.console = new ConsoleReader();
-        console.setHistoryEnabled(false);
-        console.setExpandEvents(false);
-    }
-
-    public Prompter(InputStream in, OutputStream out) throws IOException {
-        this.console = new ConsoleReader(in, out);
-        console.setHistoryEnabled(false);
-        console.setExpandEvents(false);
-    }
-
-    public ConsoleReader getConsole() {
-        return console;
+        // we set dumb to "true" only to prevent any warning when a proper terminal cannot be detected.
+        // If a proper terminal is detected by JLine then that terminal will be used and setting dumb=true
+        // won't force a dumb terminal.
+        // (https://github.com/jline/jline3/issues/291)
+        final Terminal terminal = TerminalBuilder.builder().dumb(true).build();
+        this.lineReader = LineReaderBuilder.builder().terminal(terminal).build();
     }
 
     public String prompt(final String message, final Character mask) throws IOException {
@@ -38,7 +32,7 @@ public class Prompter {
         final String prompt = String.format("%s: ", message);
         String value;
         do {
-            value = console.readLine(prompt, mask);
+            value = lineReader.readLine(prompt, mask);
         } while (StringUtils.isBlank(value));
         return value;
     }
@@ -53,7 +47,7 @@ public class Prompter {
         Objects.requireNonNull(defaultValue);
 
         final String prompt = String.format("%s [%s]: ", message, defaultValue);
-        String value = console.readLine(prompt);
+        String value = lineReader.readLine(prompt);
         if (StringUtils.isBlank(value)) {
             return defaultValue;
         }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -38,7 +38,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <jline.version>2.14.6</jline.version>
+        <jline.version>3.20.0</jline.version>
         <assertj.version>3.20.2</assertj.version>
         <jackson.version>2.12.4</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
@@ -130,7 +130,7 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>jline</groupId>
+                <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
             </dependency>
@@ -309,6 +309,10 @@
                                         <exclude>org.slf4j:slf4j-jdk14</exclude>
                                         <exclude>org.slf4j:slf4j-log4j12</exclude>
                                         <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                        <!-- JLine 2.x (EOLed) version shouldn't be pulled in,
+                                        to prevent version compatibility issues with the
+                                        Jansi library shipped in Maven -->
+                                        <exclude>jline:jline</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>


### PR DESCRIPTION
Potential fix for https://github.com/quarkusio/quarkus/issues/19491

As noted in that discussion, the JLine 2.x is EOLed and its usage it leading to issues described in that bug.

I've done absolutely zero testing of this change. I have only ensured that the whole build compiles and builds fine. I want to make sure there are no basic issues with this change and see how CI reacts. Tomorrow, I will try and get hold of the Windows box again and see if this fixes that original issue.

In the meantime, there are a couple of things to sort out:

-  I see there's a `CreateProjectMojoIT` testcase in the project. I wonder why it didn't catch this issue on our Windows CI setup
- I see that @gastaldi noted in the issue that he might have a way to get rid of the JLine usage in this code altogether, which I think would be the best/ideal thing. I have no historical knowledge of this code, so if that's possible, then I will close this PR and let's go with @gastaldi's approach. One less library dependency to maintain.