### PR TITLE
Optimize conditional dependencies resolution in Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -22,14 +22,12 @@ public class ApplicationDeploymentClasspathBuilder {
         return baseConfigurationName + DEPLOYMENT_CONFIGURATION_SUFFIX;
     }
 
-    public void createBuildClasspath(String baseConfigurationName, boolean common) {
+    public void createBuildClasspath(Set<ExtensionDependency> extensions, String baseConfigurationName, boolean common) {
         String deploymentConfigurationName = toDeploymentConfigurationName(baseConfigurationName);
         project.getConfigurations().create(deploymentConfigurationName);
 
         DependencyHandler dependencies = project.getDependencies();
-        Set<ExtensionDependency> firstLevelExtensions = DependencyUtils.loadQuarkusExtension(project,
-                project.getConfigurations().findByName(baseConfigurationName));
-        for (ExtensionDependency extension : firstLevelExtensions) {
+        for (ExtensionDependency extension : extensions) {
             if (common) {
                 commonExtensions.add(extension);
             } else if (commonExtensions.contains(extension)) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -17,24 +17,32 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 public class ConditionalDependenciesEnabler {
 
     private final Map<String, ExtensionDependency> featureVariants = new HashMap<>();
-
+    private final Set<ExtensionDependency> allExtensions = new HashSet<>();
     private final Project project;
 
     public ConditionalDependenciesEnabler(Project project) {
         this.project = project;
     }
 
-    public void declareConditionalDependencies(String baseConfigurationName) {
+    public Set<ExtensionDependency> declareConditionalDependencies(String baseConfigurationName) {
         featureVariants.clear();
-
-        Configuration resolvedConfiguration = DependencyUtils.duplicateConfiguration(project,
-                project.getConfigurations().getByName(baseConfigurationName));
-
+        allExtensions.clear();
+        Configuration baseConfiguration = project.getConfigurations().getByName(baseConfigurationName);
+        if (baseConfiguration.getIncoming().getDependencies().isEmpty()) {
+            return Collections.emptySet();
+        }
+        Configuration resolvedConfiguration = DependencyUtils.duplicateConfiguration(project, baseConfiguration);
         Set<ResolvedArtifact> runtimeArtifacts = resolvedConfiguration.getResolvedConfiguration().getResolvedArtifacts();
+
         List<ExtensionDependency> extensions = collectExtensionsForResolution(runtimeArtifacts);
+        if (extensions.isEmpty()) {
+            return allExtensions;
+        }
+
         featureVariants.putAll(extractFeatureVariants(extensions));
 
-        resolveConditionalDependencies(extensions, resolvedConfiguration, baseConfigurationName);
+        resolveConditionalDependencies(extensions, runtimeArtifacts, baseConfigurationName);
+        return allExtensions;
     }
 
     private List<ExtensionDependency> collectExtensionsForResolution(Set<ResolvedArtifact> runtimeArtifacts) {
@@ -42,6 +50,7 @@ public class ConditionalDependenciesEnabler {
         for (ResolvedArtifact artifact : runtimeArtifacts) {
             ExtensionDependency extension = DependencyUtils.getExtensionInfoOrNull(project, artifact);
             if (extension != null) {
+                allExtensions.add(extension);
                 if (!extension.conditionalDependencies.isEmpty()) {
                     if (extension.needsResolution(runtimeArtifacts)) {
                         firstLevelExtensions.add(extension);
@@ -53,18 +62,26 @@ public class ConditionalDependenciesEnabler {
     }
 
     private void resolveConditionalDependencies(List<ExtensionDependency> conditionalExtensions,
-            Configuration existingDependencies, String baseConfigurationName) {
-        final Configuration conditionalDeps = createConditionalDependenciesConfiguration(existingDependencies,
-                conditionalExtensions);
+            Set<ResolvedArtifact> runtimeArtifacts, String baseConfigurationName) {
+
         boolean hasChanged = false;
         List<ExtensionDependency> newConditionalDependencies = new ArrayList<>();
-        newConditionalDependencies.addAll(conditionalExtensions);
-        for (ResolvedArtifact artifact : conditionalDeps.getResolvedConfiguration().getResolvedArtifacts()) {
+
+        final Configuration conditionalDeps = createConditionalDependenciesConfiguration(project,
+                conditionalExtensions);
+        Set<ResolvedArtifact> resolvedArtifacts = conditionalDeps.getResolvedConfiguration().getResolvedArtifacts();
+
+        Set<ResolvedArtifact> availableRuntimeArtifacts = new HashSet<>();
+        availableRuntimeArtifacts.addAll(runtimeArtifacts);
+        availableRuntimeArtifacts.addAll(resolvedArtifacts);
+
+        for (ResolvedArtifact artifact : resolvedArtifacts) {
             ExtensionDependency extensionDependency = DependencyUtils.getExtensionInfoOrNull(project, artifact);
             if (extensionDependency != null) {
-                if (DependencyUtils.exist(conditionalDeps.getResolvedConfiguration().getResolvedArtifacts(),
+                if (DependencyUtils.exist(availableRuntimeArtifacts,
                         extensionDependency.dependencyConditions)) {
                     enableConditionalDependency(extensionDependency.extensionId);
+                    allExtensions.add(extensionDependency);
                     if (!extensionDependency.conditionalDependencies.isEmpty()) {
                         featureVariants.putAll(extractFeatureVariants(Collections.singletonList(extensionDependency)));
                     }
@@ -76,12 +93,13 @@ public class ConditionalDependenciesEnabler {
             }
         }
 
-        Configuration enhancedDependencies = DependencyUtils.duplicateConfiguration(project,
-                project.getConfigurations().getByName(baseConfigurationName));
-
         if (hasChanged) {
             if (!newConditionalDependencies.isEmpty()) {
-                resolveConditionalDependencies(newConditionalDependencies, enhancedDependencies, baseConfigurationName);
+                Configuration enhancedDependencies = DependencyUtils.duplicateConfiguration(project,
+                        project.getConfigurations().getByName(baseConfigurationName));
+                Set<ResolvedArtifact> enhancedRuntimeArtifacts = enhancedDependencies.getResolvedConfiguration()
+                        .getResolvedArtifacts();
+                resolveConditionalDependencies(newConditionalDependencies, enhancedRuntimeArtifacts, baseConfigurationName);
             }
         }
     }
@@ -96,11 +114,10 @@ public class ConditionalDependenciesEnabler {
         return possibleVariant;
     }
 
-    private Configuration createConditionalDependenciesConfiguration(Configuration existingDeps,
+    private Configuration createConditionalDependenciesConfiguration(Project project,
             List<ExtensionDependency> extensions) {
-        Configuration newConfiguration = existingDeps.copy();
-        newConfiguration.getDependencies().addAll(collectConditionalDependencies(extensions));
-        return newConfiguration;
+        Set<Dependency> dependencies = collectConditionalDependencies(extensions);
+        return project.getConfigurations().detachedConfiguration(dependencies.toArray(new Dependency[0]));
     }
 
     private Set<Dependency> collectConditionalDependencies(List<ExtensionDependency> extensionDependencies) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -87,21 +87,6 @@ public class DependencyUtils {
         return false;
     }
 
-    public static Set<ExtensionDependency> loadQuarkusExtension(Project project, Configuration configuration) {
-        Set<ExtensionDependency> extensions = new HashSet<>();
-        Configuration configurationCopy = duplicateConfiguration(project, configuration);
-
-        Set<ResolvedArtifact> resolvedArtifacts = configurationCopy.getResolvedConfiguration().getResolvedArtifacts();
-        for (ResolvedArtifact artifact : resolvedArtifacts) {
-            ExtensionDependency extension = getExtensionInfoOrNull(project, artifact);
-            if (extension != null) {
-                extensions.add(extension);
-            }
-        }
-
-        return extensions;
-    }
-
     public static boolean isTestFixtureDependency(Dependency dependency) {
         if (!(dependency instanceof ModuleDependency)) {
             return false;

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -52,7 +52,6 @@ import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.QuarkusDevModeLauncher;
-import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.runtime.LaunchMode;
 
 public class QuarkusDev extends QuarkusTask {
@@ -353,7 +352,7 @@ public class QuarkusDev extends QuarkusTask {
         if (!visited.add(project.getPath())) {
             return;
         }
-        final Configuration compileCp = project.getConfigurations().findByName(QuarkusPlugin.DEV_MODE_CONFIGURATION_NAME);
+        final Configuration compileCp = project.getConfigurations().findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
         if (compileCp != null) {
             compileCp.getIncoming().getDependencies().forEach(d -> {
                 if (d instanceof ProjectDependency) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateConfig.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.util.Collections;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -28,6 +31,16 @@ public class QuarkusGenerateConfig extends QuarkusTask {
     @Input
     public String getFile() {
         return file;
+    }
+
+    /**
+     * Create a dependency on classpath resolution. This makes sure included build are build this task runs.
+     *
+     * @return resolved compile classpath
+     */
+    @CompileClasspath
+    public FileCollection getClasspath() {
+        return QuarkusGradleUtils.getSourceSet(getProject(), SourceSet.MAIN_SOURCE_SET_NAME).getCompileClasspath();
     }
 
     @Option(description = "The name of the file to generate", option = "file")


### PR DESCRIPTION
This aim to simplify and optimize conditional dependency resolution in the gradle plugin: 

- The `quarkusDev` configuration does not extends the `compileClasspath` anymore, this avoid resolving the compile classpath twice (for the `implementation` configuration and for the `quarkusDev` configuration)
- Limitation of the number of dependency to resolve, I try to minimise the number of dependencies to resolve. The less we have, faster we are. 
- I moved the code, in a block (`beforeResolve`) that is only executed if the compile classpath is needed

close #20153 