### PR TITLE
Update SmallRye Reactive Messaging to 3.9.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.12.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.9.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>3.9.1</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>


### PR DESCRIPTION
Update SmallRye Reactive Messaging to version 3.9.1.

It includes the fix for https://github.com/smallrye/smallrye-reactive-messaging/issues/1363 (https://github.com/smallrye/smallrye-reactive-messaging/pull/1365).
