### PR TITLE
Upgrade build-reporting-maven-extension to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
             <extension>
                 <groupId>io.quarkus.bot</groupId>
                 <artifactId>build-reporting-maven-extension</artifactId>
-                <version>1.0.3</version>
+                <version>1.0.4</version>
             </extension>
         </extensions>
     </build>


### PR DESCRIPTION
Fixes module path relativization for incremental builds.