### PR TITLE
Fix issue with skip predicates in scheduled methods

### DIFF
--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -96,6 +96,7 @@ public class SchedulerProcessor {
     static final DotName SCHEDULED_NAME = DotName.createSimple(Scheduled.class.getName());
     static final DotName SCHEDULES_NAME = DotName.createSimple(Scheduled.Schedules.class.getName());
     static final DotName SKIP_NEVER_NAME = DotName.createSimple(Scheduled.Never.class.getName());
+    static final DotName SKIP_PREDICATE = DotName.createSimple(Scheduled.SkipPredicate.class.getName());
 
     static final Type SCHEDULED_EXECUTION_TYPE = Type.create(DotName.createSimple(ScheduledExecution.class.getName()),
             Kind.CLASS);
@@ -464,6 +465,11 @@ public class SchedulerProcessor {
         }
 
         return null;
+    }
+
+    @BuildStep
+    UnremovableBeanBuildItem unremoveableSkipPredicates() {
+        return new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanTypeExclusion(SKIP_PREDICATE));
     }
 
 }

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConditionalExecutionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConditionalExecutionTest.java
@@ -1,11 +1,13 @@
 package io.quarkus.scheduler.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.event.Observes;
 import javax.inject.Singleton;
@@ -44,17 +46,25 @@ public class ConditionalExecutionTest {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
+
+        assertTrue(OtherIsDisabled.TESTED.get());
+        assertEquals(0, Jobs.OTHER_COUNT.get());
     }
 
     static class Jobs {
 
         static final CountDownLatch COUNTER = new CountDownLatch(1);
+        static final AtomicInteger OTHER_COUNT = new AtomicInteger(0);
 
         @Scheduled(identity = "foo", every = "1s", skipExecutionIf = IsDisabled.class)
         void doSomething() throws InterruptedException {
             COUNTER.countDown();
         }
 
+        @Scheduled(identity = "other-foo", every = "1s", skipExecutionIf = OtherIsDisabled.class)
+        void doSomethingElse() throws InterruptedException {
+            OTHER_COUNT.incrementAndGet();
+        }
     }
 
     @Singleton
@@ -74,6 +84,19 @@ public class ConditionalExecutionTest {
 
                 SKIPPED_LATCH.countDown();
             }
+        }
+
+    }
+
+    @Singleton
+    public static class OtherIsDisabled implements Scheduled.SkipPredicate {
+
+        static final AtomicBoolean TESTED = new AtomicBoolean(false);
+
+        @Override
+        public boolean test(ScheduledExecution execution) {
+            TESTED.set(true);
+            return true;
         }
 
     }


### PR DESCRIPTION
Before this fix, the implementations where actually
eligible for bean removal

Fixes: #19900