### PR TITLE
Bump ANTLR from 4.8 to 4.9.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <mockito.version>3.11.2</mockito.version>
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
-        <antlr.version>4.8</antlr.version>
+        <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
         <keycloak.version>14.0.0</keycloak.version>
         <logstash-gelf.version>1.14.1</logstash-gelf.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,7 +75,7 @@
         <microprofile-graphql-api.version>1.1.0</microprofile-graphql-api.version>
 
         <!-- Antlr is used by the PanacheQL parser-->
-        <antlr.version>4.8</antlr.version>
+        <antlr.version>4.9.2</antlr.version>
 
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>7.10.0</elasticsearch-server.version>


### PR DESCRIPTION
This removes warnings like:
```
ANTLR Runtime version 4.9.2 used for parser compilation does not match the current runtime version 4.8
```

AFAICS, the only one complaining now (in the reverse way) is GraphQL:
```
[INFO] Running io.quarkus.vertx.graphql.it.VertxGraphqlTest
ANTLR Tool version 4.8 used for code generation does not match the current runtime version 4.9.2
2021-08-20 15:17:57,694 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT on JVM started in 4.257s. Listening on: http://localhost:8081
ANTLR Runtime version 4.8 used for parser compilation does not match the current runtime version 4.9.2
2021-08-20 15:17:57,696 INFO  [io.quarkus] (main) Profile test activated. 
ANTLR Tool version 4.8 used for code generation does not match the current runtime version 4.9.2
2021-08-20 15:17:57,696 INFO  [io.quarkus] (main) Installed features: [cdi, smallrye-context-propagation, vertx-graphql]
ANTLR Runtime version 4.8 used for parser compilation does not match the current runtime version 4.9.2
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.792 s - in io.quarkus.vertx.graphql.it.VertxGraphqlTest
2021-08-20 15:18:00,403 INFO  [io.quarkus] (main) Quarkus stopped in 0.022s
```
But seeing how little was changed in GraphQL 17.0 to use ANTLR 4.9.2, I'd say it should be ok: https://github.com/graphql-java/graphql-java/pull/2323

Ideally, GraphQL should be updated in vertx-web-graphql and then updated in Quarkus.