### PR TITLE
Upgrade to Hibernate ORM 5.6.0.Beta1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.5.7.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.6.0.Beta1</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR9</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>

--- a/extensions/hibernate-envers/runtime/pom.xml
+++ b/extensions/hibernate-envers/runtime/pom.xml
@@ -29,12 +29,6 @@
                     <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 </exclusion>
 
-                <!-- Javassist is never used in Quarkus -->
-                <exclusion>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                </exclusion>
-
                 <!-- These XML parsers are banned in the project as we use the new package -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -59,12 +59,6 @@
                     <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 </exclusion>
 
-                <!-- Javassist is never used in Quarkus -->
-                <exclusion>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                </exclusion>
-
                 <!-- These XML parsers are banned in the project as we use the new package -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
and it no longer brings Javassist among the dependencies, so cleaning that up:
 - https://in.relation.to/2021/08/27/hibernate-orm-560-beta1-release/