### PR TITLE
Rename vertx-web to reactive-routes

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -3,14 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Amazon Lambda with RESTEasy, Undertow, or Vert.x Web
+= Amazon Lambda with RESTEasy, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
 With Quarkus you can deploy your favorite Java HTTP frameworks as Amazon Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
 or https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html[AWS Gateway REST API].  This means that you can deploy your microservices written with RESTEasy (JAX-RS),
-Undertow (servlet), Vert.x Web, link:funqy-http[Funqy HTTP] or any other Quarkus HTTP framework as an AWS Lambda.
+Undertow (servlet), Reactive Routes, link:funqy-http[Funqy HTTP] or any other Quarkus HTTP framework as an AWS Lambda.
 
 You can deploy your Lambda as a pure Java jar, or you can compile your project to a native image and deploy that for a smaller
 memory footprint and startup time.  Our integration also generates SAM deployment files that can be consumed by https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html[Amazon's SAM framework].
@@ -253,7 +253,7 @@ There is nothing special about the POM other than the inclusion of the `quarkus-
 These extensions automatically generate everything you might need for your lambda deployment.
 
 Also, at least in the generated Maven archetype `pom.xml`, the `quarkus-resteasy`, `quarkus-reactive-routes`, and `quarkus-undertow`
-dependencies are all optional.  Pick which HTTP framework(s) you want to use (JAX-RS, Vertx Web, and/or Servlet) and
+dependencies are all optional.  Pick which HTTP framework(s) you want to use (JAX-RS, Reactive Routes, and/or Servlet) and
 remove the other dependencies to shrink your deployment.
 
 === Examine sam.yaml
@@ -362,12 +362,12 @@ library is not fully compatible with GraalVM so we had to do some integration wo
 
 When you invoke an HTTP request on the API Gateway, the Gateway turns that HTTP request into a JSON event document that is
 forwarded to a Quarkus Lambda.  The Quarkus Lambda parses this json and converts in into an internal representation of an HTTP
-request that can be consumed by any HTTP framework Quarkus supports (JAX-RS, servlet, Vert.x Web).
+request that can be consumed by any HTTP framework Quarkus supports (JAX-RS, servlet, Reactive Routes).
 
 API Gateway supports many different ways to securely invoke on your HTTP endpoints that are backed by Lambda and Quarkus.
 If you enable it, Quarkus will automatically parse relevant parts of the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html[event json document]
 and look for security based metadata and register a `java.security.Principal` internally that can be looked up in JAX-RS
-by injecting a `javax.ws.rs.core.SecurityContext`, via `HttpServletRequest.getUserPrincipal()` in servlet, and `RouteContext.user()` in Vert.x Web.
+by injecting a `javax.ws.rs.core.SecurityContext`, via `HttpServletRequest.getUserPrincipal()` in servlet, and `RouteContext.user()` in Reactive Routes.
 If you want more security information, the `Principal` object can be typecast to
 a class that will give you more information.
 

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -3,15 +3,15 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Azure Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
+= Azure Functions (Serverless) with RESTEasy, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
 The `quarkus-azure-functions-http` extension allows you to write microservices with RESTEasy (JAX-RS),
-Undertow (servlet), Vert.x Web, or link:funqy-http[Funqy HTTP] and make these microservices deployable to the Azure Functions runtime.
+Undertow (servlet), Reactive Routes, or link:funqy-http[Funqy HTTP] and make these microservices deployable to the Azure Functions runtime.
 
-One azure function deployment can represent any number of JAX-RS, servlet, Vert.x Web, or link:funqy-http[Funqy HTTP] endpoints.
+One azure function deployment can represent any number of JAX-RS, servlet, Reactive Routes, or link:funqy-http[Funqy HTTP] endpoints.
 
 include::./status-include.adoc[]
 
@@ -30,7 +30,7 @@ To complete this guide, you need:
 == Solution
 
 This guide walks you through running a Maven Archetype to generate a sample project that contains three http endpoints
-written with JAX-RS APIs, Servlet APIs, Vert.x Web, or link:funqy-http[Funqy HTTP] APIs.  After building, you will then be able to deploy
+written with JAX-RS APIs, Servlet APIs, Reactive Routes, or link:funqy-http[Funqy HTTP] APIs.  After building, you will then be able to deploy
 to Azure.
 
 == Creating the Maven Deployment Project
@@ -99,7 +99,7 @@ https://{appName}.azurewebsites.net/api/funqyHello
 
 == Extension maven dependencies
 
-The sample project includes the RESTEasy, Undertow, Vert.x Web, link:funqy-http[Funqy HTTP] extensions.  If you are only using one of those
+The sample project includes the RESTEasy, Undertow, Reactive Routes, link:funqy-http[Funqy HTTP] extensions.  If you are only using one of those
 APIs (i.e. jax-rs only), respectively remove the maven dependency `quarkus-resteasy`, `quarkus-undertow`, `quarkus-funqy-http`, and/or
 `quarkus-reactive-routes`.
 
@@ -118,7 +118,7 @@ your jax-rs endpoints won't route correctly.  See <<config-azure-paths>> for mor
 [#config-azure-paths]
 == Configuring Root Paths
 
-The default route prefix for an Azure Function is `/api`.  All of your JAX-RS, Servlet, Vert.x Web, and link:funqy-http[Funqy HTTP] endpoints must
+The default route prefix for an Azure Function is `/api`.  All of your JAX-RS, Servlet, Reactive Routes, and link:funqy-http[Funqy HTTP] endpoints must
 explicitly take this into account.  In the generated project this is handled by the
 `quarkus.http.root-path` switch in `application.properties`
 

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -3,15 +3,15 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
+= Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
 The `quarkus-google-cloud-functions-http` extension allows you to write microservices with RESTEasy (JAX-RS),
-Undertow (Servlet), Vert.x Web, or link:funqy-http[Funqy HTTP], and make these microservices deployable to the Google Cloud Functions runtime.
+Undertow (Servlet), Reactive Routes, or link:funqy-http[Funqy HTTP], and make these microservices deployable to the Google Cloud Functions runtime.
 
-One Google Cloud Functions deployment can represent any number of JAX-RS, Servlet, Vert.x Web, or link:funqy-http[Funqy HTTP] endpoints.
+One Google Cloud Functions deployment can represent any number of JAX-RS, Servlet, Reactive Routes, or link:funqy-http[Funqy HTTP] endpoints.
 
 include::./status-include.adoc[]
 
@@ -28,7 +28,7 @@ To complete this guide, you need:
 == Solution
 
 This guide walks you through generating a sample project followed by creating three HTTP endpoints
-written with JAX-RS APIs, Servlet APIs, Vert.x Web, or link:funqy-http[Funqy HTTP] APIs. Once built, you will be able to deploy
+written with JAX-RS APIs, Servlet APIs, Reactive Routes, or link:funqy-http[Funqy HTTP] APIs. Once built, you will be able to deploy
 the project to Google Cloud.
 
 If you don't want to follow all these steps, you can go right to the completed example.
@@ -49,7 +49,7 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=google-cloud-functions-http \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
-    -Dextensions="resteasy,google-cloud-functions-http,resteasy-json,undertow,vertx-web,funqy-http"
+    -Dextensions="resteasy,google-cloud-functions-http,resteasy-jackson,undertow,reactive-routes,funqy-http"
 ----
 
 == Login to Google Cloud
@@ -64,7 +64,7 @@ gcloud auth login
 == Creating the endpoints
 
 For this example project, we will create four endpoints, one for RESTEasy (JAX-RS), one for Undertow (Servlet),
-one for Vert.x Web (reactive routes) and one for link:funqy-http[Funqy HTTP].
+one for Reactive routes and one for link:funqy-http[Funqy HTTP].
 
 If you don't need endpoints of each type, you can remove the corresponding extensions from your `pom.xml`.
 
@@ -119,7 +119,7 @@ public class GreetingServlet extends HttpServlet {
 }
 ----
 
-=== The Vert.x Web endpoint
+=== The Reactive Routes endpoint
 
 [source,java]
 ----
@@ -189,7 +189,7 @@ You can then call your endpoints via:
 
 - For JAX-RS: {httpsTrigger.url}/hello
 - For servlet: {httpsTrigger.url}/servlet/hello
-- For Vert.x Web: {httpsTrigger.url}/vertx/hello
+- For Reactive Routes: {httpsTrigger.url}/vertx/hello
 - For Funqy: {httpsTrigger.url}/funqy
 
 == Testing locally


### PR DESCRIPTION
Renaming of vertx-web to reactive-routes in the function guides.
I also rename it in the Lambda and Azure Functions guide as I understand, the name is now Reactive Routes and not Vert.x Web.