### PR TITLE
Fix Fault Tolerance in combination with RestClient Reactive

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
@@ -12,7 +12,7 @@ import io.quarkus.gizmo.ClassOutput;
  * The {@link ClassLoader} passed to the constructor MUST contain a public visibleDefineClass method
  * This ensures that generating proxies works in any JDK version
  */
-class InjectIntoClassloaderClassOutput implements ClassOutput {
+public class InjectIntoClassloaderClassOutput implements ClassOutput {
 
     private final ClassLoader classLoader;
 
@@ -41,5 +41,18 @@ class InjectIntoClassloaderClassOutput implements ClassOutput {
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static ClassOutput wrap(ClassOutput delegate) {
+        InjectIntoClassloaderClassOutput injector = new InjectIntoClassloaderClassOutput(
+                Thread.currentThread().getContextClassLoader());
+
+        return new ClassOutput() {
+            @Override
+            public void write(String name, byte[] data) {
+                delegate.write(name, data);
+                injector.write(name, data);
+            }
+        };
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -62,6 +62,7 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.proxy.InjectIntoClassloaderClassOutput;
 import io.quarkus.deployment.util.AsmUtil;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
@@ -337,7 +338,7 @@ class RestClientReactiveProcessor {
                 String wrapperClassName = jaxrsInterface.name().toString() + CDI_WRAPPER_SUFFIX;
                 try (ClassCreator classCreator = ClassCreator.builder()
                         .className(wrapperClassName)
-                        .classOutput(new GeneratedBeanGizmoAdaptor(generatedBeans))
+                        .classOutput(InjectIntoClassloaderClassOutput.wrap(new GeneratedBeanGizmoAdaptor(generatedBeans)))
                         .interfaces(jaxrsInterface.name().toString())
                         .superClass(RestClientReactiveCDIWrapperBase.class)
                         .build()) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/AsyncRestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/AsyncRestClientFallbackTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AsyncRestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() throws ExecutionException, InterruptedException {
+        assertEquals("pong", client.ping().toCompletableFuture().get());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Asynchronous
+        @Fallback(MyFallback.class)
+        CompletionStage<String> ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<CompletionStage<String>> {
+        @Override
+        public CompletionStage<String> handle(ExecutionContext context) {
+            return completedFuture("pong");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/RestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/RestClientFallbackTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() {
+        assertEquals("pong", client.ping());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Fallback(MyFallback.class)
+        String ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<String> {
+        @Override
+        public String handle(ExecutionContext context) {
+            return "pong";
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/UniRestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/UniRestClientFallbackTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class UniRestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() {
+        assertEquals("pong", client.ping().await().indefinitely());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Fallback(MyFallback.class)
+        Uni<String> ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<Uni<String>> {
+        @Override
+        public Uni<String> handle(ExecutionContext context) {
+            return Uni.createFrom().item("pong");
+        }
+    }
+}


### PR DESCRIPTION
The fault tolerance extension loads bean classes from the deployment
classloader during fault tolerance discovery. The classes, as well as
discovered fault tolerance annotations, are transferred to runtime,
where SmallRye Fault Tolerance applies runtime configuration.

This works fine, unless one of the bean classes is generated
by another Quarkus extension. These generated classes are stored
in memory and the deployment classloader doesn't know about them.
Naturally, loading the class fails and aborts the build.

The specific problem found was in combination of Fault Tolerance
and RestClient Reactive. This commit makes sure that the RestClient
generated classes are known to the deployment classloader, but
it seems fairly obvious that this is a hacky one-off fix and
not a proper solution. I still find it worth sharing :-)