### PR TITLE
Provide actionable error message when RESTEasy can't pick Provider constructor

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/QuarkusInjectorFactory.java
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/QuarkusInjectorFactory.java
@@ -28,6 +28,10 @@ public class QuarkusInjectorFactory extends InjectorFactoryImpl {
     @SuppressWarnings("rawtypes")
     @Override
     public ConstructorInjector createConstructor(Constructor constructor, ResteasyProviderFactory providerFactory) {
+        if (constructor == null) {
+            throw new IllegalStateException(
+                    "Unable to locate proper constructor for dynamically registered provider. Make sure the class has a no-args constructor and that it uses '@Context' for field injection if necessary.");
+        }
         log.debugf("Create constructor: %s", constructor);
         return new QuarkusConstructorInjector(constructor, super.createConstructor(constructor, providerFactory));
     }


### PR DESCRIPTION
This can happen when a provider is registered via a Dynamic Feature.
Unfortunately the error message can not contain the class which causes the problem
because it is not passed into the method, the class itself is not present in fields
which can be accessed at this point and the StackWalker does not have access to parameters

Closes: #19756