### PR TITLE
Mark the uber-jar as a multi-release jar if META-INF/versions/ exists in the generated jar

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
@@ -124,7 +125,13 @@ public class PackageIT extends MojoTestBase {
         List<File> jars = getFilesEndingWith(targetDir, ".jar");
         assertThat(jars).hasSize(1);
         assertThat(getNumberOfFilesEndingWith(targetDir, ".original")).isEqualTo(1);
-
+        try (JarFile jarFile = new JarFile(jars.get(0))) {
+            // we expect this uber jar to be a multi-release jar since one of its
+            // dependencies (smallrye-classloader artifact), from which we composed this uber-jar,
+            // is a multi-release jar
+            Assertions.assertTrue(jarFile.isMultiRelease(), "uber-jar " + jars.get(0)
+                    + " was expected to be a multi-release jar but wasn't");
+        }
         ensureManifestOfJarIsReadableByJarInputStream(jars.get(0));
     }
 

--- a/integration-tests/maven/src/test/resources/projects/uberjar-check/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/uberjar-check/pom.xml
@@ -30,6 +30,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
+    <!-- dependency on smallrye-common-classloader is to test
+    a multi-release jar dependency while creating uber-jar -->
+    <dependency>
+      <groupId>io.smallrye.common</groupId>
+      <artifactId>smallrye-common-classloader</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/19991

The commit here introduces a change to mark a uber-jar as `Multi-Release: true` if the generated uber jar has a `META-INF/versions/` directory. The commit also contains a test which reproduces the issue and verifies this change. 