### PR TITLE
Add GraphQL UI to test endpoints in OIDC Dev UI

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -104,6 +104,7 @@ public interface Capability {
     String SMALLRYE_OPENTRACING = QUARKUS_PREFIX + "smallrye.opentracing";
     String SMALLRYE_HEALTH = QUARKUS_PREFIX + "smallrye.health";
     String SMALLRYE_OPENAPI = QUARKUS_PREFIX + "smallrye.openapi";
+    String SMALLRYE_GRAPHQL = QUARKUS_PREFIX + "smallrye.graphql";
     String SMALLRYE_FAULT_TOLERANCE = QUARKUS_PREFIX + "smallrye.faulttolerance";
 
     String SPRING_WEB = QUARKUS_PREFIX + "spring.web";

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -44,9 +44,12 @@ public class KeycloakDevConsoleProcessor {
                     new DevConsoleTemplateInfoBuildItem("authorizationUrl", realmUrl + "/protocol/openid-connect/auth"));
             console.produce(new DevConsoleTemplateInfoBuildItem("logoutUrl", realmUrl + "/protocol/openid-connect/logout"));
             console.produce(new DevConsoleTemplateInfoBuildItem("oidcGrantType", config.devservices.grant.type.getGrantType()));
-            console.produce(new DevConsoleTemplateInfoBuildItem("swaggerIsAvailable",
-                    capabilities.isPresent(Capability.SMALLRYE_OPENAPI)));
-
+            if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
+                console.produce(new DevConsoleTemplateInfoBuildItem("swaggerIsAvailable", true));
+            }
+            if (capabilities.isPresent(Capability.SMALLRYE_GRAPHQL)) {
+                console.produce(new DevConsoleTemplateInfoBuildItem("graphqlIsAvailable", true));
+            }
         }
     }
 

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -136,7 +136,7 @@ var port = {config:property('quarkus.http.port')};
     }
 
     function navigateToSwaggerUi(){
-        {#if info:swaggerIsAvailable}
+        {#if info:swaggerIsAvailable??}
         var url = "{config:http-path('quarkus.swagger-ui.path')}";
         
         var authorizedValue = {
@@ -160,6 +160,15 @@ var port = {config:property('quarkus.http.port')};
         
         localStorage.setItem('authorized', JSON.stringify(authorizedValue));
         window.open(url, '_blank').focus();
+        {/if}
+    }
+    
+    function navigateToGraphQLUi(){
+        {#if info:graphqlIsAvailable??}
+            var url = "{config:http-path('quarkus.smallrye-graphql.ui.root-path')}";
+            var headerJson = '{"authorization": "Bearer ' + accessToken + '"}';
+            url = url + '/?' + encodeURIComponent('headers') + '=' + encodeURIComponent(headerJson);
+            window.open(url, '_blank').focus();
         {/if}
     }
     
@@ -408,9 +417,14 @@ function signInToService(servicePath) {
                     Test your service
                 </div>
                 <div class="float-right">
-                    {#if info:swaggerIsAvailable}
+                    {#if info:swaggerIsAvailable??}
                     <a onclick="navigateToSwaggerUi();" class="btn btn-link" title="Test in Swagger UI">
                         <i class="fas fa-external-link-alt"></i> Swagger UI
+                    </a>
+                    {/if}
+                    {#if info:graphqlIsAvailable??}
+                    <a onclick="navigateToGraphQLUi();" class="btn btn-link" title="Test in GraphQL UI">
+                        <i class="fas fa-external-link-alt"></i> GraphQL UI
                     </a>
                     {/if}
                 </div>

--- a/extensions/smallrye-graphql/runtime/pom.xml
+++ b/extensions/smallrye-graphql/runtime/pom.xml
@@ -50,6 +50,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.smallrye.graphql</provides>
+                    </capabilities>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Same as for Swagger UI, this allows you to navigate from OIDC Dev UI in the logged in state to the GraphQL UI to test your endpoint (if you have graphql endpoints)

![graphql_oidc_devui](https://user-images.githubusercontent.com/6836179/133250416-2754ea17-9428-4158-901b-9e21f0f43432.gif)


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>