### PR TITLE
Use DevServicesContext instead of deprecated QuarkusIntegrationTest.Context

### DIFF
--- a/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoDbRestDataPanacheIT.java
+++ b/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoDbRestDataPanacheIT.java
@@ -6,13 +6,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 @DisabledOnOs(OS.WINDOWS)
 class MongoDbRestDataPanacheIT extends MongoDbRestDataPanacheTest {
 
-    QuarkusIntegrationTest.Context context;
+    DevServicesContext context;
 
     @Test
     public void testDevServicesProperties() {

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
@@ -4,12 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class BearerTokenAuthorizationInGraalITCase extends BearerTokenAuthorizationTest {
 
-    QuarkusIntegrationTest.Context context;
+    DevServicesContext context;
 
     @Test
     public void testDevServicesProperties() {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -219,7 +219,7 @@ public class QuarkusIntegrationTestExtension
         Class<?> c = testInstance.getClass();
         while (c != Object.class) {
             for (Field f : c.getDeclaredFields()) {
-                if (f.getType().equals(QuarkusIntegrationTest.Context.class)) {
+                if (f.getType().equals(DevServicesContext.class)) {
                     try {
                         f.setAccessible(true);
                         f.set(testInstance, createTestContext());
@@ -242,7 +242,7 @@ public class QuarkusIntegrationTestExtension
         }
     }
 
-    private QuarkusIntegrationTest.Context createTestContext() {
+    private DevServicesContext createTestContext() {
         Map<String, String> devServicesPropsCopy = devServicesProps.isEmpty() ? Collections.emptyMap()
                 : Collections.unmodifiableMap(devServicesProps);
         return new DefaultQuarkusIntegrationTestContext(devServicesPropsCopy);
@@ -293,7 +293,7 @@ public class QuarkusIntegrationTestExtension
         }
     }
 
-    private static class DefaultQuarkusIntegrationTestContext implements QuarkusIntegrationTest.Context {
+    private static class DefaultQuarkusIntegrationTestContext implements DevServicesContext {
 
         private final Map<String, String> map;
 


### PR DESCRIPTION
Use DevServicesContext instead of deprecated QuarkusIntegrationTest.Context