### PR TITLE
Trim the Avro codegen import paths to allow multi-line configuration

### DIFF
--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
@@ -46,7 +46,7 @@ public abstract class AvroCodeGenProviderBase implements CodeGenProvider {
 
         // compile the imports first
         for (String imprt : options.imports) {
-            Path importPath = Paths.get(input.toAbsolutePath().toString(), imprt).toAbsolutePath();
+            Path importPath = Paths.get(input.toAbsolutePath().toString(), imprt.trim()).toAbsolutePath();
             if (Files.isDirectory(importPath)) {
                 for (Path file : gatherAllFiles(importPath)) {
                     compileSingleFile(file, outputDir, options);


### PR DESCRIPTION
When specifying many import paths, it can be useful to split them over multiple lines.

For example:
```
<avro.codegen.avsc.imports>
    this/is/a/long/path,
    this/is/another/long/path,
    and/another/path/split/over/another/line
</avro.codegen.avsc.imports>
```

This PR trims any newline characters left over after splitting the comma delimited string.