### PR TITLE
Make jacoco work with @QuarkusIntegrationTest

### DIFF
--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -259,7 +259,6 @@ re-build the jacoco report after the integration tests are complete, and thus pr
                     <configuration>
                         <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
                         <append>true</append>
-                        <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
                     </configuration>
                 </execution>
                 <execution>


### PR DESCRIPTION
To make this work, essentially what we do is to overwrite
the build system output with the transformed bytecode
See https://github.com/quarkusio/quarkus/issues/18559#issuecomment-916701411
for more details.

Fixes: #18559