### PR TITLE
Use the same parent CL for both test and dev

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -129,7 +129,7 @@ public class TestSupport implements TestController {
                         .setAssertionsEnabled(true)
                         .setDisableClasspathCache(false)
                         .setIsolateDeployment(true)
-                        .setBaseClassLoader(getClass().getClassLoader())
+                        .setBaseClassLoader(getClass().getClassLoader().getParent())
                         .setTest(true)
                         .setAuxiliaryApplication(true)
                         .setHostApplicationIsTestOnly(devModeType == DevModeType.TEST_ONLY)


### PR DESCRIPTION
The isolated test CL does not need to access anything from the dev CL,
and it just causes leakage problems.

Fixes #19888