### PR TITLE
Fix RR bug introduced in the last race fix

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
@@ -58,7 +58,7 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
             ExecutorService executor = Executors.newSingleThreadExecutor();
             executor.submit(() -> {
                 try {
-                    Thread.sleep(2000);
+                    Thread.sleep(300);
                 } catch (InterruptedException e) {
                     LOG.debug("Error:", e);
                 }


### PR DESCRIPTION
A return was missing that mean't that it would continue to execute the
handler chain on abort.

Also prevent close() being called twice and reduce the wait time for the
tests to speed up execution.