### PR TITLE
Standalone Qute example is a lot less useful without Reflection resolver

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -40,7 +40,7 @@ A template definition is an instance of `io.quarkus.qute.Template`.
 
 If using Qute "standalone" you'll need to create an instance of `io.quarkus.qute.Engine` first.
 The `Engine` represents a central point for template management with dedicated configuration. 
-Let's use the convenient builder:
+Let's use the convenient builder (We just need add `io.quarkus.qute.ReflectionValueResolver` to defaults):
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -44,7 +44,7 @@ Let's use the convenient builder:
 
 [source,java]
 ----
-Engine engine = Engine.builder().addDefaults().build();
+Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
 ----
 
 TIP: In Quarkus, there is a preconfigured `Engine` available for injection - see <<quarkus_integration>>.


### PR DESCRIPTION
Documentation refers to item.name etc, by which I presume it refer to the ability to send an item instance into data and ability to access all it's bean style properties.

To my surprise the Builder with default resolvers just doesn't allow to add any bean style instance OR allows access to methods of objects inside the template.

Though Quarkus integration wires all the necessary resolvers in a non reflective fashion etc, user like me do use Qute as standalone in many projects and the current documentation lacks this information on how to configure to send any object via data and access inside template.

Perhaps my English wordings or the place I inserted the text in the document is not the best but there is a real need for this information as this is not obvious to me and I ended up wasting time to figure this out.

If my wording / placement is not ok, can anyone please help refine this as needed? Thanks.
