### PR TITLE
Use MultivaluedHashMap in examples

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -517,9 +517,9 @@ And the `RequestUUIDHeaderFactory` would look like:
 package org.acme.rest.client;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.UUID;
 
@@ -528,7 +528,7 @@ public class RequestUUIDHeaderFactory implements ClientHeadersFactory {
 
     @Override
     public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders, MultivaluedMap<String, String> clientOutgoingHeaders) {
-        MultivaluedMap<String, String> result = new MultivaluedMapImpl<>();
+        MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
         result.add("X-request-uuid", UUID.randomUUID().toString());
         return result;
     }

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -537,9 +537,9 @@ And the `RequestUUIDHeaderFactory` would look like:
 package org.acme.rest.client;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.UUID;
 
@@ -548,7 +548,7 @@ public class RequestUUIDHeaderFactory implements ClientHeadersFactory {
 
     @Override
     public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders, MultivaluedMap<String, String> clientOutgoingHeaders) {
-        MultivaluedMap<String, String> result = new MultivaluedMapImpl<>();
+        MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
         result.add("X-request-uuid", UUID.randomUUID().toString());
         return result;
     }

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
@@ -6,11 +6,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.ext.RuntimeDelegate;
 
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
@@ -38,7 +38,7 @@ public class VertxHttpResponse implements HttpResponse {
     public VertxHttpResponse(HttpServerRequest request, ResteasyProviderFactory providerFactory,
             final HttpMethod method, BufferAllocator allocator, VertxOutput output, RoutingContext routingContext) {
         this.routingContext = routingContext;
-        outputHeaders = new MultivaluedMapImpl<String, Object>();
+        outputHeaders = new MultivaluedHashMap<String, Object>();
         this.method = method;
         os = (method == null || !method.equals(HttpMethod.HEAD)) ? new VertxOutputStream(this, allocator)
                 : null;


### PR DESCRIPTION
The documentation for adding headers for the reactive client doesn't compile:

https://quarkus.io/version/main/guides/rest-client-reactive#custom-headers-support

since `MultivaluedMapImpl` is part of `resteasy-core` which is not a dependency of `quarkus-rest-client-reactive`.

From what I understand the "standard" non reactive client example compiles because `resteasy-core` is a dependency of `quarkus-resteasy-common` which is a dependency of `quarkus-rest-client`.

I've changed all `MultivaluedMapImpl` for consistency, let me know if only fixing the reactive case is preferred.
