### PR TITLE
Log when reactive session producers registration is skipped

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -323,6 +323,7 @@ public final class HibernateOrmProcessor {
 
         if (!hasEntities(jpaModel)) {
             // we can bail out early as there are no entities
+            LOG.warn("Hibernate ORM is disabled because no JPA entities were found");
             return;
         }
 


### PR DESCRIPTION
I spent an hour today trying to understand why `ReactiveSessionFactoryProducer` and `ReactiveSessionProducer` were not registered. I was preparing a bug reproducer which didn't require any entity.