### PR TITLE
Arc - Filter out overriden methods when looking for pre-destroy and post construct candidated

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -635,7 +635,7 @@ final class Beans {
 
     static List<MethodInfo> getCallbacks(ClassInfo beanClass, DotName annotation, IndexView index) {
         List<MethodInfo> callbacks = new ArrayList<>();
-        collectCallbacks(beanClass, callbacks, annotation, index);
+        collectCallbacks(beanClass, callbacks, annotation, index, new HashSet<>());
         Collections.reverse(callbacks);
         return callbacks;
     }
@@ -833,16 +833,21 @@ final class Beans {
         }
     }
 
-    private static void collectCallbacks(ClassInfo clazz, List<MethodInfo> callbacks, DotName annotation, IndexView index) {
+    private static void collectCallbacks(ClassInfo clazz, List<MethodInfo> callbacks, DotName annotation, IndexView index,
+            Set<String> knownMethods) {
         for (MethodInfo method : clazz.methods()) {
-            if (method.hasAnnotation(annotation) && method.returnType().kind() == Kind.VOID && method.parameters().isEmpty()) {
-                callbacks.add(method);
+            if (method.returnType().kind() == Kind.VOID && method.parameters().isEmpty()) {
+                if (method.hasAnnotation(annotation) && !knownMethods.contains(method.name())) {
+                    callbacks.add(method);
+                }
+                knownMethods.add(method.name());
             }
+
         }
         if (clazz.superName() != null) {
             ClassInfo superClass = getClassByName(index, clazz.superName());
             if (superClass != null) {
-                collectCallbacks(superClass, callbacks, annotation, index);
+                collectCallbacks(superClass, callbacks, annotation, index, knownMethods);
             }
         }
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/BeanLifecycleMethodsOverridenTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/BeanLifecycleMethodsOverridenTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.arc.test.bean.lifecycle.inheritance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Tests the behavior of overrided pre-destroy and post construct methods in beans.
+ * Inspired by CDI TCK test {@code OverridenLifecycleCallbackInterceptorTest}
+ */
+public class BeanLifecycleMethodsOverridenTest {
+
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Bird.class, Eagle.class, Falcon.class);
+
+    @Test
+    public void testOverridenMethodWithNoAnnotation() {
+        resetAll();
+        InstanceHandle<Falcon> falconInstanceHandle = Arc.container().instance(Falcon.class);
+        falconInstanceHandle.get().ping();
+        falconInstanceHandle.destroy();
+        assertEquals(0, Falcon.getInitCalled().get());
+        assertEquals(0, Falcon.getDestroyCalled().get());
+        assertEquals(0, Bird.getInitCalled().get());
+        assertEquals(0, Bird.getDestroyCalled().get());
+    }
+
+    @Test
+    public void testOverridenMethodWithLifecycleAnnotation() {
+        resetAll();
+        InstanceHandle<Eagle> eagleInstanceHandle = Arc.container().instance(Eagle.class);
+        eagleInstanceHandle.get().ping();
+        eagleInstanceHandle.destroy();
+        assertEquals(1, Eagle.getInitCalled().get());
+        assertEquals(1, Eagle.getDestroyCalled().get());
+        assertEquals(0, Bird.getInitCalled().get());
+        assertEquals(0, Bird.getDestroyCalled().get());
+    }
+
+    private void resetAll() {
+        Bird.reset();
+        Falcon.reset();
+        Eagle.reset();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Bird.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Bird.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.bean.lifecycle.inheritance;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+
+// base class defining pre destroy and post construct callbacks
+@Dependent
+public class Bird {
+
+    private static final AtomicInteger initCalled = new AtomicInteger();
+    private static final AtomicInteger destroyCalled = new AtomicInteger();
+
+    public static AtomicInteger getInitCalled() {
+        return initCalled;
+    }
+
+    public static AtomicInteger getDestroyCalled() {
+        return destroyCalled;
+    }
+
+    public static void reset() {
+        initCalled.set(0);
+        destroyCalled.set(0);
+    }
+
+    @PostConstruct
+    public void init() {
+        initCalled.incrementAndGet();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyCalled.incrementAndGet();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Eagle.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Eagle.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.bean.lifecycle.inheritance;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class Eagle extends Bird {
+
+    private static final AtomicInteger initCalled = new AtomicInteger();
+    private static final AtomicInteger destroyCalled = new AtomicInteger();
+
+    public static AtomicInteger getInitCalled() {
+        return initCalled;
+    }
+
+    public static AtomicInteger getDestroyCalled() {
+        return destroyCalled;
+    }
+
+    public static void reset() {
+        initCalled.set(0);
+        destroyCalled.set(0);
+    }
+
+    @Override
+    @PostConstruct
+    public void init() {
+        initCalled.incrementAndGet();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        destroyCalled.incrementAndGet();
+    }
+
+    public void ping() {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Falcon.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/lifecycle/inheritance/Falcon.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.bean.lifecycle.inheritance;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.enterprise.context.Dependent;
+
+// extends Bird class, overrides pre-destroy and post construct with new variant
+@Dependent
+public class Falcon extends Bird {
+    private static final AtomicInteger initCalled = new AtomicInteger();
+    private static final AtomicInteger destroyCalled = new AtomicInteger();
+
+    public static AtomicInteger getInitCalled() {
+        return initCalled;
+    }
+
+    public static AtomicInteger getDestroyCalled() {
+        return destroyCalled;
+    }
+
+    public static void reset() {
+        initCalled.set(0);
+        destroyCalled.set(0);
+    }
+
+    @Override
+    public void init() {
+        initCalled.incrementAndGet();
+    }
+
+    @Override
+    public void destroy() {
+        destroyCalled.incrementAndGet();
+    }
+
+    public void ping() {
+    }
+}


### PR DESCRIPTION
This PR makes sure we do not consider overriden methods eligible when looking for lifecycle interception methods on beans.

Fixes https://github.com/quarkusio/quarkus/issues/19678

FYI @starksm64 - this fixes the failing TCK test you were seeing.