### PR TITLE
OpenAPI Auto security based on extensions

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -38,6 +38,7 @@ import io.quarkus.oidc.runtime.OidcTokenCredentialProducer;
 import io.quarkus.oidc.runtime.TenantConfigBean;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
@@ -49,6 +50,14 @@ public class OidcBuildStep {
     @BuildStep(onlyIf = IsEnabled.class)
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC);
+    }
+
+    @BuildStep(onlyIf = IsEnabled.class)
+    public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
+        // TODO: By default quarkus.oidc.application-type = service
+        // Also look at other options (web-app, hybrid)
+        securityInformationProducer
+                .produce(SecurityInformationBuildItem.OPENIDCONNECT("quarkus.oidc.auth-server-url"));
     }
 
     @BuildStep(onlyIf = IsEnabled.class)

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -37,6 +37,7 @@ import io.quarkus.smallrye.jwt.runtime.auth.JsonWebTokenCredentialProducer;
 import io.quarkus.smallrye.jwt.runtime.auth.JwtPrincipalProducer;
 import io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator;
 import io.quarkus.smallrye.jwt.runtime.auth.RawOptionalClaimCreator;
+import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
@@ -67,6 +68,11 @@ class SmallRyeJwtProcessor {
     @BuildStep(onlyIf = IsEnabled.class)
     EnableAllSecurityServicesBuildItem security() {
         return new EnableAllSecurityServicesBuildItem();
+    }
+
+    @BuildStep(onlyIf = IsEnabled.class)
+    public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
+        securityInformationProducer.produce(SecurityInformationBuildItem.JWT());
     }
 
     /**

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -71,6 +71,12 @@ public final class SmallRyeOpenApiConfig {
     public boolean autoAddTags;
 
     /**
+     * This will automatically add security based on the security extension included (if any).
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean autoAddSecurity;
+
+    /**
      * Add a scheme value to the Basic HTTP Security Scheme
      */
     @ConfigItem(defaultValue = "basic")

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -2,6 +2,8 @@ package io.quarkus.smallrye.openapi.runtime;
 
 import java.util.List;
 
+import org.eclipse.microprofile.openapi.OASFilter;
+
 import io.quarkus.arc.Arc;
 import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.Handler;
@@ -32,9 +34,11 @@ public class OpenApiHandler implements Handler<RoutingContext> {
     }
 
     final boolean corsEnabled;
+    final OASFilter autoSecurityFilter;
 
