### PR TITLE
Fix OIDC Dev UI in case Swagger is not added

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -136,6 +136,7 @@ var port = {config:property('quarkus.http.port')};
     }
 
     function navigateToSwaggerUi(){
+        {#if info:swaggerIsAvailable}
         var url = "{config:http-path('quarkus.swagger-ui.path')}";
         
         var authorizedValue = {
@@ -159,6 +160,7 @@ var port = {config:property('quarkus.http.port')};
         
         localStorage.setItem('authorized', JSON.stringify(authorizedValue));
         window.open(url, '_blank').focus();
+        {/if}
     }
     
     function copyToClipboard(token, type){


### PR DESCRIPTION
Getting `io.quarkus.qute.TemplateException: Property not found in expression {config:http-path('quarkus.swagger-ui.path')} in template io.quarkus.quarkus-oidc/provider` otherwise

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>