### PR TITLE
Update create project command to match documentation

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -48,7 +48,7 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-json-quickstart \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy,resteasy-jackson"
+    -Dextensions="resteasy-jackson"
 cd rest-json-quickstart
 ----
 


### PR DESCRIPTION
This just make the create command consistent with the one below (that uses jsonb instead of jackson). I could also add `resteasy` on the other command, not sure what is the best way to go. 