### PR TITLE
Get rid of a bunch of compiler warning in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/deployment/KotlinCoroutineIntegrationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/deployment/KotlinCoroutineIntegrationProcessor.java
@@ -55,6 +55,7 @@ public class KotlinCoroutineIntegrationProcessor {
     @BuildStep
     MethodScannerBuildItem scanner() {
         return new MethodScannerBuildItem(new MethodScanner() {
+            @SuppressWarnings("unchecked")
             @Override
             public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
                     Map<String, Object> methodContext) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -201,7 +201,7 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
 
     @Override
     public String getRequestNormalisedPath() {
-        return context.normalisedPath();
+        return context.normalizedPath();
     }
 
     @Override
@@ -300,6 +300,7 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T unwrap(Class<T> theType) {
         if (theType == RoutingContext.class) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -247,6 +247,7 @@ public class ResteasyReactiveProcessor {
         unremoveableBeans.produce(UnremovableBeanBuildItem.beanClassNames(beanParams.toArray(new String[0])));
     }
 
+    @SuppressWarnings("unchecked")
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     public void setupEndpoints(Capabilities capabilities, BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -96,6 +96,7 @@ public class ResteasyReactiveScanningProcessor {
         });
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @BuildStep
     public ExceptionMappersBuildItem scanForExceptionMappers(CombinedIndexBuildItem combinedIndexBuildItem,
             ApplicationResultBuildItem applicationResultBuildItem,
@@ -202,6 +203,7 @@ public class ResteasyReactiveScanningProcessor {
         }
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @BuildStep
     public ContextResolversBuildItem scanForContextResolvers(CombinedIndexBuildItem combinedIndexBuildItem,
             ApplicationResultBuildItem applicationResultBuildItem,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/DefaultMediaTypeResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/DefaultMediaTypeResource.java
@@ -51,14 +51,14 @@ public class DefaultMediaTypeResource {
     @Produces(MediaType.TEXT_PLAIN)
     @POST
     public Response postIntProduce(String source) throws Exception {
-        return Response.ok().entity(new Integer(8)).build();
+        return Response.ok().entity(8).build();
     }
 
     @Path("postInt")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @POST
     public Response postInt(String source) throws Exception {
-        return Response.ok().entity(new Integer(8)).build();
+        return Response.ok().entity(8).build();
     }
 
     @Path("postIntegerProduce")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/LocalDateCustomParamConverterProviderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/LocalDateCustomParamConverterProviderTest.java
@@ -73,6 +73,7 @@ public class LocalDateCustomParamConverterProviderTest {
     @Provider
     public static class CustomLocalDateParamConverterProvider implements ParamConverterProvider {
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
             if (rawType == LocalDate.class) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/MyParameterProvider.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/MyParameterProvider.java
@@ -9,6 +9,8 @@ import javax.ws.rs.ext.Provider;
 
 @Provider
 public class MyParameterProvider implements ParamConverterProvider {
+
+    @SuppressWarnings("unchecked")
     @Override
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         if (rawType == MyParameter.class)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -66,6 +66,7 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
         throw sneakyThrow(throwable);
     }
 
+    @SuppressWarnings("unchecked")
     private <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
         throw (E) e;
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
@@ -75,6 +75,7 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
                             return modified.isUserInRole(role);
                         }
 
+                        @SuppressWarnings("unchecked")
                         @Override
                         public <T extends Credential> T getCredential(Class<T> credentialType) {
                             for (Credential cred : getCredentials()) {
@@ -90,6 +91,7 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
                             return oldCredentials;
                         }
 
+                        @SuppressWarnings("unchecked")
                         @Override
                         public <T> T getAttribute(String name) {
                             return (T) oldAttributes.get(name);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
@@ -3,8 +3,10 @@ package io.quarkus.resteasy.reactive.server.runtime.websocket;
 import java.util.Collections;
 import java.util.List;
 
+import org.jboss.resteasy.reactive.common.model.ResourceClass;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 
 public class VertxWebSocketRestHandler implements HandlerChainCustomizer {
@@ -21,7 +23,7 @@ public class VertxWebSocketRestHandler implements HandlerChainCustomizer {
     };
 
     @Override
-    public List<ServerRestHandler> handlers(Phase phase) {
+    public List<ServerRestHandler> handlers(Phase phase, ResourceClass resourceClass, ServerResourceMethod resourceMethod) {
         if (phase == Phase.AFTER_METHOD_INVOKE) {
             return Collections.singletonList(new ServerRestHandler() {
                 @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/HandlerChainCustomizer.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/HandlerChainCustomizer.java
@@ -12,8 +12,7 @@ public interface HandlerChainCustomizer {
     /**
      *
      * @param phase The phase
-     * @param serverResourceMethod The method, will be null if this has not been matched yet
-     * @return
+     * @param resourceMethod The method, will be null if this has not been matched yet
      */
     default List<ServerRestHandler> handlers(Phase phase, ResourceClass resourceClass, ServerResourceMethod resourceMethod) {
         return handlers(phase);


### PR DESCRIPTION
Now that RESTEasy Reactive is stable, let's get rid of some
needless compiler warnings