### PR TITLE
Leverage gradle daemon in integration tests

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -19,7 +19,6 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
 
     private static final String GRADLE_WRAPPER_WINDOWS = "gradlew.bat";
     private static final String GRADLE_WRAPPER_UNIX = "./gradlew";
-    private static final String GRADLE_NO_DAEMON = "--no-daemon";
     private static final String MAVEN_REPO_LOCAL = "maven.repo.local";
 
     private Map<String, String> systemProps;
@@ -32,7 +31,6 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         setupTestCommand();
         List<String> command = new LinkedList<>();
         command.add(getGradleWrapperCommand());
-        command.add(GRADLE_NO_DAEMON);
         command.addAll(getSytemProperties());
         command.add("--stacktrace");
         command.addAll(Arrays.asList(args));


### PR DESCRIPTION
This branch removes gradle daemon deactivation. 

Gradle CI jobs normally takes around 40min on linux and 1h on windows. 
On my fork with the daemon, it tooks 20min on linux and 38min on windows without any failures.

cc @ebullient 