### PR TITLE
Fix async i/o error and move startup script

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -325,7 +325,7 @@ public class DevServicesKafkaProcessor {
 
         private String hostName = null;
 
-        private static final String STARTER_SCRIPT = "/redpanda.sh";
+        private static final String STARTER_SCRIPT = "/var/lib/redpanda/redpanda.sh";
 
         private RedPandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
                 boolean useSharedNetwork) {
@@ -360,7 +360,7 @@ public class DevServicesKafkaProcessor {
 
             // Start and configure the advertised address
             String command = "#!/bin/bash\n";
-            command += "/usr/bin/rpk redpanda start --check=false --node-id 0 ";
+            command += "/usr/bin/rpk redpanda start --check=false --node-id 0 --smp 1 ";
             command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ";
             command += String.format("--advertise-kafka-addr PLAINTEXT://%s:29092,OUTSIDE://%s:%d", getHostToUse(),
                     getHostToUse(), getPortToUse());


### PR DESCRIPTION
This PR starts the redpanda server with `--smp 1` which resolves a `Could not setup Async I/O: Resource temporarily unavailable.` error when running tests using dind in k8s. This PR also moves the startup script to the `/var/lib/redpanda/` folder which is owned by the redpanda user that runs the container.

See also: https://github.com/quarkusio/quarkus/issues/19445