### PR TITLE
ArC - refactoring and improvement of build time conditions

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -66,6 +66,8 @@ _Solution_: Use the `AdditionalBeanBuildItem`.
 This build item can be used to specify one or more additional classes to be analyzed during the discovery. 
 Additional bean classes are transparently added to the application index processed by the container.
 
+IMPORTANT: It is not possible to conditionally enable/disable additional beans via the `@IfBuildProfile`, `@UnlessBuildProfile`, `@IfBuildProperty` and `@UnlessBuildProperty` annotations as described in <<cdi-reference.adoc#enable_build_profile>> and <<cdi-reference.adoc#enable_build_properties>>. Extensions should inspect the configuration or the current profile and only produce an `AdditionalBeanBuildItem` if really needed.
+
 .`AdditionalBeanBuildItem` Example
 [source,java]
 ----

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -513,6 +513,7 @@ public class CustomTracerConfiguration {
 `@DefaultBean` allows extensions (or any other code for that matter) to provide defaults while backing off if beans of that type are supplied in any
 way Quarkus supports.
 
+[[enable_build_profile]]
 === Enabling Beans for Quarkus Build Profile
 
 Quarkus adds a capability that CDI currently does not support which is to conditionally enable a bean when a Quarkus build time profile is enabled,
@@ -564,10 +565,11 @@ public class TracerConfiguration {
 
 NOTE: The runtime profile has absolutely no effect on the bean resolution using `@IfBuildProfile` and `@UnlessBuildProfile`.
 
+[[enable_build_properties]]
 === Enabling Beans for Quarkus Build Properties
 
-Quarkus adds a capability that CDI currently does not support which is to conditionally enable a bean when a Quarkus build time property has a specific value,
-via the `@io.quarkus.arc.properties.IfBuildProperty` and `@io.quarkus.arc.properties.UnlessBuildProperty` annotation.
+Quarkus adds a capability that CDI currently does not support which is to conditionally enable a bean when a Quarkus build time property has/has not a specific value,
+via the `@io.quarkus.arc.properties.IfBuildProperty` and `@io.quarkus.arc.properties.UnlessBuildProperty` annotations.
 When used in conjunction with `@io.quarkus.arc.DefaultBean`, this annotation allow for the creation of different bean configurations for different build properties.
 
 The scenario we mentioned above with `Tracer` could also be implemented in the following way:
@@ -590,6 +592,8 @@ public class TracerConfiguration {
     }
 }
 ----
+
+TIP: `@IfBuildProperty` and `@UnlessBuildProperty` are repeatable annotations, i.e. a bean will only be enabled if **all** of the conditions defined by these annotations are satisifed.
 
 If instead, it is required that the `RealTracer` bean is only used if the `some.tracer.enabled` property is not `false`, then `@UnlessBuildProperty` would be ideal. The code would look like:
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreAdditionalBeanBuildTimeConditionBuildItem.java
@@ -11,7 +11,10 @@ import io.quarkus.builder.item.MultiBuildItem;
  *
  * @see io.quarkus.arc.deployment.BuildTimeConditionBuildItem
  * @see io.quarkus.arc.deployment.AdditionalBeanBuildItem
+ * @deprecated This build item is no longer needed and will be removed at some point post Quarkus 2.3. The
+ *             {@link BuildTimeConditionBuildItem} can be used instead.
  */
+@Deprecated
 public final class PreAdditionalBeanBuildTimeConditionBuildItem extends MultiBuildItem {
 
     private final AnnotationTarget target;

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/CombinedBuildProfileAndBuildPropertiesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/CombinedBuildProfileAndBuildPropertiesTest.java
@@ -119,6 +119,7 @@ public class CombinedBuildProfileAndBuildPropertiesTest {
 
     // this will be enabled since the profile condition does not pass
     @IfBuildProperty(name = "some.prop1", stringValue = "v1")
+    @IfBuildProperty(name = "some.prop2", stringValue = "v2")
     @UnlessBuildProfile("test")
     static class BarBean {
 
@@ -185,8 +186,9 @@ public class CombinedBuildProfileAndBuildPropertiesTest {
 
     }
 
-    // this will match since both conditions pass
+    // this will match since all conditions pass
     @IfBuildProperty(name = "some.other.prop1", stringValue = "v1", enableIfMissing = true)
+    @IfBuildProperty(name = "some.prop2", stringValue = "v2")
     @UnlessBuildProfile("dev")
     static class AnotherProducer {
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/UnlessBuildPropertyTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/UnlessBuildPropertyTest.java
@@ -76,7 +76,8 @@ public class UnlessBuildPropertyTest {
         }
     }
 
-    @UnlessBuildProperty(name = "some.prop1", stringValue = "v1") // won't be enabled because the values don't match
+    @UnlessBuildProperty(name = "some.prop1", stringValue = "v1") // won't be enabled because the value matches
+    @UnlessBuildProperty(name = "some.prop1", stringValue = "v")
     @Singleton
     static class PongBean {
 
@@ -115,6 +116,7 @@ public class UnlessBuildPropertyTest {
 
         @Produces
         @UnlessBuildProperty(name = "some.prop1", stringValue = "v")
+        @UnlessBuildProperty(name = "some.prop2", stringValue = "v")
         GreetingBean matchingValueGreetingBean(FooBean fooBean) {
             return new GreetingBean() {
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.properties;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -11,7 +12,11 @@ import java.lang.annotation.Target;
  * <p>
  * By default, the bean is not enabled when the build time property is not defined at all, but this behavior is configurable
  * via the {#code enableIfMissing} property.
+ * <p>
+ * This annotation is repeatable. A bean will only be enabled if all of the conditions defined by the {@link IfBuildProperty}
+ * annotations are satisifed.
  */
+@Repeatable(IfBuildProperty.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
 public @interface IfBuildProperty {
@@ -30,4 +35,12 @@ public @interface IfBuildProperty {
      * Determines if the bean is to be enabled when the property name specified by {@code name} has not been specified at all
      */
     boolean enableIfMissing() default false;
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
+    @interface List {
+
+        IfBuildProperty[] value();
+
+    }
 }

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.properties;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -11,7 +12,11 @@ import java.lang.annotation.Target;
  * <p>
  * By default, the bean is not enabled when the build time property is not defined at all, but this behavior is configurable
  * via the {#code enableIfMissing} property.
+ * <p>
+ * This annotation is repeatable. A bean will only be enabled if all of the conditions defined by the
+ * {@link UnlessBuildProperty} annotations are satisifed.
  */
+@Repeatable(UnlessBuildProperty.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
 public @interface UnlessBuildProperty {
@@ -30,4 +35,12 @@ public @interface UnlessBuildProperty {
      * Determines if the bean is enabled when the property name specified by {@code name} has not been specified at all
      */
     boolean enableIfMissing() default false;
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
+    @interface List {
+
+        UnlessBuildProperty[] value();
+
+    }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProducer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProducer.java
@@ -1,0 +1,25 @@
+package io.quarkus.micrometer.runtime.export;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import javax.interceptor.Interceptor;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.quarkus.arc.AlternativePriority;
+
+/**
+ * This producer is only registered if the {@code quarkus.micrometer.export.prometheus.default-registry} is set to {@code true}.
+ */
+public class PrometheusMeterRegistryProducer {
+
+    @Produces
+    @Singleton
+    @AlternativePriority(Interceptor.Priority.APPLICATION + 100)
+    public PrometheusMeterRegistry registry(PrometheusConfig config, CollectorRegistry collectorRegistry, Clock clock) {
+        return new PrometheusMeterRegistry(config, collectorRegistry, clock);
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProvider.java
@@ -4,24 +4,17 @@ import java.util.Map;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
-import javax.interceptor.Interceptor;
 
-import org.jboss.logging.Logger;
-
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusDurationNamingConvention;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.prometheus.PrometheusNamingConvention;
 import io.prometheus.client.CollectorRegistry;
-import io.quarkus.arc.AlternativePriority;
 import io.quarkus.arc.DefaultBean;
-import io.quarkus.arc.properties.UnlessBuildProperty;
 import io.quarkus.micrometer.runtime.config.runtime.PrometheusRuntimeConfig;
 
 @Singleton
 public class PrometheusMeterRegistryProvider {
-    private static final Logger log = Logger.getLogger(PrometheusMeterRegistryProvider.class);
+
     static final String PREFIX = "prometheus.";
 
     @Produces
@@ -50,11 +43,4 @@ public class PrometheusMeterRegistryProvider {
         return new CollectorRegistry(true);
     }
 
-    @Produces
-    @Singleton
-    @UnlessBuildProperty(name = "quarkus.micrometer.export.prometheus.default-registry", stringValue = "false", enableIfMissing = true)
-    @AlternativePriority(Interceptor.Priority.APPLICATION + 100)
-    public PrometheusMeterRegistry registry(PrometheusConfig config, CollectorRegistry collectorRegistry, Clock clock) {
-        return new PrometheusMeterRegistry(config, collectorRegistry, clock);
-    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -40,8 +40,8 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.BuildTimeConditionBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.arc.deployment.PreAdditionalBeanBuildTimeConditionBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -104,11 +104,8 @@ public class ResteasyReactiveCommonProcessor {
     @BuildStep
     ApplicationResultBuildItem handleApplication(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            List<PreAdditionalBeanBuildTimeConditionBuildItem> buildTimeConditions,
+            List<BuildTimeConditionBuildItem> buildTimeConditions,
             ResteasyReactiveConfig config) {
-        // Use the "pre additional bean" build time conditions since we need to be able to filter the beans
-        // before actually adding them otherwise if we use normal build time conditions, we end up
-        // with a circular dependency
         ApplicationScanningResult result = ResteasyReactiveScanner
                 .scanForApplicationClass(combinedIndexBuildItem.getComputingIndex(),
                         config.buildTimeConditionAware ? getExcludedClasses(buildTimeConditions) : Collections.emptySet());
@@ -370,10 +367,10 @@ public class ResteasyReactiveCommonProcessor {
      * @param buildTimeConditions the build time conditions from which the excluded classes are extracted.
      * @return the set of classes that have been annotated with unsuccessful build time conditions.
      */
-    private static Set<String> getExcludedClasses(List<PreAdditionalBeanBuildTimeConditionBuildItem> buildTimeConditions) {
+    private static Set<String> getExcludedClasses(List<BuildTimeConditionBuildItem> buildTimeConditions) {
         return buildTimeConditions.stream()
                 .filter(item -> !item.isEnabled())
-                .map(PreAdditionalBeanBuildTimeConditionBuildItem::getTarget)
+                .map(BuildTimeConditionBuildItem::getTarget)
                 .filter(target -> target.kind() == AnnotationTarget.Kind.CLASS)
                 .map(target -> target.asClass().toString())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
- unify the behavior of IfBuildProperty and IfBuildProfile
  - CombinedIndexBuildItem is the source of BuildTimeConditionBuildItems
  - deprecate PreAdditionalBeanBuildTimeConditionBuildItem,
BuildTimeConditionBuildItem can be used instead
  - note that extensions producing AdditionalBeanBuildItem should not
rely on this functionality; IfBuildProperty and friends will be ignored
(previously IfBuildProfile exhibited this behavior)
- IfBuildProperty and UnlessBuildProperty are now repeatable; i.e.
multiple conditions can be declared
- all conditions are still combined using the logical AND; this
logic was used even before
- resolves #20099