### PR TITLE
Allow reflection for native serialization

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -6,12 +6,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Used to register a class for reflection in native mode
  */
 public final class ReflectiveClassBuildItem extends MultiBuildItem {
+
+    private static final Logger log = Logger.getLogger(ReflectiveClassBuildItem.class);
 
     private final List<String> className;
     private final boolean methods;
@@ -88,6 +92,12 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
             boolean weak, boolean serialization, String... className) {
+
+        if (serialization) {
+            log.info("ReflectiveClassBuildItem => constructors=" + constructors + " methods=" + methods + " fields=" + fields
+                    + " finalFieldsWritable=" + finalFieldsWritable + " weak=" + weak + " serialization=" + serialization + " "
+                    + Arrays.toString(className));
+        }
         for (String i : className) {
             if (i == null) {
                 throw new NullPointerException();

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -77,8 +77,8 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         return new ReflectiveClassBuildItem(true, true, true, false, true, className);
     }
 
-    public static ReflectiveClassBuildItem serializationClass(String... className) {
-        return new ReflectiveClassBuildItem(false, false, false, false, false, true, className);
+    public static ReflectiveClassBuildItem serializationClass(boolean methods, boolean fields, String... className) {
+        return new ReflectiveClassBuildItem(true, methods, fields, false, false, true, className);
     }
 
     private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
@@ -21,6 +21,7 @@ import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,6 +56,8 @@ import io.quarkus.runtime.graal.ResourcesFeature;
 import io.quarkus.runtime.graal.WeakReflection;
 
 public class NativeImageAutoFeatureStep {
+
+    private static final Logger log = Logger.getLogger(NativeImageAutoFeatureStep.class);
 
     private static final String GRAAL_AUTOFEATURE = "io/quarkus/runner/AutoFeature";
     private static final MethodDescriptor VERSION_CURRENT = ofMethod(Version.class, "getCurrent", Version.class);
@@ -123,6 +126,7 @@ public class NativeImageAutoFeatureStep {
         ClassCreator file = new ClassCreator(new ClassOutput() {
             @Override
             public void write(String s, byte[] bytes) {
+                log.info("create GeneratedNativeImageClassBuildItem name=" + s);
                 nativeImageClass.produce(new GeneratedNativeImageClassBuildItem(s, bytes));
             }
         }, GRAAL_AUTOFEATURE, null,
@@ -345,6 +349,7 @@ public class NativeImageAutoFeatureStep {
                         carray);
 
                 if (entry.getValue().constructors) {
+                    log.info("invokeStaticMethod register constructors for " + entry.getKey());
                     tc.invokeStaticMethod(
                             ofMethod(RUNTIME_REFLECTION, "register", void.class, Executable[].class),
                             constructors);
@@ -421,6 +426,8 @@ public class NativeImageAutoFeatureStep {
                     registerSerializationMethod = createRegisterSerializationForClassMethod(file);
                 }
 
+                log.info("invokeStaticMethod " + registerSerializationMethod.getDeclaringClass() + ":"
+                        + registerSerializationMethod.getName() + " on " + entry.getKey());
                 tc.invokeStaticMethod(registerSerializationMethod, clazz);
             }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
@@ -65,7 +65,7 @@ public class RegisterForReflectionBuildStep {
      */
     private void registerClass(ClassLoader classLoader, String className, boolean methods, boolean fields,
             boolean ignoreNested, boolean serialization, final BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(serialization ? ReflectiveClassBuildItem.serializationClass(className)
+        reflectiveClass.produce(serialization ? ReflectiveClassBuildItem.serializationClass(methods, fields, className)
                 : new ReflectiveClassBuildItem(methods, fields, className));
 
         if (ignoreNested) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
@@ -65,6 +65,8 @@ public class RegisterForReflectionBuildStep {
      */
     private void registerClass(ClassLoader classLoader, String className, boolean methods, boolean fields,
             boolean ignoreNested, boolean serialization, final BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        log.info("registerClass " + className + " methods=" + methods + " fields=" + fields + " ignoreNested=" + ignoreNested
+                + " serialization=" + serialization);
         reflectiveClass.produce(serialization ? ReflectiveClassBuildItem.serializationClass(methods, fields, className)
                 : new ReflectiveClassBuildItem(methods, fields, className));
 

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationTestEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationTestEndpoint.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -42,6 +44,7 @@ public class SerializationTestEndpoint extends HttpServlet {
             ExternalizablePerson ep = new ExternalizablePerson();
             ep.setName("Sheldon 2.0");
             instance.setExternalizablePerson(ep);
+            instance.setList(new ArrayList<>(List.of("Hello World!")));
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             ObjectOutputStream os = new ObjectOutputStream(out);
             os.writeObject(instance);
@@ -49,7 +52,8 @@ public class SerializationTestEndpoint extends HttpServlet {
             ObjectInputStream is = new ObjectInputStream(bais);
             SomeSerializationObject result = (SomeSerializationObject) is.readObject();
             if (result.getPerson().getName().equals("Sheldon")
-                    && result.getExternalizablePerson().getName().equals("Sheldon 2.0")) {
+                    && result.getExternalizablePerson().getName().equals("Sheldon 2.0")
+                    && result.getList().toString().equals("[Hello World!]")) {
                 resp.getWriter().write("OK");
             } else {
                 reportException("Serialized output differs from input", null, resp);

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationConfig.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationConfig.java
@@ -1,8 +1,11 @@
 package io.quarkus.it.corestuff.serialization;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@RegisterForReflection(targets = String.class, serialization = true)
+@RegisterForReflection(targets = { List.class, ArrayList.class, String.class }, serialization = true)
 public class SerializationConfig {
 
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SomeSerializationObject.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SomeSerializationObject.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.corestuff.serialization;
 
 import java.io.Serializable;
+import java.util.List;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -9,6 +10,7 @@ public class SomeSerializationObject implements Serializable {
 
     private Person person;
     private ExternalizablePerson externalizablePerson;
+    private List<String> list;
 
     public Person getPerson() {
         return person;
@@ -24,5 +26,13 @@ public class SomeSerializationObject implements Serializable {
 
     public void setExternalizablePerson(ExternalizablePerson externalizablePerson) {
         this.externalizablePerson = externalizablePerson;
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/19711

I have assumed that for reflection we needed `constructor=true` and we honor annotation parameters `methods` and `fields` (just like we do for the non serialization case).
I kept `finalFieldsWritable` and `weak` false. `weak` and `serialization` appear to be exclusive.
I am not sure `finalFieldsWritable` makes sense with `serialization`.

/cc @jaikiran @JiriOndrusek @stuartwdouglas 