### PR TITLE
Stated the filename to use when creating TokenResource.java

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -78,7 +78,7 @@ This will add the following to your `pom.xml`:
 
 == Writing the application
 
-Let's write a simple JAX-RS resource which has all the tokens returned in the authorization code grant response injected:
+Let's write a simple JAX-RS resource which has all the tokens returned in the authorization code grant response injected. Create `./src/main/java/org/acme/security/openid/connect/web/authentication/TokenResource.java` containing the following:
 
 [source,java]
 ----


### PR DESCRIPTION
When creating the TokenResource.java, the user needs to first (mentally) infer the path of the file from the package name, then manually create the package structure.

Yes, this is probably easier in an IDE, but I was trying this guide on the command line. 