### PR TITLE
Add @Incomings support to the reactive messaging extension

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/IncomingsTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/IncomingsTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.smallrye.reactivemessaging.signatures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class IncomingsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProducerOnA.class, ProducerOnB.class, MyBeanUsingMultipleIncomings.class));
+
+    @Inject
+    MyBeanUsingMultipleIncomings bean;
+
+    @Test
+    public void testIncomingsWithTwoSources() {
+        await().until(() -> bean.list().size() == 6);
+        assertThat(bean.list()).containsSubsequence("a", "b", "c");
+        assertThat(bean.list()).containsSubsequence("d", "e", "f");
+    }
+
+    @ApplicationScoped
+    public static class ProducerOnA {
+
+        @Outgoing("a")
+        public Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProducerOnB {
+
+        @Outgoing("b")
+        public Publisher<String> produce() {
+            return Multi.createFrom().items("d", "e", "f");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBeanUsingMultipleIncomings {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("a")
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
@@ -212,7 +212,7 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
 
     @Override
     public String methodAsString() {
-        if (Arc.container() != null) {
+        if (Arc.container() != null && getBean() != null) {
             return getBean().getBeanClass().getName() + "#" + getMethodName();
         } else {
             return getMethodName();


### PR DESCRIPTION
The reactive messaging extension has its own customized configuration layer to configure reactive messaging to use the Quarkus built time mechanism. This layer didn't support @Incomings.
This PR adds support for it.

Fix #19562
