### PR TITLE
Handle constraint validations that are internal errors through QuarkusErrorHandler

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveEndPointValidationInterceptor.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveEndPointValidationInterceptor.java
@@ -5,6 +5,7 @@ import javax.interceptor.AroundConstruct;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
+import javax.validation.ConstraintViolationException;
 
 import io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor;
 
@@ -16,7 +17,11 @@ public class ResteasyReactiveEndPointValidationInterceptor extends AbstractMetho
     @AroundInvoke
     @Override
     public Object validateMethodInvocation(InvocationContext ctx) throws Exception {
-        return super.validateMethodInvocation(ctx);
+        try {
+            return super.validateMethodInvocation(ctx);
+        } catch (ConstraintViolationException e) {
+            throw new ResteasyReactiveViolationException(e.getConstraintViolations());
+        }
     }
 
     @AroundConstruct

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationException.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationException.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.validator.runtime.jaxrs;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+
+/**
+ * Wrapper around a {@link javax.validation.ConstraintViolationException},
+ * used to mark a constraint violation as relative to a REST endpoint call.
+ * <p>
+ * Those violations are handled differently than violations from other, internal components:
+ * a violation on an internal component is always considered an internal error (HTTP 500),
+ * while a violation on the parameters of a REST endpoint call is a client error (HTTP 400).
+ */
+public class ResteasyReactiveViolationException extends ConstraintViolationException {
+    private static final long serialVersionUID = 657697354453281559L;
+
+    public ResteasyReactiveViolationException(String message, Set<? extends ConstraintViolation<?>> constraintViolations) {
+        super(message, constraintViolations);
+    }
+
+    public ResteasyReactiveViolationException(Set<? extends ConstraintViolation<?>> constraintViolations) {
+        super(constraintViolations);
+    }
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionImpl.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionImpl.java
@@ -11,6 +11,14 @@ import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.validation.ConstraintTypeUtil;
 
+/**
+ * Wrapper around a {@link javax.validation.ConstraintViolationException},
+ * used to mark a constraint violation as relative to a REST endpoint call.
+ * <p>
+ * Those violations are handled differently than violations from other, internal components:
+ * a violation on an internal component is always considered an internal error (HTTP 500),
+ * while a violation on the parameters of a REST endpoint call is a client error (HTTP 400).
+ */
 public class ResteasyViolationExceptionImpl extends ResteasyViolationException {
     private static final long serialVersionUID = 657697354453281559L;
 

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionMapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionMapper.java
@@ -3,9 +3,6 @@ package io.quarkus.hibernate.validator.runtime.jaxrs;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.validation.ConstraintDeclarationException;
-import javax.validation.ConstraintDefinitionException;
-import javax.validation.GroupDefinitionException;
 import javax.validation.ValidationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -23,38 +20,24 @@ public class ResteasyViolationExceptionMapper implements ExceptionMapper<Validat
 
     @Override
     public Response toResponse(ValidationException exception) {
-        if (exception instanceof ConstraintDefinitionException) {
-            return buildResponse(unwrapException(exception), MediaType.TEXT_PLAIN, Status.INTERNAL_SERVER_ERROR);
+        if (!(exception instanceof ResteasyViolationException)) {
+            // Not a violation in a REST endpoint call, but rather in an internal component.
+            // This is an internal error: handle through the QuarkusErrorHandler,
+            // which will return HTTP status 500 and log the exception.
+            throw exception;
         }
-        if (exception instanceof ConstraintDeclarationException) {
-            return buildResponse(unwrapException(exception), MediaType.TEXT_PLAIN, Status.INTERNAL_SERVER_ERROR);
+        ResteasyViolationException restEasyException = (ResteasyViolationException) exception;
+        Exception e = restEasyException.getException();
+        if (e != null | restEasyException.getReturnValueViolations().size() != 0) {
+            // This is an internal error: handle through the QuarkusErrorHandler,
+            // which will return HTTP status 500 and log the exception.
+            throw restEasyException;
         }
-        if (exception instanceof GroupDefinitionException) {
-            return buildResponse(unwrapException(exception), MediaType.TEXT_PLAIN, Status.INTERNAL_SERVER_ERROR);
-        }
-        if (exception instanceof ResteasyViolationException) {
-            ResteasyViolationException resteasyViolationException = ResteasyViolationException.class.cast(exception);
-            Exception e = resteasyViolationException.getException();
-            if (e != null) {
-                return buildResponse(unwrapException(e), MediaType.TEXT_PLAIN, Status.INTERNAL_SERVER_ERROR);
-            } else if (resteasyViolationException.getReturnValueViolations().size() == 0) {
-                return buildViolationReportResponse(resteasyViolationException, Status.BAD_REQUEST);
-            } else {
-                return buildViolationReportResponse(resteasyViolationException, Status.INTERNAL_SERVER_ERROR);
-            }
-        }
-        return buildResponse(unwrapException(exception), MediaType.TEXT_PLAIN, Status.INTERNAL_SERVER_ERROR);
+        return buildViolationReportResponse(restEasyException);
     }
 
-    protected Response buildResponse(Object entity, String mediaType, Status status) {
-        ResponseBuilder builder = Response.status(status).entity(entity);
-        builder.type(MediaType.TEXT_PLAIN);
-        builder.header(Validation.VALIDATION_HEADER, "true");
-        return builder.build();
-    }
-
-    protected Response buildViolationReportResponse(ResteasyViolationException exception, Status status) {
-        ResponseBuilder builder = Response.status(status);
+    protected Response buildViolationReportResponse(ResteasyViolationException exception) {
+        ResponseBuilder builder = Response.status(Status.BAD_REQUEST);
         builder.header(Validation.VALIDATION_HEADER, "true");
 
         // Check standard media types.
@@ -69,24 +52,6 @@ public class ResteasyViolationExceptionMapper implements ExceptionMapper<Validat
         builder.type(MediaType.TEXT_PLAIN);
         builder.entity(exception.toString());
         return builder.build();
-    }
-
-    protected String unwrapException(Throwable t) {
-        StringBuffer sb = new StringBuffer();
-        doUnwrapException(sb, t);
-        return sb.toString();
-    }
-
-    private void doUnwrapException(StringBuffer sb, Throwable t) {
-        if (t == null) {
-            return;
-        }
-        sb.append(t.toString());
-        if (t.getCause() != null && t != t.getCause()) {
-            sb.append('[');
-            doUnwrapException(sb, t.getCause());
-            sb.append(']');
-        }
     }
 
     private MediaType getAcceptMediaType(List<MediaType> accept) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -146,6 +146,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body(postBody)
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-validated")
                 .then()
@@ -156,6 +157,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body(postBody)
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-invalid-result")
                 .then()
@@ -165,6 +167,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body("{\"first\": \"Bob\"}")
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-validated")
                 .then()

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/SimpleJsonTest.java
@@ -141,6 +141,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body(postBody)
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-validated")
                 .then()
@@ -151,6 +152,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body(postBody)
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-invalid-result")
                 .then()
@@ -160,6 +162,7 @@ public class SimpleJsonTest {
         RestAssured
                 .with()
                 .body("{\"first\": \"Bob\"}")
+                .accept("application/json")
                 .contentType("application/json")
                 .post("/simple/person-validated")
                 .then()

--- a/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
+++ b/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
@@ -44,8 +44,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/EnhancedGreetingService.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/EnhancedGreetingService.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.hibernate.validator;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class EnhancedGreetingService extends GreetingService {
+
+    @Override
+    public String greeting(String name) {
+        return super.greeting("Enhanced " + name);
+    }
+}

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/GreetingService.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/GreetingService.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.hibernate.validator;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.NotNull;
+
+@ApplicationScoped
+@Priority(2)
+public class GreetingService {
+
+    public String greeting(@NotNull String name) {
+        return "hello " + name;
+    }
+
+}

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -13,6 +13,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.Validator;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
 import javax.validation.constraints.Email;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -20,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.hibernate.validator.constraints.Length;
+import org.jboss.resteasy.reactive.RestPath;
 
 import io.quarkus.it.hibernate.validator.custom.MyOtherBean;
 import io.quarkus.runtime.StartupEvent;
@@ -29,6 +31,9 @@ public class HibernateValidatorTestResource {
 
     @Inject
     Validator validator;
+
+    @Inject
+    GreetingService greetingService;
 
     public void testValidationOutsideOfResteasyContext(@Observes StartupEvent startupEvent) {
         validator.validate(new MyOtherBean(null));
@@ -61,6 +66,28 @@ public class HibernateValidatorTestResource {
                 validCategorizedEmails))));
 
         return result.build();
+    }
+
+    @GET
+    @Path("/cdi-bean-method-validation-uncaught")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testCDIBeanMethodValidationUncaught() {
+        return greetingService.greeting(null);
+    }
+
+    @GET
+    @Path("/rest-end-point-validation/{id}/")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @RestPath("id") String id) {
+        return id;
+    }
+
+    @GET
+    @Path("/rest-end-point-return-value-validation/{returnValue}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Digits(integer = 5, fraction = 0)
+    public String testRestEndPointReturnValueValidation(@RestPath("returnValue") String returnValue) {
+        return returnValue;
     }
 
     private String formatViolations(Set<? extends ConstraintViolation<?>> violations) {

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -1,9 +1,23 @@
 package io.quarkus.it.hibernate.validator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationException;
+import io.quarkus.test.InMemoryLogHandler;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,9 +26,24 @@ import io.restassured.RestAssured;
 @QuarkusTest
 @QuarkusTestResource(H2DatabaseTestResource.class)
 public class HibernateValidatorFunctionalityTest {
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+    private static final java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("io.quarkus");
+    private static final InMemoryLogHandler inMemoryLogHandler = new InMemoryLogHandler(
+            record -> record.getLevel().intValue() >= Level.WARNING.intValue());
+
+    @BeforeEach
+    public void setLogHandler() {
+        inMemoryLogHandler.getRecords().clear();
+        rootLogger.addHandler(inMemoryLogHandler);
+    }
+
+    @AfterEach
+    public void removeLogHandler() {
+        rootLogger.removeHandler(inMemoryLogHandler);
+    }
 
     @Test
-    public void testBasicFeatures() throws Exception {
+    public void testBasicFeatures() {
         StringBuilder expected = new StringBuilder();
         expected.append("failed: additionalEmails[0].<list element> (must be a well-formed email address)").append(", ")
                 .append("categorizedEmails<K>[a].<map key> (length must be between 3 and 2147483647)").append(", ")
@@ -28,4 +57,95 @@ public class HibernateValidatorFunctionalityTest {
                 .then()
                 .body(is(expected.toString()));
     }
+
+    @Test
+    public void testCDIBeanMethodValidationUncaught() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Uncaught constraint validation exceptions thrown by user beans
+        // are internal errors and should be reported as such.
+
+        // The returned body should be the standard one produced by QuarkusErrorHandler,
+        // with all the necessary information (stack trace, ...).
+        RestAssured.when()
+                .get("/hibernate-validator/test/cdi-bean-method-validation-uncaught")
+                .then()
+                .body(containsString(ConstraintViolationException.class.getName())) // Exception type
+                .body(containsString("message: must not be null")) // Exception message
+                .body(containsString("property path: greeting.name"))
+                .body(containsString(EnhancedGreetingService.class.getName()))
+                .body(containsString(HibernateValidatorTestResource.class.getName())) // Stack trace
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+
+        // There should also be some logs to raise the internal error to the developer's attention.
+        assertThat(inMemoryLogHandler.getRecords())
+                .extracting(LOG_FORMATTER::formatMessage)
+                .hasSize(1);
+        assertThat(inMemoryLogHandler.getRecords())
+                .element(0).satisfies(record -> {
+                    assertThat(record.getLevel()).isEqualTo(Level.SEVERE);
+                    assertThat(LOG_FORMATTER.formatMessage(record))
+                            .contains(
+                                    "HTTP Request to /hibernate-validator/test/cdi-bean-method-validation-uncaught failed, error id:");
+                });
+    }
+
+    @Test
+    public void testRestEndPointValidation() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Constraint validation exceptions thrown by Resteasy and related to input values
+        // are user errors and should be reported as such.
+
+        // Bad request
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .body(containsString("numeric value out of bounds"));
+
+        // There should not be any warning/error logs since user errors do not require the developer's attention.
+        assertThat(inMemoryLogHandler.getRecords())
+                .extracting(LOG_FORMATTER::formatMessage)
+                .isEmpty();
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-validation/42/")
+                .then()
+                .body(is("42"));
+    }
+
+    @Test
+    public void testRestEndPointReturnValueValidation() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Constraint validation exceptions thrown by Resteasy and related to return values
+        // are internal errors and should be reported as such.
+
+        // The returned body should be the standard one produced by QuarkusErrorHandler,
+        // with all the necessary information (stack trace, ...).
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-return-value-validation/plop/")
+                .then()
+                .body(containsString(ResteasyReactiveViolationException.class.getName())) // Exception type
+                .body(containsString("numeric value out of bounds")) // Exception message
+                .body(containsString("testRestEndPointReturnValueValidation.&lt;return value&gt;"))
+                .body(containsString(HibernateValidatorTestResource.class.getName())) // Stack trace
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+
+        // There should also be some logs to raise the internal error to the developer's attention.
+        assertThat(inMemoryLogHandler.getRecords())
+                .extracting(LOG_FORMATTER::formatMessage)
+                .hasSize(1);
+        assertThat(inMemoryLogHandler.getRecords())
+                .element(0).satisfies(record -> {
+                    assertThat(record.getLevel()).isEqualTo(Level.SEVERE);
+                    assertThat(LOG_FORMATTER.formatMessage(record))
+                            .contains(
+                                    "HTTP Request to /hibernate-validator/test/rest-end-point-return-value-validation/plop/ failed, error id:");
+                });
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-validation/42/")
+                .then()
+                .body(is("42"));
+    }
+
 }

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -48,8 +48,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -131,10 +131,25 @@ public class HibernateValidatorTestResource
     }
 
     @GET
+    @Path("/cdi-bean-method-validation-uncaught")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testCDIBeanMethodValidationUncaught() {
+        return greetingService.greeting(null);
+    }
+
+    @GET
     @Path("/rest-end-point-validation/{id}/")
     @Produces(MediaType.TEXT_PLAIN)
     public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") String id) {
         return id;
+    }
+
+    @GET
+    @Path("/rest-end-point-return-value-validation/{returnValue}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Digits(integer = 5, fraction = 0)
+    public String testRestEndPointReturnValueValidation(@PathParam("returnValue") String returnValue) {
+        return returnValue;
     }
 
     // all JAX-RS annotations are defined in the interface

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
@@ -8,4 +8,9 @@ import io.quarkus.test.junit.NativeImageTest;
 @NativeImageTest
 public class HibernateValidatorFunctionalityInGraalITCase extends HibernateValidatorFunctionalityTest {
 
+    @Override
+    protected boolean isTestsInJVM() {
+        return false;
+    }
+
 }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -1,10 +1,23 @@
 package io.quarkus.it.hibernate.validator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyViolationExceptionImpl;
+import io.quarkus.test.InMemoryLogHandler;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -18,11 +31,36 @@ import io.restassured.response.ValidatableResponse;
 @QuarkusTest
 @QuarkusTestResource(H2DatabaseTestResource.class)
 public class HibernateValidatorFunctionalityTest {
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+    private static final java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("io.quarkus");
+    private static final InMemoryLogHandler inMemoryLogHandler = new InMemoryLogHandler(
+            record -> record.getLevel().intValue() >= Level.WARNING.intValue());
+
+    @BeforeEach
+    public void setLogHandler() {
+        if (isLogChecksPossible()) {
+            inMemoryLogHandler.getRecords().clear();
+            rootLogger.addHandler(inMemoryLogHandler);
+        }
+    }
+
+    @AfterEach
+    public void removeLogHandler() {
+        if (isLogChecksPossible()) {
+            rootLogger.removeHandler(inMemoryLogHandler);
+        }
+    }
 
     private boolean isInternalErrorExceptionLeakedInQuarkusErrorHandlerResponse() {
         // True by default when running tests in the JVM, with the test/dev profile.
         // When running in native mode, the application runs with the prod profile (sort of?):
         // the stack trace isn't included in QuarkusErrorHandler responses.
+        return isTestsInJVM();
+    }
+
+    private boolean isLogChecksPossible() {
+        // True by default when running tests in the JVM, with the test/dev profile.
+        // When running in native mode, we cannot easily spy on logs.
         return isTestsInJVM();
     }
 
@@ -71,12 +109,102 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testCDIBeanMethodValidationUncaught() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Uncaught constraint validation exceptions thrown by user beans
+        // are internal errors and should be reported as such.
+
+        // The returned body should be the standard one produced by QuarkusErrorHandler,
+        // with all the necessary information (stack trace, ...).
+        ValidatableResponse response = RestAssured.when()
+                .get("/hibernate-validator/test/cdi-bean-method-validation-uncaught")
+                .then()
+                .body(containsString("Internal Server Error"))
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        if (isInternalErrorExceptionLeakedInQuarkusErrorHandlerResponse()) {
+            response
+                    .body(containsString(ConstraintViolationException.class.getName())) // Exception type
+                    .body(containsString("message: must not be null")) // Exception message
+                    .body(containsString("property path: greeting.name"))
+                    .body(containsString(EnhancedGreetingService.class.getName()))
+                    .body(containsString(HibernateValidatorTestResource.class.getName())); // Stack trace
+        }
+
+        if (isLogChecksPossible()) {
+            // There should also be some logs to raise the internal error to the developer's attention.
+            assertThat(inMemoryLogHandler.getRecords())
+                    .extracting(LOG_FORMATTER::formatMessage)
+                    .hasSize(1);
+            assertThat(inMemoryLogHandler.getRecords())
+                    .element(0).satisfies(record -> {
+                        assertThat(record.getLevel()).isEqualTo(Level.SEVERE);
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains(
+                                        "HTTP Request to /hibernate-validator/test/cdi-bean-method-validation-uncaught failed, error id:");
+                    });
+        }
+    }
+
+    @Test
     public void testRestEndPointValidation() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Constraint validation exceptions thrown by Resteasy and related to input values
+        // are user errors and should be reported as such.
+
+        // Bad request
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-validation/plop/")
                 .then()
-                .statusCode(400)
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .body(containsString("numeric value out of bounds"));
+
+        if (isLogChecksPossible()) {
+            // There should not be any warning/error logs since user errors do not require the developer's attention.
+            assertThat(inMemoryLogHandler.getRecords())
+                    .extracting(LOG_FORMATTER::formatMessage)
+                    .isEmpty();
+        }
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-validation/42/")
+                .then()
+                .body(is("42"));
+    }
+
+    @Test
+    public void testRestEndPointReturnValueValidation() {
+        // https://github.com/quarkusio/quarkus/issues/9174
+        // Constraint validation exceptions thrown by Resteasy and related to return values
+        // are internal errors and should be reported as such.
+
+        // The returned body should be the standard one produced by QuarkusErrorHandler,
+        // with all the necessary information (stack trace, ...).
+        ValidatableResponse response = RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-return-value-validation/plop/")
+                .then()
+                .body(containsString("Internal Server Error"))
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        if (isInternalErrorExceptionLeakedInQuarkusErrorHandlerResponse()) {
+            response
+                    .body(containsString(ResteasyViolationExceptionImpl.class.getName())) // Exception type
+                    .body(containsString("numeric value out of bounds")) // Exception message
+                    .body(containsString("testRestEndPointReturnValueValidation.&lt;return value&gt;"))
+                    .body(containsString(HibernateValidatorTestResource.class.getName())); // Stack trace
+        }
+
+        if (isLogChecksPossible()) {
+            // There should also be some logs to raise the internal error to the developer's attention.
+            assertThat(inMemoryLogHandler.getRecords())
+                    .extracting(LOG_FORMATTER::formatMessage)
+                    .hasSize(1);
+            assertThat(inMemoryLogHandler.getRecords())
+                    .element(0).satisfies(record -> {
+                        assertThat(record.getLevel()).isEqualTo(Level.SEVERE);
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains(
+                                        "HTTP Request to /hibernate-validator/test/rest-end-point-return-value-validation/plop/ failed, error id:");
+                    });
+        }
 
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-validation/42/")
@@ -119,6 +247,10 @@ public class HibernateValidatorFunctionalityTest {
                 .then()
                 .statusCode(400)
                 .body(containsString("numeric value out of bounds"));
+
+        if (isLogChecksPossible()) {
+            assertThat(inMemoryLogHandler.getRecords()).isEmpty();
+        }
 
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-generic-method-validation/42/")


### PR DESCRIPTION
Actually does not address #9174: constraint violations on REST service input still lead only to error status 400 and no log at all, since they are not internal errors.

But it does address other problems mentioned in [my comment](https://github.com/quarkusio/quarkus/issues/9174#issuecomment-891661700).