### PR TITLE
Fix @NoCache without fields handling in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/cache/NoCacheOnMethodsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/cache/NoCacheOnMethodsTest.java
@@ -30,37 +30,53 @@ public class NoCacheOnMethodsTest {
             });
 
     @Test
-    public void testWith() {
-        RestAssured.get("/test/with")
+    public void testWithFields() {
+        RestAssured.get("/test/withFields")
                 .then()
                 .statusCode(200)
-                .body(equalTo("with"))
+                .body(equalTo("withFields"))
                 .header("Cache-Control", "no-cache=\"f1\", no-cache=\"f2\"");
     }
 
     @Test
-    public void testWithout() {
-        RestAssured.get("/test/without")
+    public void testWithoutFields() {
+        RestAssured.get("/test/withoutFields")
                 .then()
                 .statusCode(200)
-                .body(equalTo("without"))
+                .body(equalTo("withoutFields"))
+                .header("Cache-Control", "no-cache");
+    }
+
+    @Test
+    public void testWithoutAnnotation() {
+        RestAssured.get("/test/withoutAnnotation")
+                .then()
+                .statusCode(200)
+                .body(equalTo("withoutAnnotation"))
                 .header("Cache-Control", nullValue());
     }
 
     @Path("test")
     public static class ResourceWithNoCache {
 
-        @Path("with")
+        @Path("withFields")
         @GET
         @NoCache(fields = { "f1", "f2" })
-        public String with() {
-            return "with";
+        public String withFields() {
+            return "withFields";
         }
 
-        @Path("without")
+        @Path("withoutFields")
         @GET
-        public String without() {
-            return "without";
+        @NoCache
+        public String withoutFields() {
+            return "withoutFields";
+        }
+
+        @Path("withoutAnnotation")
+        @GET
+        public String withoutAnnotation() {
+            return "withoutAnnotation";
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/CacheControlScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/CacheControlScanner.java
@@ -61,18 +61,18 @@ public class CacheControlScanner implements MethodScanner {
         if (noCacheInstance == null) {
             return null;
         }
+        ExtendedCacheControl cacheControl = new ExtendedCacheControl();
+        cacheControl.setNoCache(true);
+        cacheControl.setNoTransform(false);
         AnnotationValue fieldsValue = noCacheInstance.value("fields");
         if (fieldsValue != null) {
             String[] fields = fieldsValue.asStringArray();
             if ((fields != null) && (fields.length > 0)) {
-                ExtendedCacheControl cacheControl = new ExtendedCacheControl();
-                cacheControl.setNoCache(true);
-                cacheControl.setNoTransform(false);
                 cacheControl.getNoCacheFields().addAll(Arrays.asList(fields));
-                return cacheControl;
+
             }
         }
-        return null;
+        return cacheControl;
     }
 
     private ExtendedCacheControl cacheToCacheControl(AnnotationInstance cacheInstance) {


### PR DESCRIPTION
Fixes: #19822 (and bring RESTEasy Reactive in line with RESTEasy Classic on how the cache headers are handled)