### PR TITLE
Fix declaredType handling in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityWithMethodGenericsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SecurityWithMethodGenericsTest.java
@@ -1,0 +1,111 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.providers.serialisers.ServerDefaultTextPlainBodyHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+public class SecurityWithMethodGenericsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            BaseResource.class, AuthenticatedResource.class,
+                            CustomServerDefaultTextPlainBodyHandler.class));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void test() {
+        requestWithBasicAuth().get("/auth/allow").then().statusCode(200)
+                .body(is("allow"));
+        requestWithBasicAuth().contentType(MediaType.TEXT_PLAIN).body("12345")
+                .post("/auth/generic").then()
+                .statusCode(200);
+        requestWithBasicAuth().contentType(MediaType.TEXT_PLAIN).body("54321").post("/auth/specific").then()
+                .statusCode(200);
+    }
+
+    private RequestSpecification requestWithBasicAuth() {
+        return RestAssured.given().auth().preemptive().basic("admin", "admin");
+    }
+
+    public static abstract class BaseResource<T> {
+
+        @Path("generic")
+        @POST
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.TEXT_PLAIN)
+        public String generic(T body) {
+            return "generic";
+        }
+
+        @Path("specific")
+        @POST
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.TEXT_PLAIN)
+        public String specific(String body) {
+            return "specific";
+        }
+    }
+
+    @Path("auth")
+    @Authenticated
+    public static class AuthenticatedResource extends BaseResource<String> {
+
+        @Path("allow")
+        @GET
+        public String allow() {
+            return "allow";
+        }
+    }
+
+    @Provider
+    @Consumes("text/plain")
+    public static class CustomServerDefaultTextPlainBodyHandler extends ServerDefaultTextPlainBodyHandler {
+
+        @Override
+        public boolean isReadable(Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public Object readFrom(Class type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+            return "dummy";
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -132,8 +132,10 @@ public class ClientEndpointIndexer
     protected MethodParameter createMethodParameter(ClassInfo currentClassInfo, ClassInfo actualEndpointInfo, boolean encoded,
             Type paramType, ClientIndexedParam parameterResult, String name, String defaultValue, ParameterType type,
             String elementType, boolean single, String signature) {
+        DeclaredTypes declaredTypes = getDeclaredTypes(paramType, currentClassInfo, actualEndpointInfo);
         return new MethodParameter(name,
-                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index), signature, type, single,
+                elementType, declaredTypes.getDeclaredType(), declaredTypes.getDeclaredUnresolvedType(), signature, type,
+                single,
                 defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded);
     }
 

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -1091,6 +1091,26 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     protected void handleLocalDateParam(PARAM builder) {
     }
 
+    protected DeclaredTypes getDeclaredTypes(Type paramType, ClassInfo currentClassInfo, ClassInfo actualEndpointInfo) {
+        String declaredType = toClassName(paramType, currentClassInfo, actualEndpointInfo, index);
+        String declaredUnresolvedType;
+        if (paramType.kind() == Kind.TYPE_VARIABLE) {
+            // we need to handle this specially since we want the actual declared type here and not the resolved type
+            // that toClassName(...) gives us
+            TypeVariable typeVariable = paramType.asTypeVariable();
+            if (typeVariable.bounds().isEmpty()) {
+                declaredUnresolvedType = Object.class.getName();
+            } else {
+                declaredUnresolvedType = typeVariable.bounds().get(0).name().toString();
+            }
+
+        } else {
+            declaredUnresolvedType = declaredType;
+        }
+
+        return new DeclaredTypes(declaredType, declaredUnresolvedType);
+    }
+
     protected void handleOtherParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
             PARAM builder, String elementType) {
     }
@@ -1235,6 +1255,24 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
 
         public ResourceMethod getResourceMethod() {
             return resourceMethod;
+        }
+    }
+
+    public static class DeclaredTypes {
+        private final String declaredType;
+        private final String declaredUnresolvedType;
+
+        public DeclaredTypes(String declaredType, String declaredUnresolvedType) {
+            this.declaredType = declaredType;
+            this.declaredUnresolvedType = declaredUnresolvedType;
+        }
+
+        public String getDeclaredType() {
+            return declaredType;
+        }
+
+        public String getDeclaredUnresolvedType() {
+            return declaredUnresolvedType;
         }
     }
 

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
@@ -9,6 +9,11 @@ public class MethodParameter {
      * will be the collection type
      */
     public String declaredType;
+    /**
+     * This will only be different from the declaredType if a TypeVariable was used.
+     * It is needed for proper reflection method lookups
+     */
+    public String declaredUnresolvedType;
     public String signature;
     public ParameterType parameterType;
     public boolean encoded;
@@ -20,12 +25,14 @@ public class MethodParameter {
     public MethodParameter() {
     }
 
-    public MethodParameter(String name, String type, String declaredType, String signature, ParameterType parameterType,
+    public MethodParameter(String name, String type, String declaredType, String declaredUnresolvedType, String signature,
+            ParameterType parameterType,
             boolean single,
             String defaultValue, boolean isObtainedAsCollection, boolean optional, boolean encoded) {
         this.name = name;
         this.type = type;
         this.declaredType = declaredType;
+        this.declaredUnresolvedType = declaredUnresolvedType;
         this.signature = signature;
         this.parameterType = parameterType;
         this.single = single;

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -260,8 +260,9 @@ public class ServerEndpointIndexer
             Type paramType, ServerIndexedParameter parameterResult, String name, String defaultValue, ParameterType type,
             String elementType, boolean single, String signature) {
         ParameterConverterSupplier converter = parameterResult.getConverter();
+        DeclaredTypes declaredTypes = getDeclaredTypes(paramType, currentClassInfo, actualEndpointInfo);
         return new ServerMethodParameter(name,
-                elementType, toClassName(paramType, currentClassInfo, actualEndpointInfo, index),
+                elementType, declaredTypes.getDeclaredType(), declaredTypes.getDeclaredUnresolvedType(),
                 type, single, signature,
                 converter, defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
                 parameterResult.getCustomerParameterExtractor());

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
@@ -13,12 +13,14 @@ public class ServerMethodParameter extends MethodParameter {
     public ServerMethodParameter() {
     }
 
-    public ServerMethodParameter(String name, String type, String declaredType, ParameterType parameterType, boolean single,
+    public ServerMethodParameter(String name, String type, String declaredType, String declaredUnresolvedType,
+            ParameterType parameterType, boolean single,
             String signature,
             ParameterConverterSupplier converter, String defaultValue, boolean isObtainedAsCollection, boolean isOptional,
             boolean encoded,
             ParameterExtractor customerParameterExtractor) {
-        super(name, type, declaredType, signature, parameterType, single, defaultValue, isObtainedAsCollection, isOptional,
+        super(name, type, declaredType, declaredUnresolvedType, signature, parameterType, single, defaultValue,
+                isObtainedAsCollection, isOptional,
                 encoded);
         this.converter = converter;
         this.customerParameterExtractor = customerParameterExtractor;


### PR DESCRIPTION
In cases where a type variable was being used,
the declared type was not being set the type bound,
but to the actual resolved type.
This caused problems when a resource method was being
looked up reflectively.

What caused us to run into this issue now is the introduction of eager security. Eager security itself is not the problem, but since the reflective calls are more common now, this surfaced.

Fixes: #20008

_P.S. We might want to look into removing the reflection usage from the eager security handler_