### PR TITLE
Include the manifest file into the maven plugin jar

### DIFF
--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -207,14 +207,6 @@
                                     <include>org.fusesource.jansi:jansi</include>
                                 </includes>
                             </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/MANIFEST.MF</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I think originally it was filtered out to avoid shading warnings but I don't see any warnings removing this config now.