### PR TITLE
Remove test @Tag(failsOnJDK16)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1143,16 +1143,5 @@
             </properties>
         </profile>
 
-        <profile>
-            <id>jdk16-workarounds</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <properties>
-                <!-- auto-exclude tests that are known to fail on JDK 16 (tagged via @Tag("failsOnJDK16")) -->
-                <excludedGroups>failsOnJDK16</excludedGroups>
-            </properties>
-        </profile>
-
     </profiles>
 </project>

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartBuildIT.java
@@ -75,7 +75,6 @@ class QuarkusCodestartBuildIT extends PlatformAwareTestBase {
 
     @ParameterizedTest
     @MethodSource("provideLanguages")
-    @org.junit.jupiter.api.Tag("failsOnJDK16")
     public void testGradleKotlinDSL(String language) throws Exception {
         final List<String> codestarts = getExtensionCodestarts();
         generateProjectRunTests("gradle-kotlin-dsl", language, codestarts);

--- a/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
+++ b/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -56,7 +55,6 @@ public class KotlinDevModeIT extends RunAndCheckMojoTestBase {
     }
 
     @Test
-    @Tag("failsOnJDK16")
     public void testThatTheApplicationIsReloadedOnKotlinChangeWithCustomCompilerArgs()
             throws MavenInvocationException, IOException {
         testDir = initProject("projects/kotlin-compiler-args", "projects/kotlin-compiler-args-change");


### PR DESCRIPTION
These are the last remaining two tests that had to be excluded with that tag. Locally everything is fine but I got mixed results from CI in my fork. Let's see what CI is saying here.

FTR, for Java 16 we still have one unresolved problem (and hence one remaining `jdk16-workarounds` profile): #17093

And of course we still have to exclude kapt and dokka on Java 16+.