### PR TITLE
Fix backwards compatibility with GraalVM/Mandrel 20.3 LCMS substitutions

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
@@ -4,7 +4,8 @@ import java.awt.color.ICC_Profile;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK16OrEarlier;
+
+import io.quarkus.runtime.util.JavaVersionUtil.JDK16OrEarlier;
 
 @TargetClass(className = "sun.java2d.cmm.lcms.LCMS", onlyWith = JDK16OrEarlier.class)
 final class Target_sun_java2d_cmm_lcms_LCMS {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutionsJDK17.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutionsJDK17.java
@@ -4,7 +4,8 @@ import java.awt.color.ICC_Profile;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrLater;
+
+import io.quarkus.runtime.util.JavaVersionUtil.JDK17OrLater;
 
 @TargetClass(className = "sun.java2d.cmm.lcms.LCMS", onlyWith = JDK17OrLater.class)
 final class Target_sun_java2d_cmm_lcms_LCMS_JDK17 {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
@@ -5,9 +5,10 @@ import java.security.SecureRandom;
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrLater;
 
-@TargetClass(className = "sun.security.jca.JCAUtil", onlyWith = JDK17OrLater.class)
+import io.quarkus.runtime.util.JavaVersionUtil;
+
+@TargetClass(className = "sun.security.jca.JCAUtil", onlyWith = JavaVersionUtil.JDK17OrLater.class)
 public final class Target_sun_security_jca_JCAUtil {
 
     @Alias

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.util;
 
+import java.util.function.BooleanSupplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -10,6 +11,8 @@ public class JavaVersionUtil {
     private static boolean IS_JAVA_11_OR_NEWER;
     private static boolean IS_JAVA_13_OR_NEWER;
     private static boolean IS_GRAALVM_JDK;
+    private static boolean IS_JAVA_16_OR_OLDER;
+    private static boolean IS_JAVA_17_OR_NEWER;
 
     static {
         performChecks();
@@ -22,9 +25,13 @@ public class JavaVersionUtil {
             int first = Integer.parseInt(matcher.group(1));
             IS_JAVA_11_OR_NEWER = (first >= 11);
             IS_JAVA_13_OR_NEWER = (first >= 13);
+            IS_JAVA_16_OR_OLDER = (first <= 16);
+            IS_JAVA_17_OR_NEWER = (first >= 17);
         } else {
             IS_JAVA_11_OR_NEWER = false;
             IS_JAVA_13_OR_NEWER = false;
+            IS_JAVA_16_OR_OLDER = false;
+            IS_JAVA_17_OR_NEWER = false;
         }
 
         String vmVendor = System.getProperty("java.vm.vendor");
@@ -39,7 +46,31 @@ public class JavaVersionUtil {
         return IS_JAVA_13_OR_NEWER;
     }
 
+    public static boolean isJava16OrLower() {
+        return IS_JAVA_16_OR_OLDER;
+    }
+
+    public static boolean isJava17OrHigher() {
+        return IS_JAVA_17_OR_NEWER;
+    }
+
     public static boolean isGraalvmJdk() {
         return IS_GRAALVM_JDK;
+    }
+
+    /* Clone of com.oracle.svm.core.jdk.JDK17OrLater to work around #19645 issue with GraalVM 20.3 */
+    public static class JDK17OrLater implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return JavaVersionUtil.isJava17OrHigher();
+        }
+    }
+
+    /* Clone of com.oracle.svm.core.jdk.JDK16OrEarlier to work around #19645 issue with GraalVM 20.3 */
+    public static class JDK16OrEarlier implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return JavaVersionUtil.isJava16OrLower();
+        }
     }
 }


### PR DESCRIPTION
Closes #19645

20.3 tests: https://github.com/graalvm/mandrel/actions/runs/1165996876
21.3-dev-java17 tested locally with `native-image 21.3.0-dev35d4184a8d Mandrel Distribution (Java Version 17-internal+0-adhoc.tester.jdk17)` downloaded from https://ci.modcluster.io/view/Mandrel/job/mandrel-master-jdk17-linux-build/