### PR TITLE
Fix test references to the gone vertx-web extension

### DIFF
--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -76,7 +76,7 @@ public class CliProjectJBangTest {
                 "--package-name=custom.pkg",
                 "--output-directory=" + nested,
                 "--app-config=" + String.join(",", configs),
-                "-x vertx-web",
+                "-x reactive-routes",
                 "silly:my-project:0.1.0");
 
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
@@ -91,7 +91,7 @@ public class CliProjectJBangTest {
 
         String source = CliDriver.readFileAsString(project, javaMain);
         Assertions.assertTrue(source.contains("quarkus-reactive-routes"),
-                "Generated source should reference vertx-web. Found:\n" + source);
+                "Generated source should reference quarkus-reactive-routes. Found:\n" + source);
 
         result = CliDriver.invokeValidateDryRunBuild(project);
 


### PR DESCRIPTION
Change introduced in https://github.com/quarkusio/quarkus/commit/828a6cfa1c5ba9845913c567e94e5ea5ec783067#diff-a4add63eed9a70c424612bfc5342dc0652cb362031ef3128d9ee8a196724def3