### PR TITLE
Remove stacktraces from exceptions thrown deliberately in RESTEasy Reactive tests

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/ExceptionUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/ExceptionUtil.java
@@ -1,0 +1,14 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+public final class ExceptionUtil {
+
+    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+
+    private ExceptionUtil() {
+    }
+
+    public static <T extends Throwable> T removeStackTrace(T t) {
+        t.setStackTrace(EMPTY_STACK_TRACE);
+        return t;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/CustomExceptionMappersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/CustomExceptionMappersTest.java
@@ -8,6 +8,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -22,7 +23,7 @@ public class CustomExceptionMappersTest {
                             .addClasses(FirstResource.class, SecondResource.class,
                                     MyException.class, MyOtherException.class, UniException.class, ExtendsUniException.class,
                                     MyOtherExceptionMapper.class, UniExceptionMapper.class,
-                                    SomeBean.class);
+                                    SomeBean.class, ExceptionUtil.class);
                 }
             });
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/FirstResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/FirstResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.test.customexceptions;
 
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -23,17 +25,17 @@ public class FirstResource {
     @Produces("text/plain")
     public String throwsVariousExceptions(@RestQuery String name) {
         if (name.startsWith("IllegalArgument")) {
-            throw new IllegalArgumentException();
+            throw removeStackTrace(new IllegalArgumentException());
         } else if (name.startsWith("IllegalState")) {
-            throw new IllegalStateException("IllegalState");
+            throw removeStackTrace(new IllegalStateException("IllegalState"));
         } else if (name.startsWith("MyOther")) {
-            throw new MyOtherException();
+            throw removeStackTrace(new MyOtherException());
         } else if (name.startsWith("My")) {
-            throw new MyException();
+            throw removeStackTrace(new MyException());
         } else if (name.startsWith("Uni")) {
-            throw new UniException();
+            throw removeStackTrace(new UniException());
         }
-        throw new RuntimeException();
+        throw removeStackTrace(new RuntimeException());
     }
 
     @GET
@@ -52,7 +54,7 @@ public class FirstResource {
         } else if (name.startsWith("Uni")) {
             e = new UniException();
         }
-        return Uni.createFrom().failure(e);
+        return Uni.createFrom().failure(removeStackTrace(e));
     }
 
     @ServerExceptionMapper({ IllegalStateException.class, IllegalArgumentException.class })

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/GlobalThrowableExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/GlobalThrowableExceptionMapperTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.test.customexceptions;
 
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.*;
+
 import java.util.function.Supplier;
 
 import javax.ws.rs.GET;
