### PR TITLE
Fix NPE in TenantConfigBean preventing proper ARC shutdown leading to class loader issues

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -50,14 +50,18 @@ public class TenantConfigBean {
         @Override
         public void destroy(TenantConfigBean instance, CreationalContext<TenantConfigBean> creationalContext,
                 Map<String, Object> params) {
-            if (instance.defaultTenant != null) {
+            if (instance.defaultTenant != null && instance.defaultTenant.provider != null) {
                 instance.defaultTenant.provider.close();
             }
             for (var i : instance.staticTenantsConfig.values()) {
-                i.provider.close();
+                if (i.provider != null) {
+                    i.provider.close();
+                }
             }
             for (var i : instance.dynamicTenantsConfig.values()) {
-                i.provider.close();
+                if (i.provider != null) {
+                    i.provider.close();
+                }
             }
         }
     }


### PR DESCRIPTION
`io.quarkus.oidc.runtime.TenantConfigBean.Destroyer.destroy()` "blindly" calls `.close()` on `TenantConfigContext.provider` ignoring the fact that `provider` can be `null`.

This leads to error messages like `2021-08-25 20:25:49,167 ERROR [io.qua.arc.imp.InstanceHandleImpl] (main) Error occurred while destroying instance of bean [io.quarkus.oidc.runtime.TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean]: java.lang.NullPointerException`
with the stack trace
```
2021-08-27 09:19:05,545 ERROR [io.qua.arc.imp.InstanceHandleImpl] (main) Error occurred while destroying instance of bean [io.quarkus.oidc.runtime.TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean]: java.lang.NullPointerException
	at io.quarkus.oidc.runtime.TenantConfigBean$Destroyer.destroy(TenantConfigBean.java:54)
	at io.quarkus.oidc.runtime.TenantConfigBean$Destroyer.destroy(TenantConfigBean.java:48)
	at io.quarkus.oidc.runtime.TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean.destroy(TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean.zig:113)
	at io.quarkus.oidc.runtime.TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean.destroy(TenantConfigBean_db1a9da4c1df4426bbea69cb152051caf53ae9c3_Synthetic_Bean.zig:131)
	at io.quarkus.arc.impl.InstanceHandleImpl.destroyInternal(InstanceHandleImpl.java:90)
	at io.quarkus.arc.impl.ContextInstanceHandleImpl.destroy(ContextInstanceHandleImpl.java:20)
	at io.quarkus.arc.impl.AbstractSharedContext.destroy(AbstractSharedContext.java:79)
	at io.quarkus.arc.impl.ArcContainerImpl.shutdown(ArcContainerImpl.java:374)
	at io.quarkus.arc.Arc.shutdown(Arc.java:49)
	at io.quarkus.arc.runtime.ArcRecorder$1.run(ArcRecorder.java:44)
	at io.quarkus.runtime.StartupContext.runAllInReverseOrder(StartupContext.java:83)
	at io.quarkus.runtime.StartupContext.close(StartupContext.java:72)
	at io.quarkus.runner.ApplicationImpl.doStop(ApplicationImpl.zig:1066)
	at io.quarkus.runtime.Application.stop(Application.java:203)
	at io.quarkus.runtime.Application.stop(Application.java:155)
	at io.quarkus.runtime.Application.close(Application.java:137)
	at io.quarkus.runner.bootstrap.StartupActionImpl$3.close(StartupActionImpl.java:192)
	at io.quarkus.runner.bootstrap.RunningQuarkusApplicationImpl.close(RunningQuarkusApplicationImpl.java:35)
	at io.quarkus.test.junit.QuarkusTestExtension$4.close(QuarkusTestExtension.java:411)
	at io.quarkus.test.junit.QuarkusTestExtension$ExtensionState.close(QuarkusTestExtension.java:1293)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
```
which in turn can lead to further class loading issues, because the whole ARC-shutdown did not complete (e.g. `2021-08-25 20:26:17,799 ERROR [io.ver.ext.web.RoutingContext] (vert.x-eventloop-thread-1) Unhandled exception in router: java.util.ServiceConfigurationError: org.eclipse.microprofile.context.spi.ThreadContextProvider: io.quarkus.arc.runtime.context.ArcContextProvider not a subtype`).

`null` seems to be a valid "value" for `provider. Potential sources:
* `io.quarkus.oidc.runtime.OidcRecorder#createTenantContext` passes `null` for provider (called `client` there) if `tenantEnabled` is false
* `io.quarkus.oidc.runtime.OidcRecorder#createStaticTenantContext` passes `null` for `provider`, if the OIDC server is not available

Simple non-`null` checks as in this PR seem to solve the issue.

Note: `TenantConfigBean.Destroyer` was introduced in 434dd2e23a53ba6c76e68f21c30e20ff0748394f