### PR TITLE
Fix outdated reactive transaction management doc

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -492,29 +492,29 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 == Transactions
 
 The reactive SQL clients support transactions.
-A transaction is started with `client.begin()` and terminated with either `tx.commit()` or `tx.rollback()`.
+A transaction is started with `io.vertx.mutiny.sqlclient.SqlConnection#begin` and terminated with either `io.vertx.mutiny.sqlclient.Transaction#commit` or `io.vertx.mutiny.sqlclient.Transaction#rollback`.
 All these operations are asynchronous:
 
-* `client.begin()` returns a `Uni<Transaction>`
-* `client.commit()` and `client.rollback()` return `Uni<Void>`
+* `connection.begin()` returns a `Uni<Transaction>`
+* `transaction.commit()` and `transaction.rollback()` return `Uni<Void>`
 
 Managing transactions in the reactive programming world can be cumbersome.
-Instead of writing repetitive and complex (thus error-prone!) code, you can use the `io.vertx.mutiny.sqlclient.SqlClientHelper`.
+Instead of writing repetitive and complex (thus error-prone!) code, you can use the `io.vertx.mutiny.sqlclient.Pool#withTransaction` helper method.
 
 The following snippet shows how to run 2 insertions in the same transaction:
 
 [source, java]
 ----
 public static Uni<Void> insertTwoFruits(PgPool client, Fruit fruit1, Fruit fruit2) {
-    return SqlClientHelper.inTransactionUni(client, tx -> {
-        Uni<RowSet<Row>> insertOne = tx.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id")
+    return client.withTransaction(conn -> {
+        Uni<RowSet<Row>> insertOne = conn.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id")
                 .execute(Tuple.of(fruit1.name));
-        Uni<RowSet<Row>> insertTwo = tx.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id")
+        Uni<RowSet<Row>> insertTwo = conn.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id")
                 .execute(Tuple.of(fruit2.name));
 
-        return insertOne.and(insertTwo)
+        return Uni.combine().all().unis(insertOne, insertTwo)
                 // Ignore the results (the two ids)
-                .onItem().ignore().andContinueWithNull();
+                .discardItems();
     });
 }
 ----
@@ -525,12 +525,12 @@ You can also create dependent actions as follows:
 
 [source, java]
 ----
-return SqlClientHelper.inTransactionUni(client, tx -> tx
+return client.withTransaction(conn -> conn
 
         .preparedQuery("INSERT INTO person (firstname,lastname) VALUES ($1,$2) RETURNING id")
-                .execute(Tuple.of(person.getFirstName(), person.getLastName()))
+        .execute(Tuple.of(person.getFirstName(), person.getLastName()))
 
-        .onItem().transformToUni(id -> tx.preparedQuery("INSERT INTO addr (person_id,addrline1) VALUES ($1,$2)")
+        .onItem().transformToUni(id -> conn.preparedQuery("INSERT INTO addr (person_id,addrline1) VALUES ($1,$2)")
                 .execute(Tuple.of(id.iterator().next().getLong("id"), person.getLastName())))
 
         .onItem().ignore().andContinueWithNull());


### PR DESCRIPTION
Fixes #19996 

`SqlClientHelper` is no longer needed because the Mutiny `Pool` API has the `withConnection` method.

Also, the `begin()` method has been moved to the `SqlConnection` API and is no longer present on `Pool`.