### PR TITLE
Inefficient Usage of Java Collections

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestState.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestState.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.dev.testing;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,9 +27,9 @@ public class TestState {
     public List<TestClassResult> getPassingClasses() {
         List<TestClassResult> ret = new ArrayList<>();
         for (Map.Entry<String, Map<UniqueId, TestResult>> i : resultsByClass.entrySet()) {
-            List<TestResult> passing = new ArrayList<>();
-            List<TestResult> failing = new ArrayList<>();
-            List<TestResult> skipped = new ArrayList<>();
+            List<TestResult> passing = new LinkedList<>();
+            List<TestResult> failing = new LinkedList<>();
+            List<TestResult> skipped = new LinkedList<>();
             long time = 0;
             for (TestResult j : i.getValue().values()) {
                 if (j.getTestExecutionResult().getStatus() == TestExecutionResult.Status.FAILED) {
@@ -56,9 +57,9 @@ public class TestState {
         List<TestClassResult> ret = new ArrayList<>();
         for (Map.Entry<String, Map<UniqueId, TestResult>> i : resultsByClass.entrySet()) {
             long time = 0;
-            List<TestResult> passing = new ArrayList<>();
-            List<TestResult> failing = new ArrayList<>();
-            List<TestResult> skipped = new ArrayList<>();
+            List<TestResult> passing = new LinkedList<>();
+            List<TestResult> failing = new LinkedList<>();
+            List<TestResult> skipped = new LinkedList<>();
             for (TestResult j : i.getValue().values()) {
                 if (j.getTestExecutionResult().getStatus() == TestExecutionResult.Status.FAILED) {
                     failing.add(j);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -162,7 +163,7 @@ public class ReportAnalyzer {
         final String className;
         final String method;
         final Node parent;
-        List<Node> children = new ArrayList<>();
+        List<Node> children = new LinkedList<>();
 
         Node(int indent, String type, String className, String method, Node parent) {
             this.indent = indent;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/reflection/GrpcServerIndex.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/reflection/GrpcServerIndex.java
@@ -33,9 +33,9 @@ public class GrpcServerIndex {
         Set<String> files = new HashSet<>();
         Set<String> names = new HashSet<>();
         Set<FileDescriptor> services = new HashSet<>();
-        Map<String, FileDescriptor> descriptorsByName = new LinkedHashMap<>();
-        Map<String, FileDescriptor> descriptorsBySymbol = new LinkedHashMap<>();
-        Map<String, Map<Integer, FileDescriptor>> descriptorsByExtensionAndNumber = new LinkedHashMap<>();
+        Map<String, FileDescriptor> descriptorsByName = new HashMap<>();
+        Map<String, FileDescriptor> descriptorsBySymbol = new HashMap<>();
+        Map<String, Map<Integer, FileDescriptor>> descriptorsByExtensionAndNumber = new HashMap<>();
 
         // Collect the services
         for (ServerServiceDefinition definition : definitions) {

--- a/extensions/panache/mongodb-panache-kotlin/deployment/src/test/kotlin/io/quarkus/mongodb/panache/kotlin/deployment/TestEnhancers.java
+++ b/extensions/panache/mongodb-panache-kotlin/deployment/src/test/kotlin/io/quarkus/mongodb/panache/kotlin/deployment/TestEnhancers.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.TreeMap;
+import java.util.HashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -101,7 +101,7 @@ public class TestEnhancers {
         InputStream inputStream = config.getArchiveProducer().get().get(path).getAsset().openStream();
         new ClassReader(inputStream).accept(new TraceClassVisitor(
                 new ClassNode(Gizmo.ASM_API_VERSION), printer, null), ClassReader.EXPAND_FRAMES);
-        Map<String, BytecodeMethod> methods = new TreeMap<>();
+        Map<String, BytecodeMethod> methods = new HashMap<>();
         ListIterator<Object> iterator = printer.text.listIterator();
         while (iterator.hasNext()) {
             Object t = iterator.next();
@@ -125,7 +125,7 @@ public class TestEnhancers {
         ClassNode node = new ClassNode(Gizmo.ASM_API_VERSION);
         new ClassReader(type.getName())
                 .accept(node, ClassReader.SKIP_FRAMES);
-        Map<String, MethodNode> map = new TreeMap<>();
+        Map<String, MethodNode> map = new HashMap<>();
         node.methods.stream()
                 .filter(m -> m.visibleAnnotations != null && m.visibleAnnotations.stream()
                         .map(a -> a.desc)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -7,6 +7,7 @@ import io.quarkus.arc.processor.BuildExtension.Key;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.arc.processor.ResourceOutput.Resource.SpecialType;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -170,7 +171,7 @@ public class BeanProcessor {
                 injectionPointAnnotationsPredicate, allowMocking);
         AnnotationLiteralGenerator annotationLiteralsGenerator = new AnnotationLiteralGenerator(generateSources);
 
-        List<Resource> resources = new ArrayList<>();
+        List<Resource> resources = new LinkedList<>();
 
         // Generate interceptors
         for (InterceptorInfo interceptor : beanDeployment.getInterceptors()) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderLimiter.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassLoaderLimiter.java
@@ -3,7 +3,7 @@ package io.quarkus.bootstrap.classloading;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -81,11 +81,11 @@ public final class ClassLoaderLimiter implements ClassLoaderEventListener {
     }
 
     public static class Builder {
-        private final Set<String> vetoedResources = new TreeSet<>();
-        private final Set<String> vetoedClasses = new TreeSet<>();
-        private final Set<String> vetoedRuntimeClasses = new TreeSet<>();
-        private final Set<String> atMostOnceResources = new TreeSet<>();
-        private final Set<String> onHitPrintStacktrace = new TreeSet<>();
+        private final Set<String> vetoedResources = new HashSet<>();
+        private final Set<String> vetoedClasses = new HashSet<>();
+        private final Set<String> vetoedRuntimeClasses = new HashSet<>();
+        private final Set<String> atMostOnceResources = new HashSet<>();
+        private final Set<String> onHitPrintStacktrace = new HashSet<>();
         private boolean traceAllResourceLoad = false;
 
         private Builder() {

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/VariantListBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/VariantListBuilderImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.common.jaxrs;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -11,7 +12,7 @@ import javax.ws.rs.core.Variant;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  */
 public class VariantListBuilderImpl extends Variant.VariantListBuilder {
-    private final ArrayList<Variant> variants = new ArrayList<Variant>();
+    private final LinkedList<Variant> variants = new LinkedList<Variant>();
     private final ArrayList<Locale> currentLanguages = new ArrayList<Locale>();
     private final ArrayList<String> currentEncodings = new ArrayList<String>();
     private final ArrayList<MediaType> currentTypes = new ArrayList<MediaType>();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
@@ -166,7 +166,7 @@ final class QuarkusCommandHandlers {
                 .filter(e -> !isUnlisted(e)).collect(Collectors.toList());
     }
 
-    private static boolean matchLabels(Pattern pattern, List<String> labels) {
+    private static boolean matchLabels(Pattern pattern, Set<String> labels) {
         boolean matches = false;
         // if any label match it's ok
         for (String label : labels) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/predicate/ExtensionPredicate.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/predicate/ExtensionPredicate.java
@@ -4,6 +4,7 @@ import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getShortN
 
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.registry.catalog.Extension;
+import java.util.Set;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -102,7 +103,7 @@ public class ExtensionPredicate implements Predicate<Extension> {
                 artifactId.equalsIgnoreCase("quarkus-" + q);
     }
 
-    private static boolean matchLabels(Pattern pattern, List<String> labels) {
+    private static boolean matchLabels(Pattern pattern, Set<String> labels) {
         boolean matches = false;
         // if any label match it's ok
         for (String label : labels) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtendedKeywords.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtendedKeywords.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -23,8 +22,8 @@ public final class ExtendedKeywords {
             "these", "her", "him", "has", "over", "than", "who", "may", "down", "been", "more", "implementing", "non",
             "quarkus"));
 
-    public static List<String> extendsKeywords(String artifactId, String description, List<String> keywords) {
-        final TreeSet<String> result = new TreeSet<>();
+    public static Set<String> extendsKeywords(String artifactId, String description, List<String> keywords) {
+        final HashSet<String> result = new HashSet<>();
         keywords.forEach(it -> result.add(it.toLowerCase(Locale.US)));
         result.add(artifactId.toLowerCase(Locale.US));
         if (!StringUtils.isEmpty(description)) {
@@ -36,6 +35,6 @@ public final class ExtendedKeywords {
                 }
             }
         }
-        return new ArrayList<>(result);
+        return result;
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
@@ -6,6 +6,8 @@ import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.Extension;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -99,14 +101,14 @@ public final class ExtensionProcessor {
     }
 
     /**
-     * List of strings to use for matching.
+     * Set of strings to use for matching.
      * <br/>
      * <br/>
      * It includes a mix of static keywords, the artifactId, and keywords extracted from the description
      *
-     * @return list of keywords to use for matching.
+     * @return set of keywords to use for matching.
      */
-    public static List<String> getExtendedKeywords(Extension extension) {
+    public static Set<String> getExtendedKeywords(Extension extension) {
         return ExtendedKeywords.extendsKeywords(extension.getArtifact().getArtifactId(), extension.getDescription(),
                 getKeywords(extension));
     }
@@ -182,14 +184,14 @@ public final class ExtensionProcessor {
     }
 
     /**
-     * List of strings to use for matching.
+     * Set of strings to use for matching.
      * <br/>
      * <br/>
      * It includes a mix of static keywords, the artifactId, and keywords extracted from the description
      *
-     * @return list of keywords to use for matching.
+     * @return set of keywords to use for matching.
      */
-    public List<String> getExtendedKeywords() {
+    public Set<String> getExtendedKeywords() {
         return getExtendedKeywords(extension);
     }
 


### PR DESCRIPTION
Hi,

We find that there are several ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal, the retrieval, and removal of the first or the last element.

This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

Meanwhile, we also found several TreeMap and TreeSet objects which are not necessary to maintain the order of keys. To achieve the same functionality, HashMap and HashSet are enough. The replacement can also reduce the time cost in the modification of the set and the map objects. A similar case is the replacement of LinkedHashMap when it is not iterated actually. HashMap is also sufficient.

Also, there is no need to change the set to the list in the function `extendsKeywords` in ExtendedKeywords.java because the index-value correlation does not matter in further use. Only the iterators and the insertions are invoked to the list. We can simply maintain the content by a HashSet, and the contains method is more efficient than the one of List.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto