### PR TITLE
Fix flaky GetTransactionLifecycleTest caused by slow CI

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -49,7 +49,8 @@ public abstract class AbstractTransactionLifecycleTest {
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
                     // Ignore these particular warnings: they are not relevant to this test.
                     && !record.getMessage().contains("Using Java versions older than 11 to build Quarkus applications")
-                    && !record.getMessage().contains("Agroal does not support detecting if a connection is still usable"))
+                    && !record.getMessage().contains("Agroal does not support detecting if a connection is still usable")
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
                     .isEmpty());


### PR DESCRIPTION
Fixes e.g.:
```
[INFO] Running io.quarkus.hibernate.orm.transaction.GetTransactionLifecycleTest
2021-09-12 22:20:01,773 WARN  [io.qua.net.run.NettyRecorder] (Thread-2169) Netty DefaultChannelId initialization (with io.netty.machineId system property set to 3e:4c:c3:3e:ed:0f:72:6a) took more than a second
2021-09-12 22:20:07,284 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT on JVM started in 7.521s. Listening on: http://localhost:8081
2021-09-12 22:20:07,284 INFO  [io.quarkus] (main) Profile test activated. 
2021-09-12 22:20:07,284 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, hibernate-validator, jdbc-h2, narayana-jta, smallrye-context-propagation, smallrye-metrics, vertx]
2021-09-12 22:20:07,663 INFO  [io.quarkus] (main) Quarkus stopped in 0.039s
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.581 s <<< FAILURE! - in io.quarkus.hibernate.orm.transaction.GetTransactionLifecycleTest
[ERROR] io.quarkus.hibernate.orm.transaction.GetTransactionLifecycleTest  Time elapsed: 8.581 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting empty but was: ["Netty DefaultChannelId initialization (with io.netty.machineId system property set to 3e:4c:c3:3e:ed:0f:72:6a) took more than a second"]
	at io.quarkus.hibernate.orm.transaction.AbstractTransactionLifecycleTest.lambda$static$2(AbstractTransactionLifecycleTest.java:55)
```
https://github.com/quarkusio/quarkus/pull/20080#issuecomment-917769006

First I thought about removing the warning altogether: https://github.com/quarkusio/quarkus/blob/2cbd177416f92b9f45abb34b6f01acb8cb0f4eb5/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java#L17-L36
but we do see user logs with that from time to time:
- https://github.com/quarkusio/quarkus/issues?q=is%3Aissue+Netty+DefaultChannelId+initialization
- https://quarkusio.zulipchat.com/#narrow/search/netty.20defaultchannelid.20initialization
