### PR TITLE
Fix "Response head already sent" when JWT token is invalid

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -74,7 +74,9 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
             //generally this should be handled elsewhere
             //but if we get to this point bad things have happened
             //so it is better to send a response than to hang
-            event.response().setStatusCode(HttpResponseStatus.UNAUTHORIZED.code()).end();
+            if (!event.response().ended()) {
+                event.response().setStatusCode(HttpResponseStatus.UNAUTHORIZED.code()).end();
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes: #19621