### PR TITLE
Clean up hang detection on failed start

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -435,15 +435,7 @@ public class QuarkusTestExtension
                             } finally {
                                 tcclMethodCache.clear();
                                 GroovyCacheCleaner.clearGroovyCache();
-                                if (hangTaskKey != null) {
-                                    hangTaskKey.cancel(true);
-                                    hangTaskKey = null;
-                                }
-                                var h = hangDetectionExecutor;
-                                if (h != null) {
-                                    h.shutdownNow();
-                                    hangDetectionExecutor = null;
-                                }
+                                shutdownHangDetection();
                             }
                         }
                         try {
@@ -469,6 +461,18 @@ public class QuarkusTestExtension
             if (originalCl != null) {
                 Thread.currentThread().setContextClassLoader(originalCl);
             }
+        }
+    }
+
+    private void shutdownHangDetection() {
+        if (hangTaskKey != null) {
+            hangTaskKey.cancel(true);
+            hangTaskKey = null;
+        }
+        var h = hangDetectionExecutor;
+        if (h != null) {
+            h.shutdownNow();
+            hangDetectionExecutor = null;
         }
     }
 
@@ -1333,6 +1337,7 @@ public class QuarkusTestExtension
 
         @Override
         public void close() {
+            resetHangTimeout();
             firstException = null;
             failedBoot = false;
             ConfigProviderResolver.setInstance(null);


### PR DESCRIPTION
This can cause a false positive in the vertx-http-deployment tests where
a continuous test fails to start, then spits out a hang detection
warning a minute later.