### PR TITLE
Fix Arbitrary file write during archive extraction ("Zip Slip") vulnerability

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
@@ -161,7 +161,10 @@ public class DevModeTask {
                     try (ZipInputStream fs = new ZipInputStream(Files.newInputStream(p))) {
                         ZipEntry entry = fs.getNextEntry();
                         while (entry != null) {
-                            Path target = moduleClasses.resolve(entry.getName());
+                            Path target = moduleClasses.resolve(entry.getName()).normalize();
+                            if (!target.startsWith(moduleClasses)) {
+                                throw new IOException("Bad ZIP entry: " + target);
+                            }
                             if (entry.getName().endsWith("/")) {
                                 Files.createDirectories(target);
                             } else {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangDevModeLauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangDevModeLauncherImpl.java
@@ -63,7 +63,10 @@ public class JBangDevModeLauncherImpl implements Closeable {
                 Enumeration<? extends ZipEntry> entries = fz.entries();
                 while (entries.hasMoreElements()) {
                     ZipEntry entry = entries.nextElement();
-                    Path path = targetClasses.resolve(entry.getName());
+                    Path path = targetClasses.resolve(entry.getName()).normalize();
+                    if (!path.startsWith(targetClasses)) {
+                        throw new IOException("Bad ZIP entry: " + path);
+                    }
                     if (entry.isDirectory()) {
                         Files.createDirectories(path);
                     } else {


### PR DESCRIPTION
Extracting files from a malicious archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten.

Snyk: https://snyk.io/research/zip-slip-vulnerability
OWASP: https://owasp.org/www-community/attacks/Path_Traversal
Common Weakness Enumeration: https://cwe.mitre.org/data/definitions/22.html