### PR TITLE
Add config property for reusing jacoco data files

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -61,7 +61,9 @@ public class JacocoProcessor {
                 + config.dataFile;
         System.setProperty("jacoco-agent.destfile",
                 dataFile);
-        Files.deleteIfExists(Paths.get(dataFile));
+        if (!config.reuseDataFile) {
+            Files.deleteIfExists(Paths.get(dataFile));
+        }
 
         Instrumenter instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
         Set<String> seen = new HashSet<>();

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -17,6 +17,13 @@ public class JacocoConfig {
     public String dataFile;
 
     /**
+     * Whether to reuse ({@code true}) or delete ({@code false}) the jacoco
+     * data file on each run.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean reuseDataFile;
+
+    /**
      * If Quarkus should generate the Jacoco report
      */
     @ConfigItem(defaultValue = "true")


### PR DESCRIPTION
This is to allow aggregating coverage results from
multiple test JVMs, for example when using the Surefire
property reuseForks = false

JaCoCo itself has configuration settings to allow
appending coverage data to an existing file (which is
its default behaviour).

The Quarkus default behaviour is unchanged (the jacoco
data file is deleted before each run).