@@ -40,7 +42,7 @@ public class GlobalThrowableExceptionMapperTest {
         @Path("throwable")
         @Produces("text/plain")
         public String throwsThrowable() throws Throwable {
-            throw new Throwable();
+            throw removeStackTrace(new Throwable());
         }
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/PerClassThrowableExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/PerClassThrowableExceptionMapperTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.test.customexceptions;
 
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+
 import java.util.function.Supplier;
 
 import javax.ws.rs.GET;
@@ -49,7 +51,7 @@ public class PerClassThrowableExceptionMapperTest {
         @Path("throwable")
         @Produces("text/plain")
         public String throwsThrowable() throws Throwable {
-            throw new Throwable();
+            throw removeStackTrace(new Throwable());
         }
     }
 
@@ -60,7 +62,7 @@ public class PerClassThrowableExceptionMapperTest {
         @Path("throwable")
         @Produces("text/plain")
         public String throwsThrowable() throws Throwable {
-            throw new Throwable();
+            throw removeStackTrace(new Throwable());
         }
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SecondResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SecondResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.test.customexceptions;
 
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -10,27 +12,27 @@ public class SecondResource {
     @GET
     @Produces("text/plain")
     public String throwsMyException() {
-        throw new MyException();
+        throw removeStackTrace(new MyException());
     }
 
     @GET
     @Path("other")
     @Produces("text/plain")
     public String throwsMyOtherException() {
-        throw new MyOtherException();
+        throw removeStackTrace(new MyOtherException());
     }
 
     @GET
     @Path("uni")
     @Produces("text/plain")
     public String throwsUniException() {
-        throw new UniException();
+        throw removeStackTrace(new UniException());
     }
 
     @GET
     @Path("extendsUni")
     @Produces("text/plain")
     public String throwsExtendsUniException() {
-        throw new ExtendsUniException();
+        throw removeStackTrace(new ExtendsUniException());
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilter.java
@@ -11,6 +11,8 @@ import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestCo
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestFilter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
+
 public abstract class AsyncRequestFilter implements ResteasyReactiveContainerRequestFilter {
 
     private final String name;
@@ -58,13 +60,13 @@ public abstract class AsyncRequestFilter implements ResteasyReactiveContainerReq
                 }
                 resteasyReactiveCallbackContext.registerCompletionCallback((t) -> {
                     if (callbackException != null)
-                        throw new RuntimeException("Callback called twice");
+                        throw ExceptionUtil.removeStackTrace(new RuntimeException("Callback called twice"));
                     callbackException = Objects.toString(t);
                 });
                 if ("true".equals(ctx.getHeaderString("UseExceptionMapper")))
-                    ctx.resume(new AsyncFilterException("ouch"));
+                    ctx.resume(ExceptionUtil.removeStackTrace(new AsyncFilterException("ouch")));
                 else
-                    ctx.resume(new Throwable("ouch"));
+                    ctx.resume(ExceptionUtil.removeStackTrace(new Throwable("ouch")));
             });
         }
         LOG.debug("Filter request for " + name + " with action: " + action + " done");

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilterTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilterTest.java
@@ -16,6 +16,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
 import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -36,7 +37,7 @@ public class AsyncRequestFilterTest {
                                     AsyncResponseFilter.class,
                                     AsyncResponseFilter1.class, AsyncResponseFilter2.class, AsyncResponseFilter3.class,
                                     AsyncFilterException.class, AsyncFilterExceptionMapper.class,
-                                    AsyncRequestFilterResource.class);
+                                    AsyncRequestFilterResource.class, ExceptionUtil.class);
                 }
             });
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
@@ -13,6 +13,8 @@ import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestCo
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerResponseFilter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
+
 public abstract class AsyncResponseFilter implements ResteasyReactiveContainerResponseFilter {
 
     private final String name;
@@ -70,7 +72,7 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
             ctx.setEntity(name);
             requestContext.resume();
         } else if ("sync-throw".equals(action)) {
-            throw new AsyncFilterException("ouch");
+            throw ExceptionUtil.removeStackTrace(new AsyncFilterException("ouch"));
         } else if ("async-throw-late".equals(action)) {
             requestContext.suspend();
             ServerRequestContext resteasyReactiveCallbackContext = requestContext.getServerRequestContext();
@@ -84,13 +86,13 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
                 ctx.setEntity(name);
                 resteasyReactiveCallbackContext.registerCompletionCallback((t) -> {
                     if (callbackException != null)
-                        throw new RuntimeException("Callback called twice");
+                        throw ExceptionUtil.removeStackTrace(new RuntimeException("Callback called twice"));
                     callbackException = Objects.toString(t);
                 });
                 if ("true".equals(requestContext.getHeaderString("UseExceptionMapper")))
-                    requestContext.resume(new AsyncFilterException("ouch"));
+                    requestContext.resume(ExceptionUtil.removeStackTrace(new AsyncFilterException("ouch")));
                 else
-                    requestContext.resume(new Throwable("ouch"));
+                    requestContext.resume(ExceptionUtil.removeStackTrace(new Throwable("ouch")));
             });
         }
         LOG.debug("Filter response for " + name + " with action: " + action + " done");


### PR DESCRIPTION
This is done so developers looking at the output of tests will not be tricked
by false negatives