### PR TITLE
Add mailer-deployment to bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1622,6 +1622,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-mailer-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-mongodb-client</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
The dependency `quarkus-mail-deployment` is not set in the bom.

Work around used by custom extension:

```xml
<dependency>
  <groupId>io.quarkus</groupId>
  <artifactId>quarkus-mailer-deployment</artifactId>
  <version>${quarkus.version}</version>
</dependency>
```
