### PR TITLE
Check whether the platform catalog couldn't be resolved from a Maven mirror

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -51,7 +51,7 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
             try {
                 return catalogResolver.resolveExtensionCatalog(platforms);
             } catch (Exception e) {
-                throw new RuntimeException("Failed to resolve extensions catalog", e);
+                throw new RuntimeException("Failed to resolve extension catalog", e);
             }
         }
         return ToolsUtils.mergePlatforms(platforms, extension().getAppModelResolver());

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -368,7 +368,7 @@ public class CreateProjectMojo extends AbstractMojo {
                             new ArtifactCoords(getPlatformGroupId(mojo, groupId), getPlatformArtifactId(artifactId), "pom",
                                     getPlatformVersion(mojo, version))));
         } catch (RegistryResolutionException e) {
-            throw new MojoExecutionException("Failed to resolve the extensions catalog", e);
+            throw new MojoExecutionException("Failed to resolve the extension catalog", e);
         }
 
         if (catalog == null) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -126,7 +126,7 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
             try {
                 return catalogResolver.resolveExtensionCatalog(getImportedPlatforms());
             } catch (Exception e) {
-                throw new MojoExecutionException("Failed to resolve the Quarkus extensions catalog", e);
+                throw new MojoExecutionException("Failed to resolve the Quarkus extension catalog", e);
             }
         }
         return ToolsUtils.mergePlatforms(collectImportedPlatforms(), artifactResolver());

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/PlatformAwareTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/PlatformAwareTestBase.java
@@ -27,7 +27,7 @@ public class PlatformAwareTestBase {
             try {
                 catalog = QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog();
             } catch (Exception e) {
-                throw new RuntimeException("Failed to resolve extensions catalog", e);
+                throw new RuntimeException("Failed to resolve extension catalog", e);
             }
         }
         return catalog;

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -99,7 +99,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
             try {
                 extensionCatalog = QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog();
             } catch (Exception e) {
-                throw new RuntimeException("Failed to resolve extensions catalog", e);
+                throw new RuntimeException("Failed to resolve extension catalog", e);
             }
         }
         return extensionCatalog;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
@@ -10,9 +10,12 @@ import io.quarkus.registry.client.RegistryPlatformExtensionsResolver;
 import io.quarkus.registry.util.PlatformArtifacts;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
 public class MavenPlatformExtensionsResolver implements RegistryPlatformExtensionsResolver {
 
@@ -44,13 +47,36 @@ public class MavenPlatformExtensionsResolver implements RegistryPlatformExtensio
         try {
             jsonPath = artifactResolver.resolve(catalogArtifact);
         } catch (Exception e) {
-            throw new RegistryResolutionException("Failed to resolve Quarkus extensions catalog " + catalogArtifact,
-                    e);
+            RemoteRepository repo = null;
+            Throwable t = e;
+            while (t != null) {
+                if (t instanceof ArtifactNotFoundException) {
+                    repo = ((ArtifactNotFoundException) t).getRepository();
+                    break;
+                }
+                t = t.getCause();
+            }
+            final StringBuilder buf = new StringBuilder();
+            buf.append("Failed to resolve Quarkus extension catalog ").append(catalogArtifact);
+            if (repo != null) {
+                buf.append(" from ").append(repo.getId()).append(" (").append(repo.getUrl()).append(")");
+                final List<RemoteRepository> mirrored = repo.getMirroredRepositories();
+                if (!mirrored.isEmpty()) {
+                    buf.append(" which is a mirror of ");
+                    buf.append(mirrored.get(0).getId()).append(" (").append(mirrored.get(0).getUrl()).append(")");
+                    for (int i = 1; i < mirrored.size(); ++i) {
+                        buf.append(", ").append(mirrored.get(i).getId()).append(" (").append(mirrored.get(i).getUrl())
+                                .append(")");
+                    }
+                    buf.append(". The mirror may be out of sync.");
+                }
+            }
+            throw new RegistryResolutionException(buf.toString(), e);
         }
         try {
             return JsonCatalogMapperHelper.deserialize(jsonPath, JsonExtensionCatalog.class);
         } catch (IOException e) {
-            throw new RegistryResolutionException("Failed to parse Quarkus extensions catalog " + jsonPath, e);
+            throw new RegistryResolutionException("Failed to parse Quarkus extension catalog " + jsonPath, e);
         }
     }
 

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/QuarkusPlatformAwareMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/QuarkusPlatformAwareMojoTestBase.java
@@ -18,7 +18,7 @@ public class QuarkusPlatformAwareMojoTestBase extends MojoTestBase {
             try {
                 catalog = QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog();
             } catch (RegistryResolutionException e) {
-                throw new RuntimeException("Failed to resolve the extensions catalog", e);
+                throw new RuntimeException("Failed to resolve the extension catalog", e);
             } finally {
                 disableDevToolsTestConfig(System.getProperties());
             }


### PR DESCRIPTION
If an extension catalog which is normally expected to be provided by Maven Central could not be resolved from a mirror,indicate that the mirror might not be up-to-date at the moment in the error message.

Example errors:

1) Maven plugin

````
[aloubyansky@localhost test]$ mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] The POM for io.smallrye.config:smallrye-config:jar:2.4.4 is missing, no dependency information available
[WARNING] Failed to resolve the Quarkus extension registry descriptor of registry.quarkus.io from aliyunmaven (https://maven.aliyun.com/repository/public) having applied the mirrors and/or proxies from the Maven settings to registry.quarkus.io (https://registry.quarkus.io/maven). Re-trying with the original registry.quarkus.io repository configuration.
[INFO] Looking for the newly published extensions in registry.quarkus.io
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.641 s
[INFO] Finished at: 2021-08-26T17:21:05+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) on project standalone-pom: Failed to resolve the extensions catalog: Failed to resolve Quarkus extension catalog io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final from aliyunmaven (https://maven.aliyun.com/repository/public) which is a mirror of central (https://repo.maven.apache.org/maven2) and is possibly not yet fully synched right now: Failed to resolve artifact io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final: Could not find artifact io.quarkus.platform:quarkus-optaplanner-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final in aliyunmaven (https://maven.aliyun.com/repository/public) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
````

2) CLI

````
[aloubyansky@localhost test]$ qs create
Creating an app (default project type, see --help).
Looking for the newly published extensions in registry.quarkus.io
[ERROR] ❗  Unable to create project: Failed to resolve Quarkus extension catalog io.quarkus.platform:quarkus-kogito-bom-quarkus-platform-descriptor:json:2.1.4.Final:2.1.4.Final from aliyunmaven (https://maven.aliyun.com/repository/public) which is a mirror of central (https://repo.maven.apache.org/maven2) and is possibly not yet fully synched right now
````