### PR TITLE
Re-enable remaining excluded Timeout* tests in microprofile-rest-client TCK for Java 16+

### DIFF
--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -185,15 +185,44 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- the following tests fail for yet unknown reasons (assertion failures) -->
-                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest</exclude>
-                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest</exclude>
-                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest</exclude>
-                                <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest</exclude>
-                            </excludes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <!-- the following tests are run in a separate surefire execution
+                                        by setting certain JDK system properties during launch -->
+                                        <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest</exclude>
+                                        <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest</exclude>
+                                        <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest</exclude>
+                                        <exclude>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jdk16-plain-socket-workaround</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <!-- Temporary workaround to prevent org.eclipse.microprofile.rest.client.tck.timeout.Timeout* tests
+                                        from failing because of a different exception type being thrown in Java 13+
+                                        during socket connections -->
+                                        <jdk.net.usePlainSocketImpl>true</jdk.net.usePlainSocketImpl>
+                                    </systemPropertyVariables>
+                                    <includes>
+                                        <include>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest</include>
+                                        <include>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest</include>
+                                        <include>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest</include>
+                                        <include>org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/17093

JDK 13+ re-implemented the internal implementation details of the `Socket` API as part of https://openjdk.java.net/jeps/353. This implementation change now leads to `java.net.NoRouteToHostException` instead of the `java.net.ConnectException` in previous Java versions.

These specific TCK tests which are failing in Java 16+, are intentionally trying to connect to a host/port combination that isn't accessible (`http://microprofile.io:1234/null`)[1].  In the RestEasy client implementation, Apache HTTP client (4.5.x) gets used and that is the library which deals with socket connections. One part of that code deals with HTTP request retries[2]. This `DefaultHttpRequestRetryHandler` in the Apache HTTP client library has a logic which decides if a particular exception during the HTTP request handling needs to be retried. As can be seen in [2], it does _not_ retry for a specific set of exception types. `java.net.ConnectException` is one such exception type where it does _not_ retry. Since until Java 13, this is the exception that gets thrown for `Socket.connect(...)` calls against this specific URL, those failures aren't retried and the tests complete in a timely fashion. However, in Java 16, since a `java.net.NoRouteToHostException` gets thrown in this flow and since that exception type isn't marked as "do not retry exception type", this retry handler initiates a retry of this HTTP request. This it does for 3 times (from what I can see in the logs/code). As a result, this leads to an increased "wait time" (due to the wait time for each of the 3 attempts as against just 1 attempt) and the test goes past the expected timeout. 

The OpenJDK team, as noted in the JEP as well as the release notes[3], states that efforts have been made to keep this change backward compatible as much as possible, but there are chances that a different type of `SocketException` might now get thrown. Do note that the new `java.net.NoRouteToHostException` that is now getting thrown is still a `IOException` (and `SocketException`), so it isn't breaking any API contract defined by the `Socket.connect(...)` javadoc. I'll bring this up separately with the OpenJDK team to see if they want to continue this changed expection type behaviour. Until then, this commit uses the `jdk.net.usePlainSocketImpl=true` system property as recommended in [3] to use the old implementation of the Socket API. That should help us have these tests running against Java 16+.

In any case, this workaround shouldn't stay for too long, since the real fix/change will either be in JDK itself or in the Apache HTTP client library which needs to decide how it wants to address this change.

[1] https://github.com/eclipse/microprofile-rest-client/blob/master/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTestBase.java#L41
[2] https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.java#L102
[3] https://bugs.openjdk.java.net/browse/JDK-8223354