### PR TITLE
Fix Multiple Hibernate ORM DevUI entries

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleInfoSupplier.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleInfoSupplier.java
@@ -58,6 +58,12 @@ public class HibernateOrmDevConsoleInfoSupplier implements Supplier<HibernateOrm
         }
     }
 
+    public static void clearData() {
+        INSTANCE.persistenceUnits.clear();
+        INSTANCE.createDDLs.clear();
+        INSTANCE.dropDDLs.clear();
+    }
+
     private static String generateDDL(SchemaExport.Action action, Metadata metadata, ServiceRegistry serviceRegistry,
             String importFiles) {
         SchemaExport schemaExport = new SchemaExport();

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleIntegrator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleIntegrator.java
@@ -21,6 +21,6 @@ public class HibernateOrmDevConsoleIntegrator implements Integrator {
     @Override
     public void disintegrate(SessionFactoryImplementor sessionFactoryImplementor,
             SessionFactoryServiceRegistry sessionFactoryServiceRegistry) {
-        // Nothing to do
+        HibernateOrmDevConsoleInfoSupplier.clearData();
     }
 }


### PR DESCRIPTION
New entries occurred when the application performed a dev-mode reload

With existing code the UI could end up looking like this:

![pus](https://user-images.githubusercontent.com/4374975/132489832-4e1ea115-0fd8-482c-928b-8c5aea67c1fc.png)

Fix change fixes the problem by first clearing the metadata when the application reloads
