### PR TITLE
Don't try to remove node8-typescript image

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,6 +1,6 @@
 # Reclaim disk space, otherwise we only have 13 GB free at the start of a job
 
-time docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
+time docker rmi node:10 node:12
 # That is 18 GB
 time sudo rm -rf /usr/share/dotnet
 # That is 1.2 GB


### PR DESCRIPTION
Fixes `Error: No such image: mcr.microsoft.com/azure-pipelines/node8-typescript:latest`.