### PR TITLE
Remove unnecessary Jackson dependency from oidc extension

### DIFF
--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -34,10 +34,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-common-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/oidc-client/runtime/pom.xml
+++ b/extensions/oidc-client/runtime/pom.xml
@@ -28,10 +28,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -50,10 +50,6 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/19688#issuecomment-906358106 for the reasoning behind this

Fixes: #19688