### PR TITLE
Upgrade the Oracle JDBC driver to benefit from JDK11 baseline

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4490,7 +4490,7 @@
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc8</artifactId>
+                <artifactId>ojdbc11</artifactId>
                 <version>${oracle-jdbc.version}</version>
             </dependency>
             <dependency>

--- a/extensions/jdbc/jdbc-oracle/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-oracle/runtime/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
+            <artifactId>ojdbc11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>


### PR DESCRIPTION

The oracle JDBC driver ships in multiple flavours; we can now safely use the one requiring JDK11, rather than needing to use the one compatible with JDK8.