### PR TITLE
Allow use of PEM certificates in Kafka Streams extension

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -275,26 +275,26 @@ public class KafkaStreamsProducer {
 
     private static void setTrustStoreConfig(TrustStoreConfig tsc, Properties properties) {
         if (tsc != null) {
-            setProperty(tsc.type, properties, "ssl.truststore.type");
-            setProperty(tsc.location, properties, "ssl.truststore.location");
-            setProperty(tsc.password, properties, "ssl.truststore.password");
-            setProperty(tsc.certificates, properties, "ssl.truststore.certificates");
+            setProperty(tsc.type, properties, SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
+            setProperty(tsc.location, properties, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+            setProperty(tsc.password, properties, SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+            setProperty(tsc.certificates, properties, SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
         }
     }
 
     private static void setKeyStoreConfig(KeyStoreConfig ksc, Properties properties) {
         if (ksc != null) {
-            setProperty(ksc.type, properties, "ssl.keystore.type");
-            setProperty(ksc.location, properties, "ssl.keystore.location");
-            setProperty(ksc.password, properties, "ssl.keystore.password");
-            setProperty(ksc.key, properties, "ssl.keystore.key");
-            setProperty(ksc.certificateChain, properties, "ssl.keystore.certificate.chain");
+            setProperty(ksc.type, properties, SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
+            setProperty(ksc.location, properties, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            setProperty(ksc.password, properties, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+            setProperty(ksc.key, properties, SslConfigs.SSL_KEYSTORE_KEY_CONFIG);
+            setProperty(ksc.certificateChain, properties, SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG);
         }
     }
 
     private static void setKeyConfig(KeyConfig kc, Properties properties) {
         if (kc != null) {
-            setProperty(kc.password, properties, "ssl.key.password");
+            setProperty(kc.password, properties, SslConfigs.SSL_KEY_PASSWORD_CONFIG);
         }
     }
 

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -259,9 +259,9 @@ public class KafkaStreamsProducer {
             setProperty(ssl.cipherSuites, streamsProperties, SslConfigs.SSL_CIPHER_SUITES_CONFIG);
             setProperty(ssl.enabledProtocols, streamsProperties, SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG);
 
-            setStoreConfig(ssl.truststore, streamsProperties, "ssl.truststore");
-            setStoreConfig(ssl.keystore, streamsProperties, "ssl.keystore");
-            setStoreConfig(ssl.key, streamsProperties, "ssl.key");
+            setTrustStoreConfig(ssl.truststore, streamsProperties);
+            setKeyStoreConfig(ssl.keystore, streamsProperties);
+            setKeyConfig(ssl.key, streamsProperties);
 
             setProperty(ssl.keymanagerAlgorithm, streamsProperties, SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG);
             setProperty(ssl.trustmanagerAlgorithm, streamsProperties, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
@@ -273,11 +273,28 @@ public class KafkaStreamsProducer {
         return streamsProperties;
     }
 
-    private static void setStoreConfig(StoreConfig sc, Properties properties, String key) {
-        if (sc != null) {
-            setProperty(sc.type, properties, key + ".type");
-            setProperty(sc.location, properties, key + ".location");
-            setProperty(sc.password, properties, key + ".password");
+    private static void setTrustStoreConfig(TrustStoreConfig tsc, Properties properties) {
+        if (tsc != null) {
+            setProperty(tsc.type, properties, "ssl.truststore.type");
+            setProperty(tsc.location, properties, "ssl.truststore.location");
+            setProperty(tsc.password, properties, "ssl.truststore.password");
+            setProperty(tsc.certificates, properties, "ssl.truststore.certificates");
+        }
+    }
+
+    private static void setKeyStoreConfig(KeyStoreConfig ksc, Properties properties) {
+        if (ksc != null) {
+            setProperty(ksc.type, properties, "ssl.keystore.type");
+            setProperty(ksc.location, properties, "ssl.keystore.location");
+            setProperty(ksc.password, properties, "ssl.keystore.password");
+            setProperty(ksc.key, properties, "ssl.keystore.key");
+            setProperty(ksc.certificateChain, properties, "ssl.keystore.certificate.chain");
+        }
+    }
+
+    private static void setKeyConfig(KeyConfig kc, Properties properties) {
+        if (kc != null) {
+            setProperty(kc.password, properties, "ssl.key.password");
         }
     }
 

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KeyConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KeyConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.kafka.streams.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class KeyConfig {
+    /**
+     * Password of the private key in the key store
+     */
+    @ConfigItem
+    public Optional<String> password;
+}

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KeyStoreConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KeyStoreConfig.java
@@ -6,22 +6,34 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class StoreConfig {
+public class KeyStoreConfig {
     /**
-     * Store type
+     * Key store type
      */
     @ConfigItem
     public Optional<String> type;
 
     /**
-     * Store location
+     * Key store location
      */
     @ConfigItem
     public Optional<String> location;
 
     /**
-     * Store password
+     * Key store password
      */
     @ConfigItem
     public Optional<String> password;
+
+    /**
+     * Key store private key
+     */
+    @ConfigItem
+    public Optional<String> key;
+
+    /**
+     * Key store certificate chain
+     */
+    @ConfigItem
+    public Optional<String> certificateChain;
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/SslConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/SslConfig.java
@@ -35,17 +35,17 @@ public class SslConfig {
     /**
      * Truststore config
      */
-    public StoreConfig truststore;
+    public TrustStoreConfig truststore;
 
     /**
      * Keystore config
      */
-    public StoreConfig keystore;
+    public KeyStoreConfig keystore;
 
     /**
      * Key config
      */
-    public StoreConfig key;
+    public KeyConfig key;
 
     /**
      * The algorithm used by key manager factory for SSL connections

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/TrustStoreConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/TrustStoreConfig.java
@@ -1,0 +1,33 @@
+package io.quarkus.kafka.streams.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class TrustStoreConfig {
+    /**
+     * Trust store type
+     */
+    @ConfigItem
+    public Optional<String> type;
+
+    /**
+     * Trust store location
+     */
+    @ConfigItem
+    public Optional<String> location;
+
+    /**
+     * Trust store password
+     */
+    @ConfigItem
+    public Optional<String> password;
+
+    /**
+     * Trust store certificates
+     */
+    @ConfigItem
+    public Optional<String> certificates;
+}


### PR DESCRIPTION
The Kafka Streams extension supports to configure some of the SSL properties at runtime. However, it does not match all the options in latest Kafka Streams API version. In particular the options which can be used for using PEM certificates are missing:
* The `ssl.truststore.certificates` option
* The `ssl.keystore.certificate.chain` and `ssl.keystore.key` options

Using PEM certificates directly is handy, especially in environments such as Kubernetes, where PEM certificates are (unlike PKCS or JKS certificate stores) much more common. This PR adds the missing options so that they can be configured at runtime and used.

In addition to this, the `ssl.key.*` supports some options which do not exist in Kafka - `ssl.key.location` and `ssl.key.type`. This PR removes them.
