### PR TITLE
Bump kubernetes-client-bom from 5.7.0 to 5.7.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -170,7 +170,7 @@
         <okhttp.version>3.14.9</okhttp.version>
         <sentry.version>5.1.2</sentry.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.7.0</kubernetes-client.version>
+        <kubernetes-client.version>5.7.2</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Kubernetes Client 5.7.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.7.2

Just speeding up the dependabot process to see if CI reports any issue.

Supersedes  #19831. This one should be backportable since it generates Jandex files compatible with Jandex 2.3.

/cc @metacosm @gastaldi