### PR TITLE
Updated netty to 4.1.68.Final (current latest)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <infinispan.version>12.0.1.Final</infinispan.version>
         <infinispan.protostream.version>4.4.0.Alpha4</infinispan.protostream.version>
         <caffeine.version>2.9.0</caffeine.version>
-        <netty.version>4.1.49.Final</netty.version>
+        <netty.version>4.1.68.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <mutiny.version>0.14.0</mutiny.version>


### PR DESCRIPTION
This  PR is supposed to fix some CVE related to Netty:

- [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290)
- [CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295)
- [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409)