### PR TITLE
Fix SmallRye Fault Tolerance type representation

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.srcdeps.mvn</groupId>
+    <artifactId>srcdeps-maven-local-repository</artifactId>
+    <version>4.0.0</version>
+  </extension>
+  <extension>
+    <groupId>org.srcdeps.mvn</groupId>
+    <artifactId>srcdeps-maven-enforcer</artifactId>
+    <version>4.0.0</version>
+  </extension>
+</extensions>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <smallrye-open-api.version>2.1.9</smallrye-open-api.version>
         <smallrye-graphql.version>1.3.1</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>5.2.2-SNAPSHOT</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.2.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -1,6 +1,5 @@
 package io.quarkus.deployment.util;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -377,55 +376,4 @@ public final class JandexUtil {
         }
     }
 
-    public static Class<?> loadRawType(Type type) {
-        switch (type.kind()) {
-            case VOID:
-                return void.class;
-            case PRIMITIVE:
-                switch (type.asPrimitiveType().primitive()) {
-                    case BOOLEAN:
-                        return boolean.class;
-                    case CHAR:
-                        return char.class;
-                    case BYTE:
-                        return byte.class;
-                    case SHORT:
-                        return short.class;
-                    case INT:
-                        return int.class;
-                    case LONG:
-                        return long.class;
-                    case FLOAT:
-                        return float.class;
-                    case DOUBLE:
-                        return double.class;
-                    default:
-                        throw new IllegalArgumentException("Unknown primitive type: " + type);
-                }
-            case CLASS:
-                return load(type.asClassType().name());
-            case PARAMETERIZED_TYPE:
-                return load(type.asParameterizedType().name());
-            case ARRAY:
-                Class<?> component = loadRawType(type.asArrayType().component());
-                int dimensions = type.asArrayType().dimensions();
-                return Array.newInstance(component, new int[dimensions]).getClass();
-            case WILDCARD_TYPE:
-                return loadRawType(type.asWildcardType().extendsBound());
-            case TYPE_VARIABLE:
-                return load(type.asTypeVariable().name());
-            case UNRESOLVED_TYPE_VARIABLE:
-                return Object.class; // can't do better here
-            default:
-                throw new IllegalArgumentException("Unknown type: " + type);
-        }
-    }
-
-    private static Class<?> load(DotName name) {
-        try {
-            return Thread.currentThread().getContextClassLoader().loadClass(name.toString());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
@@ -2,16 +2,13 @@ package io.quarkus.deployment.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
@@ -303,72 +300,6 @@ public class JandexUtilTest {
     }
 
     public static class ErasedRepo2 extends MultiBoundedRepo {
-    }
-
-    @Test
-    public void testLoadRawType() {
-        Index index = index(TestMethods.class);
-        ClassInfo clazz = index.getClassByName(DotName.createSimple(TestMethods.class.getName()));
-
-        assertEquals(void.class, JandexUtil.loadRawType(clazz.method("aaa").returnType()));
-        assertEquals(int.class, JandexUtil.loadRawType(clazz.method("bbb").returnType()));
-        assertEquals(String.class, JandexUtil.loadRawType(clazz.method("ccc").returnType()));
-        assertEquals(List.class, JandexUtil.loadRawType(clazz.method("ddd").returnType()));
-        assertEquals(String[][].class, JandexUtil.loadRawType(clazz.method("eee").returnType()));
-        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("fff").returnType()));
-        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("ggg").returnType()));
-        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("hhh").returnType()));
-        assertEquals(Comparable.class, JandexUtil.loadRawType(clazz.method("iii").returnType()));
-        assertEquals(Comparable.class, JandexUtil.loadRawType(clazz.method("jjj").returnType()));
-        assertEquals(Serializable.class, JandexUtil.loadRawType(clazz.method("kkk").returnType()));
-        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("lll").returnType()
-                .asParameterizedType().arguments().get(0)));
-        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("mmm").returnType()
-                .asParameterizedType().arguments().get(0)));
-        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("nnn").returnType()
-                .asParameterizedType().arguments().get(0)));
-        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("ooo").returnType()
-                .asParameterizedType().arguments().get(0)));
-        assertEquals(Number.class, JandexUtil.loadRawType(clazz.method("ppp").returnType()
-                .asParameterizedType().arguments().get(0)));
-        assertEquals(Object.class, JandexUtil.loadRawType(clazz.method("qqq").returnType()
-                .asParameterizedType().arguments().get(0)));
-    }
-
-    public interface TestMethods<X> {
-        void aaa();
-
-        int bbb();
-
-        String ccc();
-
-        List<String> ddd();
-
-        String[][] eee();
-
-        X fff();
-
-        <Y extends Number> Y ggg();
-
-        <Y extends Number & Comparable<Y>> Y hhh();
-
-        <Y extends Comparable<Y>> Y iii();
-
-        <Y extends Comparable<Y> & Serializable> Y jjj();
-
-        <Y extends Serializable & Comparable<Y>> Y kkk();
-
-        List<?> lll();
-
-        List<? extends Number> mmm();
-
-        List<? super String> nnn();
-
-        List<? extends X> ooo();
-
-        <Y extends Number> List<? extends Y> ppp();
-
-        <Y extends Number> List<? super Y> qqq();
     }
 
     private static Index index(Class<?>... classes) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/AsyncRestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/AsyncRestClientFallbackTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AsyncRestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() throws ExecutionException, InterruptedException {
+        assertEquals("pong", client.ping().toCompletableFuture().get());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Asynchronous
+        @Fallback(MyFallback.class)
+        CompletionStage<String> ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<CompletionStage<String>> {
+        @Override
+        public CompletionStage<String> handle(ExecutionContext context) {
+            return completedFuture("pong");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/RestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/RestClientFallbackTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() {
+        assertEquals("pong", client.ping());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Fallback(MyFallback.class)
+        String ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<String> {
+        @Override
+        public String handle(ExecutionContext context) {
+            return "pong";
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/UniRestClientFallbackTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ft/UniRestClientFallbackTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.rest.client.reactive.ft;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class UniRestClientFallbackTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestEndpoint.class, Client.class, MyFallback.class)
+                    .addAsResource(new StringAsset(setUrlForClass(Client.class)), "application.properties"));
+
+    @Inject
+    @RestClient
+    Client client;
+
+    @Test
+    public void testFallbackWasUsed() {
+        assertEquals("pong", client.ping().await().indefinitely());
+    }
+
+    @Path("/test")
+    public static class TestEndpoint {
+        @GET
+        public String get() {
+            throw new WebApplicationException(404);
+        }
+    }
+
+    @RegisterRestClient
+    public interface Client {
+        @GET
+        @Path("/test")
+        @Fallback(MyFallback.class)
+        Uni<String> ping();
+    }
+
+    public static class MyFallback implements FallbackHandler<Uni<String>> {
+        @Override
+        public Uni<String> handle(ExecutionContext context) {
+            return Uni.createFrom().item("pong");
+        }
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/SmallRyeFaultToleranceRecorder.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/SmallRyeFaultToleranceRecorder.java
@@ -28,9 +28,9 @@ public class SmallRyeFaultToleranceRecorder {
                 operation.validate();
 
                 QuarkusFaultToleranceOperationProvider.CacheKey cacheKey = new QuarkusFaultToleranceOperationProvider.CacheKey(
-                        ftMethod.beanClass, ftMethod.method.reflect());
+                        ftMethod.beanClass.loadFromTCCL(), ftMethod.method.reflect());
                 operationCache.put(cacheKey, operation);
-            } catch (FaultToleranceDefinitionException | NoSuchMethodException e) {
+            } catch (FaultToleranceDefinitionException | NoSuchMethodException | ClassNotFoundException e) {
                 allExceptions.add(e);
             }
         }

--- a/srcdeps.yaml
+++ b/srcdeps.yaml
@@ -1,0 +1,12 @@
+configModelVersion: 3.0
+logToConsole: true
+verbosity: info
+repositories:
+  io.smallrye.faulttolerance:
+    includes:
+    - io.smallrye:smallrye-fault-tolerance*
+    urls:
+    - git:https://github.com/Ladicek/smallrye-fault-tolerance.git
+    buildVersionPattern: .*-SNAPSHOT
+    buildRef: branch-typename-instead-of-class
+    skipTests: true


### PR DESCRIPTION
The Fault Tolerance extension performs discovery at build time.
It finds bean classes that use fault tolerance annotations and
passes that information to runtime (where SmallRye Fault Tolerance
applies runtime configuration). SmallRye Fault Tolerance used to
use `Class` objects to represent types, and so the discovery
process used to load bean classes from the deployment classloader.

This works fine, unless one of the bean classes is generated
by another Quarkus extension. These generated classes are stored
in memory and the deployment classloader doesn't know about them.
Naturally, attempting to load the class fails and aborts the build.

This commit fixes the problem by upgrading to a newer SmallRye
Fault Tolerance version that no longer using `Class` objects
to represent types. Instead, types are represented as simple
`TypeName` objects that hold a binary name of the type and can
load the type at runtime (from TCCL).

The problem was found specifically with RestClient Reactive,
so Fault Tolerance tests are added there.