### PR TITLE
Easily go back to Dev UI from Swagger and GraphQL UI

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,8 +45,8 @@
         <smallrye-config.version>2.4.4</smallrye-config.version>
         <smallrye-health.version>3.1.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.1</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.13</smallrye-open-api.version>
-        <smallrye-graphql.version>1.3.2</smallrye-graphql.version>
+        <smallrye-open-api.version>2.1.14</smallrye-open-api.version>
+        <smallrye-graphql.version>1.3.3</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.2.1</smallrye-jwt.version>

--- a/core/deployment/src/main/resources/META-INF/branding/smallrye-graphql-ui-graphiql.css
+++ b/core/deployment/src/main/resources/META-INF/branding/smallrye-graphql-ui-graphiql.css
@@ -51,11 +51,11 @@ body {
     padding-top: 12px !important;   
 }
 
-#graphiql .title a::after {
+#graphQLUiTitleLink::after {
   content: "GraphQL UI";
 }
 
-#graphiql .title a {
+#graphQLUiTitleLink {
     display: flex;
     align-items:center;
     color: white;
@@ -64,9 +64,13 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
-#graphiql .title img {
+#graphQLUiLogoLink img {
     border-right: 1px solid darkgrey;
     padding-right: 10px;
     margin-right: 10px;
     height: 30px;
+}
+
+.graphiql-container .title {
+    display: flex;
 }

--- a/core/deployment/src/main/resources/META-INF/branding/smallrye-open-api-ui.css
+++ b/core/deployment/src/main/resources/META-INF/branding/smallrye-open-api-ui.css
@@ -10,11 +10,16 @@ html{
     padding-bottom: 5px !important;
 }
 
-#swagger-ui .swagger-ui .topbar a {
-    max-width: 180px;
+#swaggerUiLogoLink {
+    max-width: 50px;
+    min-width: 50px;
 }
 
-#swagger-ui .topbar-wrapper .link a::after {
+#swaggerUiTitleLink {
+    max-width: 120px;
+}
+
+#swaggerUiTitleLink::after {
     content: "Swagger UI";
     font-size: 1.25rem;
     font-weight: normal;

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -100,6 +100,8 @@ public class SmallRyeGraphQLProcessor {
     private static final String LINE_FORMAT = LINE_TO_UPDATE + "%s';";
     private static final String UI_LINE_TO_UPDATE = "const ui = '";
     private static final String UI_LINE_FORMAT = UI_LINE_TO_UPDATE + "%s';";
+    private static final String LOGO_LINE_TO_UPDATE = "const logo = '";
+    private static final String LOGO_LINE_FORMAT = LOGO_LINE_TO_UPDATE + "%s';";
 
     // Branding files to monitor for changes
     private static final String BRANDING_DIR = "META-INF/branding/";
@@ -519,6 +521,8 @@ public class SmallRyeGraphQLProcessor {
                 WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLPath, LINE_TO_UPDATE, LINE_FORMAT);
                 WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLUiPath,
                         UI_LINE_TO_UPDATE, UI_LINE_FORMAT);
+                WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), nonApplicationRootPathBuildItem.resolvePath("dev"),
+                        LOGO_LINE_TO_UPDATE, LOGO_LINE_FORMAT);
 
                 smallRyeGraphQLBuildProducer
                         .produce(new SmallRyeGraphQLBuildItem(tempPath.toAbsolutePath().toString(), graphQLUiPath));
@@ -545,6 +549,11 @@ public class SmallRyeGraphQLProcessor {
                                 .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLUiPath,
                                         UI_LINE_TO_UPDATE,
                                         UI_LINE_FORMAT)
+                                .getBytes(StandardCharsets.UTF_8);
+                        content = WebJarUtil
+                                .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLUiPath,
+                                        LOGO_LINE_TO_UPDATE,
+                                        LOGO_LINE_FORMAT)
                                 .getBytes(StandardCharsets.UTF_8);
                     }
                     fileName = GRAPHQL_UI_FINAL_DESTINATION + "/" + fileName;

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -132,7 +132,7 @@ public class SwaggerUiProcessor {
                         SWAGGER_UI_WEBJAR_PREFIX);
                 // Update index.html
                 WebJarUtil.updateFile(tempPath.resolve("index.html"),
-                        generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig));
+                        generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig, nonApplicationRootPathBuildItem));
 
                 swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(tempPath.toAbsolutePath().toString(), swaggerUiPath));
 
@@ -151,7 +151,7 @@ public class SwaggerUiProcessor {
                     if (fileName.equals(theme.toString()) || !fileName.startsWith("theme-")) {
                         byte[] content;
                         if (fileName.endsWith("index.html")) {
-                            content = generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig);
+                            content = generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig, null);
                         } else {
                             content = file.getValue();
                         }
@@ -194,12 +194,18 @@ public class SwaggerUiProcessor {
         }
     }
 
-    private byte[] generateIndexHtml(String openApiPath, String swaggerUiPath, SwaggerUiConfig swaggerUiConfig)
+    private byte[] generateIndexHtml(String openApiPath, String swaggerUiPath, SwaggerUiConfig swaggerUiConfig,
+            NonApplicationRootPathBuildItem nonApplicationRootPath)
             throws IOException {
         Map<Option, String> options = new HashMap<>();
         Map<String, String> urlsMap = null;
 
         options.put(Option.selfHref, swaggerUiPath);
+        if (nonApplicationRootPath != null) {
+            options.put(Option.backHref, nonApplicationRootPath.resolvePath("dev"));
+        } else {
+            options.put(Option.backHref, swaggerUiPath);
+        }
 
         // Only add the url if the user did not specified urls
         if (swaggerUiConfig.urls != null && !swaggerUiConfig.urls.isEmpty()) {


### PR DESCRIPTION
Swagger UI and GraphQL UI is external UIs, this change allow users to click on the Quarkus logo to go back to Dev UI (if in dev mode)
![backToDevUi](https://user-images.githubusercontent.com/6836179/132829297-b75d032e-764e-44f7-8a21-30cd5b32f950.gif)

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>