### PR TITLE
Set default jvm-target in kotlin sample project

### DIFF
--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     kotlin("jvm")
 }
 
+// This is a fix as kotlin 1.5.30 does not support Java 17 yet
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    tasks.quarkusDev {
+        compilerArgs = listOf("-jvm-target", "16")
+    }
+}
 dependencies {
     implementation(project(":port"))
     implementation(project(":domain"))


### PR DESCRIPTION
This forces the JVM target to 11 in a sample kotlin project. 

This makes sures, quarkus dev is working even with jdk 17 (which is not a valid target for kotlin yet)