### PR TITLE
RestEasy Reactive: don't bail out from scanning on no @Path annotations

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.rest.client.reactive;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoPathInTheAppTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PlaylistService.class));
+
+    private WireMockServer server;
+
+    @BeforeEach
+    public void setUp() {
+        server = new WireMockServer(8181);
+        server.stubFor(WireMock.get("/hello")
+                .willReturn(aResponse().withBody("hello, world!").withStatus(200)));
+        server.start();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        server.shutdown();
+    }
+
+    @Test
+    void shouldGet() {
+        PlaylistService client = RestClientBuilder.newBuilder().baseUri(URI.create("http://localhost:8181/hello"))
+                .build(PlaylistService.class);
+        assertThat(client.get()).isEqualTo("hello, world!");
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/PlaylistService.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/PlaylistService.java
@@ -1,0 +1,9 @@
+package io.quarkus.rest.client.reactive;
+
+import javax.ws.rs.GET;
+
+public interface PlaylistService {
+
+    @GET
+    String get();
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientProxies.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientProxies.java
@@ -23,7 +23,9 @@ public class ClientProxies {
                 throw new InvalidRestClientDefinitionException(
                         "Failed to generate client for class " + clazz + " : " + failure);
             } else {
-                throw new IllegalArgumentException("Not a REST client interface: " + clazz);
+                throw new IllegalArgumentException("Not a REST client interface: " + clazz + ". No @Path annotation " +
+                        "found on the class or any methods of the interface and no HTTP method annotations " +
+                        "(@POST, @PUT, @GET, @HEAD, @DELETE, etc) found on any of the methods");
             }
         }
         //noinspection unchecked

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -122,11 +122,6 @@ public class ResteasyReactiveScanner {
 
         Collection<AnnotationInstance> allPaths = new ArrayList<>(paths);
 
-        if (allPaths.isEmpty()) {
-            // no detected @Path, bail out
-            return null;
-        }
-
         Map<DotName, ClassInfo> scannedResources = new HashMap<>();
         Map<DotName, String> scannedResourcePaths = new HashMap<>();
         Map<DotName, ClassInfo> possibleSubResources = new HashMap<>();


### PR DESCRIPTION
fixes #19556