-    public OpenApiHandler(boolean corsEnabled) {
+    public OpenApiHandler(boolean corsEnabled, OASFilter autoSecurityFilter) {
         this.corsEnabled = corsEnabled;
+        this.autoSecurityFilter = autoSecurityFilter;
     }
 
     @Override
@@ -77,6 +81,7 @@ public class OpenApiHandler implements Handler<RoutingContext> {
     private OpenApiDocumentService getOpenApiDocumentService() {
         if (this.openApiDocumentService == null) {
             this.openApiDocumentService = Arc.container().instance(OpenApiDocumentService.class).get();
+            this.openApiDocumentService.init(this.autoSecurityFilter);
         }
         return this.openApiDocumentService;
     }

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 
+import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
 
 import io.quarkus.runtime.ShutdownContext;
@@ -16,9 +17,10 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class OpenApiRecorder {
 
-    public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig, HttpConfiguration configuration) {
+    public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig, HttpConfiguration configuration,
+            OASFilter autoSecurityFilter) {
         if (runtimeConfig.enable) {
-            return new OpenApiHandler(configuration.corsEnabled);
+            return new OpenApiHandler(configuration.corsEnabled, autoSecurityFilter);
         } else {
             return new OpenApiNotFoundHandler();
         }

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoBasicSecurityFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoBasicSecurityFilter.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.runtime.filter;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+
+/**
+ * Add Basic Authentication security automatically based on the added security extensions
+ */
+public class AutoBasicSecurityFilter extends AutoSecurityFilter {
+    private String basicSecuritySchemeValue;
+
+    public AutoBasicSecurityFilter() {
+        super();
+    }
+
+    public AutoBasicSecurityFilter(String securitySchemeName, String securitySchemeDescription,
+            String basicSecuritySchemeValue) {
+        super(securitySchemeName, securitySchemeDescription);
+        this.basicSecuritySchemeValue = basicSecuritySchemeValue;
+    }
+
+    public String getBasicSecuritySchemeValue() {
+        return basicSecuritySchemeValue;
+    }
+
+    public void setBasicSecuritySchemeValue(String basicSecuritySchemeValue) {
+        this.basicSecuritySchemeValue = basicSecuritySchemeValue;
+    }
+
+    @Override
+    protected SecurityScheme getSecurityScheme() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        securityScheme.setType(SecurityScheme.Type.HTTP);
+        securityScheme.setScheme(basicSecuritySchemeValue);
+        return securityScheme;
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoJWTSecurityFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoJWTSecurityFilter.java
@@ -1,0 +1,48 @@
+package io.quarkus.smallrye.openapi.runtime.filter;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+
+/**
+ * Add JWT Authentication security automatically based on the added security extensions
+ */
+public class AutoJWTSecurityFilter extends AutoSecurityFilter {
+    private String jwtSecuritySchemeValue;
+    private String jwtBearerFormat;
+
+    public AutoJWTSecurityFilter() {
+        super();
+    }
+
+    public AutoJWTSecurityFilter(String securitySchemeName, String securitySchemeDescription, String jwtSecuritySchemeValue,
+            String jwtBearerFormat) {
+        super(securitySchemeName, securitySchemeDescription);
+        this.jwtSecuritySchemeValue = jwtSecuritySchemeValue;
+        this.jwtBearerFormat = jwtBearerFormat;
+    }
+
+    public String getJwtSecuritySchemeValue() {
+        return jwtSecuritySchemeValue;
+    }
+
+    public void setJwtSecuritySchemeValue(String jwtSecuritySchemeValue) {
+        this.jwtSecuritySchemeValue = jwtSecuritySchemeValue;
+    }
+
+    public String getJwtBearerFormat() {
+        return jwtBearerFormat;
+    }
+
+    public void setJwtBearerFormat(String jwtBearerFormat) {
+        this.jwtBearerFormat = jwtBearerFormat;
+    }
+
+    @Override
+    protected SecurityScheme getSecurityScheme() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        securityScheme.setType(SecurityScheme.Type.HTTP);
+        securityScheme.setScheme(jwtSecuritySchemeValue);
+        securityScheme.setBearerFormat(jwtBearerFormat);
+        return securityScheme;
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoSecurityFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoSecurityFilter.java
@@ -1,0 +1,82 @@
+package io.quarkus.smallrye.openapi.runtime.filter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.jboss.logging.Logger;
+
+/**
+ * Auto add security
+ */
+public abstract class AutoSecurityFilter implements OASFilter {
+    private static final Logger log = Logger.getLogger(AutoSecurityFilter.class);
+
+    private String securitySchemeName;
+    private String securitySchemeDescription;
+
+    public AutoSecurityFilter() {
+
+    }
+
+    public AutoSecurityFilter(String securitySchemeName, String securitySchemeDescription) {
+        this.securitySchemeName = securitySchemeName;
+        this.securitySchemeDescription = securitySchemeDescription;
+    }
+
+    public String getSecuritySchemeName() {
+        return securitySchemeName;
+    }
+
+    public void setSecuritySchemeName(String securitySchemeName) {
+        this.securitySchemeName = securitySchemeName;
+    }
+
+    public String getSecuritySchemeDescription() {
+        return securitySchemeDescription;
+    }
+
+    public void setSecuritySchemeDescription(String securitySchemeDescription) {
+        this.securitySchemeDescription = securitySchemeDescription;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        // Make sure components are created
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(OASFactory.createComponents());
+        }
+
+        Map<String, SecurityScheme> securitySchemes = new HashMap<>();
+
+        // Add any existing security
+        if (openAPI.getComponents().getSecuritySchemes() != null
+                && !openAPI.getComponents().getSecuritySchemes().isEmpty()) {
+            securitySchemes.putAll(openAPI.getComponents().getSecuritySchemes());
+        }
+
+        SecurityScheme securityScheme = getSecurityScheme();
+        securityScheme.setDescription(securitySchemeDescription);
+        securitySchemes.put(securitySchemeName, securityScheme);
+        openAPI.getComponents().setSecuritySchemes(securitySchemes);
+    }
+
+    protected abstract SecurityScheme getSecurityScheme();
+
+    protected String getUrl(String configKey, String defaultValue, String shouldEndWith) {
+        Config c = ConfigProvider.getConfig();
+
+        String u = c.getOptionalValue(configKey, String.class).orElse(defaultValue);
+
+        if (u != null && !u.endsWith(shouldEndWith)) {
+            u = u + shouldEndWith;
+        }
+        return u;
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoUrl.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/AutoUrl.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.openapi.runtime.filter;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Create a URL from a config, or a default value
+ */
+public class AutoUrl {
+
+    private String defaultValue;
+    private String configKey;
+    private String path;
+
+    public AutoUrl() {
+    }
+
+    public AutoUrl(String defaultValue, String configKey, String path) {
+        this.defaultValue = defaultValue;
+        this.configKey = configKey;
+        this.path = path;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+
+    public void setConfigKey(String configKey) {
+        this.configKey = configKey;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getFinalUrlValue() {
+        Config c = ConfigProvider.getConfig();
+
+        String u = c.getOptionalValue(this.configKey, String.class).orElse(defaultValue);
+
+        if (u != null && path != null && !u.endsWith(path)) {
+            u = u + path;
+        }
+
+        return u;
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/OpenIDConnectSecurityFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/OpenIDConnectSecurityFilter.java
@@ -1,0 +1,71 @@
+package io.quarkus.smallrye.openapi.runtime.filter;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+
+/**
+ * Add OAuth 2 (Implicit) Authentication security automatically based on the added security extensions
+ */
+public class OpenIDConnectSecurityFilter extends AutoSecurityFilter {
+
+    private AutoUrl authorizationUrl;
+    private AutoUrl refreshUrl;
+    private AutoUrl tokenUrl;
+
+    public OpenIDConnectSecurityFilter() {
+        super();
+    }
+
+    public OpenIDConnectSecurityFilter(String securitySchemeName, String securitySchemeDescription,
+            AutoUrl authorizationUrl,
+            AutoUrl refreshUrl,
+            AutoUrl tokenUrl) {
+        super(securitySchemeName, securitySchemeDescription);
+        this.authorizationUrl = authorizationUrl;
+        this.refreshUrl = refreshUrl;
+        this.tokenUrl = tokenUrl;
+    }
+
+    public AutoUrl getAuthorizationUrl() {
+        return authorizationUrl;
+    }
+
+    public void setAuthorizationUrl(AutoUrl authorizationUrl) {
+        this.authorizationUrl = authorizationUrl;
+    }
+
+    public AutoUrl getRefreshUrl() {
+        return refreshUrl;
+    }
+
+    public void setRefreshUrl(AutoUrl refreshUrl) {
+        this.refreshUrl = refreshUrl;
+    }
+
+    public AutoUrl getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public void setTokenUrl(AutoUrl tokenUrl) {
+        this.tokenUrl = tokenUrl;
+    }
+
+    @Override
+    protected SecurityScheme getSecurityScheme() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+
+        securityScheme.setType(SecurityScheme.Type.OAUTH2);
+        OAuthFlows oAuthFlows = OASFactory.createOAuthFlows();
+        OAuthFlow oAuthFlow = OASFactory.createOAuthFlow();
+        oAuthFlow.authorizationUrl(this.authorizationUrl.getFinalUrlValue());
+        oAuthFlow.refreshUrl(this.refreshUrl.getFinalUrlValue());
+        oAuthFlow.tokenUrl(this.tokenUrl.getFinalUrlValue());
+        oAuthFlows.setImplicit(oAuthFlow);
+        securityScheme.setFlows(oAuthFlows);
+
+        return securityScheme;
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -89,7 +89,8 @@ public class HttpSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem initBasicAuth(
             HttpSecurityRecorder recorder,
-            HttpBuildTimeConfig buildTimeConfig) {
+            HttpBuildTimeConfig buildTimeConfig,
+            BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
         if ((buildTimeConfig.auth.form.enabled || isMtlsClientAuthenticationEnabled(buildTimeConfig))
                 && !buildTimeConfig.auth.basic) {
             //if form auth is enabled and we are not then we don't install
@@ -105,6 +106,7 @@ public class HttpSecurityProcessor {
                 && !buildTimeConfig.auth.basic) {
             //if not explicitly enabled we make this a default bean, so it is the fallback if nothing else is defined
             configurator.defaultBean();
+            securityInformationProducer.produce(SecurityInformationBuildItem.BASIC());
         }
 
         return configurator.done();
@@ -119,7 +121,8 @@ public class HttpSecurityProcessor {
             Capabilities capabilities,
             BuildProducer<BeanContainerListenerBuildItem> beanContainerListenerBuildItemBuildProducer,
             HttpBuildTimeConfig buildTimeConfig,
-            List<HttpSecurityPolicyBuildItem> httpSecurityPolicyBuildItemList) {
+            List<HttpSecurityPolicyBuildItem> httpSecurityPolicyBuildItemList,
+            BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
         Map<String, Supplier<HttpSecurityPolicy>> policyMap = new HashMap<>();
         for (HttpSecurityPolicyBuildItem e : httpSecurityPolicyBuildItemList) {
             if (policyMap.containsKey(e.getName())) {
@@ -131,6 +134,7 @@ public class HttpSecurityProcessor {
         if (buildTimeConfig.auth.form.enabled) {
         } else if (buildTimeConfig.auth.basic) {
             beanProducer.produce(AdditionalBeanBuildItem.unremovableOf(BasicAuthenticationMechanism.class));
+            securityInformationProducer.produce(SecurityInformationBuildItem.BASIC());
         }
 
         if (capabilities.isPresent(Capability.SECURITY)) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/SecurityInformationBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/SecurityInformationBuildItem.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Contains information on the security model used in the application
+ */
+public final class SecurityInformationBuildItem extends MultiBuildItem {
+
+    private final SecurityModel securityModel;
+    private final Optional<OpenIDConnectInformation> openIDConnectInformation;
+
+    public static SecurityInformationBuildItem BASIC() {
+        return new SecurityInformationBuildItem(SecurityModel.basic, Optional.empty());
+    }
+
+    public static SecurityInformationBuildItem JWT() {
+        return new SecurityInformationBuildItem(SecurityModel.jwt, Optional.empty());
+    }
+
+    public static SecurityInformationBuildItem OPENIDCONNECT(String urlConfigKey) {
+        return new SecurityInformationBuildItem(SecurityModel.oidc,
+                Optional.of(new OpenIDConnectInformation(urlConfigKey)));
+    }
+
+    public SecurityInformationBuildItem(SecurityModel securityModel,
+            Optional<OpenIDConnectInformation> openIDConnectInformation) {
+        this.securityModel = securityModel;
+        this.openIDConnectInformation = openIDConnectInformation;
+    }
+
+    public SecurityModel getSecurityModel() {
+        return securityModel;
+    }
+
+    public Optional<OpenIDConnectInformation> getOpenIDConnectInformation() {
+        return openIDConnectInformation;
+    }
+
+    public enum SecurityModel {
+        basic,
+        jwt,
+        oidc
+    }
+
+    public static class OpenIDConnectInformation {
+        private final String urlConfigKey;
+
+        public OpenIDConnectInformation(String urlConfigKey) {
+            this.urlConfigKey = urlConfigKey;
+        }
+
+        public String getUrlConfigKey() {
+            return urlConfigKey;
+        }
+    }
+}


### PR DESCRIPTION
This is another PR in an effort to create better defaults for OpenAPI.
This PR adds Auto Security Scheme based on the included security extension. Users can still set this themselves using annotations or config, but when setting nothing we "discover" the appropriate settings.

This can reduce the code significantly. Already, with other already merged PR, a typical REST endpoint can reduce like indicated below:

![before_after](https://user-images.githubusercontent.com/6836179/130941789-b9c1db38-7339-4042-b54c-5a2972a4be15.png)

This also works nice with the new Keycloak DevServices:

https://user-images.githubusercontent.com/6836179/130943140-968ba75b-03e1-475f-b159-608bd1920f5a.mp4

Fix #18597


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>
