### PR TITLE
Added flags to the AppDependency and simplified the AppModel

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/CascadingConditionalDependenciesTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/CascadingConditionalDependenciesTest.java
@@ -68,17 +68,23 @@ public class CascadingConditionalDependenciesTest extends ExecutableOutputOutcom
     protected void assertDeploymentDeps(List<AppDependency> deploymentDeps) throws Exception {
         final Set<AppDependency> expected = new HashSet<>();
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION), "runtime"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-e-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-e-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-f-deployment", TsArtifact.DEFAULT_VERSION), "runtime"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-f-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithSingleConditionTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithSingleConditionTest.java
@@ -43,11 +43,14 @@ public class ConditionalDependencyWithSingleConditionTest extends ExecutableOutp
         final List<AppDependency> deploymentDeps = appModel.getDeploymentDependencies();
         final Set<AppDependency> expected = new HashSet<>();
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithTwoConditionsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithTwoConditionsTest.java
@@ -44,13 +44,17 @@ public class ConditionalDependencyWithTwoConditionsTest extends ExecutableOutput
     protected void assertDeploymentDeps(List<AppDependency> deploymentDeps) throws Exception {
         final Set<AppDependency> expected = new HashSet<>();
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/UnsatisfiedConditionalDependencyWithTwoConditionsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/UnsatisfiedConditionalDependencyWithTwoConditionsTest.java
@@ -41,9 +41,11 @@ public class UnsatisfiedConditionalDependencyWithTwoConditionsTest extends Execu
     protected void assertDeploymentDeps(List<AppDependency> deploymentDeps) throws Exception {
         final Set<AppDependency> expected = new HashSet<>();
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(new AppDependency(
-                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile"));
+                new AppArtifact(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BasicExecutableOutputOutcomeTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BasicExecutableOutputOutcomeTest.java
@@ -31,7 +31,7 @@ public class BasicExecutableOutputOutcomeTest extends ExecutableOutputOutcomeTes
         final TsArtifact providedDep = TsArtifact.jar("provided-dep");
 
         final TsArtifact optionalDep = TsArtifact.jar("optional-dep");
-        addToExpectedLib(optionalDep); // TODO should direct optional deps be included?
+        addToExpectedLib(optionalDep);
 
         final TsArtifact directRtDep = TsArtifact.jar("runtime-dep");
         addToExpectedLib(directRtDep);

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
@@ -69,16 +69,23 @@ public class ExcludeExtensionDepsTest extends ExecutableOutputOutcomeTestBase {
     protected void assertAppModel(AppModel appModel) throws Exception {
         final Set<AppDependency> expectedDeployDeps = new HashSet<>();
         expectedDeployDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expectedDeployDeps, new HashSet<>(appModel.getDeploymentDependencies()));
         final Set<AppDependency> expectedRuntimeDeps = new HashSet<>();
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b", "1"), "compile"));
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-1", "1"), "compile"));
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-2", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b", "1"), "compile",
+                AppDependency.DIRECT_FLAG, AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                AppDependency.DEPLOYMENT_CP_FLAG));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-1", "1"), "compile",
+                AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-2", "1"), "compile",
+                AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         expectedRuntimeDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-1", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-1", "1"), "compile",
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         expectedRuntimeDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-2", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-dep-trans-2", "1"), "compile",
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expectedRuntimeDeps, new HashSet<>(appModel.getUserDependencies()));
         final Set<AppDependency> expectedFullDeps = new HashSet<>();
         expectedFullDeps.addAll(expectedDeployDeps);

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
@@ -61,16 +61,23 @@ public class ExcludeLibDepsTest extends ExecutableOutputOutcomeTestBase {
     protected void assertAppModel(AppModel appModel) throws Exception {
         final Set<AppDependency> expectedDeployDeps = new HashSet<>();
         expectedDeployDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expectedDeployDeps, new HashSet<>(appModel.getDeploymentDependencies()));
         final Set<AppDependency> expectedRuntimeDeps = new HashSet<>();
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a", "1"), "compile"));
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-1", "1"), "compile"));
-        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-2", "1"), "compile"));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a", "1"), "compile",
+                AppDependency.DIRECT_FLAG, AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                AppDependency.DEPLOYMENT_CP_FLAG));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-1", "1"), "compile",
+                AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
+        expectedRuntimeDeps.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-2", "1"), "compile",
+                AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         expectedRuntimeDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-1", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-1", "1"), "compile",
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         expectedRuntimeDeps
-                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-2", "1"), "compile"));
+                .add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-dep-trans-2", "1"), "compile",
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expectedRuntimeDeps, new HashSet<>(appModel.getUserDependencies()));
         final Set<AppDependency> expectedFullDeps = new HashSet<>();
         expectedFullDeps.addAll(expectedDeployDeps);

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExecutableOutputOutcomeTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExecutableOutputOutcomeTestBase.java
@@ -110,6 +110,7 @@ public abstract class ExecutableOutputOutcomeTestBase extends CreatorOutcomeTest
         return platformPropsDep;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void testCreator(QuarkusBootstrap creator) throws Exception {
         System.setProperty("quarkus.package.type", "legacy-jar");
@@ -193,6 +194,7 @@ public abstract class ExecutableOutputOutcomeTestBase extends CreatorOutcomeTest
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertExtensionDependencies(AppModel appModel, String[] expectedExtensions) {
         final Set<AppArtifact> expectedRuntime = new HashSet<>(expectedExtensions.length);
         final Set<AppArtifact> expectedDeployment = new HashSet<>(expectedExtensions.length);

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
@@ -68,12 +68,16 @@ public class OptionalDepsTest extends ExecutableOutputOutcomeTestBase {
     @Override
     protected void assertDeploymentDeps(List<AppDependency> deploymentDeps) throws Exception {
         final Set<AppDependency> expected = new HashSet<>();
-        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile", true));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile", true,
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(
-                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment-dep", "1"), "compile", true));
-        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile", true));
+                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment-dep", "1"), "compile", true,
+                        AppDependency.DEPLOYMENT_CP_FLAG));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile", true,
+                AppDependency.DEPLOYMENT_CP_FLAG));
         expected.add(
-                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-d-deployment", "1"), "compile", false));
+                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-d-deployment", "1"), "compile", false,
+                        AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
@@ -43,8 +43,10 @@ public class ProvidedExtensionDepsTest extends ExecutableOutputOutcomeTestBase {
     @Override
     protected void assertDeploymentDeps(List<AppDependency> deploymentDeps) throws Exception {
         final Set<AppDependency> expected = new HashSet<>();
-        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile"));
-        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment-dep", "1"), "compile"));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment-dep", "1"), "compile",
+                AppDependency.DEPLOYMENT_CP_FLAG));
         assertEquals(expected, new HashSet<>(deploymentDeps));
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/Dependency.java
@@ -19,4 +19,5 @@ public interface Dependency {
 
     String getScope();
 
+    int getFlags();
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/QuarkusModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/QuarkusModel.java
@@ -7,11 +7,7 @@ public interface QuarkusModel {
 
     Workspace getWorkspace();
 
-    List<Dependency> getAppDependencies();
-
-    List<Dependency> getExtensionDependencies();
-
-    List<Dependency> getEnforcedPlatformDependencies();
+    List<Dependency> getDependencies();
 
     PlatformImports getPlatformImports();
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DependencyImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/DependencyImpl.java
@@ -16,20 +16,27 @@ public class DependencyImpl implements Dependency, Serializable {
     private final Set<File> paths = new HashSet<>();
     private final String scope;
     private final String type;
+    private int flags;
 
     public DependencyImpl(String name, String groupId, String version, File path, String scope, String type,
-            String classifier) {
-        this(name, groupId, version, scope, type, classifier);
+            String classifier, int... flags) {
+        this(name, groupId, version, scope, type, classifier, flags);
         this.paths.add(path);
     }
 
-    public DependencyImpl(String name, String groupId, String version, String scope, String type, String classifier) {
+    public DependencyImpl(String name, String groupId, String version, String scope, String type, String classifier,
+            int... flags) {
         this.name = name;
         this.groupId = groupId;
         this.version = version;
         this.scope = scope;
         this.type = type;
         this.classifier = classifier;
+        int allFlags = 0;
+        for (int flag : flags) {
+            allFlags |= flag;
+        }
+        this.flags = allFlags;
     }
 
     @Override
@@ -72,6 +79,19 @@ public class DependencyImpl implements Dependency, Serializable {
     }
 
     @Override
+    public int getFlags() {
+        return flags;
+    }
+
+    public void setFlag(int flag) {
+        flags |= flag;
+    }
+
+    public boolean isFlagSet(int flag) {
+        return (flags & flag) > 0;
+    }
+
+    @Override
     public String toString() {
         return "DependencyImpl{" +
                 "name='" + name + '\'' +
@@ -85,22 +105,22 @@ public class DependencyImpl implements Dependency, Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        DependencyImpl that = (DependencyImpl) o;
-        return name.equals(that.name) &&
-                groupId.equals(that.groupId) &&
-                version.equals(that.version) &&
-                paths.equals(that.paths) &&
-                scope.equals(that.scope) &&
-                type.equals(that.type);
+    public int hashCode() {
+        return Objects.hash(classifier, flags, groupId, name, paths, scope, type, version);
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(name, groupId, version, paths, scope, type);
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DependencyImpl other = (DependencyImpl) obj;
+        return Objects.equals(classifier, other.classifier) && flags == other.flags
+                && Objects.equals(groupId, other.groupId) && Objects.equals(name, other.name)
+                && Objects.equals(paths, other.paths) && Objects.equals(scope, other.scope)
+                && Objects.equals(type, other.type) && Objects.equals(version, other.version);
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/QuarkusModelImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/QuarkusModelImpl.java
@@ -10,20 +10,14 @@ import java.util.List;
 public class QuarkusModelImpl implements QuarkusModel, Serializable {
 
     private final Workspace workspace;
-    private final List<Dependency> appDependencies;
-    private final List<Dependency> extensionDependencies;
-    private final List<Dependency> enforcedPlatformDependencies;
+    private final List<Dependency> dependencies;
     private final PlatformImports platformImports;
 
     public QuarkusModelImpl(Workspace workspace,
-            List<Dependency> appDependencies,
-            List<Dependency> extensionDependencies,
-            List<Dependency> enforcedPlatformDependencies,
+            List<Dependency> dependencies,
             PlatformImports platformImports) {
         this.workspace = workspace;
-        this.appDependencies = appDependencies;
-        this.extensionDependencies = extensionDependencies;
-        this.enforcedPlatformDependencies = enforcedPlatformDependencies;
+        this.dependencies = dependencies;
         this.platformImports = platformImports;
     }
 
@@ -33,18 +27,8 @@ public class QuarkusModelImpl implements QuarkusModel, Serializable {
     }
 
     @Override
-    public List<Dependency> getAppDependencies() {
-        return appDependencies;
-    }
-
-    @Override
-    public List<Dependency> getExtensionDependencies() {
-        return extensionDependencies;
-    }
-
-    @Override
-    public List<Dependency> getEnforcedPlatformDependencies() {
-        return enforcedPlatformDependencies;
+    public List<Dependency> getDependencies() {
+        return dependencies;
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.resolver.replace.test;
 
+import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
@@ -51,7 +52,7 @@ public class ManagedReplacedDependencyTestCase extends CollectDependenciesBase {
         addManagedDep(ext201);
         addManagedDep(ext301);
 
-        addCollectedDep(ext301.getRuntime());
+        addCollectedDep(ext301.getRuntime(), AppDependency.DIRECT_FLAG, AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG);
         addCollectedDeploymentDep(ext301.getDeployment());
     }
 }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/SimpleReplacedDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/SimpleReplacedDependencyTestCase.java
@@ -1,9 +1,7 @@
 package io.quarkus.bootstrap.resolver.replace.test;
 
-import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
-import io.quarkus.bootstrap.resolver.PropsBuilder;
-import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 
 /**
  *
@@ -13,18 +11,6 @@ public class SimpleReplacedDependencyTestCase extends CollectDependenciesBase {
 
     @Override
     protected void setupDependencies() throws Exception {
-
-        final TsArtifact extension = TsArtifact.jar("extension");
-        final TsArtifact deployment = new TsArtifact("deployment").addDependency(extension);
-
-        installAsDep(
-                extension,
-                newJar().addEntry(
-                        PropsBuilder.build(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, deployment.toString()),
-                        BootstrapConstants.DESCRIPTOR_PATH)
-                        .getPath(workDir),
-                true);
-
-        install(deployment, true);
+        installAsDep(new TsQuarkusExt("extension"));
     }
 }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/SystemPropertyOverridesPomPropertyDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/SystemPropertyOverridesPomPropertyDependencyTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.resolver.test;
 
+import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
@@ -30,7 +31,7 @@ public class SystemPropertyOverridesPomPropertyDependencyTestCase extends Collec
         setSystemProperty("x.version", "3");
 
         // it is expected that the system property will dominate
-        addCollectedDep(x13);
+        addCollectedDep(x13, AppDependency.DIRECT_FLAG);
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/VersionPropertyDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/VersionPropertyDependencyTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.resolver.test;
 
+import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 
@@ -20,6 +21,6 @@ public class VersionPropertyDependencyTestCase extends CollectDependenciesBase {
         setPomProperty("x.version", "2");
         addDep(new TsArtifact("x", "${x.version}"));
 
-        addCollectedDep(x12);
+        addCollectedDep(x12, AppDependency.DIRECT_FLAG);
     }
 }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMajorUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMajorUpdatesTest.java
@@ -47,14 +47,21 @@ public class CheckForLatestMajorUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "3.1.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "3.1.1").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "3.1.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "3.1.1").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMicroUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMicroUpdatesTest.java
@@ -44,14 +44,21 @@ public class CheckForLatestMicroUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "1.0.2").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "1.0.2").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.2").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.2").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMinorUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForLatestMinorUpdatesTest.java
@@ -44,14 +44,21 @@ public class CheckForLatestMinorUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "1.2.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "1.2.1").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "1.2.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "1.2.1").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMajorUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMajorUpdatesTest.java
@@ -46,14 +46,21 @@ public class CheckForNextMajorUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "2.0.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "2.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "2.0.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "2.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMicroUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMicroUpdatesTest.java
@@ -44,14 +44,21 @@ public class CheckForNextMicroUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "1.0.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "1.0.1").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.1").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.1").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMinorUpdatesTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckForNextMinorUpdatesTest.java
@@ -44,14 +44,21 @@ public class CheckForNextMinorUpdatesTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "1.1.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "1.1.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "1.1.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "1.1.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckUpdatesDisableTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/CheckUpdatesDisableTest.java
@@ -47,14 +47,21 @@ public class CheckUpdatesDisableTest extends CreatorOutcomeTestBase {
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", "1.0.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.0").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/UpdateToNextMicroAndPersistStateTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/update/UpdateToNextMicroAndPersistStateTest.java
@@ -60,14 +60,21 @@ public class UpdateToNextMicroAndPersistStateTest extends CreatorOutcomeTestBase
 
         final AppModel effectiveModel = outcome.getAppModel();
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1", expectedVersion).toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1", expectedVersion).toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("random").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_CP_FLAG, AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2", "1.0.0").toAppArtifact(), "compile", AppDependency.DIRECT_FLAG,
+                        AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG, AppDependency.RUNTIME_CP_FLAG,
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getUserDependencies());
 
         assertEquals(Arrays.asList(new AppDependency[] {
-                new AppDependency(TsArtifact.jar("ext1-deployment", expectedVersion).toAppArtifact(), "compile"),
-                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile")
+                new AppDependency(TsArtifact.jar("ext1-deployment", expectedVersion).toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG),
+                new AppDependency(TsArtifact.jar("ext2-deployment", "1.0.0").toAppArtifact(), "compile",
+                        AppDependency.DEPLOYMENT_CP_FLAG)
         }), effectiveModel.getDeploymentDependencies());
 
         outcome.getCurationResult().persist(outcome.getQuarkusBootstrap().getAppModelResolver());

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
@@ -23,7 +23,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,30 +100,23 @@ public class QuarkusModelHelper {
     public static AppModel convert(QuarkusModel model, AppArtifact appArtifact) throws AppModelResolverException {
         AppModel.Builder appBuilder = new AppModel.Builder();
 
-        final List<AppDependency> userDeps = new ArrayList<>();
-        Map<AppArtifactKey, AppDependency> versionMap = new HashMap<>();
-        model.getAppDependencies().stream().map(QuarkusModelHelper::toAppDependency).forEach(appDependency -> {
-            userDeps.add(appDependency);
-            versionMap.put(appDependency.getArtifact().getKey(), appDependency);
-        });
-
         final Map<String, Object> capabilities = new HashMap<>();
-        final List<AppDependency> deploymentDeps = new ArrayList<>();
         final Map<String, CapabilityContract> capabilitiesContracts = new HashMap<>();
-        for (Dependency extensionDependency : model.getExtensionDependencies()) {
-            AppDependency appDep = toAppDependency(extensionDependency);
-            for (Path artifactPath : appDep.getArtifact().getPaths()) {
+        for (Dependency extensionDependency : model.getDependencies()) {
+            boolean extension = false;
+            for (File f : extensionDependency.getPaths()) {
+                final Path artifactPath = f.toPath();
                 if (!Files.exists(artifactPath) || !extensionDependency.getType().equals("jar")) {
                     continue;
                 }
                 if (Files.isDirectory(artifactPath)) {
-                    processQuarkusDir(appDep.getArtifact(),
+                    extension |= processQuarkusDir(extensionDependency,
                             artifactPath.resolve(BootstrapConstants.META_INF),
                             appBuilder, capabilities, capabilitiesContracts);
                 } else {
                     try (FileSystem artifactFs = FileSystems.newFileSystem(artifactPath,
                             QuarkusModelHelper.class.getClassLoader())) {
-                        processQuarkusDir(appDep.getArtifact(),
+                        extension |= processQuarkusDir(extensionDependency,
                                 artifactFs.getPath(BootstrapConstants.META_INF),
                                 appBuilder, capabilities, capabilitiesContracts);
                     } catch (IOException e) {
@@ -132,15 +124,10 @@ public class QuarkusModelHelper {
                     }
                 }
             }
-            if (!userDeps.contains(appDep)) {
-                AppDependency deploymentDep = alignVersion(appDep, versionMap);
-                deploymentDeps.add(deploymentDep);
-            }
+            appBuilder.addDependency(toAppDependency(extensionDependency, extensionDependency.getFlags(),
+                    extension ? AppDependency.RUNTIME_EXTENSION_ARTIFACT_FLAG : 0));
         }
         appBuilder.setCapabilitiesContracts(capabilitiesContracts);
-
-        final List<AppDependency> fullDeploymentDeps = new ArrayList<>(userDeps);
-        fullDeploymentDeps.addAll(deploymentDeps);
 
         if (!appArtifact.isResolved()) {
             PathsCollection.Builder paths = PathsCollection.builder();
@@ -162,16 +149,17 @@ public class QuarkusModelHelper {
                     new AppArtifactKey(coords.getGroupId(), coords.getArtifactId(), null, coords.getType()));
         }
 
-        appBuilder.addRuntimeDeps(userDeps)
-                .addFullDeploymentDeps(fullDeploymentDeps)
-                .addDeploymentDeps(deploymentDeps)
-                .setAppArtifact(appArtifact)
+        appBuilder.setAppArtifact(appArtifact)
                 .setPlatformImports(model.getPlatformImports());
         return appBuilder.build();
     }
 
-    public static AppDependency toAppDependency(Dependency dependency) {
-        return new AppDependency(toAppArtifact(dependency), "runtime");
+    public static AppDependency toAppDependency(Dependency dependency, int... flags) {
+        int allFlags = dependency.getFlags();
+        for (int f : flags) {
+            allFlags |= f;
+        }
+        return new AppDependency(toAppArtifact(dependency), "runtime", allFlags);
     }
 
     private static AppArtifact toAppArtifact(Dependency dependency) {
@@ -204,20 +192,22 @@ public class QuarkusModelHelper {
         return rtProps;
     }
 
-    private static void processQuarkusDir(AppArtifact a, Path quarkusDir, AppModel.Builder appBuilder,
+    private static boolean processQuarkusDir(Dependency d, Path quarkusDir, AppModel.Builder appBuilder,
             Map<String, Object> capabilities, Map<String, CapabilityContract> capabilitiesContracts) {
         if (!Files.exists(quarkusDir)) {
-            return;
+            return false;
         }
         final Path quarkusDescr = quarkusDir.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME);
         if (!Files.exists(quarkusDescr)) {
-            return;
+            return false;
         }
         final Properties extProps = QuarkusModelHelper.resolveDescriptor(quarkusDescr);
         if (extProps == null) {
-            return;
+            return false;
         }
-        final String extensionCoords = a.toString();
+        final String extensionCoords = d.getGroupId() + ":" + d.getName() + ":"
+                + (d.getClassifier() == null ? "" : d.getClassifier()) + ":"
+                + (d.getType() == null || d.getType().isEmpty() ? "jar" : d.getType()) + ":" + d.getVersion();
         appBuilder.handleExtensionProperties(extProps, extensionCoords);
 
         final String providesCapabilities = extProps.getProperty(BootstrapConstants.PROP_PROVIDES_CAPABILITIES);
@@ -225,6 +215,7 @@ public class QuarkusModelHelper {
             capabilitiesContracts.put(extensionCoords,
                     CapabilityContract.providesCapabilities(extensionCoords, providesCapabilities));
         }
+        return true;
     }
 
     static AppDependency alignVersion(AppDependency dependency, Map<AppArtifactKey, AppDependency> versionMap) {

--- a/integration-tests/gradle/src/main/resources/.quarkus/config.yaml
+++ b/integration-tests/gradle/src/main/resources/.quarkus/config.yaml
@@ -4,4 +4,4 @@ registries:
 - test.registry.quarkus.io:
     maven:
         repository:
-            url: file://$testResourcesDir/test-registry-repo
+            url: file://${project.build.outputDirectory}/test-registry-repo


### PR DESCRIPTION
In addition to the runtime and/or deployment classpath origin, I need to be able to know more info about dependencies in the AppModel, such as:
* whether a dependency is a direct one or transitive
* whether it is an extension artifact or not
* there could be more in the future

Instead of adding more and more fields and also potentially complicating the AppModel impl, I though using flags would be a better alternative.

This PR includes the following changes:

* Added flags to the AppDependency to indicate whether a dependency i…s a direct one, an extension, belongs to the runtime and/or deployment CP
* Simplified the AppModel by mering all the dependencies into a single list
* Simplified Gradle's QuarkusModel impl and initialization

Also fixes #19497