### PR TITLE
Do not propagate java compiler argument in kotlin compilation provider

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -121,7 +121,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         Task quarkusBuild = tasks.create(QUARKUS_BUILD_TASK_NAME, QuarkusBuild.class);
         quarkusBuild.dependsOn(quarkusGenerateCode);
-        Task quarkusDev = tasks.create(QUARKUS_DEV_TASK_NAME, QuarkusDev.class);
+        QuarkusDev quarkusDev = tasks.create(QUARKUS_DEV_TASK_NAME, QuarkusDev.class);
         Task quarkusRemoteDev = tasks.create(QUARKUS_REMOTE_DEV_TASK_NAME, QuarkusRemoteDev.class);
         Task quarkusTest = tasks.create(QUARKUS_TEST_TASK_NAME, QuarkusTest.class);
         tasks.create(QUARKUS_TEST_CONFIG_TASK_NAME, QuarkusTestConfig.class);
@@ -233,6 +233,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                 });
 
         project.getPlugins().withId("org.jetbrains.kotlin.jvm", plugin -> {
+            quarkusDev.shouldPropagateJavaCompilerArgs(false);
             tasks.getByName("compileKotlin").dependsOn(quarkusGenerateCode);
             tasks.getByName("compileTestKotlin").dependsOn(quarkusGenerateCodeTests);
         });

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -74,6 +74,8 @@ public class QuarkusDev extends QuarkusTask {
 
     private List<String> compilerArgs = new LinkedList<>();
 
+    private boolean shouldPropagateJavaCompilerArgs = true;
+
     @Inject
     public QuarkusDev() {
         super("Development mode: enables hot deployment with background compilation");
@@ -303,7 +305,7 @@ public class QuarkusDev extends QuarkusTask {
             builder.targetJavaVersion(javaPluginConvention.getTargetCompatibility().toString());
         }
 
-        if (getCompilerArgs().isEmpty()) {
+        if (getCompilerArgs().isEmpty() && shouldPropagateJavaCompilerArgs) {
             getJavaCompileTask()
                     .map(compileTask -> compileTask.getOptions().getCompilerArgs())
                     .ifPresent(builder::compilerOptions);
@@ -570,5 +572,9 @@ public class QuarkusDev extends QuarkusTask {
             getProject().getLogger().debug("Adding dependency {}", file);
             classPathManifest.classpathEntry(file);
         }
+    }
+
+    public void shouldPropagateJavaCompilerArgs(boolean shouldPropagateJavaCompilerArgs) {
+        this.shouldPropagateJavaCompilerArgs = shouldPropagateJavaCompilerArgs;
     }
 }

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'io.quarkus'
+}
+
+repositories {
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-kotlin'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/gradle.properties
@@ -1,0 +1,4 @@
+kotlinVersion=1.5.30
+
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version  "${kotlinVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/src/main/kotlin/org/acme/GreetingResource.kt
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/src/main/kotlin/org/acme/GreetingResource.kt
@@ -1,0 +1,16 @@
+package org.acme
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("/hello")
+class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello(): String {
+        return "hello"
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableMap;
+
+public class BasicKotlinApplicationModuleDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "basic-kotlin-application-project";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hello");
+
+        final String uuid = UUID.randomUUID().toString();
+        replace("src/main/kotlin/org/acme/GreetingResource.kt",
+                ImmutableMap.of("return \"hello\"", "return \"" + uuid + "\""));
+
+        assertUpdatedResponseContains("/hello", uuid);
+    }
+}


### PR DESCRIPTION
This makes sure java compiler arguments are not used if the kotlin plugin is not used.

close #18166 