### PR TITLE
Fix for typo in kafka docs

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1990,7 +1990,7 @@ public Multi<String> stream() {
     return Multi.createBy().merging()
             .streams(
                     fruits.map(this::toJson),
-                    getPingStream()
+                    emitAPeriodicPing()
             );
 }
 


### PR DESCRIPTION
In Kafka docs, there is an example of working with Server-side events. The example uses inconsistent method names( the method is defined as emitAPeriodicPing() but called  as getPingStream()).