### PR TITLE
Bump kubernetes-client-bom from 5.7.2 to 5.7.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -150,7 +150,7 @@
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
         <kotlin.version>1.5.30</kotlin.version>
         <kotlin.coroutine.version>1.5.1</kotlin.coroutine.version>
-        <dekorate.version>2.3.0</dekorate.version>
+        <dekorate.version>2.5.0</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.1.0</awaitility.version>
@@ -170,7 +170,7 @@
         <okhttp.version>3.14.9</okhttp.version>
         <sentry.version>5.1.2</sentry.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.7.2</kubernetes-client.version>
+        <kubernetes-client.version>5.7.3</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Kubernetes Client 5.7.3 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.7.3

Just speeding up the dependabot process to see if CI reports any issue.

This should take care of #19950. It's still compatible with the older Jandex version (2.3), so should be back-portable to 2.2.x

/cc @metacosm @gastaldi

Fixes: #19950 