### PR TITLE
Add memory settings according to redpanda docker quickstart

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -361,6 +361,7 @@ public class DevServicesKafkaProcessor {
             // Start and configure the advertised address
             String command = "#!/bin/bash\n";
             command += "/usr/bin/rpk redpanda start --check=false --node-id 0 --smp 1 ";
+            command += "--memory 1G --overprovisioned --reserve-memory 0M ";
             command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ";
             command += String.format("--advertise-kafka-addr PLAINTEXT://%s:29092,OUTSIDE://%s:%d", getHostToUse(),
                     getHostToUse(), getPortToUse());


### PR DESCRIPTION
This PR adds a few additional settings when starting Redpanda as suggested by the [docker quick-start guide](https://vectorized.io/docs/quick-start-docker/) of Redpanda. Starting Redpanda with just `--smp 1` has a side effect where it fails running locally in some situations (see also #19736). Adding all suggested parameters proved to be working in both a docker-in-docker setup, as well as in the failing local setup.

(CC: @Ladicek)