### PR TITLE
Documentation Fix: Changing Type to reflect Kotlin implementation

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache-kotlin.adoc
@@ -35,7 +35,7 @@ https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-object
 [source,kotlin]
 ----
 class Person : PanacheMongoEntity() {
-    companion object: PanacheCompanion<Person> {  // <1>
+    companion object: PanacheMongoCompanion<Person> {  // <1>
         fun findByName(name: String) = find("name", name).firstResult()
         fun findAlive() = list("status", Status.Alive)
         fun deleteStefs() = delete("name", "Stef")


### PR DESCRIPTION
Changing PanacheCompanion to PanacheMongoCompanion which seems to be the correct Type for Kotlin implementation; I was trying to configure my project with  PanacheCompanion which didn't exist then I found out I had to use a different Type so I thought it would be good to make the change in here.