### PR TITLE
Support injecting OIDC WireMockServer into tests

### DIFF
--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWireMock.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWireMock.java
@@ -1,0 +1,24 @@
+package io.quarkus.test.oidc.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+/**
+ * Used to specify that the field should be injected with the {@link WireMockServer}
+ * server that provides mock HTTP API for OIDC clients.
+ * <p>
+ * Note: for this injection to work the test must use {@link OidcWiremockTestResource}.
+ * </p>
+ * <p>
+ * The main purpose of injecting the {@link WireMockServer} is for tests to be able
+ * to mock extra URLs not covered by {@link OidcWiremockTestResource}.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface OidcWireMock {
+}

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -26,6 +26,11 @@ import com.google.common.collect.ImmutableSet;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.jwt.build.Jwt;
 
+/**
+ * Provides a mock OIDC server to tests.
+ *
+ * @see OidcWireMock
+ */
 public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleManager {
 
     private static final Logger LOG = Logger.getLogger(OidcWiremockTestResource.class);
@@ -190,6 +195,12 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .jws()
                 .keyId("1")
                 .sign("privateKey.jwk");
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(server,
+                new TestInjector.AnnotatedAndMatchesType(OidcWireMock.class, WireMockServer.class));
     }
 
     @Override

--- a/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
+++ b/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.test.oidc.server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.TestResourceManager;
+
+/**
+ * Validates the injection of {@link WireMockServer} objects into test instances by {@link OidcWiremockTestResource}.
+ */
+class OidcWiremockTestResourceInjectionTest {
+
+    @Test
+    void testWireMockServerInjection() {
+        TestResourceManager manager = new TestResourceManager(CustomTest.class);
+        manager.start();
+
+        CustomTest test = new CustomTest();
+        manager.inject(test);
+        assertNotNull(test.server);
+    }
+
+    @QuarkusTestResource(OidcWiremockTestResource.class)
+    public static class CustomTest {
+        @OidcWireMock
+        WireMockServer server;
+    }
+}


### PR DESCRIPTION
* Define a custom annotation: InjectWireMock

* Override inject(TestInjector) in OidcWiremockTestResource
to allow tests to receive the WireMockServer
used by OidcWiremockTestResource

This is to allow (external) tests to mock
extra URLs, that are not covered by OidcWiremockTestResource

----

If this PR is accepted, please consider back-porting to Quarkus 2.2.x