### PR TITLE
Change dev mode working directory

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -227,7 +227,7 @@ public class DevMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.sourceDirectory}")
     private File sourceDir;
 
-    @Parameter(defaultValue = "${project.build.directory}")
+    @Parameter
     private File workingDir;
 
     @Parameter(defaultValue = "${jvm.args}")
@@ -765,7 +765,7 @@ public class DevMojo extends AbstractMojo {
             final ProcessBuilder processBuilder = new ProcessBuilder(launcher.args())
                     .redirectErrorStream(true)
                     .inheritIO()
-                    .directory(workingDir == null ? buildDir : workingDir);
+                    .directory(workingDir == null ? project.getBasedir() : workingDir);
             if (!environmentVariables.isEmpty()) {
                 processBuilder.environment().putAll(environmentVariables);
             }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -141,7 +141,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         run(false, "-Dquarkus.args='1 2'");
 
         // Wait until this file exists
-        final File done = new File(testDir, "target/done.txt");
+        final File done = new File(testDir, "done.txt");
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
                 .atMost(20, TimeUnit.MINUTES).until(() -> done.exists());
@@ -159,7 +159,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         run(false);
 
         // Wait until this file exists
-        final File done = new File(testDir, "target/done.txt");
+        final File done = new File(testDir, "done.txt");
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
                 .atMost(20, TimeUnit.MINUTES).until(() -> done.exists());
@@ -817,7 +817,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
     @Test
     public void testThatExternalConfigOverridesConfigInJar() throws MavenInvocationException, IOException {
         testDir = initProject("projects/classic", "projects/project-classic-external-config");
-        File configurationFile = new File(testDir, "target/config/application.properties");
+        File configurationFile = new File(testDir, "config/application.properties");
         assertThat(configurationFile).doesNotExist();
 
         String uuid = UUID.randomUUID().toString();


### PR DESCRIPTION
This will now be the same as surefire, so tests will see the same
user.dir for both surefire tests and continuous tests.

This is technically a breaking change, but should not really affect the
majority of applications. The old behaviour can be restored using

`<workingDir>${project.build.directory}</workingDir>`

in the maven plugin configuration.