### PR TITLE
Initialize HibernateOrmConfigPersistenceUnitLog#queriesSlowerThanMs

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -153,7 +153,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          * If set, Hibernate will log queries that took more than specified number of milliseconds to execute.
          */
         @ConfigItem
-        public Optional<Long> queriesSlowerThanMs;
+        public Optional<Long> queriesSlowerThanMs = Optional.empty();
 
         public boolean isAnyPropertySet() {
             return sql || !formatSql || jdbcWarnings.isPresent() || queriesSlowerThanMs.isPresent();


### PR DESCRIPTION
Other fields are already initialized and this was not, so I believe this should fix it.

Fixes #19593