### PR TITLE
Include relevant upstream catalogs even if their versions aren't recommended for new projects

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
@@ -2,15 +2,15 @@ package io.quarkus.cli.common;
 
 import io.quarkus.cli.Version;
 import io.quarkus.maven.ArtifactCoords;
-import io.quarkus.maven.StreamCoords;
 import io.quarkus.platform.tools.ToolsConstants;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
 public class TargetQuarkusVersionGroup {
     final static String FULL_EXAMPLE = ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID + ":"
             + ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID + ":2.2.0.Final";
-    StreamCoords streamCoords = null;
+    PlatformStreamCoords streamCoords = null;
     String validStream = null;
 
     ArtifactCoords platformBom = null;
@@ -25,7 +25,7 @@ public class TargetQuarkusVersionGroup {
         stream = stream.trim();
         if (!stream.isEmpty()) {
             try {
-                streamCoords = StreamCoords.fromString(stream);
+                streamCoords = PlatformStreamCoords.fromString(stream);
                 validStream = stream;
             } catch (IllegalArgumentException iex) {
                 throw new CommandLine.ParameterException(spec.commandLine(),
@@ -94,7 +94,7 @@ public class TargetQuarkusVersionGroup {
         return streamCoords != null;
     }
 
-    public StreamCoords getStream() {
+    public PlatformStreamCoords getStream() {
         return streamCoords;
     }
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/common/TargetQuarkusVersionGroupTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/common/TargetQuarkusVersionGroupTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.cli.Version;
 import io.quarkus.maven.ArtifactCoords;
-import io.quarkus.maven.StreamCoords;
 import io.quarkus.platform.tools.ToolsConstants;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
 
 public class TargetQuarkusVersionGroupTest {
     final static String clientVersion = Version.clientVersion();
@@ -64,7 +64,7 @@ public class TargetQuarkusVersionGroupTest {
     void testStreamUseDFullyQualified() {
         qvg.setStream("stream-platform:stream-version");
 
-        StreamCoords coords = qvg.getStream();
+        PlatformStreamCoords coords = qvg.getStream();
         Assertions.assertEquals("stream-platform", coords.getPlatformKey());
         Assertions.assertEquals("stream-version", coords.getStreamId());
     }
@@ -73,7 +73,7 @@ public class TargetQuarkusVersionGroupTest {
     void testStreamUseDefaultPlatformKey() {
         qvg.setStream(":stream-version");
 
-        StreamCoords coords = qvg.getStream();
+        PlatformStreamCoords coords = qvg.getStream();
         Assertions.assertNull(coords.getPlatformKey());
         Assertions.assertEquals("stream-version", coords.getStreamId());
     }
@@ -82,7 +82,7 @@ public class TargetQuarkusVersionGroupTest {
     void testStreamUseDefaultStreamId() {
         qvg.setStream("stream-platform:");
 
-        StreamCoords coords = qvg.getStream();
+        PlatformStreamCoords coords = qvg.getStream();
         Assertions.assertEquals("stream-platform", coords.getPlatformKey());
         Assertions.assertEquals("", coords.getStreamId());
     }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -120,6 +120,9 @@ public class TestRegistryClient implements RegistryClient {
     public PlatformCatalog resolvePlatforms(String quarkusVersion) throws RegistryResolutionException {
         final Path json = TestRegistryClientBuilder.getRegistryPlatformsCatalogPath(registryDir, quarkusVersion);
         log.debug("%s resolvePlatforms %s", config.getId(), json);
+        if (!Files.exists(json)) {
+            return null;
+        }
         try {
             return JsonCatalogMapperHelper.deserialize(json, JsonPlatformCatalog.class);
         } catch (IOException e) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingArchivedUpstreamVersionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingArchivedUpstreamVersionTest.java
@@ -1,0 +1,162 @@
+package io.quarkus.devtools.project.create;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*-downstream")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.4 release
+                .newRelease("2.0.4-downstream")
+                .quarkusVersion("2.2.2-downstream")
+                .upstreamQuarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                // foo platform member
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4-downstream").release().stream().platform()
+                .newStream("1.0")
+                // 1.0.4 release
+                .newRelease("1.0.4-downstream")
+                .quarkusVersion("1.1.1-downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                // foo platform member
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4-downstream").release()
+                .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "1.0.4-downstream").release()
+                .stream().platform().registry()
+                .newNonPlatformCatalog("1.1.1-downstream").addExtension("io.acme", "ext-d", "4.0-downstream").registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.5 release
+                .newRelease("2.0.5")
+                .quarkusVersion("2.2.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.5").release()
+                .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "2.0.5").release()
+                .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "2.0.5").release().stream()
+                // 2.0.4 release
+                .newArchivedRelease("2.0.4")
+                .quarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4").release()
+                .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "2.0.4").release()
+                .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "2.0.4").release().stream().platform()
+                // 1.0 STREAM
+                .newStream("1.0")
+                .newRelease("1.0.5")
+                .quarkusVersion("1.1.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.5").addExtension("io.acme", "ext-e", "1.0.5")
+                .release()
+                .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "1.0.5").release()
+                .stream()
+                .newArchivedRelease("1.0.4")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4").addExtension("io.acme", "ext-e", "1.0.4")
+                .release()
+                .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "1.0.4").release()
+                .stream().platform().registry()
+                .newNonPlatformCatalog("2.2.2").addExtension("io.acme", "ext-c", "5.1").addExtension("io.acme", "ext-d", "6.0")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void addExtensionsFromAlreadyImportedPlatform() throws Exception {
+        final Path projectDir = newProjectDir("downstream-upstream-platform");
+        createProject(projectDir, Arrays.asList("ext-a"));
+
+        assertModel(projectDir,
+                toPlatformBomCoords("acme-foo-bom"),
+                Arrays.asList(new ArtifactCoords("io.acme", "ext-a", null)),
+                "2.0.4-downstream");
+
+        addExtensions(projectDir, Arrays.asList("ext-b", "ext-c", "ext-d", "ext-e"));
+        assertModel(projectDir,
+                Arrays.asList(mainPlatformBom(), platformMemberBomCoords("acme-foo-bom"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-bar-bom", "pom", "2.0.4"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-e-bom", "pom", "2.0.4")),
+                Arrays.asList(new ArtifactCoords("io.acme", "ext-a", null),
+                        new ArtifactCoords("io.acme", "ext-b", null),
+                        new ArtifactCoords("io.acme", "ext-e", null),
+                        new ArtifactCoords("io.acme", "ext-c", "jar", "5.1"),
+                        new ArtifactCoords("io.acme", "ext-d", "jar", "6.0")),
+                "2.0.4-downstream");
+    }
+
+    @Test
+    public void createWithExtensionsFromDifferentPlatforms() throws Exception {
+        final Path projectDir = newProjectDir("create-downstream-upstream-platform");
+        createProject(projectDir, Arrays.asList("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                Arrays.asList(mainPlatformBom(), platformMemberBomCoords("acme-foo-bom"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-bar-bom", "pom", "2.0.4")),
+                Arrays.asList(new ArtifactCoords("io.acme", "ext-a", null), new ArtifactCoords("io.acme", "ext-b", null)),
+                "2.0.4-downstream");
+    }
+
+    @Test
+    public void createPreferringOlderStreamToNewerStreamCoveringLessExtensions() throws Exception {
+        final Path projectDir = newProjectDir("create-downstream-upstream-platform");
+        createProject(projectDir, Arrays.asList("ext-a", "ext-b", "ext-e"));
+
+        assertModel(projectDir,
+                Arrays.asList(mainPlatformBom(), platformMemberBomCoords("acme-foo-bom"), platformMemberBomCoords("acme-e-bom"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-bar-bom", "pom", "1.0.4")),
+                Arrays.asList(new ArtifactCoords("io.acme", "ext-a", null), new ArtifactCoords("io.acme", "ext-b", null),
+                        new ArtifactCoords("io.acme", "ext-e", null)),
+                "1.0.4-downstream");
+    }
+
+    @Test
+    public void createUsingStream2_0() throws Exception {
+        final Path projectDir = newProjectDir("created-using-downstream-stream");
+        createProject(projectDir, new PlatformStreamCoords(DOWNSTREAM_PLATFORM_KEY, "2.0"),
+                Arrays.asList("ext-a", "ext-b", "ext-e"));
+
+        assertModel(projectDir,
+                Arrays.asList(mainPlatformBom(), platformMemberBomCoords("acme-foo-bom"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-e-bom", "pom", "2.0.4"),
+                        new ArtifactCoords(UPSTREAM_PLATFORM_KEY, "acme-bar-bom", "pom", "2.0.4")),
+                Arrays.asList(new ArtifactCoords("io.acme", "ext-a", null), new ArtifactCoords("io.acme", "ext-b", null),
+                        new ArtifactCoords("io.acme", "ext-e", null)),
+                "2.0.4-downstream");
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -56,6 +56,14 @@ class RegistryExtensionResolver {
                 : VERSION_RECOGNIZED;
     }
 
+    boolean isExclusiveProviderOf(String quarkusVersion) {
+        return checkQuarkusVersion(quarkusVersion) == VERSION_EXCLUSIVE_PROVIDER;
+    }
+
+    boolean isAcceptsQuarkusVersionQueries(String quarkusVersion) {
+        return checkQuarkusVersion(quarkusVersion) >= 0;
+    }
+
     int checkPlatform(ArtifactCoords platform) {
         // TODO this should be allowed to check the full coordinates
         return checkQuarkusVersion(platform.getVersion());

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamCoords.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamCoords.java
@@ -1,17 +1,17 @@
-package io.quarkus.maven;
+package io.quarkus.registry.catalog;
 
-public class StreamCoords {
+public class PlatformStreamCoords {
     final String platformKey;
     final String streamId;
 
-    public static StreamCoords fromString(String stream) {
+    public static PlatformStreamCoords fromString(String stream) {
         final int colon = stream.indexOf(':');
         String platformKey = colon <= 0 ? null : stream.substring(0, colon);
         String streamId = colon < 0 ? stream : stream.substring(colon + 1);
-        return new StreamCoords(platformKey, streamId);
+        return new PlatformStreamCoords(platformKey, streamId);
     }
 
-    public StreamCoords(String platformKey, String streamId) {
+    public PlatformStreamCoords(String platformKey, String streamId) {
         this.platformKey = platformKey;
         this.streamId = streamId;
     }

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/catalog/json/JsonCatalogMergerTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/catalog/json/JsonCatalogMergerTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.registry.catalog.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.catalog.Platform;
+import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.PlatformRelease;
+import io.quarkus.registry.catalog.PlatformStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class JsonCatalogMergerTest {
+
+    @Test
+    void testMergePlatformCatalogs() throws Exception {
+
+        final List<PlatformCatalog> catalogs = new ArrayList<>();
+
+        JsonPlatformCatalog c = new JsonPlatformCatalog();
+        catalogs.add(c);
+        JsonPlatform p = new JsonPlatform();
+        c.addPlatform(p);
+        p.setPlatformKey("platform");
+        JsonPlatformStream s = new JsonPlatformStream();
+        s.setId("2.0");
+        p.addStream(s);
+        JsonPlatformRelease r = new JsonPlatformRelease();
+        r.setQuarkusCoreVersion("2.0.0");
+        r.setVersion(JsonPlatformReleaseVersion.fromString("2.2.2"));
+        r.setMemberBoms(Collections.singletonList(ArtifactCoords.fromString("org.acme:acme-quarkus-bom::pom:2.2.2")));
+        s.addRelease(r);
+
+        s = new JsonPlatformStream();
+        s.setId("1.0");
+        p.addStream(s);
+        r = new JsonPlatformRelease();
+        r.setQuarkusCoreVersion("1.0.1");
+        r.setVersion(JsonPlatformReleaseVersion.fromString("1.1.2"));
+        r.setMemberBoms(Collections.singletonList(ArtifactCoords.fromString("org.acme:acme-quarkus-bom::pom:1.1.2")));
+        s.addRelease(r);
+
+        c = new JsonPlatformCatalog();
+        catalogs.add(c);
+        p = new JsonPlatform();
+        c.addPlatform(p);
+        p.setPlatformKey("platform");
+        s = new JsonPlatformStream();
+        s.setId("2.0");
+        p.addStream(s);
+        r = new JsonPlatformRelease();
+        r.setQuarkusCoreVersion("2.0.1");
+        r.setVersion(JsonPlatformReleaseVersion.fromString("2.2.3"));
+        r.setMemberBoms(Collections.singletonList(ArtifactCoords.fromString("org.acme:acme-quarkus-bom::pom:2.2.3")));
+        s.addRelease(r);
+
+        s = new JsonPlatformStream();
+        s.setId("1.0");
+        p.addStream(s);
+        r = new JsonPlatformRelease();
+        r.setQuarkusCoreVersion("1.0.0");
+        r.setVersion(JsonPlatformReleaseVersion.fromString("1.1.1"));
+        r.setMemberBoms(Collections.singletonList(ArtifactCoords.fromString("org.acme:acme-quarkus-bom::pom:1.1.1")));
+        s.addRelease(r);
+
+        final PlatformCatalog merged = JsonCatalogMerger.mergePlatformCatalogs(catalogs);
+        Collection<Platform> platforms = merged.getPlatforms();
+        assertThat(platforms.size()).isEqualTo(1);
+        Platform platform = platforms.iterator().next();
+        assertThat(platform.getPlatformKey()).isEqualTo("platform");
+        assertThat(platform.getStreams().size()).isEqualTo(2);
+        Iterator<PlatformStream> streams = platform.getStreams().iterator();
+        PlatformStream stream = streams.next();
+        assertThat(stream.getId()).isEqualTo("2.0");
+        assertThat(stream.getReleases().size()).isEqualTo(2);
+        Iterator<PlatformRelease> releases = stream.getReleases().iterator();
+        PlatformRelease release = releases.next();
+        assertThat(release.getVersion()).isEqualTo(JsonPlatformReleaseVersion.fromString("2.2.2"));
+        assertThat(release.getQuarkusCoreVersion()).isEqualTo("2.0.0");
+        release = releases.next();
+        assertThat(release.getVersion()).isEqualTo(JsonPlatformReleaseVersion.fromString("2.2.3"));
+        assertThat(release.getQuarkusCoreVersion()).isEqualTo("2.0.1");
+
+        stream = streams.next();
+        assertThat(stream.getId()).isEqualTo("1.0");
+        assertThat(stream.getReleases().size()).isEqualTo(2);
+        releases = stream.getReleases().iterator();
+        release = releases.next();
+        assertThat(release.getVersion()).isEqualTo(JsonPlatformReleaseVersion.fromString("1.1.2"));
+        assertThat(release.getQuarkusCoreVersion()).isEqualTo("1.0.1");
+        release = releases.next();
+        assertThat(release.getVersion()).isEqualTo(JsonPlatformReleaseVersion.fromString("1.1.1"));
+        assertThat(release.getQuarkusCoreVersion()).isEqualTo("1.0.0");
+    }
+}


### PR DESCRIPTION
It may happen that downstream platform versions reference upstream Quarkus versions that are not recommended any more for new projects in the upstream community. This PR fixes a few issues making sure the dev tools still list the relevant upstream catalogs for downstream versions.

Also deprecated io.quarkus.maven.StreamCoords in favor of io.quarkus.registry.catalog.PlatformStreamCoords