### PR TITLE
Exclude jline from the Maven's plugin classpath

### DIFF
--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -39,6 +39,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Possibly fixes #19673

@knutwannheden could you please give this a try?