### PR TITLE
Remove hard coded kotlin version in Gradle tests

### DIFF
--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -184,12 +184,12 @@
         <!-- END update-dependencies.sh -->
     </dependencies>
     <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-            </testResource>
-        </testResources>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.5.30
+kotlinVersion=${kotlin.version}
 
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
     id 'io.quarkus'
-    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.allopen'
 }
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/gradle.properties
@@ -1,2 +1,3 @@
+kotlinVersion=${kotlin.version}
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
@@ -11,7 +11,9 @@ pluginManagement {
         }
     }
     plugins {
-      id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
+        id 'org.jetbrains.kotlin.plugin.allopen' version "${kotlinVersion}"
     }
 }
 rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.allopen'
     id 'io.quarkus'
 }
 

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/gradle.properties
@@ -1,2 +1,3 @@
+kotlinVersion=${kotlin.version}
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
@@ -12,7 +12,9 @@ pluginManagement {
         }
     }
     plugins {
-      id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
+        id 'org.jetbrains.kotlin.plugin.allopen' version "${kotlinVersion}"
     }
 }
 rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/gradle.properties
@@ -3,5 +3,5 @@
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus
 
-kotlinVersion=1.5.30
+kotlinVersion=${kotlin.version}
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version "1.5.30"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.5.30"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.allopen'
     id 'io.quarkus'
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/gradle.properties
@@ -1,2 +1,3 @@
+kotlinVersion=${kotlin.version}
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
@@ -12,7 +12,9 @@ pluginManagement {
         }
     }
     plugins {
-      id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
+        id 'org.jetbrains.kotlin.plugin.allopen' version "${kotlinVersion}"
     }
 }
 rootProject.name='code-with-quarkus'


### PR DESCRIPTION
As discussed previously, this remove hard coded kotlin version to rely on quarkus kotlin version property set in `build-parent/pom.xml` https://github.com/quarkusio/quarkus/blob/main/build-parent/pom.xml#L23.