### PR TITLE
Calculate byte-buddy version dynamically in ConditionalDependenciesTest

### DIFF
--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -45,6 +45,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- Make sure to have Hibernate's byte-buddy on the classpath, not the one from Mockito.
+                     See also ConditionalDependenciesTest -->
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- The following dependencies are generated in a way that is consistent with other normal IT modules,
              that is "runtime" deps are defined with scope compile and "minimal extension deployment dependencies"

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConditionalDependenciesTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConditionalDependenciesTest.java
@@ -6,11 +6,16 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import net.bytebuddy.ByteBuddy;
 
 /**
  * This class uses test order because all tests depend on extension publication which can be done once.
@@ -79,10 +84,17 @@ public class ConditionalDependenciesTest extends QuarkusGradleWrapperTestBase {
         assertThat(mainLib.resolve("org.acme.ext-c-1.0-SNAPSHOT.jar")).exists();
         assertThat(mainLib.resolve("org.acme.ext-e-1.0-SNAPSHOT.jar")).exists();
         assertThat(mainLib.resolve("org.acme.ext-d-1.0-SNAPSHOT.jar")).doesNotExist();
-        assertThat(mainLib.resolve("net.bytebuddy.byte-buddy-1.11.12.jar")).doesNotExist();
+
+        String byteBuddyJar = Optional.ofNullable(ByteBuddy.class.getProtectionDomain().getCodeSource().getLocation())
+                .map(url -> Pattern.compile("byte-buddy-(\\d.+)\\.jar").matcher(url.getPath()))
+                .filter(Matcher::find)
+                .map(matcher -> "net.bytebuddy.byte-buddy-" + matcher.group(1) + ".jar")
+                .orElseThrow(() -> new IllegalStateException("Could not determine byte-buddy version"));
+
+        assertThat(mainLib.resolve(byteBuddyJar)).doesNotExist();
 
         final Path deploymentLib = buildDir.toPath().resolve("quarkus-app").resolve("lib").resolve("deployment");
-        assertThat(deploymentLib.resolve("net.bytebuddy.byte-buddy-1.11.12.jar")).exists();
+        assertThat(deploymentLib.resolve(byteBuddyJar)).exists();
     }
 
     @Test


### PR DESCRIPTION
Fixes #18838

This ain't pretty:
BB's MANIFEST.MF doesn't provide an implementation version (which could be retrieved easily via `java.lang.Package.getImplementationVersion()`), only a "Bundle-Version".
So instead of going the longer way to find the jar, load the Manifest and get the Bundle-Version, I went with getting the jar and extracting the version directly from it's name. YMMV!

The part with the exclusion isn't great either: Here in this module, mockito wins over hibernate and so we end up with 1.11.13, not 1.11.12 (or before the latest hibernate update: 1.11.8).
Do we have to manage byte-buddy in the BOM? /cc @aloubyansky @Sanne

PS: I briefly considered using something like shrinkwrap-resolvers or similar, but that seemed overly complicated/loaded.