### PR TITLE
Set default jvm-target in basic kotlin sample project

### DIFF
--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -24,3 +24,10 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+// This is a fix as kotlin 1.5.30 does not support Java 17 yet
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    tasks.quarkusDev {
+        compilerArgs = ["-jvm-target", "16"]
+    }
+}


### PR DESCRIPTION
Just like #19794

This now _really_ seems to be the last failure in the EA build.