### PR TITLE
Re-enable single parsing of compiler graphs in native-image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -42,7 +42,7 @@ public class NativeConfig {
     /**
      * If {@code -H:+InlineBeforeAnalysis} flag will be added to the native-image run
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "true")
     public boolean inlineBeforeAnalysis;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -14,6 +14,7 @@ final class GraalVM {
         static final Version VERSION_20_3 = new Version("GraalVM 20.3", 20, 3, Distribution.ORACLE);
         static final Version VERSION_21_1 = new Version("GraalVM 21.1", 21, 1, Distribution.ORACLE);
         static final Version VERSION_21_2 = new Version("GraalVM 21.2", 21, 2, Distribution.ORACLE);
+        static final Version VERSION_21_3 = new Version("GraalVM 21.3", 21, 3, Distribution.ORACLE);
 
         static final Version MINIMUM = VERSION_20_3;
         static final Version CURRENT = VERSION_21_2;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -578,7 +578,7 @@ public class NativeImageBuildStep {
                     } else if (prop.getKey().equals("quarkus.native.enable-all-charsets") && prop.getValue() != null) {
                         addAllCharsets |= Boolean.parseBoolean(prop.getValue());
                     } else if (prop.getKey().equals("quarkus.native.inline-before-analysis") && prop.getValue() != null) {
-                        inlineBeforeAnalysis |= Boolean.parseBoolean(prop.getValue());
+                        inlineBeforeAnalysis = Boolean.parseBoolean(prop.getValue());
                     } else {
                         // todo maybe just -D is better than -J-D in this case
                         if (prop.getValue() == null) {
@@ -661,14 +661,14 @@ public class NativeImageBuildStep {
                     // This option was removed in GraalVM 21.1 https://github.com/oracle/graal/pull/3258
                     nativeImageArgs.add("--enable-all-security-services");
                 }
-                if (inlineBeforeAnalysis) {
-                    if (graalVMVersion.isNewerThan(GraalVM.Version.VERSION_20_3)) {
-                        nativeImageArgs.add("-H:+InlineBeforeAnalysis");
+                if (graalVMVersion.isNewerThan(GraalVM.Version.VERSION_20_3)) {
+                    if (inlineBeforeAnalysis) {
+                        if (graalVMVersion.isOlderThan(GraalVM.Version.VERSION_21_3)) {
+                            // Enabled by default in GraalVM >= 21.3
+                            nativeImageArgs.add("-H:+InlineBeforeAnalysis");
+                        }
                     } else {
-                        log.warn(
-                                "The InlineBeforeAnalysis feature is not supported in GraalVM versions prior to 21.0.0."
-                                        + " InlineBeforeAnalysis will thus not be enabled, please consider using a newer"
-                                        + " GraalVM version if your application relies on this feature.");
+                        nativeImageArgs.add("-H:-InlineBeforeAnalysis");
                     }
                 }
                 if (!noPIE.isEmpty()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -713,10 +713,6 @@ public class NativeImageBuildStep {
                 }
 
                 if (graalVMVersion.isNewerThan(GraalVM.Version.VERSION_21_1)) {
-
-                    // Disable single parsing of compiler graphs till https://github.com/oracle/graal/issues/3435 gets fixed
-                    nativeImageArgs.add("-H:-ParseOnce");
-
                     // AdditionalSecurityProviders
                     if (nativeImageSecurityProviders != null && !nativeImageSecurityProviders.isEmpty()) {
                         String additionalSecurityProviders = nativeImageSecurityProviders.stream()

--- a/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/graal/DomHelper.java
+++ b/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/graal/DomHelper.java
@@ -18,6 +18,8 @@ import org.postgresql.util.PSQLState;
 import org.postgresql.xml.DefaultPGXmlFactoryFactory;
 import org.postgresql.xml.PGXmlFactoryFactory;
 
+import com.oracle.svm.core.annotate.NeverInline;
+
 /**
  * Used by PgSQLXML: easier to keep the actual code separated from the substitutions.
  */
@@ -48,10 +50,9 @@ public final class DomHelper {
         }
     }
 
-    //When GraalVM can figure out a constant name for the target method to be invoked reflectively,
-    //it automatically registers it for reflection. We don't want that to happen in this particular case.
+    @NeverInline("Prevent GraalVM from figuring out the target method to be invoked reflectively, so that it can't automatically register it for reflection")
     private static String obfuscatedMethodName() {
-        return "reallyProcessDom" + "Result";
+        return "reallyProcessDomResult";
     }
 
     public static String reallyProcessDomResult(DOMResult domResult, BaseConnection conn) throws SQLException {


### PR DESCRIPTION
GraalVM 21.2-dev introduced a new enhancement (enabled by default) to avoid parsing compiler graphs twice.
This enhancement however resulted in increased memory usage (https://github.com/oracle/graal/issues/3435) which then resulted in Quarkus' Integration Test failures in CI.
In GraalVM 21.2 and 21.3-dev this appears to no longer be an issue.

I have tested this branch with [GraalVM CE](https://github.com/zakkak/quarkus/runs/3371447400?check_suite_focus=true) and [Mandrel](https://github.com/graalvm/mandrel/actions/runs/1146954848) 21.2, as well as with [GraalVM CE](https://github.com/graalvm/mandrel/actions/runs/1147285998) and [Mandrel](https://github.com/graalvm/mandrel/actions/runs/1147027008) 21.3-dev.

Things look good except for `io.quarkus.it.jpa.postgresql.JPAFunctionalityInGraalITCase` which fails when compiled with 21.3-dev with:
```
[ERROR] io.quarkus.it.jpa.postgresql.JPAFunctionalityInGraalITCase.verifyJdkXmlParsersHavebeenEcludedFromNative  Time elapsed: 0.137 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: Type 'javax.xml.transform.TransformerFactory' was found in the report in target/quarkus-integration-test-jpa-postgresql-999-SNAPSHOT-native-image-source-jar/reports/used_classes_quarkus-integration-test-jpa-postgresql-999-SNAPSHOT-runner_20210819_173859.txt
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:117)
	at io.quarkus.test.junit.nativeimage.ClassInclusionReport.assertContainsNot(ClassInclusionReport.java:67)
	at io.quarkus.test.junit.nativeimage.ClassInclusionReport.assertContainsNot(ClassInclusionReport.java:53)
	at io.quarkus.it.jpa.postgresql.JPAFunctionalityInGraalITCase.verifyJdkXmlParsersHavebeenEcludedFromNative(JPAFunctionalityInGraalITCase.java:25)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestMethod(QuarkusTestExtension.java:895)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:210)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:206)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:131)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:65)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:188)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:154)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:128)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
```

~~Keeping this as draft for now.~~

Closes: #19446