### PR TITLE
Fix NPE in QuarkusTestExtension.runAfterAllCallbacks() on failed boot (2.2)

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1143,7 +1143,7 @@ public class QuarkusTestExtension
     }
 
     private void runAfterAllCallbacks(ExtensionContext context) throws Exception {
-        if (isNativeOrIntegrationTest(context.getRequiredTestClass())) {
+        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || failedBoot) {
             return;
         }
         if (afterAllCallbacks.isEmpty()) {


### PR DESCRIPTION
Basically backports this: https://github.com/quarkusio/quarkus/pull/19666/commits/fc697fcb044436a030d4d00d31e1641f108e55ec#diff-462fa0cb443c21c9406c8b4daeb31500f20a4c9b46a0b039adcc93dee6a3bea4R1139

More context can be found in #19982