### PR TITLE
Make it easier to access the static OidcTenantConfig from custom tenant resolvers

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -2,7 +2,7 @@ package io.quarkus.oidc.runtime;
 
 import io.quarkus.oidc.OidcTenantConfig;
 
-class TenantConfigContext {
+public class TenantConfigContext {
 
     /**
      * OIDC Provider
@@ -24,5 +24,9 @@ class TenantConfigContext {
         this.provider = client;
         this.oidcConfig = config;
         this.ready = ready;
+    }
+
+    public OidcTenantConfig getOidcTenantConfig() {
+        return oidcConfig;
     }
 }


### PR DESCRIPTION
User has asked for an option to access the static tenant configuration from custom resolvers - the only thing which prevents it for now is the fact that `TenantConfigContext` is package private - I don't recall it was on done on purpose, most of other runtime classes are also public