### PR TITLE
Detect CapabilityBuildItems provided directly from build steps and log corresponding warnings

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/CapabilityBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/CapabilityBuildItem.java
@@ -2,6 +2,8 @@ package io.quarkus.deployment.builditem;
 
 import java.util.Objects;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -24,6 +26,12 @@ import io.quarkus.deployment.Capability;
  */
 public final class CapabilityBuildItem extends MultiBuildItem {
 
+    private static volatile Logger log;
+
+    private static Logger getLog() {
+        return log == null ? log = Logger.getLogger(CapabilityBuildItem.class) : log;
+    }
+
     private final String name;
     private final String provider;
 
@@ -35,7 +43,17 @@ public final class CapabilityBuildItem extends MultiBuildItem {
      */
     @Deprecated
     public CapabilityBuildItem(String name) {
-        this(name, "<unknown>");
+        this(name, StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass().getName());
+        final String msg = "An instance of " + CapabilityBuildItem.class.getName()
+                + " was created using a deprecated constructor by "
+                + provider + " to provide capability '" + name
+                + "'. Please report this issue to the extension maintainers to fix it in the future releases.";
+        final Logger log = getLog();
+        if (log.isDebugEnabled()) {
+            log.debug(msg, new Exception(msg));
+        } else {
+            log.warn(msg);
+        }
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CapabilityAggregationStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CapabilityAggregationStep.java
@@ -1,13 +1,23 @@
 package io.quarkus.deployment.steps;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.CapabilityErrors;
 import io.quarkus.bootstrap.model.ExtensionCapabilities;
+import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.BooleanSupplierFactoryBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -17,6 +27,14 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 
 public class CapabilityAggregationStep {
 
+    public static final class CapabilitiesConfiguredInDescriptorsBuildItem extends SimpleBuildItem {
+        private final Set<String> names;
+
+        private CapabilitiesConfiguredInDescriptorsBuildItem(Set<String> names) {
+            this.names = names;
+        }
+    }
+
     /**
      * Provides capabilities configured in the extension descriptors.
      *
@@ -25,10 +43,12 @@ public class CapabilityAggregationStep {
      * @param supplierFactory boolean supplier factory
      */
     @BuildStep
-    void provideCapabilities(BuildProducer<CapabilityBuildItem> producer, CurateOutcomeBuildItem curateOutcomeBuildItem,
-            BooleanSupplierFactoryBuildItem supplierFactory) {
+    void provideCapabilities(BuildProducer<CapabilityBuildItem> producer,
+            BuildProducer<CapabilitiesConfiguredInDescriptorsBuildItem> configuredCapsProducer,
+            CurateOutcomeBuildItem curateOutcomeBuildItem, BooleanSupplierFactoryBuildItem supplierFactory) {
         final ApplicationModel appModel = curateOutcomeBuildItem.getApplicationModel();
 
+        final Set<String> capabilityNames = new HashSet<>();
         for (ExtensionCapabilities contract : appModel.getExtensionCapabilities()) {
             final String provider = contract.getExtension();
             for (String capability : contract.getProvidesCapabilities()) {
@@ -56,9 +76,11 @@ public class CapabilityAggregationStep {
                 }
                 if (provide) {
                     producer.produce(new CapabilityBuildItem(name, provider));
+                    capabilityNames.add(name);
                 }
             }
         }
+        configuredCapsProducer.produce(new CapabilitiesConfiguredInDescriptorsBuildItem(capabilityNames));
     }
 
     /**
@@ -69,10 +91,13 @@ public class CapabilityAggregationStep {
      * @return aggregated capabilities
      */
     @BuildStep
-    Capabilities aggregateCapabilities(List<CapabilityBuildItem> capabilities) {
+    Capabilities aggregateCapabilities(List<CapabilityBuildItem> capabilities,
+            CapabilitiesConfiguredInDescriptorsBuildItem configuredCaps, CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
-        Map<String, Object> providedCapabilities = new HashMap<>();
+        final Map<String, Object> providedCapabilities = new HashMap<>();
         CapabilityErrors capabilityErrors = null;
+
+        Map<String, List<String>> capsProvidedByBuildSteps = Collections.emptyMap();
 
         for (CapabilityBuildItem capabilityItem : capabilities) {
 
@@ -91,6 +116,31 @@ public class CapabilityAggregationStep {
                 capabilityErrors.addConflict(capability, provider);
                 providedCapabilities.put(capability, capabilityErrors);
             }
+
+            if (!configuredCaps.names.contains(capability)) {
+                if (capsProvidedByBuildSteps.isEmpty()) {
+                    capsProvidedByBuildSteps = new HashMap<>();
+                }
+                capsProvidedByBuildSteps.computeIfAbsent(provider, k -> new ArrayList<>(1)).add(capability);
+            }
+        }
+
+        // capabilities are supposed to be configured in the extension descriptors and not produced directly by build steps
+        if (!capsProvidedByBuildSteps.isEmpty()) {
+            final StringWriter buf = new StringWriter();
+            try (BufferedWriter writer = new BufferedWriter(buf)) {
+                writer.append("The following capabilities were found to be missing from the processed extension descriptors:");
+                for (Map.Entry<String, List<String>> provider : capsProvidedByBuildSteps.entrySet()) {
+                    for (String capability : provider.getValue()) {
+                        writer.newLine();
+                        writer.append(" - " + capability + " provided by ").append(provider.getKey());
+                    }
+                }
+                writer.newLine();
+                writer.append("Please report this issue to the extension maintainers to get it fixed in the future releases.");
+            } catch (IOException e) {
+            }
+            Logger.getLogger(CapabilityAggregationStep.class).warn(buf.toString());
         }
 
         if (capabilityErrors != null && !capabilityErrors.isEmpty()) {


### PR DESCRIPTION
Capabilities provided by extension build steps directly are not visible to the devtools that could help make the right choice for the users creating new projects or adding new extensions to an existing one.