### PR TITLE
Relocation of the quarkus-vertx-web extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5402,6 +5402,18 @@
                 <artifactId>quarkus-apache-httpclient-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <!-- Relocations -->
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-vertx-web</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-vertx-web-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -198,6 +198,9 @@
         <module>google-cloud-functions-http</module>
         <module>google-cloud-functions</module>
         <module>grpc-common</module>
+
+        <!-- Relocations -->
+        <module>vertx-web</module>
     </modules>
 
     <build>

--- a/extensions/vertx-web/deployment/pom.xml
+++ b/extensions/vertx-web/deployment/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-vertx-web-deployment</artifactId>
+
+    <distributionManagement>
+        <relocation>
+            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <message>The artifact ${artifactId} is now named quarkus-reactive-routes-deployment. Please update your dependency.</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/extensions/vertx-web/pom.xml
+++ b/extensions/vertx-web/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-vertx-web-parent</artifactId>
+    <name>Quarkus - Vert.x - Web (Relocation only)</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-vertx-web</artifactId>
+
+    <distributionManagement>
+        <relocation>
+            <artifactId>quarkus-reactive-routes</artifactId>
+            <message>The artifact ${artifactId} is now named quarkus-reactive-routes. Please update your dependency.</message>
+        </relocation>
+    </distributionManagement>
+</project>


### PR DESCRIPTION
The renaming of the quarkus-vertx-web extension to quarkus-reactive-routes is a breaking change.
This PR introduces a Maven relocation and so allows a smooth transition. Applications using the old artifact will get relocated automatically. A warning is displayed in the log indicating the relocation. 