### PR TITLE
Bump kotlin to 1.5.30, coroutines to 1.5.1, dokka to 1.5.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -148,8 +148,8 @@
         <awssdk.version>2.17.25</awssdk.version>
         <aws-alexa-sdk.version>2.40.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.5.21</kotlin.version>
-        <kotlin.coroutine.version>1.5.0</kotlin.coroutine.version>
+        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.coroutine.version>1.5.1</kotlin.coroutine.version>
         <dekorate.version>2.3.0</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,8 +20,8 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.5.21</kotlin.version>
-        <dokka.version>1.4.32</dokka.version>
+        <kotlin.version>1.5.30</kotlin.version>
+        <dokka.version>1.5.0</dokka.version>
         <scala.version>2.12.13</scala.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
         <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -33,7 +33,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.30</kotlin.version>
         <scala.version>2.12.13</scala.version>
         <scala-plugin.version>4.4.0</scala-plugin.version>
 

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
     id 'io.quarkus'
-    id 'org.jetbrains.kotlin.jvm' version "1.5.21"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.21"
+    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
 }
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.5.21"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.21"
+    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
     id 'io.quarkus'
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/gradle.properties
@@ -3,5 +3,5 @@
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus
 
-kotlinVersion=1.5.21
+kotlinVersion=1.5.30
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version "1.5.21"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.21"
+    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
     id 'io.quarkus'
 }
 

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.21</kotlin.version>
+        <kotlin.version>1.5.30</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.21</kotlin.version>
+        <kotlin.version>1.5.30</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Fixes the two Gradle tests on Java 17 EA (https://github.com/quarkusio/quarkus/issues/18372#issuecomment-905007147).

I bumped the other two for general alignment. I ran dokka-maven-plugin via `-Ddokka` and it LGTM.

PS: Both kapt and dokka (would) still need `add-opens`. Only that NoSuchMethodError should be gone now: https://youtrack.jetbrains.com/issue/KT-47583