### PR TITLE
Automatically configure connector name

### DIFF
--- a/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
@@ -201,18 +201,10 @@ public class QuotesResource {
 <2> On a post request, generate a random UUID and send it to the Kafka topic using the emitter.
 <3> Return the same UUID to the client.
 
-We need to instruct Quarkus to map the `quote-requests` channel to a Kafka topic.
-In the `src/main/resources/application.properties` file in the _producer_ project, add:
-
-[source, properties]
-----
-# Configure the outgoing `quote-requests` Kafka topic
-mp.messaging.outgoing.quote-requests.connector=smallrye-kafka
-----
-
-All we need to specify is the `smallrye-kafka` connector.
+At this stage no configuration is required.
 By default, the Kafka connector uses the channel name (`quote-requests`) as the Kafka topic name.
 Quarkus configures the serializer automatically, because it finds that the `Emitter` produces `String` values.
+As we have only added the Kafka connector we don't need to configure the connector type to use.
 
 == Processing quote requests
 
@@ -265,12 +257,10 @@ As with the previous example, we need to configure the connectors in the `applic
 %dev.quarkus.http.port=8081
 
 # Configure the incoming `quote-requests` Kafka topic
-mp.messaging.incoming.requests.connector=smallrye-kafka
 mp.messaging.incoming.requests.topic=quote-requests
 mp.messaging.incoming.requests.auto.offset.reset=earliest
 
 # Configure the outgoing `quotes` Kafka topic
-mp.messaging.outgoing.quotes.connector=smallrye-kafka
 mp.messaging.outgoing.quotes.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 ----
 
@@ -322,14 +312,7 @@ public Multi<Quote> stream() {
 <2> Indicates that the content is sent using `Server Sent Events`
 <3> Returns the stream (_Reactive Stream_)
 
-Again we need to configure the incoming `quotes` channel inside _producer_ project.
-Add the following inside `application.properties` file:
-
-[source, properties]
-----
-# Configure the incoming `quotes` Kafka topic
-mp.messaging.incoming.quotes.connector=smallrye-kafka
-----
+Again no configuration is required at this stage.
 
 [NOTE]
 ====

--- a/extensions/reactive-messaging-http/deployment/src/main/java/io/quarkus/reactivemessaging/http/deployment/ReactiveHttpProcessor.java
+++ b/extensions/reactive-messaging-http/deployment/src/main/java/io/quarkus/reactivemessaging/http/deployment/ReactiveHttpProcessor.java
@@ -53,6 +53,7 @@ import io.quarkus.reactivemessaging.http.runtime.converters.ObjectConverter;
 import io.quarkus.reactivemessaging.http.runtime.converters.StringConverter;
 import io.quarkus.reactivemessaging.http.runtime.serializers.Serializer;
 import io.quarkus.reactivemessaging.http.runtime.serializers.SerializerFactoryBase;
+import io.quarkus.smallrye.reactivemessaging.deployment.ConnectorProviderBuildItem;
 import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.smallrye.mutiny.Multi;
@@ -73,6 +74,11 @@ public class ReactiveHttpProcessor {
     private static final DotName PUBLISHER_BUILDER = DotName.createSimple(PublisherBuilder.class.getName());
     private static final DotName SUBSCRIBER = DotName.createSimple(Subscriber.class.getName());
     private static final DotName SUBSCRIBER_BUILDER = DotName.createSimple(SubscriberBuilder.class.getName());
+
+    @BuildStep
+    ConnectorProviderBuildItem connectorProviderBuildItem() {
+        return new ConnectorProviderBuildItem("quarkus-http");
+    }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/reactive-messaging-http/deployment/src/test/java/io/quarkus/reactivemessaging/http/RegistrationForReflectionTest.java
+++ b/extensions/reactive-messaging-http/deployment/src/test/java/io/quarkus/reactivemessaging/http/RegistrationForReflectionTest.java
@@ -30,6 +30,7 @@ import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.ConnectorProviderBuildItem;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.Multi;
 
@@ -78,6 +79,13 @@ public class RegistrationForReflectionTest {
                             }
                         }).consumes(ReflectiveClassBuildItem.class)
                         .produces(GeneratedResourceBuildItem.class).build();
+                chainBuilder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        //this stops the endpoints being automatically started, to avoid having to configure paths
+                        context.produce(new ConnectorProviderBuildItem("bogus-connector"));
+                    }
+                }).produces(ConnectorProviderBuildItem.class).build();
             }
         };
     }

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/SmallRyeReactiveMessagingAmqpProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/SmallRyeReactiveMessagingAmqpProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.amqp.deployment;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.ConnectorProviderBuildItem;
 
 public class SmallRyeReactiveMessagingAmqpProcessor {
 
@@ -11,4 +12,8 @@ public class SmallRyeReactiveMessagingAmqpProcessor {
         return new FeatureBuildItem(Feature.SMALLRYE_REACTIVE_MESSAGING_AMQP);
     }
 
+    @BuildStep
+    ConnectorProviderBuildItem connectorProviderBuildItem() {
+        return new ConnectorProviderBuildItem("smallrye-amqp");
+    }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
@@ -27,9 +27,11 @@ class DefaultSerdeDiscoveryState {
     private Boolean hasApicurio1;
     private Boolean hasApicurio2;
     private Boolean hasJsonb;
+    final boolean onlyKafka;
 
-    DefaultSerdeDiscoveryState(IndexView index) {
+    DefaultSerdeDiscoveryState(IndexView index, boolean onlyKafka) {
         this.index = index;
+        this.onlyKafka = onlyKafka;
     }
 
     boolean isKafkaConnector(boolean incoming, String channelName) {
@@ -38,7 +40,7 @@ class DefaultSerdeDiscoveryState {
             String connectorKey = "mp.messaging." + channelType + "." + channelName + ".connector";
             String connector = ConfigProvider.getConfig()
                     .getOptionalValue(connectorKey, String.class)
-                    .orElse("ignored");
+                    .orElse(onlyKafka ? KafkaConnector.CONNECTOR_NAME : "ignored");
             return KafkaConnector.CONNECTOR_NAME.equals(connector);
         });
     }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
@@ -46,7 +46,7 @@ public class DefaultSerdeConfigTest {
     private static void doTest(Tuple[] expectations, Class<?>... classesToIndex) {
         List<RunTimeConfigurationDefaultBuildItem> configs = new ArrayList<>();
 
-        DefaultSerdeDiscoveryState discovery = new DefaultSerdeDiscoveryState(index(classesToIndex)) {
+        DefaultSerdeDiscoveryState discovery = new DefaultSerdeDiscoveryState(index(classesToIndex), false) {
             @Override
             boolean isKafkaConnector(boolean incoming, String channelName) {
                 return true;

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/SmallRyeReactiveMessagingMqttProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/SmallRyeReactiveMessagingMqttProcessor.java
@@ -3,10 +3,16 @@ package io.quarkus.smallrye.reactivemessaging.mqtt.deployment;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.ConnectorProviderBuildItem;
 
 public class SmallRyeReactiveMessagingMqttProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.SMALLRYE_REACTIVE_MESSAGING_MQTT);
+    }
+
+    @BuildStep
+    ConnectorProviderBuildItem connectorProviderBuildItem() {
+        return new ConnectorProviderBuildItem("smallrye-mqtt");
     }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ConnectorProviderBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ConnectorProviderBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.reactivemessaging.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class ConnectorProviderBuildItem extends MultiBuildItem {
+
+    final String name;
+
+    public ConnectorProviderBuildItem(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
If only one connector extension is present and the config property is
not specified then default to the installed extension.