### PR TITLE
Add audit table suffix config property

### DIFF
--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversAuditTableSuffixTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversAuditTableSuffixTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversAuditTableSuffixTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAuditedEntity.class, MyRevisionEntity.class, MyRevisionListener.class,
+                            EnversTestAuditTableSuffixResource.class)
+                    .addAsResource("application-with-store-data-at-delete.properties", "application.properties"));
+
+    @Test
+    public void testAuditTableSuffix() {
+        RestAssured.when().get("/audit-table-suffix").then()
+                .body(is("OK"));
+    }
+
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversTestAuditTableSuffixResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/EnversTestAuditTableSuffixResource.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.envers;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.configuration.internal.AuditEntitiesConfiguration;
+import org.hibernate.internal.SessionImpl;
+
+@Path("/audit-table-suffix")
+@ApplicationScoped
+public class EnversTestAuditTableSuffixResource {
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    @ConfigProperty(name = "quarkus.hibernate-envers.audit-table-suffix")
+    String configuredSuffix;
+
+    @GET
+    public String getAuditTableName() {
+        AuditEntitiesConfiguration auditEntitiesConfiguration = ((((SessionImpl) em.getDelegate())
+                .getFactory().getServiceRegistry()).getParentServiceRegistry())
+                        .getService(EnversService.class).getAuditEntitiesConfiguration();
+
+        String calculatedAuditTableName = auditEntitiesConfiguration.getAuditTableName("entity", "table");
+        String expectedAuditTableName = "table" + configuredSuffix;
+        if (expectedAuditTableName.equals(calculatedAuditTableName)) {
+            return "OK";
+        }
+        return "Obtained audit table name " + calculatedAuditTableName + " is not same as expected: " + expectedAuditTableName;
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-store-data-at-delete.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-store-data-at-delete.properties
@@ -3,3 +3,4 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-envers.store-data-at-delete=true
+quarkus.hibernate-envers.audit-table-suffix=_SUFFIX

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
@@ -11,4 +11,11 @@ public class HibernateEnversBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean storeDataAtDelete;
+
+    /**
+     * Defines a suffix for historical data table.
+     */
+    @ConfigItem(defaultValue = "_AUD")
+    public String auditTableSuffix;
+
 }

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
@@ -26,6 +26,7 @@ public class HibernateEnversRecorder {
         @Override
         public void contributeBootProperties(BiConsumer<String, Object> propertyCollector) {
             addConfig(propertyCollector, EnversSettings.STORE_DATA_AT_DELETE, buildTimeConfig.storeDataAtDelete);
+            addConfig(propertyCollector, EnversSettings.AUDIT_TABLE_SUFFIX, buildTimeConfig.auditTableSuffix);
         }
 
         public static <T> void addConfig(BiConsumer<String, Object> propertyCollector, String configPath, T value) {


### PR DESCRIPTION
I added quarkus config key quarkus.hibernate-envers.audit-table-suffix which is mapped to hibernate.envers.audit_table_suffix. Default value is "_AUD".
Please review my changes.