### PR TITLE
Fix combination of multiple `@Nested` tests with root lifecycle methods

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxbTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxbTestCase.java
@@ -2,11 +2,6 @@ package io.quarkus.it.main;
 
 import static org.hamcrest.Matchers.contains;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -15,27 +10,9 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class JaxbTestCase {
 
-    private static final AtomicInteger count = new AtomicInteger(0);
-
-    @BeforeEach
-    public void beforeInEnclosing() {
-        count.incrementAndGet();
+    @Test
+    public void testNews() {
+        RestAssured.when().get("/test/jaxb/getnews").then()
+                .body("author", contains("Emmanuel Bernard"));
     }
-
-    @Nested
-    class SomeClass {
-
-        @BeforeEach
-        public void beforeInTest() {
-            count.incrementAndGet();
-        }
-
-        @Test
-        public void testNews() {
-            RestAssured.when().get("/test/jaxb/getnews").then()
-                    .body("author", contains("Emmanuel Bernard"));
-            Assertions.assertEquals(2, count.get());
-        }
-    }
-
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
@@ -1,0 +1,127 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests {@link Nested} support of {@link QuarkusTest}. Notes:
+ * <ul>
+ * <li>to avoid unexpected execution order, don't use surefire's {@code -Dtest=...}, use {@code -Dgroups=nested} instead</li>
+ * <li>order of nested test classes is reversed by JUnit (and there's no way to enforce a specific order)</li>
+ * </ul>
+ */
+@QuarkusTest
+@Tag("nested")
+public class QuarkusTestNestedTestCase {
+
+    private static final AtomicInteger COUNT_BEFORE_ALL = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_BEFORE_EACH = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_TEST = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_AFTER_EACH = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_AFTER_ALL = new AtomicInteger(0);
+
+    @BeforeAll
+    static void beforeAll() {
+        COUNT_BEFORE_ALL.incrementAndGet();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        COUNT_BEFORE_EACH.incrementAndGet();
+    }
+
+    @Test
+    void test() {
+        assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+        assertEquals(1, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(0, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+        assertEquals(0, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+    }
+
+    @Nested
+    @TestMethodOrder(OrderAnnotation.class)
+    class FirstNested {
+
+        @BeforeEach
+        void beforeEach() {
+            COUNT_BEFORE_EACH.incrementAndGet();
+        }
+
+        @Test
+        @Order(1)
+        void testOne() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(5, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(2, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(3, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @Test
+        @Order(2)
+        void testTwo() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(7, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(3, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(5, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @AfterEach
+        void afterEach() {
+            COUNT_AFTER_EACH.incrementAndGet();
+        }
+    }
+
+    @Nested
+    class SecondNested {
+
+        @BeforeEach
+        void beforeEach() {
+            COUNT_BEFORE_EACH.incrementAndGet();
+        }
+
+        @Test
+        void testOne() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(3, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(1, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(1, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @AfterEach
+        void afterEach() {
+            COUNT_AFTER_EACH.incrementAndGet();
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        COUNT_AFTER_EACH.incrementAndGet();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+        assertEquals(7, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(4, COUNT_TEST.get(), "COUNT_TEST");
+        assertEquals(7, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(0, COUNT_AFTER_ALL.getAndIncrement(), "COUNT_AFTER_ALL");
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -22,7 +22,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -196,8 +195,6 @@ public class QuarkusTestExtension
             //we only every dump once
         }
     };
-
-    private final IdentityHashMap<Method, Method> tcclMethodCache = new IdentityHashMap<>();
 
     static {
         ClassLoader classLoader = QuarkusTestExtension.class.getClassLoader();
@@ -433,7 +430,6 @@ public class QuarkusTestExtension
                                 }
                                 tm.close();
                             } finally {
-                                tcclMethodCache.clear();
                                 GroovyCacheCleaner.clearGroovyCache();
                                 shutdownHangDetection();
                             }
@@ -1102,10 +1098,8 @@ public class QuarkusTestExtension
 
     private Method determineTCCLExtensionMethod(Method originalMethod, Class<?> c)
             throws ClassNotFoundException {
-        Method newMethod = tcclMethodCache.get(originalMethod);
-        if (newMethod != null) {
-            return newMethod;
-        }
+
+        Method newMethod = null;
         while (c != Object.class) {
             if (c.getName().equals(originalMethod.getDeclaringClass().getName())) {
                 try {
@@ -1129,7 +1123,6 @@ public class QuarkusTestExtension
             }
             c = c.getSuperclass();
         }
-        tcclMethodCache.put(originalMethod, newMethod);
         return newMethod;
     }
 


### PR DESCRIPTION
Fixes #19843

Also enhances `tcclMethodCache` to cover negative lookups.