### PR TITLE
LambdaContainerHandlerSubstitution class must be marked final

### DIFF
--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/graal/LambdaContainerHandlerSubstitution.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/graal/LambdaContainerHandlerSubstitution.java
@@ -5,7 +5,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 @TargetClass(LambdaContainerHandler.class)
-public class LambdaContainerHandlerSubstitution {
+public final class LambdaContainerHandlerSubstitution {
 
     // afterburner does not work in native mode, so let's ensure it's never registered
     @Substitute


### PR DESCRIPTION
Fixes #19886 

```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.114 s - in io.quarkus.it.amazon.lambda.AmazonLambdaV1SimpleIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M5:verify (default) @ quarkus-integration-test-amazon-lambda-rest ---

```