### PR TITLE
Make @TestSecurity work correctly with unannotated JAX-RS endpoints security feature

### DIFF
--- a/docs/src/main/asciidoc/security-authorization.adoc
+++ b/docs/src/main/asciidoc/security-authorization.adoc
@@ -152,7 +152,7 @@ There are three configuration settings that alter the RBAC Deny behavior:
 
 `quarkus.security.jaxrs.deny-unannotated-endpoints=true|false`::
 If set to true, the access will be denied for all JAX-RS endpoints by default, so if a JAX-RS endpoint does not have any security annotations
-then it will default to `@DenyAll` behaviour. This is useful to ensure you cannot accidently expose an endpoint that is supposed to be secured. Defaults to `false`.
+then it will default to `@DenyAll` behaviour. This is useful to ensure you cannot accidentally expose an endpoint that is supposed to be secured. Defaults to `false`.
 
 `quarkus.security.jaxrs.default-roles-allowed=role1,role2`::
 Defines the default role requirements for unannotated endpoints. The role '**' is a special role that means any authenticated user. This cannot be combined with

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/DenyAllInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/DenyAllInterceptor.java
@@ -7,6 +7,8 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
+import io.quarkus.security.spi.runtime.AuthorizationController;
+
 /**
  *
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -19,8 +21,15 @@ public class DenyAllInterceptor {
     @Inject
     SecurityHandler handler;
 
+    @Inject
+    AuthorizationController controller;
+
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
-        return handler.handle(ic);
+        if (controller.isAuthorizationEnabled()) {
+            return handler.handle(ic);
+        } else {
+            return ic.proceed();
+        }
     }
 }

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildItem.java
@@ -13,10 +13,8 @@ import io.quarkus.builder.item.MultiBuildItem;
  * Contains classes that need to have @DenyAll on all methods that don't have security annotations
  */
 public final class AdditionalSecuredClassesBuildItem extends MultiBuildItem {
+
     public final Collection<ClassInfo> additionalSecuredClasses;
-    /**
-     * The roles alloe
-     */
     public final Optional<List<String>> rolesAllowed;
 
     public AdditionalSecuredClassesBuildItem(Collection<ClassInfo> additionalSecuredClasses) {


### PR DESCRIPTION
The use of `quarkus.security.jaxrs.deny-unannotated-endpoints=true` essentially
results in the addition of a `DenyAllInterceptor` to the invocation chain
of a JAX-RS endpoint.
Because this interceptor did not take into account the `AuthorizationController`
(like the `RolesAllowedInterceptor` already does), it would result in endpoints
being secured even though security was supposed to be disabled for the specific test.

Fixes: #19896