### PR TITLE
Improve DevServices test integration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -25,6 +26,7 @@ import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
@@ -219,6 +221,16 @@ public class StartupActionImpl implements StartupAction {
     @Override
     public ClassLoader getClassLoader() {
         return runtimeClassLoader;
+    }
+
+    @Override
+    public Map<String, String> getDevServicesProperties() {
+        DevServicesLauncherConfigResultBuildItem result = buildResult
+                .consumeOptional(DevServicesLauncherConfigResultBuildItem.class);
+        if (result == null) {
+            return Collections.emptyMap();
+        }
+        return new HashMap<>(result.getConfig());
     }
 
     private Map<String, byte[]> extractTransformers(Set<String> eagerClasses) {

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1235,3 +1235,22 @@ The `settings.json` placed in the root of your project directory or in the works
 === IntelliJ JUnit template
 
 Nothing needed in IntelliJ because the IDE will pick the `systemPropertyVariables` from the surefire plugin configuration in `pom.xml`.
+
+== Testing Dev Services
+
+By default tests should just work with link:dev-services[Dev Services], however from some use cases you may need access to
+the automatically configured properties in your tests.
+
+You can do this with `io.quarkus.test.common.DevServicesContext`, which can be injected directly into any `@QuarkusTest`
+or `@QuarkusIntegrationTest`. All you need to do is define a field of type `DevServicesContext` and it will be automatically
+injected. Using this you can retrieve any properties that have been set. Generally this is used to directly connect to a
+resource from the test itself, e.g. to connect to kafka to send messages to the application under test.
+
+Injection is also supported into objects that implement `io.quarkus.test.common.DevServicesContext.ContextAware`. If you
+have a field that implements `io.quarkus.test.common.DevServicesContext.ContextAware` Quarkus will call the
+`setIntegrationTestContext` method to pass the context into this object. This allows client logic to be encapsulated in
+a utility class.
+
+`QuarkusTestResourceLifecycleManager` implementations can also implement `ContextAware` to get access to these properties,
+which allows you to setup the resource before Quarkus starts (e.g. configure a KeyCloak instance, add data to a database etc).
+

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -34,6 +34,11 @@ public class DevServicesConfig {
     public Optional<String> realmPath;
 
     /**
+     * The JAVA_OPTS passed to the keycloak JVM
+     */
+    @ConfigItem
+    public Optional<String> javaOpts;
+    /**
      * The Keycloak realm.
      * This property will be used to create the realm if the realm file pointed to by the 'realm-path' property does not exist.
      * Setting this property is recommended even if realm file exists
@@ -134,6 +139,7 @@ public class DevServicesConfig {
                 && Objects.equals(realmPath, that.realmPath)
                 && Objects.equals(realmName, that.realmName)
                 && Objects.equals(users, that.users)
+                && Objects.equals(javaOpts, that.javaOpts)
                 && Objects.equals(roles, that.roles);
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -65,6 +65,7 @@ public class KeycloakDevServicesProcessor {
     private static final String KEYCLOAK_URL_KEY = "keycloak.url";
 
     private static final int KEYCLOAK_EXPOSED_PORT = 8080;
+    private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final String KEYCLOAK_DOCKER_REALM_PATH = "/tmp/realm.json";
     private static final String KEYCLOAK_USER_PROP = "KEYCLOAK_USER";
     private static final String KEYCLOAK_PASSWORD_PROP = "KEYCLOAK_PASSWORD";
@@ -228,7 +229,7 @@ public class KeycloakDevServicesProcessor {
         QuarkusOidcContainer oidcContainer = new QuarkusOidcContainer(dockerImageName,
                 capturedDevServicesConfiguration.port,
                 useSharedContainer,
-                capturedDevServicesConfiguration.realmPath);
+                capturedDevServicesConfiguration.realmPath, capturedDevServicesConfiguration.javaOpts);
 
         oidcContainer.start();
 
@@ -263,13 +264,15 @@ public class KeycloakDevServicesProcessor {
         private final Optional<String> realm;
         private boolean realmFileExists;
         private String hostName = null;
+        private final Optional<String> javaOpts;
 
         public QuarkusOidcContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
-                Optional<String> realm) {
+                Optional<String> realm, Optional<String> javaOpts) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.realm = realm;
+            this.javaOpts = javaOpts;
         }
 
         @Override
@@ -293,6 +296,9 @@ public class KeycloakDevServicesProcessor {
             addEnv(KEYCLOAK_USER_PROP, KEYCLOAK_ADMIN_USER);
             addEnv(KEYCLOAK_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
             addEnv(KEYCLOAK_VENDOR_PROP, KEYCLOAK_DB_VENDOR);
+            if (javaOpts.isPresent()) {
+                addEnv(JAVA_OPTS, javaOpts.get());
+            }
 
             if (realm.isPresent()) {
                 if (Thread.currentThread().getContextClassLoader().getResource(realm.get()) != null) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -14,6 +14,8 @@ public interface StartupAction {
 
     ClassLoader getClassLoader();
 
+    Map<String, String> getDevServicesProperties();
+
     /**
      * Runs the application by running the main method of the main class. As this is a blocking method a new
      * thread is created to run this task.

--- a/integration-tests/oidc-token-propagation/pom.xml
+++ b/integration-tests/oidc-token-propagation/pom.xml
@@ -14,10 +14,6 @@
     <name>Quarkus - Integration Tests - OpenID Connect Token Propagation</name>
     <description>Module that contains OpenID Connect Token Propagation tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -30,7 +26,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -157,18 +153,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -179,90 +169,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
-                                            <JAVA_OPTS>-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile=preview</JAVA_OPTS>
-                                        </env>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${basedir}/../../.github/docker-prune.sh</executable>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integration-tests/oidc-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/oidc-token-propagation/src/main/resources/application.properties
@@ -1,6 +1,8 @@
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
+%prod.quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
+
+quarkus.keycloak.devservices.java-opts=-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile=preview
 
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationITCase.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.keycloak;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OidcTokenPropagationITCase extends OidcTokenPropagationTest {
+}

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationInGraalITCase.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationInGraalITCase.java
@@ -1,7 +1,0 @@
-package io.quarkus.it.keycloak;
-
-import io.quarkus.test.junit.NativeImageTest;
-
-@NativeImageTest
-public class OidcTokenPropagationInGraalITCase extends OidcTokenPropagationTest {
-}

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -4,16 +4,17 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
-import org.keycloak.representations.AccessTokenResponse;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.server.KeycloakTestClient;
 import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
 public class OidcTokenPropagationTest {
-    public static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+
+    final KeycloakTestClient client = new KeycloakTestClient();
 
     @Test
     public void testGetUserNameWithJwtTokenPropagation() {
@@ -54,16 +55,7 @@ public class OidcTokenPropagationTest {
                 .body(equalTo("alice"));
     }
 
-    public static String getAccessToken(String userName) {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", userName)
-                .param("password", userName)
-                .param("client_id", "quarkus-app")
-                .param("client_secret", "secret")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/quarkus/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
+    public String getAccessToken(String userName) {
+        return client.getAccessToken(userName, userName, "quarkus-app", "secret");
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DevServicesContext.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DevServicesContext.java
@@ -1,0 +1,35 @@
+package io.quarkus.test.common;
+
+import java.util.Map;
+
+/**
+ * Interface that can be used to get properties from DevServices for {@link QuarkusTest} and {@link QuarkusIntegrationTest}
+ * based tests.
+ *
+ * This can be injected into fields on a test class, or injected into {@link ContextAware} objects on the test class
+ * or {@link io.quarkus.test.common.TestResourceManager} implementations.
+ *
+ */
+public interface DevServicesContext {
+
+    /**
+     * Returns a map containing all the properties creates by potentially launched dev services.
+     * If no dev services where launched, the map will be empty.
+     */
+    Map<String, String> devServicesProperties();
+
+    /**
+     * Interface that can be implemented to allow automatic injection of the context.
+     *
+     * If you have a field on a test class that implements this interface the then context
+     * will be injected into it.
+     *
+     * {@link io.quarkus.test.common.QuarkusTestResourceLifecycleManager} implementations can also
+     * implement this. This allows for them to setup the resource created by Dev Services after
+     * it has been started.
+     *
+     */
+    interface ContextAware {
+        void setIntegrationTestContext(DevServicesContext context);
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -47,6 +47,11 @@ public class TestResourceManager implements Closeable {
 
     public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
             boolean disableGlobalTestResources) {
+        this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, Collections.emptyMap());
+    }
+
+    public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
+            boolean disableGlobalTestResources, Map<String, String> devServicesProperties) {
         this.parallelTestResourceEntries = new ArrayList<>();
         this.sequentialTestResourceEntries = new ArrayList<>();
 
@@ -63,6 +68,17 @@ public class TestResourceManager implements Closeable {
 
         this.allTestResourceEntries = new ArrayList<>(sequentialTestResourceEntries);
         this.allTestResourceEntries.addAll(parallelTestResourceEntries);
+        DevServicesContext context = new DevServicesContext() {
+            @Override
+            public Map<String, String> devServicesProperties() {
+                return devServicesProperties;
+            }
+        };
+        for (var i : allTestResourceEntries) {
+            if (i.getTestResource() instanceof DevServicesContext.ContextAware) {
+                ((DevServicesContext.ContextAware) i.getTestResource()).setIntegrationTestContext(context);
+            }
+        }
     }
 
     public void init() {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTest.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTest.java
@@ -4,9 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Map;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.common.DevServicesContext;
 
 /**
  * Annotation that indicates that this test should be run the result of the Quarkus build.
@@ -36,13 +37,12 @@ public @interface QuarkusIntegrationTest {
     /**
      * If used as a field of class annotated with {@link QuarkusIntegrationTest}, the field is populated
      * with an implementation that allows accessing contextual test information
+     *
+     * @deprecated Use {@link DevServicesContext} instead.
      */
-    interface Context {
+    @Deprecated
+    interface Context extends DevServicesContext {
 
-        /**
-         * Returns a map containing all the properties creates by potentially launched dev services.
-         * If no dev services where launched, the map will be empty.
-         */
-        Map<String, String> devServicesProperties();
     }
+
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -369,11 +369,12 @@ public class QuarkusTestExtension
 
             //must be done after the TCCL has been set
             testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
-                    .getConstructor(Class.class, Class.class, List.class, boolean.class)
+                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class)
                     .newInstance(requiredTestClass,
                             profile != null ? profile : null,
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
-                            profileInstance != null && profileInstance.disableGlobalTestResources());
+                            profileInstance != null && profileInstance.disableGlobalTestResources(),
+                            startupAction.getDevServicesProperties());
             testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
                     .invoke(testResourceManager);
@@ -1135,7 +1136,7 @@ public class QuarkusTestExtension
     }
 
     private void runAfterAllCallbacks(ExtensionContext context) throws Exception {
-        if (isNativeOrIntegrationTest(context.getRequiredTestClass())) {
+        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || failedBoot) {
             return;
         }
         if (afterAllCallbacks.isEmpty()) {

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestClient.java
@@ -4,10 +4,11 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.keycloak.representations.AccessTokenResponse;
 
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 
-public class KeycloakTestAdmin {
+public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     private final static String AUTH_SERVER_URL_PROP = "quarkus.oidc.auth-server-url";
     private final static String CLIENT_ID_PROP = "quarkus.oidc.client-id";
@@ -17,13 +18,13 @@ public class KeycloakTestAdmin {
         RestAssured.useRelaxedHTTPSValidation();
     }
 
-    private QuarkusIntegrationTest.Context testContext;
+    private DevServicesContext testContext;
 
-    public KeycloakTestAdmin() {
+    public KeycloakTestClient() {
 
     }
 
-    public KeycloakTestAdmin(QuarkusIntegrationTest.Context testContext) {
+    public KeycloakTestClient(QuarkusIntegrationTest.Context testContext) {
         this.testContext = testContext;
     }
 
@@ -58,7 +59,7 @@ public class KeycloakTestAdmin {
         return getPropertyValue(CLIENT_SECRET_PROP, "secret");
     }
 
-    private String getAuthServerUrl() {
+    public String getAuthServerUrl() {
         String authServerUrl = getPropertyValue(AUTH_SERVER_URL_PROP, null);
         if (authServerUrl == null) {
             throw new ConfigurationException(AUTH_SERVER_URL_PROP + " is not configured");
@@ -76,4 +77,8 @@ public class KeycloakTestAdmin {
         return value == null ? defaultValue : value;
     }
 
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.testContext = context;
+    }
 }


### PR DESCRIPTION
Also improce the KeyCloak test client, and modify a KC test to use
DevServices.

This adds a new DevServicesContext which can be injected into
QuarkusTest and QuarkusIntegrationTest, as well as TestResourceManager
implementation (to allow the dev service to be configured).