### PR TITLE
Add the ability for extensions to exclude GraalVM config from jars [Revisited]

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ExcludeConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ExcludeConfigBuildItem.java
@@ -28,7 +28,7 @@ public final class ExcludeConfigBuildItem extends MultiBuildItem {
     }
 
     public ExcludeConfigBuildItem(String jarFile) {
-        this(jarFile, "META-INF/native-image/native-image.properties");
+        this(jarFile, "/META-INF/native-image/native-image\\.properties");
     }
 
     public String getJarFile() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ExcludeConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ExcludeConfigBuildItem.java
@@ -1,0 +1,41 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that allows extension to configure the native-image compiler to effectively
+ * ignore certain configuration files in specific jars.
+ *
+ * The {@code jarFile} property specifies the name of the jar file or a regular expression that can be used to
+ * match multiple jar files.
+ * Matching jar files using regular expressions should be done as a last resort.
+ *
+ * The {@code resourceName} property specifies the name of the resource file or a regular expression that can be used to
+ * match multiple resource files.
+ * For the match to work, the resources need to be part of the matched jar file(s) (see {@code jarFile}).
+ * Matching resource files using regular expressions should be done as a last resort.
+ *
+ * See https://github.com/oracle/graal/pull/3179 for more details.
+ */
+public final class ExcludeConfigBuildItem extends MultiBuildItem {
+
+    private final String jarFile;
+    private final String resourceName;
+
+    public ExcludeConfigBuildItem(String jarFile, String resourceName) {
+        this.jarFile = jarFile;
+        this.resourceName = resourceName;
+    }
+
+    public ExcludeConfigBuildItem(String jarFile) {
+        this(jarFile, "META-INF/native-image/native-image.properties");
+    }
+
+    public String getJarFile() {
+        return jarFile;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -26,6 +26,7 @@ import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
@@ -81,7 +82,8 @@ public class NativeImageBuildStep {
             NativeImageSourceJarBuildItem nativeImageSourceJarBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
             PackageConfig packageConfig,
-            List<NativeImageSystemPropertyBuildItem> nativeImageProperties) {
+            List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
+            List<ExcludeConfigBuildItem> excludeConfigs) {
 
         Path outputDir;
         try {
@@ -100,6 +102,7 @@ public class NativeImageBuildStep {
                 .setNativeConfig(nativeConfig)
                 .setOutputTargetBuildItem(outputTargetBuildItem)
                 .setNativeImageProperties(nativeImageProperties)
+                .setExcludeConfigs(excludeConfigs)
                 .setOutputDir(outputDir)
                 .setRunnerJarName(runnerJar.getFileName().toString())
                 // the path to native-image is not known now, it is only known at the time the native-sources will be consumed
@@ -130,6 +133,7 @@ public class NativeImageBuildStep {
             PackageConfig packageConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
+            List<ExcludeConfigBuildItem> excludeConfigs,
             List<NativeImageSecurityProviderBuildItem> nativeImageSecurityProviders,
             Optional<ProcessInheritIODisabled> processInheritIODisabled) {
         if (nativeConfig.debug.enabled) {
@@ -187,6 +191,7 @@ public class NativeImageBuildStep {
                     .setNativeConfig(nativeConfig)
                     .setOutputTargetBuildItem(outputTargetBuildItem)
                     .setNativeImageProperties(nativeImageProperties)
+                    .setExcludeConfigs(excludeConfigs)
                     .setNativeImageSecurityProviders(nativeImageSecurityProviders)
                     .setOutputDir(outputDir)
                     .setRunnerJarName(runnerJarName)
@@ -477,6 +482,7 @@ public class NativeImageBuildStep {
             private NativeConfig nativeConfig;
             private OutputTargetBuildItem outputTargetBuildItem;
             private List<NativeImageSystemPropertyBuildItem> nativeImageProperties;
+            private List<ExcludeConfigBuildItem> excludeConfigs;
             private List<NativeImageSecurityProviderBuildItem> nativeImageSecurityProviders;
             private Path outputDir;
             private String runnerJarName;
@@ -497,6 +503,11 @@ public class NativeImageBuildStep {
 
             public Builder setNativeImageProperties(List<NativeImageSystemPropertyBuildItem> nativeImageProperties) {
                 this.nativeImageProperties = nativeImageProperties;
+                return this;
+            }
+
+            public Builder setExcludeConfigs(List<ExcludeConfigBuildItem> excludeConfigs) {
+                this.excludeConfigs = excludeConfigs;
                 return this;
             }
 
@@ -699,6 +710,13 @@ public class NativeImageBuildStep {
                                 .map(p -> p.getSecurityProvider())
                                 .collect(Collectors.joining(","));
                         nativeImageArgs.add("-H:AdditionalSecurityProviders=" + additionalSecurityProviders);
+                    }
+
+                    // --exclude-config options
+                    for (ExcludeConfigBuildItem excludeConfig : excludeConfigs) {
+                        nativeImageArgs.add("--exclude-config");
+                        nativeImageArgs.add(excludeConfig.getJarFile());
+                        nativeImageArgs.add(excludeConfig.getResourceName());
                     }
                 }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -595,8 +595,6 @@ public class NativeImageBuildStep {
                         "-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime"); //the default collection policy results in full GC's 50% of the time
                 nativeImageArgs.add("-H:+JNI");
                 nativeImageArgs.add("-H:+AllowFoldMethods");
-                nativeImageArgs.add("-jar");
-                nativeImageArgs.add(runnerJarName);
 
                 if (nativeConfig.enableFallbackImages) {
                     nativeImageArgs.add("-H:FallbackThreshold=5");
@@ -721,6 +719,10 @@ public class NativeImageBuildStep {
                 }
 
                 nativeImageArgs.add(nativeImageName);
+
+                //Make sure to have the -jar as last one, as it otherwise breaks "--exclude-config"
+                nativeImageArgs.add("-jar");
+                nativeImageArgs.add(runnerJarName);
 
                 return new NativeImageInvokerInfo(nativeImageArgs);
             }


### PR DESCRIPTION
Resolves: #17482

It seems that by listing the arguments in this particular order, we can workaround the GraalVM issue. Thanks @galderz !
