### PR TITLE
Add missing @PathParam value in examples

### DIFF
--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -319,7 +319,9 @@ as follows:
 [source,java]
 ----
 import java.util.Collections;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.eclipse.microprofile.faulttolerance.Fallback;
+
 ...
 public class CoffeeResource {
     ...

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -250,6 +250,18 @@ Consider these endpoints:
 
 [source,java]
 ----
+package org.acme.vertx;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
 @Path("/hello")
 @Produces(MediaType.APPLICATION_JSON)
 public class VertxJsonResource {


### PR DESCRIPTION
This adds missing value on `@PathParam` annotation examples. 
