### PR TITLE
Fix quarkus.http.host-enabled=false without domain socket

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -244,7 +244,7 @@ public class VertxHttpRecorder {
         if (startVirtual) {
             initializeVirtual(vertx.get());
         }
-        if (startSocket) {
+        if (startSocket && (httpConfiguration.hostEnabled || httpConfiguration.domainSocketEnabled)) {
             // Start the server
             if (closeTask == null) {
                 doServerStart(vertx.get(), httpBuildTimeConfig, httpConfiguration, launchMode, ioThreads,


### PR DESCRIPTION
Fixes #19370 (well, it _should_ - I actually tested this only with QuarkusTests in my app, related to #14927)

See also: https://github.com/quarkusio/quarkus/issues/19370#issuecomment-913873727