### PR TITLE
Remove tomcat-annotations-api from Jaeger

### DIFF
--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -30,6 +30,12 @@
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
+                <!-- it also pulls in the jakarta annotations via the 'org.apache.tomcat:tomcat-annotations-api' which seems to be a copy of 'jakarta.annotation:jakarta.annotation-api'-->
+                <!-- https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-annotations-api -->
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-annotations-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -45,6 +51,10 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>


### PR DESCRIPTION
This dependency is just a copy of jakarta.annotation-api

Fixes: #20125