### PR TITLE
Qute: Remove Standalone lines should be true by default as doc says it is

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -31,6 +31,7 @@ public final class EngineBuilder {
         this.resultMappers = new ArrayList<>();
         this.parserHooks = new ArrayList<>();
         this.strictRendering = true;
+        this.removeStandaloneLines = true;
     }
 
     public EngineBuilder addSectionHelper(SectionHelperFactory<?> factory) {


### PR DESCRIPTION
Quarkus integrated qute works fine as it configures to remove the standalone lines. But using standalone Qute does not. 