### PR TITLE
Change the default for `printDatafetcherException` to true in Dev Mode

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLConfig.java
@@ -91,10 +91,10 @@ public class SmallRyeGraphQLConfig {
     Optional<String> defaultErrorMessage;
 
     /**
-     * Print the data fetcher exception to the log file.
+     * Print the data fetcher exception to the log file. Default `true` in dev and test mode, default `false` in prod.
      */
-    @ConfigItem(defaultValue = "false")
-    boolean printDataFetcherException;
+    @ConfigItem
+    Optional<Boolean> printDataFetcherException;
 
     /**
      * Make the schema available over HTTP.

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -399,6 +399,22 @@ public class SmallRyeGraphQLProcessor {
         return classes;
     }
 
+    @BuildStep
+    void printDataFetcherExceptionInDevMode(SmallRyeGraphQLConfig graphQLConfig,
+            LaunchModeBuildItem launchMode,
+            BuildProducer<SystemPropertyBuildItem> systemProperties) {
+
+        // User did not set this explisitly 
+        if (!graphQLConfig.printDataFetcherException.isPresent()) {
+            if (launchMode.getLaunchMode().isDevOrTest()) {
+                systemProperties.produce(new SystemPropertyBuildItem(ConfigKey.PRINT_DATAFETCHER_EXCEPTION, TRUE));
+            }
+        } else {
+            systemProperties.produce(new SystemPropertyBuildItem(ConfigKey.PRINT_DATAFETCHER_EXCEPTION,
+                    String.valueOf(graphQLConfig.printDataFetcherException.get())));
+        }
+    }
+
     // Services Integrations
 
     @BuildStep


### PR DESCRIPTION
Most time support is needed, developer first need to switch this flag. A better default that plain false everywhere, is to make this true by default for dev mode, and false for prod

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>