### PR TITLE
Fix LambdaDevServicesContinuousTestingTestCase flaky test

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/util/QuarkusModelHelper.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.gradle.api.GradleException;
 
 public class QuarkusModelHelper {
 
@@ -187,7 +187,7 @@ public class QuarkusModelHelper {
         try (BufferedReader reader = Files.newBufferedReader(path)) {
             rtProps.load(reader);
         } catch (IOException e) {
-            throw new GradleException("Failed to load extension description " + path, e);
+            throw new UncheckedIOException("Failed to load extension description " + path, e);
         }
         return rtProps;
     }


### PR DESCRIPTION
GradleException may not always be in the classpath. While running the test in the IDE I get the same output as in CI: 

```bash
/home/ggastald/.sdkman/candidates/java/11.0.12-open/bin/java -ea -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dmaven.home=/home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/plugins/maven/lib/maven3 -Dmaven.repo.local=/home/ggastald/.m2/repository -Dproject.version=999-SNAPSHOT -Dproject.groupId=io.quarkus -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir=/home/ggastald/workspace/quarkus/extensions/amazon-lambda/deployment/target -Didea.test.cyclic.buffer.size=1048576 -javaagent:/home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/lib/idea_rt.jar=35811:/home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/bin -Dfile.encoding=UTF-8 -classpath /home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/lib/idea_rt.jar:/home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/plugins/junit/lib/junit5-rt.jar:/home/ggastald/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5080.55/plugins/junit/lib/junit-rt.jar:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/deployment/target/test-classes:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/deployment/target/classes:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/common-deployment/target/classes:/home/ggastald/.m2/repository/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar:/home/ggastald/workspace/quarkus/core/deployment/target/classes:/home/ggastald/.m2/repository/org/aesh/readline/2.1/readline-2.1.jar:/home/ggastald/.m2/repository/org/fusesource/jansi/jansi/1.18/jansi-1.18.jar:/home/ggastald/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar:/home/ggastald/.m2/repository/org/wildfly/common/wildfly-common/1.5.4.Final-format-001/wildfly-common-1.5.4.Final-format-001.jar:/home/ggastald/.m2/repository/io/quarkus/gizmo/gizmo/1.0.9.Final/gizmo-1.0.9.Final.jar:/home/ggastald/.m2/repository/org/ow2/asm/asm-util/9.1/asm-util-9.1.jar:/home/ggastald/.m2/repository/org/jboss/jandex/2.4.0.Final/jandex-2.4.0.Final.jar:/home/ggastald/.m2/repository/org/ow2/asm/asm/9.1/asm-9.1.jar:/home/ggastald/.m2/repository/org/ow2/asm/asm-commons/9.1/asm-commons-9.1.jar:/home/ggastald/.m2/repository/org/ow2/asm/asm-tree/9.1/asm-tree-9.1.jar:/home/ggastald/.m2/repository/org/ow2/asm/asm-analysis/9.1/asm-analysis-9.1.jar:/home/ggastald/workspace/quarkus/core/devmode-spi/target/classes:/home/ggastald/.m2/repository/io/quarkus/quarkus-class-change-agent/999-SNAPSHOT/quarkus-class-change-agent-999-SNAPSHOT.jar:/home/ggastald/workspace/quarkus/core/builder/target/classes:/home/ggastald/.m2/repository/org/graalvm/sdk/graal-sdk/21.2.0/graal-sdk-21.2.0.jar:/home/ggastald/.m2/repository/org/junit/platform/junit-platform-launcher/1.8.0/junit-platform-launcher-1.8.0.jar:/home/ggastald/workspace/quarkus/extensions/arc/deployment/target/classes:/home/ggastald/workspace/quarkus/extensions/vertx-http/dev-console-spi/target/classes:/home/ggastald/workspace/quarkus/extensions/vertx-http/dev-console-runtime-spi/target/classes:/home/ggastald/workspace/quarkus/independent-projects/arc/runtime/target/classes:/home/ggastald/.m2/repository/jakarta/transaction/jakarta.transaction-api/1.3.3/jakarta.transaction-api-1.3.3.jar:/home/ggastald/workspace/quarkus/extensions/arc/runtime/target/classes:/home/ggastald/.m2/repository/org/eclipse/microprofile/context-propagation/microprofile-context-propagation-api/1.2/microprofile-context-propagation-api-1.2.jar:/home/ggastald/workspace/quarkus/independent-projects/arc/processor/target/classes:/home/ggastald/workspace/quarkus/extensions/jackson/deployment/target/classes:/home/ggastald/workspace/quarkus/extensions/jackson/spi/target/classes:/home/ggastald/workspace/quarkus/extensions/jackson/runtime/target/classes:/home/ggastald/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.5/jackson-databind-2.12.5.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.5/jackson-datatype-jsr310-2.12.5.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.12.5/jackson-datatype-jdk8-2.12.5.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/module/jackson-module-parameter-names/2.12.5/jackson-module-parameter-names-2.12.5.jar:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/common-runtime/target/classes:/home/ggastald/.m2/repository/com/amazonaws/aws-lambda-java-core/1.2.1/aws-lambda-java-core-1.2.1.jar:/home/ggastald/.m2/repository/com/amazonaws/aws-lambda-java-events/3.10.0/aws-lambda-java-events-3.10.0.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-joda/2.12.5/jackson-datatype-joda-2.12.5.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.5/jackson-annotations-2.12.5.jar:/home/ggastald/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.5/jackson-core-2.12.5.jar:/home/ggastald/.m2/repository/joda-time/joda-time/2.10.8/joda-time-2.10.8.jar:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/event-server/target/classes:/home/ggastald/.m2/repository/io/vertx/vertx-web/4.1.3/vertx-web-4.1.3.jar:/home/ggastald/.m2/repository/io/vertx/vertx-web-common/4.1.3/vertx-web-common-4.1.3.jar:/home/ggastald/.m2/repository/io/vertx/vertx-auth-common/4.1.3/vertx-auth-common-4.1.3.jar:/home/ggastald/.m2/repository/io/vertx/vertx-bridge-common/4.1.3/vertx-bridge-common-4.1.3.jar:/home/ggastald/.m2/repository/io/vertx/vertx-core/4.1.3/vertx-core-4.1.3.jar:/home/ggastald/.m2/repository/io/netty/netty-common/4.1.67.Final/netty-common-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-buffer/4.1.67.Final/netty-buffer-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-transport/4.1.67.Final/netty-transport-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-handler/4.1.67.Final/netty-handler-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-codec/4.1.67.Final/netty-codec-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-handler-proxy/4.1.67.Final/netty-handler-proxy-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-codec-socks/4.1.67.Final/netty-codec-socks-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-codec-http/4.1.67.Final/netty-codec-http-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-codec-http2/4.1.67.Final/netty-codec-http2-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-resolver/4.1.67.Final/netty-resolver-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-resolver-dns/4.1.67.Final/netty-resolver-dns-4.1.67.Final.jar:/home/ggastald/.m2/repository/io/netty/netty-codec-dns/4.1.67.Final/netty-codec-dns-4.1.67.Final.jar:/home/ggastald/workspace/quarkus/extensions/amazon-lambda/runtime/target/classes:/home/ggastald/.m2/repository/io/rest-assured/rest-assured/4.4.0/rest-assured-4.4.0.jar:/home/ggastald/.m2/repository/org/codehaus/groovy/groovy/3.0.8/groovy-3.0.8.jar:/home/ggastald/.m2/repository/org/codehaus/groovy/groovy-xml/3.0.8/groovy-xml-3.0.8.jar:/home/ggastald/.m2/repository/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar:/home/ggastald/.m2/repository/org/apache/httpcomponents/httpcore/4.4.14/httpcore-4.4.14.jar:/home/ggastald/.m2/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar:/home/ggastald/.m2/repository/org/apache/httpcomponents/httpmime/4.5.13/httpmime-4.5.13.jar:/home/ggastald/.m2/repository/org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar:/home/ggastald/.m2/repository/org/ccil/cowan/tagsoup/tagsoup/1.2.1/tagsoup-1.2.1.jar:/home/ggastald/.m2/repository/io/rest-assured/json-path/4.4.0/json-path-4.4.0.jar:/home/ggastald/.m2/repository/org/codehaus/groovy/groovy-json/3.0.8/groovy-json-3.0.8.jar:/home/ggastald/.m2/repository/io/rest-assured/rest-assured-common/4.4.0/rest-assured-common-4.4.0.jar:/home/ggastald/.m2/repository/io/rest-assured/xml-path/4.4.0/xml-path-4.4.0.jar:/home/ggastald/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar:/home/ggastald/.m2/repository/com/sun/xml/bind/jaxb-impl/2.3.3/jaxb-impl-2.3.3.jar:/home/ggastald/workspace/quarkus/test-framework/junit5-internal/target/classes:/home/ggastald/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-api/1.2.6/shrinkwrap-api-1.2.6.jar:/home/ggastald/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-spi/1.2.6/shrinkwrap-spi-1.2.6.jar:/home/ggastald/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-impl-base/1.2.6/shrinkwrap-impl-base-1.2.6.jar:/home/ggastald/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.8.0/junit-jupiter-api-5.8.0.jar:/home/ggastald/.m2/repository/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar:/home/ggastald/.m2/repository/org/junit/platform/junit-platform-commons/1.8.0/junit-platform-commons-1.8.0.jar:/home/ggastald/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/home/ggastald/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.8.0/junit-jupiter-params-5.8.0.jar:/home/ggastald/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.8.0/junit-jupiter-engine-5.8.0.jar:/home/ggastald/.m2/repository/org/junit/platform/junit-platform-engine/1.8.0/junit-platform-engine-1.8.0.jar:/home/ggastald/workspace/quarkus/core/runtime/target/classes:/home/ggastald/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar:/home/ggastald/.m2/repository/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar:/home/ggastald/workspace/quarkus/core/launcher/target/classes:/home/ggastald/.m2/repository/io/smallrye/config/smallrye-config/2.4.4/smallrye-config-2.4.4.jar:/home/ggastald/.m2/repository/io/smallrye/config/smallrye-config-core/2.4.4/smallrye-config-core-2.4.4.jar:/home/ggastald/.m2/repository/org/eclipse/microprofile/config/microprofile-config-api/2.0/microprofile-config-api-2.0.jar:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-annotation/1.6.0/smallrye-common-annotation-1.6.0.jar:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-expression/1.6.0/smallrye-common-expression-1.6.0.jar:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-function/1.6.0/smallrye-common-function-1.6.0.jar:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-constraint/1.6.0/smallrye-common-constraint-1.6.0.jar:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-classloader/1.6.0/smallrye-common-classloader-1.6.0.jar:/home/ggastald/.m2/repository/io/smallrye/config/smallrye-config-common/2.4.4/smallrye-config-common-2.4.4.jar:/home/ggastald/.m2/repository/org/jboss/logging/jboss-logging/3.4.2.Final/jboss-logging-3.4.2.Final.jar:/home/ggastald/.m2/repository/org/jboss/logmanager/jboss-logmanager-embedded/1.0.9/jboss-logmanager-embedded-1.0.9.jar:/home/ggastald/.m2/repository/org/jboss/logging/jboss-logging-annotations/2.2.1.Final/jboss-logging-annotations-2.2.1.Final.jar:/home/ggastald/.m2/repository/org/jboss/threads/jboss-threads/3.4.2.Final/jboss-threads-3.4.2.Final.jar:/home/ggastald/.m2/repository/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar:/home/ggastald/.m2/repository/org/jboss/slf4j/slf4j-jboss-logmanager/1.1.0.Final/slf4j-jboss-logmanager-1.1.0.Final.jar:/home/ggastald/workspace/quarkus/independent-projects/bootstrap/runner/target/classes:/home/ggastald/workspace/quarkus/test-framework/common/target/classes:/home/ggastald/workspace/quarkus/extensions/jsonp/deployment/target/classes:/home/ggastald/workspace/quarkus/extensions/jsonp/runtime/target/classes:/home/ggastald/.m2/repository/org/glassfish/jakarta.json/1.1.6/jakarta.json-1.1.6.jar:/home/ggastald/.m2/repository/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar:/home/ggastald/.m2/repository/jakarta/enterprise/jakarta.enterprise.cdi-api/2.0.2/jakarta.enterprise.cdi-api-2.0.2.jar:/home/ggastald/.m2/repository/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar:/home/ggastald/.m2/repository/jakarta/interceptor/jakarta.interceptor-api/1.2.5/jakarta.interceptor-api-1.2.5.jar:/home/ggastald/workspace/quarkus/independent-projects/tools/utilities/target/classes:/home/ggastald/.m2/repository/org/awaitility/awaitility/4.1.0/awaitility-4.1.0.jar:/home/ggastald/workspace/quarkus/test-framework/junit5/target/classes:/home/ggastald/workspace/quarkus/independent-projects/bootstrap/core/target/classes:/home/ggastald/workspace/quarkus/independent-projects/bootstrap/app-model/target/classes:/home/ggastald/workspace/quarkus/independent-projects/bootstrap/maven-resolver/target/classes:/home/ggastald/.m2/repository/org/apache/maven/maven-embedder/3.8.1/maven-embedder-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-settings/3.8.1/maven-settings-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-core/3.8.1/maven-core-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-artifact/3.8.1/maven-artifact-3.8.1.jar:/home/ggastald/.m2/repository/org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-plugin-api/3.8.1/maven-plugin-api-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-model/3.8.1/maven-model-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-model-builder/3.8.1/maven-model-builder-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-builder-support/3.8.1/maven-builder-support-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-api/1.6.2/maven-resolver-api-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-util/1.6.2/maven-resolver-util-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.3.3/maven-shared-utils-3.3.3.jar:/home/ggastald/.m2/repository/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar:/home/ggastald/.m2/repository/com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar:/home/ggastald/.m2/repository/com/google/guava/guava/30.1.1-jre/guava-30.1.1-jre.jar:/home/ggastald/.m2/repository/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/home/ggastald/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/home/ggastald/.m2/repository/org/codehaus/plexus/plexus-utils/3.2.1/plexus-utils-3.2.1.jar:/home/ggastald/.m2/repository/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar:/home/ggastald/.m2/repository/commons-cli/commons-cli/1.4/commons-cli-1.4.jar:/home/ggastald/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.4/org.eclipse.sisu.plexus-0.3.4.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-settings-builder/3.8.1/maven-settings-builder-3.8.1.jar:/home/ggastald/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar:/home/ggastald/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar:/home/ggastald/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-resolver-provider/3.8.1/maven-resolver-provider-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/maven-repository-metadata/3.8.1/maven-repository-metadata-3.8.1.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-spi/1.6.2/maven-resolver-spi-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-impl/1.6.2/maven-resolver-impl-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-connector-basic/1.6.2/maven-resolver-connector-basic-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/resolver/maven-resolver-transport-wagon/1.6.2/maven-resolver-transport-wagon-1.6.2.jar:/home/ggastald/.m2/repository/org/apache/maven/wagon/wagon-http/3.4.3/wagon-http-3.4.3.jar:/home/ggastald/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.4.3/wagon-http-shared-3.4.3.jar:/home/ggastald/.m2/repository/org/jsoup/jsoup/1.14.2/jsoup-1.14.2.jar:/home/ggastald/.m2/repository/org/apache/maven/wagon/wagon-provider-api/3.4.3/wagon-provider-api-3.4.3.jar:/home/ggastald/.m2/repository/org/apache/maven/wagon/wagon-file/3.4.3/wagon-file-3.4.3.jar:/home/ggastald/workspace/quarkus/independent-projects/bootstrap/gradle-resolver/target/classes:/home/ggastald/.m2/repository/io/smallrye/common/smallrye-common-io/1.6.0/smallrye-common-io-1.6.0.jar:/home/ggastald/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.4/org.eclipse.sisu.inject-0.3.4.jar:/home/ggastald/.m2/repository/org/junit/jupiter/junit-jupiter/5.8.0/junit-jupiter-5.8.0.jar:/home/ggastald/.m2/repository/com/thoughtworks/xstream/xstream/1.4.18/xstream-1.4.18.jar:/home/ggastald/.m2/repository/io/github/x-stream/mxparser/1.2.2/mxparser-1.2.2.jar:/home/ggastald/.m2/repository/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit5 io.quarkus.amazon.lambda.deployment.testing.LambdaDevServicesContinuousTestingTestCase,testLambda
Tests paused
Running tests for the first time
Starting test run, 1 tests to run.
Running 1/1. Running: #JUnit Jupiter
Running 1/1. Running: io.quarkus.amazon.lambda.deployment.testing.LambdaHandlerET#LambdaHandlerET
Running 1/1. Running: io.quarkus.amazon.lambda.deployment.testing.LambdaHandlerET#testSimpleLambdaSuccess()
2021-09-14 18:05:28,952 INFO  [io.qua.ama.lam.run.MockEventServer] (build-14) Mock Lambda Event Server Started
2021-09-14 18:05:29,058 ERROR [io.qua.test] (Test runner thread) ==================== TEST REPORT #1 ====================
2021-09-14 18:05:29,063 ERROR [io.qua.test] (Test runner thread) Test LambdaHandlerET#testSimpleLambdaSuccess() failed 
: java.lang.RuntimeException: java.lang.NoClassDefFoundError: org/gradle/api/GradleException
	at io.quarkus.test.junit.QuarkusTestExtension.throwBootFailureException(QuarkusTestExtension.java:574)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestClassConstructor(QuarkusTestExtension.java:647)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.api.extension.InvocationInterceptor.interceptTestClassConstructor(InvocationInterceptor.java:73)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:77)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeTestClassConstructor(ClassBasedTestDescriptor.java:355)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateTestClass(ClassBasedTestDescriptor.java:302)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.instantiateTestClass(ClassTestDescriptor.java:79)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateAndPostProcessTestInstance(ClassBasedTestDescriptor.java:280)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$4(ClassBasedTestDescriptor.java:272)
	at java.base/java.util.Optional.orElseGet(Optional.java:369)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$5(ClassBasedTestDescriptor.java:271)
	at org.junit.jupiter.engine.execution.TestInstancesProvider.getTestInstances(TestInstancesProvider.java:31)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$prepare$0(TestMethodTestDescriptor.java:102)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:101)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$2(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:90)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:95)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:91)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:60)
	at io.quarkus.deployment.dev.testing.JunitTestRunner.runTests(JunitTestRunner.java:222)
	at io.quarkus.deployment.dev.testing.TestRunner.runInternal(TestRunner.java:251)
	at io.quarkus.deployment.dev.testing.TestRunner$1.run(TestRunner.java:130)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NoClassDefFoundError: org/gradle/api/GradleException
	at io.quarkus.bootstrap.utils.BuildToolHelper.enableGradleAppModelForTest(BuildToolHelper.java:101)
	at io.quarkus.test.junit.AbstractJvmQuarkusTestExtension.createAugmentor(AbstractJvmQuarkusTestExtension.java:119)
	at io.quarkus.test.junit.QuarkusTestExtension.doJavaStart(QuarkusTestExtension.java:214)
	at io.quarkus.test.junit.QuarkusTestExtension.ensureStarted(QuarkusTestExtension.java:551)
	at io.quarkus.test.junit.QuarkusTestExtension.beforeAll(QuarkusTestExtension.java:589)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeBeforeAllCallbacks$10(ClassBasedTestDescriptor.java:381)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeBeforeAllCallbacks(ClassBasedTestDescriptor.java:381)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:205)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:80)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:148)
	... 33 more
Caused by: java.lang.ClassNotFoundException: org.gradle.api.GradleException
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 44 more

2021-09-14 18:05:29,100 ERROR [io.qua.test] (Test runner thread) >>>>>>>>>>>>>>>>>>>> 1 TEST FAILED <<<<<<<<<<<<<<<<<<<<
1 test failed (0 passing, 0 skipped), 1 test was run in 492ms. Tests completed at 18:05:29.
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
            Powered by Quarkus 999-SNAPSHOT
2021-09-14 18:05:31,002 INFO  [io.qua.ama.lam.run.AbstractLambdaPollLoop] (Lambda Thread) Listening on: http://localhost:8080/_lambda_/2018-06-01/runtime/invocation/next
2021-09-14 18:05:31,020 INFO  [io.quarkus] (Quarkus Main Thread) Quarkus 999-SNAPSHOT on JVM started in 4.477s. 
2021-09-14 18:05:31,023 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
2021-09-14 18:05:31,025 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [amazon-lambda, cdi]
2021-09-14 18:05:31,207 WARN  [io.qua.ama.lam.run.AbstractLambdaPollLoop] (Lambda Thread) Aborting lambda poll loop: ending dev/test mode
2021-09-14 18:05:31,207 ERROR [io.qua.ama.lam.run.AbstractLambdaPollLoop] (Lambda Thread) Lambda init error: java.lang.IllegalStateException: Interrupted while waiting for another thread to stop the application
	at io.quarkus.runtime.Application.interruptedOnAwaitStop(Application.java:244)
	at io.quarkus.runtime.Application.stop(Application.java:187)
	at io.quarkus.runtime.Application.stop(Application.java:155)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop$1.run(AbstractLambdaPollLoop.java:140)
	at java.base/java.lang.Thread.run(Thread.java:829)

2021-09-14 18:05:31,215 INFO  [io.quarkus] (Quarkus Main Thread) Quarkus stopped in 0.012s

org.opentest4j.AssertionFailedError: 
Expected :1
Actual   :0
```