### PR TITLE
Introduce the AnnotationStore concept into RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -51,6 +51,7 @@ import org.jboss.resteasy.reactive.common.processor.EndpointIndexer;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 import org.jboss.resteasy.reactive.common.processor.scanning.ApplicationScanningResult;
 import org.jboss.resteasy.reactive.common.processor.scanning.ResourceScanningResult;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationsTransformer;
 import org.jboss.resteasy.reactive.common.util.Encode;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.DeploymentInfo;
@@ -113,6 +114,7 @@ import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.ForbiddenExc
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.UnauthorizedExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityHandler;
 import io.quarkus.resteasy.reactive.server.runtime.security.SecurityContextOverrideHandler;
+import io.quarkus.resteasy.reactive.server.spi.AnnotationsTransformerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.DynamicFeatureBuildItem;
@@ -282,6 +284,7 @@ public class ResteasyReactiveProcessor {
             ContextResolversBuildItem contextResolversBuildItem,
             List<ApplicationClassPredicateBuildItem> applicationClassPredicateBuildItems,
             List<MethodScannerBuildItem> methodScanners, ResteasyReactiveServerConfig serverConfig,
+            List<AnnotationsTransformerBuildItem> annotationTransformerBuildItems,
             LaunchModeBuildItem launchModeBuildItem)
             throws NoSuchMethodException {
 
@@ -426,6 +429,15 @@ public class ResteasyReactiveProcessor {
                 serverEndpointIndexerBuilder
                         .setDefaultProducesHandler(new DefaultProducesHandler.DelegatingDefaultProducesHandler(handlers));
             }
+
+            if (!annotationTransformerBuildItems.isEmpty()) {
+                List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>(annotationTransformerBuildItems.size());
+                for (AnnotationsTransformerBuildItem bi : annotationTransformerBuildItems) {
+                    annotationsTransformers.add(bi.getAnnotationsTransformer());
+                }
+                serverEndpointIndexerBuilder.setAnnotationsTransformers(annotationsTransformers);
+            }
+
             serverEndpointIndexer = serverEndpointIndexerBuilder.build();
 
             for (ClassInfo i : scannedResources.values()) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/transformation/AnnotationTransformationTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/transformation/AnnotationTransformationTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.resteasy.reactive.server.test.transformation;
+
+import static io.restassured.RestAssured.*;
+import static org.jboss.jandex.AnnotationInstance.create;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationsTransformer;
+import org.jboss.resteasy.reactive.common.processor.transformation.Transformation;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.resteasy.reactive.server.spi.AnnotationsTransformerBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AnnotationTransformationTest {
+
+    private static final DotName MY_GET = DotName.createSimple(MyGet.class.getName());
+    private static final DotName MY_QUERY = DotName.createSimple(MyQuery.class.getName());
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+                                @Override
+                                public boolean appliesTo(AnnotationTarget.Kind kind) {
+                                    return kind == AnnotationTarget.Kind.METHOD;
+                                }
+
+                                @Override
+                                public void transform(TransformationContext transformationContext) {
+                                    AnnotationTarget target = transformationContext.getTarget();
+                                    if (target.kind() != AnnotationTarget.Kind.METHOD) {
+                                        return;
+                                    }
+                                    MethodInfo methodInfo = target.asMethod();
+                                    Transformation transform = transformationContext.transform();
+                                    boolean complete = false;
+
+                                    if (methodInfo.hasAnnotation(MY_GET)) {
+                                        complete = true;
+                                        transform.add(GET);
+                                    }
+
+                                    for (AnnotationInstance annotation : methodInfo.annotations()) {
+                                        if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
+                                            if (annotation.name().equals(MY_QUERY)) {
+                                                complete = true;
+                                                AnnotationValue annotationValue = annotation.value();
+                                                transform.add(create(QUERY_PARAM, annotation.target(),
+                                                        Collections.singletonList(annotationValue)));
+                                            }
+                                        }
+                                    }
+
+                                    if (complete) {
+                                        transform.done();
+                                    }
+                                }
+                            }));
+                        }
+                    }).produces(AnnotationsTransformerBuildItem.class).build();
+                }
+            })
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestResource.class, MyGet.class, MyQuery.class));
+
+    @Test
+    public void testNoPath() {
+        get("/test")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("no path"))
+                .and().contentType("text/plain");
+    }
+
+    @Test
+    public void testHello() {
+        get("/test/hello")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("hello world"))
+                .and().contentType("text/plain");
+
+        get("/test/hello?nm=foo")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("hello foo"))
+                .and().contentType("text/plain");
+    }
+
+    @Path("test")
+    public static class TestResource {
+
+        @MyGet
+        public String noPath() {
+            return "no path";
+        }
+
+        @Path("hello")
+        @MyGet
+        public String hello(@MyQuery("nm") @DefaultValue("world") String name) {
+            return "hello " + name;
+        }
+
+    }
+
+    @Target({ ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyGet {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.PARAMETER })
+    public @interface MyQuery {
+        String value();
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/AnnotationsTransformerBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/AnnotationsTransformerBuildItem.java
@@ -1,0 +1,33 @@
+package io.quarkus.resteasy.reactive.server.spi;
+
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationStore;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationsTransformer;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Make it possible to add, remove or alter annotations on various components.
+ * The provided transformer uses {@link AnnotationsTransformer#appliesTo(AnnotationTarget.Kind)} to limit the scope
+ * of transformer to classes, fields, methods, method params or a combination of those.
+ *
+ * These metadata changes are not stored in Jandex directly (Jandex is immutable) but instead in an abstraction
+ * layer. Users/extensions can access {@link AnnotationStore} to view the updated annotation
+ * model.
+ *
+ * NOTE: Extensions that operate purely on Jandex index analysis won't be able to see any changes made via
+ * {@link AnnotationsTransformer}!
+ */
+public final class AnnotationsTransformerBuildItem extends MultiBuildItem {
+
+    private final AnnotationsTransformer transformer;
+
+    public AnnotationsTransformerBuildItem(AnnotationsTransformer transformer) {
+        this.transformer = transformer;
+    }
+
+    public AnnotationsTransformer getAnnotationsTransformer() {
+        return transformer;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AbstractAnnotationsTransformation.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AbstractAnnotationsTransformation.java
@@ -1,0 +1,74 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+
+abstract class AbstractAnnotationsTransformation<T extends AnnotationsTransformation<T>, C extends Collection<AnnotationInstance>>
+        implements AnnotationsTransformation<T> {
+
+    private final AnnotationTarget target;
+    private final Consumer<C> resultConsumer;
+    protected final C modifiedAnnotations;
+
+    /**
+     * 
+     * @param annotations Mutable collection of annotations
+     * @param target
+     * @param resultConsumer
+     */
+    public AbstractAnnotationsTransformation(C annotations, AnnotationTarget target,
+            Consumer<C> resultConsumer) {
+        this.target = target;
+        this.resultConsumer = resultConsumer;
+        this.modifiedAnnotations = annotations;
+    }
+
+    public T add(AnnotationInstance annotation) {
+        modifiedAnnotations.add(annotation);
+        return self();
+    }
+
+    public T addAll(Collection<AnnotationInstance> annotations) {
+        modifiedAnnotations.addAll(annotations);
+        return self();
+    }
+
+    public T addAll(AnnotationInstance... annotations) {
+        Collections.addAll(modifiedAnnotations, annotations);
+        return self();
+    }
+
+    public T add(Class<? extends Annotation> annotationType, AnnotationValue... values) {
+        add(DotName.createSimple(annotationType.getName()), values);
+        return self();
+    }
+
+    public T add(DotName name, AnnotationValue... values) {
+        add(AnnotationInstance.create(name, target, values));
+        return self();
+    }
+
+    public T remove(Predicate<AnnotationInstance> predicate) {
+        modifiedAnnotations.removeIf(predicate);
+        return self();
+    }
+
+    public T removeAll() {
+        modifiedAnnotations.clear();
+        return self();
+    }
+
+    public void done() {
+        resultConsumer.accept(modifiedAnnotations);
+    }
+
+    protected abstract T self();
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationStore.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationStore.java
@@ -1,0 +1,207 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
+
+/**
+ * Applies {@link AnnotationsTransformer}s and caches the results of transformations.
+ *
+ * @author Martin Kouba
+ * @see AnnotationsTransformer
+ */
+public final class AnnotationStore {
+
+    private final ConcurrentMap<AnnotationTargetKey, Collection<AnnotationInstance>> transformed;
+
+    private final EnumMap<Kind, List<AnnotationsTransformer>> transformersMap;
+
+    public AnnotationStore(Collection<AnnotationsTransformer> transformers) {
+        if (transformers == null || transformers.isEmpty()) {
+            this.transformed = null;
+            this.transformersMap = null;
+        } else {
+            this.transformed = new ConcurrentHashMap<>();
+            this.transformersMap = new EnumMap<>(Kind.class);
+            this.transformersMap.put(Kind.CLASS, initTransformers(Kind.CLASS, transformers));
+            this.transformersMap.put(Kind.METHOD, initTransformers(Kind.METHOD, transformers));
+            this.transformersMap.put(Kind.FIELD, initTransformers(Kind.FIELD, transformers));
+        }
+    }
+
+    /**
+     * All {@link AnnotationsTransformer}s are applied and the result is cached.
+     * 
+     * @param target
+     * @return the annotation instance for the given target
+     */
+    public Collection<AnnotationInstance> getAnnotations(AnnotationTarget target) {
+        if (transformed != null) {
+            return transformed.computeIfAbsent(new AnnotationTargetKey(target), this::transform);
+        }
+        return getOriginalAnnotations(target);
+    }
+
+    /**
+     * 
+     * @param target
+     * @param name
+     * @return the annotation instance if present, {@code null} otherwise
+     * @see #getAnnotations(AnnotationTarget)
+     */
+    public AnnotationInstance getAnnotation(AnnotationTarget target, DotName name) {
+        return Annotations.find(getAnnotations(target), name);
+    }
+
+    /**
+     * 
+     * @param target
+     * @param name
+     * @return {@code true} if the specified target contains the specified annotation, @{code false} otherwise
+     * @see #getAnnotations(AnnotationTarget)
+     */
+    public boolean hasAnnotation(AnnotationTarget target, DotName name) {
+        return Annotations.contains(getAnnotations(target), name);
+    }
+
+    /**
+     * 
+     * @param target
+     * @param names
+     * @return {@code true} if the specified target contains any of the specified annotations, @{code false} otherwise
+     * @see #getAnnotations(AnnotationTarget)
+     */
+    public boolean hasAnyAnnotation(AnnotationTarget target, Iterable<DotName> names) {
+        return Annotations.containsAny(getAnnotations(target), names);
+    }
+
+    private Collection<AnnotationInstance> transform(AnnotationTargetKey key) {
+        AnnotationTarget target = key.target;
+        Collection<AnnotationInstance> annotations = getOriginalAnnotations(target);
+        List<AnnotationsTransformer> transformers = transformersMap.get(target.kind());
+        if (transformers.isEmpty()) {
+            return annotations;
+        }
+        TransformationContextImpl transformationContext = new TransformationContextImpl(target, annotations);
+        for (AnnotationsTransformer transformer : transformers) {
+            transformer.transform(transformationContext);
+        }
+        return transformationContext.getAnnotations();
+    }
+
+    private Collection<AnnotationInstance> getOriginalAnnotations(AnnotationTarget target) {
+        switch (target.kind()) {
+            case CLASS:
+                return target.asClass().classAnnotations();
+            case METHOD:
+                // Note that the returning collection also contains method params annotations
+                return target.asMethod().annotations();
+            case FIELD:
+                return target.asField().annotations();
+            default:
+                throw new IllegalArgumentException("Unsupported annotation target");
+        }
+    }
+
+    private List<AnnotationsTransformer> initTransformers(Kind kind, Collection<AnnotationsTransformer> transformers) {
+        List<AnnotationsTransformer> found = new ArrayList<>();
+        for (AnnotationsTransformer transformer : transformers) {
+            if (transformer.appliesTo(kind)) {
+                found.add(transformer);
+            }
+        }
+        if (found.isEmpty()) {
+            return Collections.emptyList();
+        }
+        found.sort(AnnotationsTransformer::compare);
+        return found;
+    }
+
+    static class TransformationContextImpl extends AnnotationsTransformationContext<Collection<AnnotationInstance>>
+            implements AnnotationsTransformer.TransformationContext {
+
+        public TransformationContextImpl(AnnotationTarget target,
+                Collection<AnnotationInstance> annotations) {
+            super(target, annotations);
+        }
+
+        @Override
+        public Transformation transform() {
+            return new Transformation(new ArrayList<>(getAnnotations()), getTarget(), this::setAnnotations);
+        }
+
+    }
+
+    /**
+     * We cannot use annotation target directly as a key in a Map. Only {@link MethodInfo} overrides equals/hashCode.
+     */
+    static final class AnnotationTargetKey {
+
+        final AnnotationTarget target;
+
+        public AnnotationTargetKey(AnnotationTarget target) {
+            this.target = target;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            AnnotationTargetKey other = (AnnotationTargetKey) obj;
+            if (target.kind() != other.target.kind()) {
+                return false;
+            }
+            switch (target.kind()) {
+                case METHOD:
+                    return target.asMethod().equals(other.target);
+                case FIELD:
+                    FieldInfo field = target.asField();
+                    FieldInfo otherField = other.target.asField();
+                    return Objects.equals(field.name(), otherField.name())
+                            && Objects.equals(field.declaringClass().name(), otherField.declaringClass().name());
+                case CLASS:
+                    return target.asClass().name().equals(other.target.asClass().name());
+                default:
+                    throw unsupportedAnnotationTarget(target);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            switch (target.kind()) {
+                case METHOD:
+                    return target.asMethod().hashCode();
+                case FIELD:
+                    return Objects.hash(target.asField().name(), target.asField().declaringClass().name());
+                case CLASS:
+                    return target.asClass().name().hashCode();
+                default:
+                    throw unsupportedAnnotationTarget(target);
+            }
+        }
+
+    }
+
+    private static IllegalArgumentException unsupportedAnnotationTarget(AnnotationTarget target) {
+        return new IllegalArgumentException("Unsupported annotation target: " + target.kind());
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/Annotations.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/Annotations.java
@@ -1,0 +1,128 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+final class Annotations {
+
+    private Annotations() {
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @param name
+     * @return the first matching annotation instance with the given name or null
+     */
+    public static AnnotationInstance find(Collection<AnnotationInstance> annotations, DotName name) {
+        if (annotations.isEmpty()) {
+            return null;
+        }
+        for (AnnotationInstance annotationInstance : annotations) {
+            if (annotationInstance.name().equals(name)) {
+                return annotationInstance;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @param name
+     * @return {@code true} if the given collection contains an annotation instance with the given name, {@code false} otherwise
+     */
+    public static boolean contains(Collection<AnnotationInstance> annotations, DotName name) {
+        return find(annotations, name) != null;
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @param names
+     * @return {@code true} if the given collection contains an annotation instance with any of the given names, {@code false}
+     *         otherwise
+     */
+    public static boolean containsAny(Collection<AnnotationInstance> annotations, Iterable<DotName> names) {
+        if (annotations.isEmpty()) {
+            return false;
+        }
+        for (AnnotationInstance annotationInstance : annotations) {
+            for (DotName name : names) {
+                if (annotationInstance.name().equals(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @return the parameter annotations
+     */
+    public static Set<AnnotationInstance> getParameterAnnotations(Collection<AnnotationInstance> annotations) {
+        return getAnnotations(Kind.METHOD_PARAMETER, annotations);
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @return the annotations for the given kind
+     */
+    public static Set<AnnotationInstance> getAnnotations(Kind kind, Collection<AnnotationInstance> annotations) {
+        return getAnnotations(kind, null, annotations);
+    }
+
+    /**
+     * 
+     * @param annotations
+     * @return the annotations for the given kind and name
+     */
+    public static Set<AnnotationInstance> getAnnotations(Kind kind, DotName name, Collection<AnnotationInstance> annotations) {
+        if (annotations.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<AnnotationInstance> ret = new HashSet<>();
+        for (AnnotationInstance annotation : annotations) {
+            if (kind != annotation.target().kind()) {
+                continue;
+            }
+            if (name != null && !annotation.name().equals(name)) {
+                continue;
+            }
+            ret.add(annotation);
+        }
+        return ret;
+    }
+
+    /**
+     * 
+     * @param transformedAnnotations
+     * @param method
+     * @param position
+     * @return the parameter annotations for the given position
+     */
+    public static Set<AnnotationInstance> getParameterAnnotations(
+            Function<AnnotationTarget, Collection<AnnotationInstance>> transformedAnnotations, MethodInfo method,
+            int position) {
+        Set<AnnotationInstance> annotations = new HashSet<>();
+        for (AnnotationInstance annotation : transformedAnnotations.apply(method)) {
+            if (Kind.METHOD_PARAMETER == annotation.target().kind()
+                    && annotation.target().asMethodParameter().position() == position) {
+                annotations.add(annotation);
+            }
+        }
+        return annotations;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformation.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformation.java
@@ -1,0 +1,79 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.function.Predicate;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodParameterInfo;
+
+/**
+ * Represents a transformation of a collection of {@link AnnotationInstance} instances.
+ */
+public interface AnnotationsTransformation<T extends AnnotationsTransformation<T>> {
+
+    /**
+     * 
+     * @param annotation
+     * @return self
+     */
+    T add(AnnotationInstance annotation);
+
+    /**
+     * 
+     * @param annotations
+     * @return self
+     */
+    T addAll(Collection<AnnotationInstance> annotations);
+
+    /**
+     * 
+     * @param annotations
+     * @return self
+     */
+    T addAll(AnnotationInstance... annotations);
+
+    /**
+     * NOTE: The annotation target is derived from the transformation context. If you need to add an annotation instance
+     * to a method parameter use methods consuming {@link AnnotationInstance} directly and supply the correct
+     * {@link MethodParameterInfo}.
+     * 
+     * @param annotationType
+     * @param values
+     * @return self
+     */
+    T add(Class<? extends Annotation> annotationType, AnnotationValue... values);
+
+    /**
+     * NOTE: The annotation target is derived from the transformation context.. If you need to add an annotation instance
+     * to a method parameter use methods consuming {@link AnnotationInstance} directly and supply the correct
+     * {@link MethodParameterInfo}.
+     * 
+     * @param name
+     * @param values
+     * @return self
+     */
+    T add(DotName name, AnnotationValue... values);
+
+    /**
+     * Remove all annotations matching the given predicate.
+     * 
+     * @param predicate
+     * @return self
+     */
+    T remove(Predicate<AnnotationInstance> predicate);
+
+    /**
+     * Remove all annotations.
+     * 
+     * @return self
+     */
+    T removeAll();
+
+    /**
+     * Applies the transformation.
+     */
+    void done();
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformationContext.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformationContext.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.util.Collection;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+
+/**
+ * Transformation context base for an {@link AnnotationsTransformation}.
+ */
+abstract class AnnotationsTransformationContext<C extends Collection<AnnotationInstance>> {
+
+    protected final AnnotationTarget target;
+    private C annotations;
+
+    /**
+     * 
+     * @param target
+     * @param annotations Mutable collection of annotations
+     */
+    public AnnotationsTransformationContext(AnnotationTarget target,
+            C annotations) {
+        this.target = target;
+        this.annotations = annotations;
+    }
+
+    public AnnotationTarget getTarget() {
+        return target;
+    }
+
+    public C getAnnotations() {
+        return annotations;
+    }
+
+    void setAnnotations(C annotations) {
+        this.annotations = annotations;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/AnnotationsTransformer.java
@@ -1,0 +1,299 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+
+/**
+ * Allows a build-time extension to override the annotations that exist on bean classes.
+ * <p>
+ * The container should use {@link AnnotationStore} to obtain annotations of any {@link org.jboss.jandex.ClassInfo},
+ * {@link org.jboss.jandex.FieldInfo} and {@link org.jboss.jandex.MethodInfo}.
+ *
+ * @see Builder
+ */
+public interface AnnotationsTransformer {
+
+    int DEFAULT_PRIORITY = 1000;
+
+    static int compare(AnnotationsTransformer e1, AnnotationsTransformer e2) {
+        return Integer.compare(e2.getPriority(), e1.getPriority());
+    }
+
+    /**
+     * Processors with higher priority are called first.
+     *
+     * @return the priority
+     */
+    default int getPriority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    /**
+     * By default, the transformation is applied to all kinds of targets.
+     *
+     * @param kind
+     * @return {@code true} if the transformation applies to the specified kind, {@code false} otherwise
+     */
+    default boolean appliesTo(Kind kind) {
+        return true;
+    }
+
+    /**
+     *
+     * @param transformationContext
+     */
+    void transform(TransformationContext transformationContext);
+
+    /**
+     * 
+     * @return a new builder instance
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A transformation context.
+     */
+    interface TransformationContext {
+
+        AnnotationTarget getTarget();
+
+        /**
+         * The initial set of annotations instances corresponds to {@link org.jboss.jandex.ClassInfo#classAnnotations()},
+         * {@link org.jboss.jandex.FieldInfo#annotations()} and {@link org.jboss.jandex.MethodInfo#annotations()} respectively.
+         * 
+         * @return the annotation instances
+         */
+        Collection<AnnotationInstance> getAnnotations();
+
+        /**
+         * The transformation is not applied until the {@link Transformation#done()} method is invoked.
+         * 
+         * @return a new transformation
+         */
+        Transformation transform();
+
+        default boolean isClass() {
+            return getTarget().kind() == Kind.CLASS;
+        }
+
+        default boolean isField() {
+            return getTarget().kind() == Kind.FIELD;
+        }
+
+        default boolean isMethod() {
+            return getTarget().kind() == Kind.METHOD;
+        }
+
+    }
+
+    /**
+     * A convenient builder.
+     */
+    final class Builder {
+
+        private int priority;
+        private Predicate<Kind> appliesTo;
+        private Predicate<TransformationContext> predicate;
+
+        private Builder() {
+            this.priority = DEFAULT_PRIORITY;
+        }
+
+        /**
+         * 
+         * @param appliesToKind
+         * @return self
+         * @see AnnotationsTransformer#appliesTo(Kind)
+         */
+        public Builder appliesTo(Kind appliesToKind) {
+            return appliesTo(kind -> kind == appliesToKind);
+        }
+
+        /**
+         * 
+         * @param appliesTo
+         * @return self
+         * @see AnnotationsTransformer#appliesTo(Kind)
+         */
+        public Builder appliesTo(Predicate<Kind> appliesTo) {
+            this.appliesTo = appliesTo;
+            return this;
+        }
+
+        /**
+         * 
+         * @param priority
+         * @return self
+         */
+        public Builder priority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ALL of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsAll(List<DotName> annotationNames) {
+            return when(context -> {
+                for (DotName annotationName : annotationNames) {
+                    if (!Annotations.contains(context.getAnnotations(), annotationName)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ALL of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsAll(DotName... annotationNames) {
+            return whenContainsAll(List.of(annotationNames));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ALL of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        @SafeVarargs
+        public final Builder whenContainsAll(Class<? extends Annotation>... annotationNames) {
+            return whenContainsAll(
+                    Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ANY of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsAny(List<DotName> annotationNames) {
+            return when(context -> Annotations.containsAny(context.getAnnotations(), annotationNames));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ANY of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsAny(DotName... annotationNames) {
+            return whenContainsAny(List.of(annotationNames));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must contain ANY of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        @SafeVarargs
+        public final Builder whenContainsAny(Class<? extends Annotation>... annotationNames) {
+            return whenContainsAny(
+                    Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must NOT contain any of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsNone(List<DotName> annotationNames) {
+            return when(context -> !Annotations.containsAny(context.getAnnotations(), annotationNames));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must NOT contain any of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        public Builder whenContainsNone(DotName... annotationNames) {
+            return whenContainsNone(List.of(annotationNames));
+        }
+
+        /**
+         * {@link TransformationContext#getAnnotations()} must NOT contain any of the given annotations.
+         * 
+         * @param annotationNames
+         * @return self
+         */
+        @SafeVarargs
+        public final Builder whenContainsNone(Class<? extends Annotation>... annotationNames) {
+            return whenContainsNone(
+                    Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
+        }
+
+        /**
+         * The transformation logic is only performed if the given predicate is evaluated to true. Multiple predicates are
+         * logically-ANDed.
+         * 
+         * @param when
+         * @return self
+         */
+        public Builder when(Predicate<TransformationContext> when) {
+            if (predicate == null) {
+                predicate = when;
+            } else {
+                predicate = predicate.and(when);
+            }
+            return this;
+        }
+
+        /**
+         * The given transformation logic is only performed if all conditions added via {@link #when(Predicate)} are met.
+         * 
+         * @param consumer
+         * @return a new annotation transformer
+         */
+        public AnnotationsTransformer transform(Consumer<TransformationContext> consumer) {
+            Predicate<Kind> appliesTo = this.appliesTo;
+            int priority = this.priority;
+            Consumer<TransformationContext> transform = Objects.requireNonNull(consumer);
+            Predicate<TransformationContext> predicate = this.predicate;
+            return new AnnotationsTransformer() {
+
+                @Override
+                public int getPriority() {
+                    return priority;
+                }
+
+                @Override
+                public boolean appliesTo(Kind kind) {
+                    return appliesTo != null ? appliesTo.test(kind) : true;
+                }
+
+                @Override
+                public void transform(TransformationContext context) {
+                    if (predicate == null || predicate.test(context)) {
+                        transform.accept(context);
+                    }
+                }
+
+            };
+        }
+
+    }
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/Transformation.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/transformation/Transformation.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.reactive.common.processor.transformation;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+
+public final class Transformation extends AbstractAnnotationsTransformation<Transformation, Collection<AnnotationInstance>> {
+
+    public Transformation(Collection<AnnotationInstance> annotations, AnnotationTarget target,
+            Consumer<Collection<AnnotationInstance>> transformationConsumer) {
+        super(annotations, target, transformationConsumer);
+    }
+
+    @Override
+    protected Transformation self() {
+        return this;
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -38,6 +38,7 @@ import org.jboss.resteasy.reactive.common.processor.AdditionalReaders;
 import org.jboss.resteasy.reactive.common.processor.AdditionalWriters;
 import org.jboss.resteasy.reactive.common.processor.EndpointIndexer;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationStore;
 import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.ListConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalDateParamConverter;
@@ -157,7 +158,8 @@ public class ServerEndpointIndexer
     }
 
     @Override
-    protected void handleAdditionalMethodProcessing(ServerResourceMethod method, ClassInfo currentClassInfo, MethodInfo info) {
+    protected void handleAdditionalMethodProcessing(ServerResourceMethod method, ClassInfo currentClassInfo, MethodInfo info,
+            AnnotationStore annotationStore) {
         Supplier<EndpointInvoker> invokerSupplier = null;
         for (HandlerChainCustomizer i : method.getHandlerChainCustomizers()) {
             invokerSupplier = i.alternateInvoker(method);
@@ -170,7 +172,7 @@ public class ServerEndpointIndexer
         }
         method.setInvoker(invokerSupplier);
         Set<String> methodAnnotationNames = new HashSet<>();
-        List<AnnotationInstance> instances = info.annotations();
+        Collection<AnnotationInstance> instances = annotationStore.getAnnotations(info);
         for (AnnotationInstance instance : instances) {
             methodAnnotationNames.add(instance.name().toString());
         }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/CacheControlScanner.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/CacheControlScanner.java
@@ -11,6 +11,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.resteasy.reactive.Cache;
 import org.jboss.resteasy.reactive.NoCache;
+import org.jboss.resteasy.reactive.common.processor.EndpointIndexer;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationStore;
 import org.jboss.resteasy.reactive.common.util.ExtendedCacheControl;
 import org.jboss.resteasy.reactive.server.handlers.CacheControlHandler;
 import org.jboss.resteasy.reactive.server.model.FixedHandlerChainCustomizer;
@@ -24,7 +26,8 @@ public class CacheControlScanner implements MethodScanner {
     @Override
     public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
             Map<String, Object> methodContext) {
-        ExtendedCacheControl cacheControl = noCacheToCacheControl(method.annotation(NO_CACHE));
+        AnnotationStore annotationStore = (AnnotationStore) methodContext.get(EndpointIndexer.METHOD_CONTEXT_ANNOTATION_STORE);
+        ExtendedCacheControl cacheControl = noCacheToCacheControl(annotationStore.getAnnotation(method, NO_CACHE));
         if (cacheControl != null) {
             if (method.annotation(CACHE) != null) {
                 throw new IllegalStateException(
@@ -33,7 +36,7 @@ public class CacheControlScanner implements MethodScanner {
             }
             return cacheControlToCustomizerList(cacheControl);
         } else {
-            cacheControl = noCacheToCacheControl(actualEndpointClass.classAnnotation(NO_CACHE));
+            cacheControl = noCacheToCacheControl(annotationStore.getAnnotation(actualEndpointClass, NO_CACHE));
             if (cacheControl != null) {
                 if (actualEndpointClass.classAnnotation(CACHE) != null) {
                     throw new IllegalStateException(

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
@@ -329,7 +329,7 @@ public class ServerSerialisers extends Serialisers {
                 selectedResourceWriters = new ArrayList<>(1);
                 selectedResourceWriters.add(resourceWriter);
             } else {
-                int compare = MediaTypeHelper.COMPARATOR.compare(current.getValue(), selectedMediaTypes.getValue());
+                int compare = MediaTypeHelper.Q_COMPARATOR.compare(current.getValue(), selectedMediaTypes.getValue());
                 if (compare == 0) {
                     selectedResourceWriters.add(resourceWriter);
                 } else if (compare < 0) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
@@ -131,6 +131,7 @@ public class MediaTypeMapper implements ServerRestHandler {
         }
 
         public void setupServerMediaType() {
+            MediaTypeHelper.sortByQSWeight(mtsWithParams); // TODO: this isn't completely correct as we are supposed to take q and then qs into account...
             serverMediaType = new ServerMediaType(mtsWithParams, StandardCharsets.UTF_8.name(), true, false);
         }
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ContextResolvers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ContextResolvers.java
@@ -52,7 +52,7 @@ public class ContextResolvers {
                         bestMatch = match;
                         add = true;
                     } else {
-                        int cmp = MediaTypeHelper.COMPARATOR.compare(bestMatch, match);
+                        int cmp = MediaTypeHelper.Q_COMPARATOR.compare(bestMatch, match);
                         if (cmp == 0) {
                             // same fitness
                             add = true;


### PR DESCRIPTION
This concept (and most of the implementation) is taken directly from Arc.
The purpose of this is to allow extension to map other annotations from other 
REST frameworks onto the JAX-RS semantics

This works is a necessary foundation for #19819, but I would like to get it in sooner rather than later so I can avoid having to potentially rebase.