### PR TITLE
Clarify the getting started documentation when building an uber-jar

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
@@ -22,12 +22,14 @@ The application can be packaged using:
 It produces the `quarkus-run.jar` file in the `{buildtool.build-dir}/quarkus-app/` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `{buildtool.build-dir}/quarkus-app/lib/` directory.
 
+The application is now runnable using `java -jar {buildtool.build-dir}/quarkus-app/quarkus-run.jar`.
+
 If you want to build an _über-jar_, execute the following command:
 ```shell script
 {buildtool.cli} {buildtool.cmd.package-uber-jar}
 ```
 
-The application is now runnable using `java -jar {buildtool.build-dir}/quarkus-app/quarkus-run.jar`.
+The application, packaged as an _über-jar_, is now runnable using `java -jar {buildtool.build-dir}/*-runner.jar`.
 
 ## Creating a native executable
 

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
@@ -22,12 +22,14 @@ mvn package
 It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
 
+The application is now runnable using `java -jar target/quarkus-app/quarkus-run.jar`.
+
 If you want to build an _über-jar_, execute the following command:
 ```shell script
 mvn package -Dquarkus.package.type=uber-jar
 ```
 
-The application is now runnable using `java -jar target/quarkus-app/quarkus-run.jar`.
+The application, packaged as an _über-jar_, is now runnable using `java -jar target/*-runner.jar`.
 
 ## Creating a native executable
 


### PR DESCRIPTION
The "getting started" documentation isn't clear when you want to build an uber-jar, as the command that is given only works for exploded JARs. This is trying to clarify it.