### PR TITLE
Oracle JDBC metadata overrides

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathAggregateBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathAggregateBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Do not use directly: use {@see io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathBuildItem}
+ * instead.
+ */
+public final class NativeImageAllowIncompleteClasspathAggregateBuildItem extends SimpleBuildItem {
+
+    private final boolean allow;
+
+    public NativeImageAllowIncompleteClasspathAggregateBuildItem(boolean allow) {
+        this.allow = allow;
+    }
+
+    public boolean isAllow() {
+        return allow;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * If any build item of this type is produced, the native-image build tool
+ * will run with {@literal --allow-incomplete-classpath} set.
+ * <p>
+ * This should be strongly discouraged as it makes diagnostics of any issue
+ * much more complex, and we have it seen affect error message of code
+ * seemingly unrelated to the code which is having the broken classpath.
+ * <p>
+ * Use of this build item will trigger a warning during build.
+ *
+ * @Deprecated Please don't use it unless there is general consensus that we can't practically find a better solution.
+ */
+@Deprecated
+public final class NativeImageAllowIncompleteClasspathBuildItem extends MultiBuildItem {
+
+    private final String extensionName;
+
+    /**
+     * @param extensionName Name the extension requiring this, so that it can be shamed appropriately during build.
+     */
+    public NativeImageAllowIncompleteClasspathBuildItem(String extensionName) {
+        this.extensionName = extensionName;
+    }
+
+    public String getExtensionName() {
+        return extensionName;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAllowIncompleteClasspathAggregateStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAllowIncompleteClasspathAggregateStep.java
@@ -1,0 +1,38 @@
+package io.quarkus.deployment.steps;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathAggregateBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathBuildItem;
+
+@SuppressWarnings("deprecation")
+public final class NativeImageAllowIncompleteClasspathAggregateStep {
+
+    private static final Logger log = Logger.getLogger(NativeImageAllowIncompleteClasspathAggregateStep.class);
+
+    @BuildStep
+    NativeImageAllowIncompleteClasspathAggregateBuildItem aggregateIndividualItems(
+            List<NativeImageAllowIncompleteClasspathBuildItem> list) {
+        if (list.isEmpty()) {
+            return new NativeImageAllowIncompleteClasspathAggregateBuildItem(false);
+        } else {
+            final String extensionsRequiringBrokenClasspath = list.stream()
+                    .map(NativeImageAllowIncompleteClasspathBuildItem::getExtensionName)
+                    .collect(Collectors.joining(","));
+            log.warn("The following extensions have required the '--allow-incomplete-classpath' flag to be set: {"
+                    + extensionsRequiringBrokenClasspath
+                    + "}. This is a global flag which might have unexpected effects on other extensions as well, and is a hint of the library "
+                    +
+                    "needing some additional refactoring to better support GraalVM native-image. In the case of 3rd party dependencies and/or"
+                    +
+                    " proprietary code there is not much we can do - please ask for support to your library vendor." +
+                    " If you incur in any problem with other Quarkus extensions, please try reproducing the problem without these extensions first.");
+            return new NativeImageAllowIncompleteClasspathAggregateBuildItem(true);
+        }
+    }
+
+}

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -1,0 +1,99 @@
+package io.quarkus.jdbc.oracle.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+
+/**
+ * The Oracle JDBC driver includes a {@literal META-INF/native-image} which enables a set
+ * of global flags we need to control better, so to ensure such flags do not interfere
+ * with requirements of other libraries.
+ * <p>
+ * For this reason, the {@literal META-INF/native-image/native-image.properties} resource
+ * is excluded explicitly; then we re-implement the equivalent directives using Quarkus
+ * build items.
+ * <p>
+ * Other resources such as {@literal jni-config.json} and {@literal resource-config.json}
+ * are not excluded, so to ensure we match the recommendations from the Oracle JDBC
+ * engineering team and make it easier to pick up improvements in these when the driver
+ * gets updated.
+ * <p>
+ * Regarding {@literal reflect-config.json}, we also prefer excluding it for the time
+ * being even though it's strictly not necessary: the reason is that the previous driver
+ * version had a build-breaking mistake; this was fixed in version 21.3 so should no
+ * longer be necessary, but the previous driver had been tested more widely and would
+ * require it, so this would facilitate the option to revert to the older version in
+ * case of problems.
+ */
+public final class OracleMetadataOverrides {
+
+    static final String DRIVER_JAR_MATCH_REGEX = ".*com\\.oracle\\.database\\.jdbc.*";
+    static final String NATIVE_IMAGE_RESOURCE_MATCH_REGEX = "/META-INF/native-image/(?:native-image\\.properties|reflect-config\\.json)";
+
+    /**
+     * Should match the contents of {@literal reflect-config.json}
+     * 
+     * @param reflectiveClass builItem producer
+     */
+    @BuildStep
+    void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        //This is to match the Oracle metadata (which we excluded so that we can apply fixes):
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.internal.ACProxyable"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.T4CDriverExtension"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.T2CDriverExtension"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.ShardingDriverExtension"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.Ano"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.AuthenticationService"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.DataIntegrityService"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.EncryptionService"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.SupervisorService"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.Message11"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, "oracle.sql.TypeDescriptor"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.sql.TypeDescriptorFactory"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.sql.AnyDataFactory"));
+        reflectiveClass
+                .produce(new ReflectiveClassBuildItem(true, false, false, "com.sun.rowset.providers.RIOptimisticProvider"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.logging.annotations.Supports"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.logging.annotations.Feature"));
+    }
+
+    @BuildStep
+    void runtimeInitializeDriver(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitialized) {
+        //These re-implement all the "--initialize-at-build-time" arguments found in the native-image.properties :
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.OracleDriver"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.OracleDriver"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("java.sql.DriverManager"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.LogicalConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.pool.OraclePooledConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.pool.OracleDataSource"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.datasource.impl.OracleDataSource"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.pool.OracleOCIConnectionPool"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.OracleTimeoutThreadPerVM"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TimeoutInterruptHandler"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.HAManager"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.Clock"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TcpMultiplexer"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TcpMultiplexer"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TcpMultiplexer$LazyHolder"));
+        runtimeInitialized
+                .produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(
+                "oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource$BlockReleaser"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.xa.client.OracleXADataSource"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.replay.OracleXADataSourceImpl"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.datasource.OracleXAConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.xa.client.OracleXAConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.xa.client.OracleXAHeteroConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.T4CXAConnection"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.security.o5logon.O5Logon"));
+    }
+
+    @BuildStep
+    ExcludeConfigBuildItem excludeOracleDirectives() {
+        // Excludes both native-image.properties and reflect-config.json, which are reimplemented above
+        return new ExcludeConfigBuildItem(DRIVER_JAR_MATCH_REGEX, NATIVE_IMAGE_RESOURCE_MATCH_REGEX);
+    }
+
+}

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -3,6 +3,7 @@ package io.quarkus.jdbc.oracle.deployment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
@@ -94,6 +95,11 @@ public final class OracleMetadataOverrides {
     ExcludeConfigBuildItem excludeOracleDirectives() {
         // Excludes both native-image.properties and reflect-config.json, which are reimplemented above
         return new ExcludeConfigBuildItem(DRIVER_JAR_MATCH_REGEX, NATIVE_IMAGE_RESOURCE_MATCH_REGEX);
+    }
+
+    @BuildStep
+    NativeImageAllowIncompleteClasspathBuildItem naughtyDriver() {
+        return new NativeImageAllowIncompleteClasspathBuildItem("quarkus-jdbc-oracle");
     }
 
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleReflections.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleReflections.java
@@ -3,7 +3,6 @@ package io.quarkus.jdbc.oracle.deployment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 /**
  * Registers the {@code oracle.jdbc.driver.OracleDriver} so that it can be loaded
@@ -24,22 +23,4 @@ public final class OracleReflections {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
     }
 
-    @BuildStep
-    void runtimeInitializeDriver(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitialized) {
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.OracleDriver"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.SQLUtil$XMLFactory"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.NamedTypeAccessor$XMLFactory"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.OracleTimeoutThreadPerVM"));
-        runtimeInitialized
-                .produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.T4CTTIoauthenticate"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TcpMultiplexer$LazyHolder"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.security.o5logon.O5Logon"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(
-                "oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource$BlockReleaser"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.TimeoutInterruptHandler"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.net.nt.Clock"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.NoSupportHAManager"));
-        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.LogicalConnection"));
-    }
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/RegexMatchTest.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/RegexMatchTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.jdbc.oracle.deployment;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * The metadata override facility of GraalVM's native-image
+ * works with regular expressions.
+ * We're testing our expressions here to match against the
+ * constants the compiler is expecting (inferred by debugging
+ * the compiler) as it's otherwise a bit tricky to assert
+ * if they have been applied.
+ */
+public class RegexMatchTest {
+
+    @Test
+    public void jarRegexIsMatching() {
+        final String EXAMPLE_CLASSPATH = "/home/sanne/sources/quarkus/integration-tests/jpa-oracle/target/quarkus-integration-test-jpa-oracle-999-SNAPSHOT-native-image-source-jar/lib/com.oracle.database.jdbc.ojdbc11-21.3.0.0.jar";
+        final Pattern pattern = Pattern.compile(OracleMetadataOverrides.DRIVER_JAR_MATCH_REGEX);
+        final Matcher matcher = pattern.matcher(EXAMPLE_CLASSPATH);
+        Assert.assertTrue(matcher.find());
+    }
+
+    @Test
+    public void resourceRegexIsMatching() {
+        //We need to exclude both of these:
+        final String RES1 = "/META-INF/native-image/native-image.properties";
+        final String RES2 = "/META-INF/native-image/reflect-config.json";
+        final Pattern pattern = Pattern.compile(OracleMetadataOverrides.NATIVE_IMAGE_RESOURCE_MATCH_REGEX);
+
+        Assert.assertTrue(pattern.matcher(RES1).find());
+        Assert.assertTrue(pattern.matcher(RES2).find());
+
+        //While this one should NOT be ignored:
+        final String RES3 = "/META-INF/native-image/resource-config.json";
+        final String RES4 = "/META-INF/native-image/jni-config.json";
+        Assert.assertFalse(pattern.matcher(RES3).find());
+        Assert.assertFalse(pattern.matcher(RES4).find());
+    }
+
+}

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.datasource.jdbc.url=${oracledb.url}
 quarkus.datasource.jdbc.max-size=1
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false
+
+#Unfortunately, this is currently required when using the Oracle JDBC driver:
+quarkus.native.additional-build-args=--allow-incomplete-classpath

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -5,6 +5,3 @@ quarkus.datasource.jdbc.url=${oracledb.url}
 quarkus.datasource.jdbc.max-size=1
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false
-
-#Unfortunately, this is currently required when using the Oracle JDBC driver:
-quarkus.native.additional-build-args=--allow-incomplete-classpath


### PR DESCRIPTION

This overrides the native-image metadata from the Oracle JDBC driver, so to allow us to better control the flags.

For it to work it sill needs to set `--allow-incomplete-classpath`, but rather than allowing this flag to be picked up automatically we set it explicitly, and take this opportunity to log a warning about it.

The fact that we now are in better control of the metadata will allow us to apply further fixes, improvements and optimisations.