### PR TITLE
Add a substitution for sun.security.jca.JCAUtil for Java 17

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
@@ -1,0 +1,16 @@
+package io.quarkus.runtime.graal;
+
+import java.security.SecureRandom;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK17OrLater;
+
+@TargetClass(className = "sun.security.jca.JCAUtil", onlyWith = JDK17OrLater.class)
+public final class Target_sun_security_jca_JCAUtil {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private static SecureRandom def;
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/19633

This is applicable only for Java 17, because the `JCAUtil#def` static field got introduced in this recent version.

I think this substitution should really belong to GraalVM repo itself. But unfortunately, these days, getting inputs or changes reviewed there takes weeks. So I think we can have this here in the meantime. I'll propose this change in GraalVM repo too and if that gets accepted anytime later, we can remove this from Quarkus.