### PR TITLE
Bump netty-bom from 4.1.67 to 4.1.68

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -131,7 +131,7 @@
         <infinispan.version>12.1.7.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <netty.version>4.1.67.Final</netty.version>
+        <netty.version>4.1.68.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.2.Final</jboss-logging.version>
         <mutiny.version>1.0.0</mutiny.version>


### PR DESCRIPTION
[CVE-2021-37137](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-37137) is reported against Netty 4.1.67 and should be addressed by 4.1.68.