### PR TITLE
Fix use of OpenTelemetry OTLP exporter in native mode

### DIFF
--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/restclient/ClientTracingFilter.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/restclient/ClientTracingFilter.java
@@ -26,7 +26,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 @Priority(Priorities.HEADER_DECORATOR)
 public class ClientTracingFilter implements ClientRequestFilter, ClientResponseFilter {
-    private static final TextMapPropagator TEXT_MAP_PROPAGATOR = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+    private final TextMapPropagator TEXT_MAP_PROPAGATOR = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
 
     private static final String SCOPE_KEY = ClientTracingFilter.class.getName() + ".scope";
     private static final String SPAN_KEY = ClientTracingFilter.class.getName() + ".span";

--- a/integration-tests/resteasy-reactive-rest-client/pom.xml
+++ b/integration-tests/resteasy-reactive-rest-client/pom.xml
@@ -31,6 +31,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
+        <!-- Support for OpenTelemetry by exporting to otlp -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+        </dependency>
 
         <!-- Needed for InMemorySpanExporter to verify captured traces -->
         <dependency>
@@ -89,6 +94,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Essentially the fact that ClientTracingFilter was using a static
field for TextMapPropagator was causing GraalVM to initialize
the entire telemetry infrastructure at build time

Fixes: #19877