### PR TITLE
Fallback to the original registry repo config in case applied mirror/proxy from settings didn't work

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryClientMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/RegistryClientMixin.java
@@ -81,8 +81,8 @@ public class RegistryClientMixin {
             catalogResolver = getExtensionCatalogResolver(log);
         } catch (RegistryResolutionException e) {
             log.warn(
-                    "None of the configured Quarkus extension registries appear to be available at the moment. "
-                            + "It should still be possible to create a new project by providing the exact Quarkus platform BOM coordinates, "
+                    "Configured Quarkus extension registries appear to be unavailable at the moment. "
+                            + "It should still be possible to create a project by providing the groupId:artifactId:version of the desired Quarkus platform BOM, "
                             + "e.g. 'quarkus create -P "
                             + ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID + ":"
                             + ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID + ":" + Version.clientVersion() + "'");

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
@@ -90,7 +90,8 @@ public class CreateJBangMojo extends AbstractMojo {
         try {
             mvn = MavenArtifactResolver.builder()
                     .setRepositorySystem(repoSystem)
-                    .setRepositorySystemSession(MojoUtils.muteTransferListener(repoSession))
+                    .setRepositorySystemSession(
+                            getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
                     .setRemoteRepositories(repos)
                     .setRemoteRepositoryManager(remoteRepoManager)
                     .build();

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -203,7 +203,8 @@ public class CreateProjectMojo extends AbstractMojo {
         try {
             mvn = MavenArtifactResolver.builder()
                     .setRepositorySystem(repoSystem)
-                    .setRepositorySystemSession(MojoUtils.muteTransferListener(repoSession))
+                    .setRepositorySystemSession(
+                            getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
                     .setRemoteRepositories(repos)
                     .setRemoteRepositoryManager(remoteRepoManager)
                     .build();

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -171,7 +171,8 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
             try {
                 artifactResolver = MavenArtifactResolver.builder()
                         .setRepositorySystem(repoSystem)
-                        .setRepositorySystemSession(MojoUtils.muteTransferListener(repoSession))
+                        .setRepositorySystemSession(
+                                getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
                         .setRemoteRepositories(repos)
                         .setRemoteRepositoryManager(remoteRepositoryManager)
                         .build();


### PR DESCRIPTION
This change provides a better user experience when Maven mirrors and/or proxies are present in the local Maven settings.

ADDING A * MIRROR
````
    <mirror>
        <id>aliyunmaven</id>
        <mirrorOf>*</mirrorOf>
        <name>阿里云公共仓库</name>
        <url>https://maven.aliyun.com/repository/public</url>
    </mirror>
````
1. For registry.quarkus.io:

1.2. Maven plugin:
````
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] The POM for io.smallrye.config:smallrye-config:jar:2.4.4 is missing, no dependency information available
[WARNING] Failed to resolve the Quarkus extension registry descriptor of registry.quarkus.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.quarkus.io (https://registry.quarkus.io/maven). Re-trying with the original registry.quarkus.io repository configuration.
[INFO] Looking for the newly published extensions in registry.quarkus.io
Set the project groupId [org.acme]: 
````
2. Non-existing registry.playground.io

2.1. Maven plugin:
````
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] The POM for io.smallrye.config:smallrye-config:jar:2.4.4 is missing, no dependency information available
[WARNING] Failed to resolve the Quarkus extension registry descriptor of registry.playground.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.playground.io (https://registry.playground.io/maven). Re-trying with the original registry.playground.io repository configuration.
[WARNING] Could not transfer metadata io.playground.registry:quarkus-registry-descriptor:1.0-SNAPSHOT/maven-metadata.xml from/to registry.playground.io (https://registry.playground.io/maven): transfer failed for https://registry.playground.io/maven/io/playground/registry/quarkus-registry-descriptor/1.0-SNAPSHOT/maven-metadata.xml
[WARNING] The extension catalog will be narrowed to the io.quarkus:quarkus-bom:999-SNAPSHOT platform release. To enable the complete Quarkiverse extension catalog along with the latest recommended platform releases, please, make sure the following registries are accessible from your environment: registry.playground.io
Set the project groupId [org.acme]: 
````
2.2. CLI:
````
[aloubyansky@localhost test]$ qs create
Creating an app (default project type, see --help).
[WARN] 🔥  Failed to resolve the Quarkus extension registry descriptor of registry.playground.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.playground.io (https://registry.playground.io/maven). Re-trying with the original registry.playground.io repository configuration.
[WARN] 🔥  Configured Quarkus extension registries appear to be unavailable at the moment. It should still be possible to create a project by providing the groupId:artifactId:version of the desired Quarkus platform BOM, e.g. 'quarkus create -P io.quarkus.platform:quarkus-bom:999-SNAPSHOT'
[ERROR] ❗  Unable to create project: Failed to resolve the Quarkus extension registry descriptor of registry.playground.io from registry.playground.io (https://registry.playground.io/maven)
````

3. Interestingly I caught a moment when 2.1.4.Final became available in the Central but not in the Chinese mirror, resulting in

3.1. CLI error:
````
[aloubyansky@localhost test]$ qs create
Creating an app (default project type, see --help).
[WARN] 🔥  Failed to resolve the Quarkus extension registry descriptor of registry.quarkus.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.quarkus.io (https://registry.quarkus.io/maven). Re-trying with the original registry.quarkus.io repository configuration.
Looking for the newly published extensions in registry.quarkus.io
[ERROR] ❗  Unable to create project: Failed to resolve Quarkus extensions catalog io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final
````

3.2. Maven plugin error:
````
[aloubyansky@localhost test]$ mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] The POM for io.smallrye.config:smallrye-config:jar:2.4.4 is missing, no dependency information available
[WARNING] Failed to resolve the Quarkus extension registry descriptor of registry.quarkus.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.quarkus.io (https://registry.quarkus.io/maven). Re-trying with the original registry.quarkus.io repository configuration.
[INFO] Looking for the newly published extensions in registry.quarkus.io
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.919 s
[INFO] Finished at: 2021-08-26T15:46:43+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) on project standalone-pom: Failed to resolve the extensions catalog: Failed to resolve Quarkus extensions catalog io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final: Failed to resolve artifact io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final: Could not find artifact io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final in aliyunmaven (https://maven.aliyun.com/repository/public) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
````