### PR TITLE
Test execution message is now copy/paste friendly

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -104,7 +104,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         Files.deleteIfExists(logFile);
         Files.createDirectories(logFile.getParent());
 
-        System.out.println("Executing " + args);
+        System.out.println("Executing \"" + String.join(" ", args) + "\"");
 
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -66,7 +66,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         args.add("-jar");
         args.add(jarPath.toAbsolutePath().toString());
 
-        System.out.println("Executing " + args);
+        System.out.println("Executing \"" + String.join(" ", args) + "\"");
 
         Files.deleteIfExists(logFile);
         Files.createDirectories(logFile.getParent());

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -96,7 +96,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
             args.add("-D" + e.getKey() + "=" + e.getValue());
         }
 
-        System.out.println("Executing " + args);
+        System.out.println("Executing \"" + String.join(" ", args) + "\"");
 
         Files.deleteIfExists(logFile);
         Files.createDirectories(logFile.getParent());


### PR DESCRIPTION
The "Executing" message shown in the ArtifactLauncher implementations now allows you to copy/paste the command easily

eg. 
From:
```bash
Executing [/home/ggastald/Downloads/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-runner, -Dquarkus.http.port=8081, -Dquarkus.http.ssl-port=8444, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=/home/ggastald/Downloads/code-with-quarkus/target/quarkus.log, -Dquarkus.log.file.enable=true]
```
To
```bash
Executing "/home/ggastald/Downloads/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-runner -Dquarkus.http.port=8081 -Dquarkus.http.ssl-port=8444 -Dtest.url=http://localhost:8081 -Dquarkus.log.file.path=/home/ggastald/Downloads/code-with-quarkus/target/quarkus.log -Dquarkus.log.file.enable=true"
```
