### PR TITLE
Fix continuous testing race

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -73,8 +73,10 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.QuarkusClassWriter;
 import io.quarkus.deployment.dev.ClassScanResult;
 import io.quarkus.deployment.dev.DevModeContext;
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
 import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.dev.console.QuarkusConsole;
+import io.quarkus.dev.testing.TestWatchedFiles;
 import io.quarkus.dev.testing.TracingHandler;
 
 /**
@@ -379,6 +381,11 @@ public class JunitTestRunner {
 
                 QuarkusConsole.INSTANCE.setOutputFilter(null);
 
+                //this has to happen before notifying the listeners
+                Map<String, Boolean> watched = TestWatchedFiles.retrieveWatchedFilePaths();
+                if (watched != null) {
+                    RuntimeUpdatesProcessor.INSTANCE.setWatchedFilePaths(watched, true);
+                }
                 for (TestRunListener listener : listeners) {
                     listener.runComplete(new TestRunResults(runId, classScanResult, classScanResult == null, start,
                             System.currentTimeMillis(), toResultsMap(testState.getCurrentResults())));

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunner.java
@@ -24,8 +24,6 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.deployment.dev.ClassScanResult;
 import io.quarkus.deployment.dev.DevModeContext;
-import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
-import io.quarkus.dev.testing.TestWatchedFiles;
 import io.quarkus.runtime.configuration.HyphenateEnumConverter;
 
 public class TestRunner {
@@ -253,10 +251,6 @@ public class TestRunner {
         runner.runTests();
         synchronized (this) {
             runner = null;
-        }
-        Map<String, Boolean> watched = TestWatchedFiles.retrieveWatchedFilePaths();
-        if (watched != null) {
-            RuntimeUpdatesProcessor.INSTANCE.setWatchedFilePaths(watched, true);
         }
         if (disabled) {
             return;


### PR DESCRIPTION
Files to watch must be updated before the listeners are notified,
otherwise the test may modify the config file before the file set has
been updated, and the tests will not be run.