### PR TITLE
Ability to initialize Maven repos from env vars

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-depchain</artifactId>
             <type>pom</type>

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/ReposInitializedFromEnvVarsTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/ReposInitializedFromEnvVarsTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.jupiter.api.Test;
+
+public class ReposInitializedFromEnvVarsTest {
+
+    @Test
+    void initFromEnvVars() throws Exception {
+
+        final Map<String, String> env = new HashMap<>();
+        env.put(BootstrapMavenContext.BOOTSTRAP_MAVEN_REPOS, "example-repo,other-snapshot");
+        env.put(BootstrapMavenContext.BOOTSTRAP_MAVEN_REPO_PREFIX + "EXAMPLE_REPO_URL", "https://example-repo.org/maven");
+        env.put(BootstrapMavenContext.BOOTSTRAP_MAVEN_REPO_PREFIX + "EXAMPLE_REPO_SNAPSHOT", "false");
+        env.put(BootstrapMavenContext.BOOTSTRAP_MAVEN_REPO_PREFIX + "OTHER_SNAPSHOT_URL", "https://other.org/maven/snapshots");
+        env.put(BootstrapMavenContext.BOOTSTRAP_MAVEN_REPO_PREFIX + "OTHER_SNAPSHOT_RELEASE", "false");
+
+        final List<RemoteRepository> repos = new ArrayList<>();
+        BootstrapMavenContext.readMavenReposFromEnv(repos, env);
+
+        assertThat(repos.size()).isEqualTo(2);
+
+        RemoteRepository r = repos.get(0);
+        assertThat(r).isNotNull();
+        assertThat(r.getId()).isEqualTo("example-repo");
+        assertThat(r.getUrl()).isEqualTo("https://example-repo.org/maven");
+        assertThat(r.getPolicy(false).isEnabled()).isTrue();
+        assertThat(r.getPolicy(true).isEnabled()).isFalse();
+
+        r = repos.get(1);
+        assertThat(r).isNotNull();
+        assertThat(r.getId()).isEqualTo("other-snapshot");
+        assertThat(r.getUrl()).isEqualTo("https://other.org/maven/snapshots");
+        assertThat(r.getPolicy(false).isEnabled()).isFalse();
+        assertThat(r.getPolicy(true).isEnabled()).isTrue();
+    }
+}

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -26,6 +26,8 @@
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+
+        <assertj.version>3.20.2</assertj.version>
     </properties>
     <modules>
         <module>bom</module>
@@ -36,6 +38,15 @@
         <module>runner</module>
         <module>gradle-resolver</module>
     </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
This change allows to initialize the Quarkus Maven resolver with repositories configured in environment variables. E.g.
````
export BOOTSTRAP_MAVEN_REPOS=example-repo,other-repo
export BOOTSTRAP_MAVEN_REPO_EXAMPLE_REPO_URL=https://example.com/maven2
export BOOTSTRAP_MAVEN_REPO_EXAMPLE_REPO_SNAPSHOT=false
export BOOTSTRAP_MAVEN_REPO_OTHER_REPO_URL=https://other.org/maven
````