### PR TITLE
Update JNA to work with Apple M1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <quarkus-spring-security-api.version>5.2.Final</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <mockito.version>3.12.4</mockito.version>
-        <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
+        <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
         <keycloak.version>14.0.0</keycloak.version>


### PR DESCRIPTION
Testcontainers requires a minimum version of 5.8.0 to work with Apple's M1.  This just updates the BOM version of JNA to that version.