### PR TITLE
Support for TokenIntrospection and UserInfo cache

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -437,6 +437,13 @@ Please see link:security-openid-connect#token-verification-introspection for det
 
 Note that in case of `web-app` applications only `IdToken` is verified by default since the access token is not used by default to access the current Quarkus `web-app` endpoint and instead meant to be propagated to the services expecting this access token, for example, to the OpenId Connect Provider's UserInfo endpoint, etc. However if you expect the access token to contain the roles required to access the current Quarkus endpoint (`quarkus.oidc.roles.source=accesstoken`) then it will also be verified.
 
+[[token-introspection-userinfo-cache]]
+== Token Introspection and UserInfo Cache
+
+Code flow access tokens are not introspected unless they are expected to be the source of roles but will be used to get `UserInfo`. So there will be one or two remote calls with the code flow access token, if the token introspection and/or `UserInfo` are required.
+
+Please see link:security-openid-connect#token-introspection-userinfo-cache for more information about using a default token cache or registering a custom cache implementation.
+
 [[session-management]]
 == Session Management
 

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -388,6 +388,46 @@ quarkus.oidc.introspection-path=/protocol/openid-connect/tokens/introspect
 
 Note that `io.quarkus.oidc.TokenIntrospection` (a simple `javax.json.JsonObject` wrapper) object will be created and can be either injected or accessed as a SecurityIdentity `introspection` attribute if either JWT or opaque token has been successfully introspected.
 
+[[token-introspection-userinfo-cache]]
+== Token Introspection and UserInfo Cache
+
+All opaque and sometimes JWT Bearer access tokens have to be remotely introspected. If `UserInfo` is also required then the same access token will be used to do a remote call to OpenId Connect Provider again. So, if `UserInfo` is required and the current access token is opaque then for every such token there will be 2 remote calls done - one to introspect it and one to get UserInfo with it, and if the token is JWT then usually only a single remote call will be needed - to get UserInfo with it.
+
+The cost of making up to 2 remote calls per every incoming bearer or code flow access token can sometimes be problematic.
+
+If it is the case in your production then it can be recommended that the token introspection and `UserInfo` data are cached for a short period of time, for example, for 3 or 5 minutes.
+
+`quarkus-oidc` provides `quarkus.oidc.TokenIntrospectionCache` and `quarkus.oidc.UserInfoCache` interfaces which can be used to implement `@ApplicationScoped` cache implementation which can be used to store and retrieve `quarkus.oidc.TokenIntrospection` and/or `quarkus.oidc.UserInfo` objects, for example:
+
+[source, java]
+----
+@ApplicationScoped
+@AlternativePriority(1)
+public class CustomIntrospectionUserInfoCache implements TokenIntrospectionCache, UserInfoCache {
+...
+}
+----
+
+Each OIDC tenant can either permit or deny storing its `quarkus.oidc.TokenIntrospection` and/or `quarkus.oidc.UserInfo` data with boolean `quarkus.oidc."tenant".allow-token-introspection-cache` and `quarkus.oidc."tenant".allow-user-info-cache` properties.
+
+Additionally, `quarkus-oidc` provides a simple default memory based token cache which implements both `quarkus.oidc.TokenIntrospectionCache` and `quarkus.oidc.UserInfoCache` interfaces.
+
+It can be activated and configured as follows:
+
+[source, properties]
+----
+# 'max-size' is 0 by default so the cache can be activated by setting 'max-size' to a positive value.
+quarkus.oidc.token-cache.max-size=1000
+# 'time-to-live' specifies how long a cache entry can be valid for and will be used by a clean up timer.
+quarkus.oidc.token-cache.time-to-live=3M
+# 'clean-up-timer-interval' is not set by default so the clean up timer can be activated by setting 'clean-up-timer-interval'.
+quarkus.oidc.token-cache.clean-up-timer-interval=1M
+----
+
+The default cache uses a token as a key and each entry can have `TokenIntrospection` and/or `UserInfo`. It will only keep up to a `max-size` number of entries. If the cache is full when a new entry is to be added then an attempt will be made to find a space for it by removing a single expired entry. Additionally, the clean up timer, if activated, will periodically check for the expired entries and remove them.
+
+Please experiment with the default cache implementation or register a custom one.
+
 [[single-page-applications]]
 == Single Page Applications
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.deployment;
 
+import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -13,4 +14,12 @@ public class OidcBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
+
+    /**
+     * Enable the registration of the Default TokenIntrospection and UserInfo Cache implementation bean.
+     * Note it only allows to use the default implementation, one needs to configure it in order to activate it,
+     * please see {@link OidcConfig#tokenCache}.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean defaultTokenCacheEnabled;
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTokenStateManager.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTokenStateManager.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 
 import io.quarkus.arc.AlternativePriority;
 import io.quarkus.oidc.AuthorizationCodeTokens;
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenStateManager;
 import io.quarkus.oidc.runtime.DefaultTokenStateManager;
@@ -20,14 +21,14 @@ public class CustomTokenStateManager implements TokenStateManager {
 
     @Override
     public Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            AuthorizationCodeTokens sessionContent, TokenStateManager.CreateTokenStateRequestContext requestContext) {
+            AuthorizationCodeTokens sessionContent, OidcRequestContext<String> requestContext) {
         return tokenStateManager.createTokenState(routingContext, oidcConfig, sessionContent, requestContext)
                 .map(t -> (t + "|custom"));
     }
 
     @Override
     public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            String tokenState, TokenStateManager.GetTokensRequestContext requestContext) {
+            String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext) {
         if (!tokenState.endsWith("|custom")) {
             throw new IllegalStateException();
         }
@@ -37,7 +38,7 @@ public class CustomTokenStateManager implements TokenStateManager {
 
     @Override
     public Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
-            TokenStateManager.DeleteTokensRequestContext requestContext) {
+            OidcRequestContext<Void> requestContext) {
         if (!tokenState.endsWith("|custom")) {
             throw new IllegalStateException();
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcContext.java
@@ -1,0 +1,12 @@
+package io.quarkus.oidc;
+
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * OIDC Context that can be used to run blocking OIDC tasks.
+ */
+public interface OidcContext<T> {
+    Uni<T> runBlocking(Supplier<T> function);
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcRequestContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcRequestContext.java
@@ -7,6 +7,6 @@ import io.smallrye.mutiny.Uni;
 /**
  * OIDC Context that can be used to run blocking OIDC tasks.
  */
-public interface OidcContext<T> {
+public interface OidcRequestContext<T> {
     Uni<T> runBlocking(Supplier<T> function);
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -112,6 +112,24 @@ public class OidcTenantConfig extends OidcCommonConfig {
     @ConfigItem
     public TokenStateManager tokenStateManager = new TokenStateManager();
 
+    /**
+     * Allow caching the token introspection data.
+     * Note enabling this property does not enable the cache itself but only permits to cache the token introspection
+     * for a given tenant. If the default token cache can be used then please see {@link OidcConfig.TokenCache} how to enable
+     * it.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean allowTokenIntrospectionCache = true;
+
+    /**
+     * Allow caching the user info data.
+     * Note enabling this property does not enable the cache itself but only permits to cache the user info data
+     * for a given tenant. If the default token cache can be used then please see {@link OidcConfig.TokenCache} how to enable
+     * it.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean allowUserInfoCache = true;
+
     @ConfigGroup
     public static class Logout {
 
@@ -869,5 +887,21 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
     public void setApplicationType(ApplicationType type) {
         this.applicationType = type;
+    }
+
+    public boolean isAllowTokenIntrospectionCache() {
+        return allowTokenIntrospectionCache;
+    }
+
+    public void setAllowTokenIntrospectionCache(boolean allowTokenIntrospectionCache) {
+        this.allowTokenIntrospectionCache = allowTokenIntrospectionCache;
+    }
+
+    public boolean isAllowUserInfoCache() {
+        return allowUserInfoCache;
+    }
+
+    public void setAllowUserInfoCache(boolean allowUserInfoCache) {
+        this.allowUserInfoCache = allowUserInfoCache;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
@@ -1,7 +1,5 @@
 package io.quarkus.oidc;
 
-import java.util.function.Supplier;
-
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -22,7 +20,7 @@ public interface TenantConfigResolver {
      * @param context the routing context
      * @return the tenant configuration. If {@code null}, indicates that the default configuration/tenant should be chosen
      *
-     * @deprecated Use {@link #resolve(RoutingContext, TenantConfigRequestContext))} instead.
+     * @deprecated Use {@link #resolve(RoutingContext, OidcRequestContext<OidcTenantConfig>))} instead.
      */
     @Deprecated
     default OidcTenantConfig resolve(RoutingContext context) {
@@ -36,20 +34,7 @@ public interface TenantConfigResolver {
      * @return the tenant configuration. If the uni resolves to {@code null}, indicates that the default configuration/tenant
      *         should be chosen
      */
-    default Uni<OidcTenantConfig> resolve(RoutingContext routingContext, TenantConfigRequestContext requestContext) {
+    default Uni<OidcTenantConfig> resolve(RoutingContext routingContext, OidcRequestContext<OidcTenantConfig> requestContext) {
         return Uni.createFrom().item(resolve(routingContext));
     }
-
-    /**
-     * A context object that can be used to run blocking tasks.
-     * <p>
-     * Blocking {@code TenantConfigResolver} providers should use this context object to run blocking tasks, to prevent
-     * excessive and unnecessary delegation to thread pools.
-     */
-    interface TenantConfigRequestContext {
-
-        Uni<OidcTenantConfig> runBlocking(Supplier<OidcTenantConfig> function);
-
-    }
-
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospection.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospection.java
@@ -20,4 +20,8 @@ public class TokenIntrospection extends AbstractJsonObjectResponse {
     public TokenIntrospection(JsonObject json) {
         super(json);
     }
+
+    public String getIntrospectionString() {
+        return getNonNullJsonString();
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospectionCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospectionCache.java
@@ -1,0 +1,30 @@
+package io.quarkus.oidc;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Token introspection cache.
+ */
+public interface TokenIntrospectionCache {
+
+    /**
+     * Add a new {@link TokenIntrospection} result to the cache.
+     *
+     * @param token the token which has been introspected
+     * @param introspection the token introspection result
+     * @param oidcConfig the tenant configuration
+     * @param requestContext the request context which can be used to run the blocking tasks
+     */
+    Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcConfig,
+            OidcContext<Void> requestContext);
+
+    /**
+     * Get the cached {@link TokenIntrospection} result.
+     *
+     * @param token the token which has to be introspected
+     * @param oidcConfig the tenant configuration
+     * @param requestContext the request context which can be used to run the blocking tasks
+     */
+    Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
+            OidcContext<TokenIntrospection> requestContext);
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospectionCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospectionCache.java
@@ -16,7 +16,7 @@ public interface TokenIntrospectionCache {
      * @param requestContext the request context which can be used to run the blocking tasks
      */
     Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcConfig,
-            OidcContext<Void> requestContext);
+            OidcRequestContext<Void> requestContext);
 
     /**
      * Get the cached {@link TokenIntrospection} result.
@@ -26,5 +26,5 @@ public interface TokenIntrospectionCache {
      * @param requestContext the request context which can be used to run the blocking tasks
      */
     Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
-            OidcContext<TokenIntrospection> requestContext);
+            OidcRequestContext<TokenIntrospection> requestContext);
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
@@ -1,7 +1,5 @@
 package io.quarkus.oidc;
 
-import java.util.function.Supplier;
-
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -26,7 +24,7 @@ public interface TokenStateManager {
      * @return the token state
      *
      * @deprecated Use
-     *             {@link #createTokenState(RoutingContext, OidcTenantConfig, AuthorizationCodeTokens, CreateTokenStateRequestContext)}
+     *             {@link #createTokenState(RoutingContext, OidcTenantConfig, AuthorizationCodeTokens, OidcRequestContext)}
      *
      */
     @Deprecated
@@ -46,7 +44,7 @@ public interface TokenStateManager {
      * @return the token state
      */
     default Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            AuthorizationCodeTokens tokens, CreateTokenStateRequestContext requestContext) {
+            AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
         return Uni.createFrom().item(createTokenState(routingContext, oidcConfig, tokens));
     }
 
@@ -55,11 +53,11 @@ public interface TokenStateManager {
      *
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
-     * @param tokens the token state
+     * @param tokenState the token state
      *
      * @return the authorization code flow tokens
      *
-     * @deprecated Use {@link #getTokens(RoutingContext, OidcTenantConfig, String, GetTokensRequestContext)} instead.
+     * @deprecated Use {@link #getTokens(RoutingContext, OidcTenantConfig, String, OidcRequestContext)} instead.
      */
     @Deprecated
     default AuthorizationCodeTokens getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
@@ -71,13 +69,13 @@ public interface TokenStateManager {
      *
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
-     * @param tokens the token state
+     * @param tokenState the token state
      * @param requestContext the request context
      *
      * @return the authorization code flow tokens
      */
     default Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            String tokenState, GetTokensRequestContext requestContext) {
+            String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext) {
         return Uni.createFrom().item(getTokens(routingContext, oidcConfig, tokenState));
     }
 
@@ -86,9 +84,9 @@ public interface TokenStateManager {
      *
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
-     * @param tokens the token state
+     * @param tokenState the token state
      *
-     * @deprecated Use {@link #deleteTokens(RoutingContext, OidcTenantConfig, String, DeleteTokensRequestContext)} instead
+     * @deprecated Use {@link #deleteTokens(RoutingContext, OidcTenantConfig, String, OidcRequestContext)} instead
      */
     @Deprecated
     default void deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
@@ -100,41 +98,12 @@ public interface TokenStateManager {
      *
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
-     * @param tokens the token state
+     * @param tokenState the token state
      */
     default Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
-            DeleteTokensRequestContext requestContext) {
+            OidcRequestContext<Void> requestContext) {
         deleteTokens(routingContext, oidcConfig, tokenState);
         return Uni.createFrom().voidItem();
     }
 
-    /**
-     * A context object that can be used to create a token state by running a blocking task.
-     * <p>
-     * Blocking providers should use this context to prevent excessive and unnecessary delegation to thread pools.
-     */
-    interface CreateTokenStateRequestContext {
-
-        Uni<String> runBlocking(Supplier<String> function);
-    }
-
-    /**
-     * A context object that can be used to convert the token state to the tokens by running a blocking task.
-     * <p>
-     * Blocking providers should use this context to prevent excessive and unnecessary delegation to thread pools.
-     */
-    interface GetTokensRequestContext {
-
-        Uni<AuthorizationCodeTokens> runBlocking(Supplier<AuthorizationCodeTokens> function);
-    }
-
-    /**
-     * A context object that can be used to delete the token state by running a blocking task.
-     * <p>
-     * Blocking providers should use this context to prevent excessive and unnecessary delegation to thread pools.
-     */
-    interface DeleteTokensRequestContext {
-
-        Uni<Void> runBlocking(Supplier<Void> function);
-    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
@@ -16,4 +16,8 @@ public class UserInfo extends AbstractJsonObjectResponse {
     public UserInfo(JsonObject json) {
         super(json);
     }
+
+    public String getUserInfoString() {
+        return getNonNullJsonString();
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfoCache.java
@@ -15,7 +15,8 @@ public interface UserInfoCache {
      * @param oidcConfig the tenant configuration
      * @param requestContext the request context which can be used to run the blocking tasks
      */
-    Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcConfig, OidcContext<Void> requestContext);
+    Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcConfig,
+            OidcRequestContext<Void> requestContext);
 
     /**
      * Get the cached {@link UserInfo}.
@@ -27,5 +28,5 @@ public interface UserInfoCache {
      * @param oidcConfig the tenant configuration
      * @param requestContext the request context which can be used to run the blocking tasks
      */
-    Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig, OidcContext<UserInfo> requestContext);
+    Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig, OidcRequestContext<UserInfo> requestContext);
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfoCache.java
@@ -1,0 +1,31 @@
+package io.quarkus.oidc;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * UserInfo cache.
+ */
+public interface UserInfoCache {
+
+    /**
+     * Add a new {@link UserInfo} to the cache.
+     *
+     * @param token the token which was used to get {@link UserInfo}
+     * @param userInfo {@link UserInfo}
+     * @param oidcConfig the tenant configuration
+     * @param requestContext the request context which can be used to run the blocking tasks
+     */
+    Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcConfig, OidcContext<Void> requestContext);
+
+    /**
+     * Get the cached {@link UserInfo}.
+     *
+     * @param token the token which will be used to get new {@link UserInfo} if no {@link UserInfo} is cached.
+     *        Effectively this token is a cache key which has to be stored when
+     *        {@link #addUserInfo(String, UserInfo, OidcTenantConfig, AddUserInfoRequestContext)}
+     *        is called.
+     * @param oidcConfig the tenant configuration
+     * @param requestContext the request context which can be used to run the blocking tasks
+     */
+    Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig, OidcContext<UserInfo> requestContext);
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractBlockingTaskRunner.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractBlockingTaskRunner.java
@@ -1,0 +1,42 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.ExecutorRecorder;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+
+public abstract class AbstractBlockingTaskRunner<T> {
+    public Uni<T> runBlocking(Supplier<T> function) {
+        return Uni.createFrom().deferred(new Supplier<Uni<? extends T>>() {
+            @Override
+            public Uni<T> get() {
+                if (BlockingOperationControl.isBlockingAllowed()) {
+                    try {
+                        return Uni.createFrom().item(function.get());
+                    } catch (Throwable t) {
+                        return Uni.createFrom().failure(t);
+                    }
+                } else {
+                    return Uni.createFrom().emitter(new Consumer<UniEmitter<? super T>>() {
+                        @Override
+                        public void accept(UniEmitter<? super T> uniEmitter) {
+                            ExecutorRecorder.getCurrent().execute(new Runnable() {
+                                @Override
+                                public void run() {
+                                    try {
+                                        uniEmitter.complete(function.get());
+                                    } catch (Throwable t) {
+                                        uniEmitter.fail(t);
+                                    }
+                                }
+                            });
+                        }
+                    });
+                }
+            }
+        });
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
@@ -13,13 +13,15 @@ import javax.json.JsonReader;
 import javax.json.JsonValue;
 
 public class AbstractJsonObjectResponse {
+    private String jsonString;
     private JsonObject json;
 
     public AbstractJsonObjectResponse() {
     }
 
-    public AbstractJsonObjectResponse(String introspectionJson) {
-        this(toJsonObject(introspectionJson));
+    public AbstractJsonObjectResponse(String jsonString) {
+        this(toJsonObject(jsonString));
+        this.jsonString = jsonString;
     }
 
     public AbstractJsonObjectResponse(JsonObject json) {
@@ -47,6 +49,10 @@ public class AbstractJsonObjectResponse {
         return json.getJsonObject(name);
     }
 
+    public JsonObject getJsonObject() {
+        return json;
+    }
+
     public Object get(String name) {
         return json.get(name);
     }
@@ -61,6 +67,10 @@ public class AbstractJsonObjectResponse {
 
     public Set<Map.Entry<String, JsonValue>> getAllProperties() {
         return Collections.unmodifiableSet(json.entrySet());
+    }
+
+    protected String getNonNullJsonString() {
+        return jsonString == null ? json.toString() : jsonString;
     }
 
     private static JsonObject toJsonObject(String userInfoJson) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BlockingTaskRunner.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BlockingTaskRunner.java
@@ -3,12 +3,13 @@ package io.quarkus.oidc.runtime;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.runtime.ExecutorRecorder;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
-public abstract class AbstractBlockingTaskRunner<T> {
+public class BlockingTaskRunner<T> implements OidcRequestContext<T> {
     public Uni<T> runBlocking(Supplier<T> function) {
         return Uni.createFrom().deferred(new Supplier<Uni<? extends T>>() {
             @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -23,7 +23,6 @@ import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.Authentication;
 import io.quarkus.oidc.SecurityEvent;
-import io.quarkus.oidc.TokenStateManager;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.AuthenticationCompletionException;
@@ -56,9 +55,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     private static final String STATE_COOKIE_NAME = "q_auth";
     private static final String POST_LOGOUT_COOKIE_NAME = "q_post_logout";
 
-    private final CreateTokenStateRequestContext createTokenStateRequestContext = new CreateTokenStateRequestContext();
-    private final GetTokensRequestContext getTokenStateRequestContext = new GetTokensRequestContext();
-    private final DeleteTokensRequestContext deleteTokensRequestContext = new DeleteTokensRequestContext();
+    private final BlockingTaskRunner<String> createTokenStateRequestContext = new BlockingTaskRunner<String>();
+    private final BlockingTaskRunner<AuthorizationCodeTokens> getTokenStateRequestContext = new BlockingTaskRunner<AuthorizationCodeTokens>();
+    private final BlockingTaskRunner<Void> deleteTokensRequestContext = new BlockingTaskRunner<Void>();
 
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager) {
@@ -656,17 +655,5 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     static String getCookieSuffix(String tenantId) {
         return !"Default".equals(tenantId) ? "_" + tenantId : "";
-    }
-
-    private static class CreateTokenStateRequestContext extends AbstractBlockingTaskRunner<String>
-            implements TokenStateManager.CreateTokenStateRequestContext {
-    }
-
-    private static class GetTokensRequestContext extends AbstractBlockingTaskRunner<AuthorizationCodeTokens>
-            implements TokenStateManager.GetTokensRequestContext {
-    }
-
-    private static class DeleteTokensRequestContext extends AbstractBlockingTaskRunner<Void>
-            implements TokenStateManager.DeleteTokensRequestContext {
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -56,7 +56,7 @@ public class DefaultTenantConfigResolver {
     @ConfigProperty(name = "quarkus.http.proxy.enable-forwarded-prefix")
     boolean enableHttpForwardedPrefix;
 
-    private final TenantConfigRequestContext blockingRequestContext = new TenantConfigRequestContext();
+    private final BlockingTaskRunner<OidcTenantConfig> blockingRequestContext = new BlockingTaskRunner<OidcTenantConfig>();
 
     private volatile boolean securityEventObserved;
 
@@ -214,7 +214,4 @@ public class DefaultTenantConfigResolver {
         return enableHttpForwardedPrefix;
     }
 
-    private static class TenantConfigRequestContext extends AbstractBlockingTaskRunner<OidcTenantConfig>
-            implements TenantConfigResolver.TenantConfigRequestContext {
-    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntUnaryOperator;
 
-import io.quarkus.oidc.OidcContext;
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.TokenIntrospectionCache;
@@ -65,7 +65,7 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
 
     @Override
     public Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcTenantConfig,
-            OidcContext<Void> requestContext) {
+            OidcRequestContext<Void> requestContext) {
         if (cacheConfig.maxSize > 0) {
             CacheEntry entry = findValidCacheEntry(token);
             if (entry != null) {
@@ -80,14 +80,14 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
 
     @Override
     public Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
-            OidcContext<TokenIntrospection> requestContext) {
+            OidcRequestContext<TokenIntrospection> requestContext) {
         CacheEntry entry = findValidCacheEntry(token);
         return entry == null ? NULL_INTROSPECTION_UNI : Uni.createFrom().item(entry.introspection);
     }
 
     @Override
     public Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcTenantConfig,
-            OidcContext<Void> requestContext) {
+            OidcRequestContext<Void> requestContext) {
         if (cacheConfig.maxSize > 0) {
             CacheEntry entry = findValidCacheEntry(token);
             if (entry != null) {
@@ -102,7 +102,7 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
 
     @Override
     public Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig,
-            OidcContext<UserInfo> requestContext) {
+            OidcRequestContext<UserInfo> requestContext) {
         CacheEntry entry = findValidCacheEntry(token);
         return entry == null ? NULL_USERINFO_UNI : Uni.createFrom().item(entry.userInfo);
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
@@ -1,0 +1,194 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
+
+import io.quarkus.oidc.OidcContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.oidc.TokenIntrospectionCache;
+import io.quarkus.oidc.UserInfo;
+import io.quarkus.oidc.UserInfoCache;
+import io.quarkus.oidc.runtime.OidcConfig.TokenCache;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+/**
+ * Default TokenIntrospection and UserInfo Cache implementation.
+ * A single cache entry can keep TokenIntrospection and/or UserInfo.
+ * 
+ * In most cases it is the opaque bearer access tokens which are introspected
+ * but the code flow access tokens can also be introspected if they have the roles claims.
+ *
+ * In either case, if a remote request to fetch UserInfo is required then it will be the same access token
+ * which has been introspected which will be used to request UserInfo.
+ */
+public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectionCache, UserInfoCache {
+    private static final Uni<TokenIntrospection> NULL_INTROSPECTION_UNI = Uni.createFrom().nullItem();
+    private static final Uni<UserInfo> NULL_USERINFO_UNI = Uni.createFrom().nullItem();
+    private static final IntUnaryOperator DECREMENT_OPERATOR = (n -> (n > 0) ? n - 1 : n);
+
+    private TokenCache cacheConfig;
+
+    private Map<String, CacheEntry> cacheMap;
+    private AtomicInteger cacheSize = new AtomicInteger();
+    private IntUnaryOperator incrementOperator;
+
+    public DefaultTokenIntrospectionUserInfoCache(OidcConfig oidcConfig, Vertx vertx) {
+        this.cacheConfig = oidcConfig.tokenCache;
+        init(vertx);
+    }
+
+    private void init(Vertx vertx) {
+        if (cacheConfig.maxSize > 0) {
+            cacheMap = new ConcurrentHashMap<>();
+            incrementOperator = new IncrementOperator(cacheConfig.maxSize);
+            if (cacheConfig.cleanUpTimerInterval.isPresent()) {
+                vertx.setPeriodic(cacheConfig.cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
+                    @Override
+                    public void handle(Long event) {
+                        // Remove all the entries which have expired
+                        removeInvalidEntries(true);
+                    }
+
+                });
+            }
+        } else {
+            cacheMap = Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcTenantConfig,
+            OidcContext<Void> requestContext) {
+        if (cacheConfig.maxSize > 0) {
+            CacheEntry entry = findValidCacheEntry(token);
+            if (entry != null) {
+                entry.introspection = introspection;
+            } else if (prepareSpaceForNewCacheEntry()) {
+                cacheMap.put(token, new CacheEntry(introspection));
+            }
+        }
+
+        return CodeAuthenticationMechanism.VOID_UNI;
+    }
+
+    @Override
+    public Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
+            OidcContext<TokenIntrospection> requestContext) {
+        CacheEntry entry = findValidCacheEntry(token);
+        return entry == null ? NULL_INTROSPECTION_UNI : Uni.createFrom().item(entry.introspection);
+    }
+
+    @Override
+    public Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcTenantConfig,
+            OidcContext<Void> requestContext) {
+        if (cacheConfig.maxSize > 0) {
+            CacheEntry entry = findValidCacheEntry(token);
+            if (entry != null) {
+                entry.userInfo = userInfo;
+            } else if (prepareSpaceForNewCacheEntry()) {
+                cacheMap.put(token, new CacheEntry(userInfo));
+            }
+        }
+
+        return CodeAuthenticationMechanism.VOID_UNI;
+    }
+
+    @Override
+    public Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig,
+            OidcContext<UserInfo> requestContext) {
+        CacheEntry entry = findValidCacheEntry(token);
+        return entry == null ? NULL_USERINFO_UNI : Uni.createFrom().item(entry.userInfo);
+    }
+
+    public int getCacheSize() {
+        return cacheMap.size();
+    }
+
+    public void clearCache() {
+        cacheMap.clear();
+    }
+
+    private void removeInvalidEntries(boolean removeAll) {
+        long now = now();
+        for (Iterator<Map.Entry<String, CacheEntry>> it = cacheMap.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, CacheEntry> next = it.next();
+            if (isEntryExpired(next.getValue(), now)) {
+                it.remove();
+                cacheSize.updateAndGet(DECREMENT_OPERATOR);
+                if (!removeAll) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private boolean prepareSpaceForNewCacheEntry() {
+        int currentSize = cacheSize.get();
+        if (currentSize == cacheConfig.maxSize) {
+            removeInvalidEntries(false);
+        }
+        // Get a new size - it can still be equal to the max size but guaranteed not to be greater than it.
+        int newSize = cacheSize.updateAndGet(incrementOperator);
+
+        // Increment has happened if the new size is still less than the max size
+        // or equal to it but greater than the captured current size. 
+        return newSize < cacheConfig.maxSize || newSize > currentSize;
+    }
+
+    private CacheEntry findValidCacheEntry(String token) {
+        CacheEntry entry = cacheMap.get(token);
+        if (entry != null) {
+            long now = now();
+            if (isEntryExpired(entry, now)) {
+                // Entry has expired, remote introspection will be required
+                entry = null;
+                cacheMap.remove(token);
+                cacheSize.updateAndGet(DECREMENT_OPERATOR);
+            }
+        }
+        return entry;
+    }
+
+    private boolean isEntryExpired(CacheEntry entry, long now) {
+        return entry.createdTime + cacheConfig.timeToLive.toMillis() < now;
+    }
+
+    private static long now() {
+        return System.currentTimeMillis();
+    }
+
+    private static class CacheEntry {
+        volatile TokenIntrospection introspection;
+        volatile UserInfo userInfo;
+        long createdTime = System.currentTimeMillis();
+
+        public CacheEntry(TokenIntrospection introspection) {
+            this.introspection = introspection;
+        }
+
+        public CacheEntry(UserInfo userInfo) {
+            this.userInfo = userInfo;
+        }
+    }
+
+    private static class IncrementOperator implements IntUnaryOperator {
+        int maxSize;
+
+        IncrementOperator(int maxSize) {
+            this.maxSize = maxSize;
+        }
+
+        @Override
+        public int applyAsInt(int n) {
+            return n < maxSize ? n + 1 : n;
+        }
+
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime;
 import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.oidc.AuthorizationCodeTokens;
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenStateManager;
 import io.smallrye.mutiny.Uni;
@@ -18,7 +19,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
 
     @Override
     public Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            AuthorizationCodeTokens tokens, TokenStateManager.CreateTokenStateRequestContext requestContext) {
+            AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
         StringBuilder sb = new StringBuilder();
         sb.append(tokens.getIdToken());
         if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
@@ -62,7 +63,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
 
     @Override
     public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
-            TokenStateManager.GetTokensRequestContext requestContext) {
+            OidcRequestContext<AuthorizationCodeTokens> requestContext) {
         String[] tokens = CodeAuthenticationMechanism.COOKIE_PATTERN.split(tokenState);
         String idToken = tokens[0];
 
@@ -98,7 +99,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
 
     @Override
     public Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
-            TokenStateManager.DeleteTokensRequestContext requestContext) {
+            OidcRequestContext<Void> requestContext) {
         if (oidcConfig.tokenStateManager.splitTokens) {
             CodeAuthenticationMechanism.removeCookie(routingContext, getAccessTokenCookie(routingContext, oidcConfig),
                     oidcConfig);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
@@ -1,10 +1,13 @@
 package io.quarkus.oidc.runtime;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -25,4 +28,36 @@ public class OidcConfig {
     @ConfigDocMapKey("tenant")
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, OidcTenantConfig> namedTenants;
+
+    /**
+     * Default TokenIntrospection and UserInfo Cache configuration which is used for all the tenants if it is enabled.
+     */
+    @ConfigItem
+    public TokenCache tokenCache = new TokenCache();
+
+    /**
+     * Default TokenIntrospection and UserInfo cache configuration.
+     */
+    @ConfigGroup
+    public static class TokenCache {
+        /**
+         * Maximum number of cache entries.
+         * Set it to a positive value if the cache has to be enabled.
+         */
+        @ConfigItem(defaultValue = "0")
+        public int maxSize = 0;
+
+        /**
+         * Maximum amount of time a given cache entry is valid for.
+         */
+        @ConfigItem(defaultValue = "3M")
+        public Duration timeToLive = Duration.ofMinutes(3);
+
+        /**
+         * Clean up timer interval.
+         * If this property is set then a timer will check and remove the stale entries periodically.
+         */
+        @ConfigItem
+        public Optional<Duration> cleanUpTimerInterval = Optional.empty();
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -14,7 +14,6 @@ import org.jose4j.lang.UnresolvableKeyException;
 
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
-import io.quarkus.oidc.OidcContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTokenCredential;
@@ -47,9 +46,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     @Inject
     DefaultTenantConfigResolver tenantResolver;
 
-    private UniVoidOidcContext uniVoidOidcContext = new UniVoidOidcContext();
-    private GetIntrospectionRequestContext getIntrospectionRequestContext = new GetIntrospectionRequestContext();
-    private GetUserInfoRequestContext getUserInfoRequestContext = new GetUserInfoRequestContext();
+    private BlockingTaskRunner<Void> uniVoidOidcContext = new BlockingTaskRunner<Void>();
+    private BlockingTaskRunner<TokenIntrospection> getIntrospectionRequestContext = new BlockingTaskRunner<TokenIntrospection>();
+    private BlockingTaskRunner<UserInfo> getUserInfoRequestContext = new BlockingTaskRunner<UserInfo>();
 
     @Override
     public Class<TokenAuthenticationRequest> getRequestType() {
@@ -369,13 +368,5 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 }
             });
         }
-    }
-
-    private static class GetIntrospectionRequestContext extends AbstractBlockingTaskRunner<TokenIntrospection>
-            implements OidcContext<TokenIntrospection> {
-    }
-
-    private static class GetUserInfoRequestContext extends AbstractBlockingTaskRunner<UserInfo>
-            implements OidcContext<UserInfo> {
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -14,9 +14,14 @@ import org.jose4j.lang.UnresolvableKeyException;
 
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.OidcContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTokenCredential;
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.oidc.TokenIntrospectionCache;
+import io.quarkus.oidc.UserInfo;
+import io.quarkus.oidc.UserInfoCache;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.credential.TokenCredential;
@@ -36,11 +41,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     static final String NEW_AUTHENTICATION = "new_authentication";
 
     private static final Uni<TokenVerificationResult> NULL_CODE_ACCESS_TOKEN_UNI = Uni.createFrom().nullItem();
-    private static final Uni<JsonObject> NULL_USER_INFO_UNI = Uni.createFrom().nullItem();
+    private static final Uni<UserInfo> NULL_USER_INFO_UNI = Uni.createFrom().nullItem();
     private static final String CODE_ACCESS_TOKEN_RESULT = "code_flow_access_token_result";
 
     @Inject
     DefaultTenantConfigResolver tenantResolver;
+
+    private UniVoidOidcContext uniVoidOidcContext = new UniVoidOidcContext();
+    private GetIntrospectionRequestContext getIntrospectionRequestContext = new GetIntrospectionRequestContext();
+    private GetUserInfoRequestContext getUserInfoRequestContext = new GetUserInfoRequestContext();
 
     @Override
     public Class<TokenAuthenticationRequest> getRequestType() {
@@ -105,12 +114,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             vertxContext.put(CODE_ACCESS_TOKEN_RESULT, codeAccessTokenResult);
         }
 
-        Uni<JsonObject> userInfo = getUserInfoUni(vertxContext, request, resolvedContext);
+        Uni<UserInfo> userInfo = resolvedContext.oidcConfig.authentication.isUserInfoRequired()
+                ? getUserInfoUni(vertxContext, request, resolvedContext)
+                : NULL_USER_INFO_UNI;
 
         return userInfo.onItemOrFailure().transformToUni(
-                new BiFunction<JsonObject, Throwable, Uni<? extends SecurityIdentity>>() {
+                new BiFunction<UserInfo, Throwable, Uni<? extends SecurityIdentity>>() {
                     @Override
-                    public Uni<SecurityIdentity> apply(JsonObject userInfo, Throwable t) {
+                    public Uni<SecurityIdentity> apply(UserInfo userInfo, Throwable t) {
                         if (t != null) {
                             return Uni.createFrom().failure(new AuthenticationFailedException(t));
                         }
@@ -120,7 +131,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<SecurityIdentity> createSecurityIdentityWithOidcServer(RoutingContext vertxContext,
-            TokenAuthenticationRequest request, TenantConfigContext resolvedContext, final JsonObject userInfo) {
+            TokenAuthenticationRequest request, TenantConfigContext resolvedContext, final UserInfo userInfo) {
         Uni<TokenVerificationResult> tokenUni = verifyTokenUni(resolvedContext,
                 request.getToken().getToken());
 
@@ -190,7 +201,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                 }
                             }
                             if (userInfo != null) {
-                                OidcUtils.setSecurityIdentityRoles(builder, resolvedContext.oidcConfig, userInfo);
+                                OidcUtils.setSecurityIdentityRoles(builder, resolvedContext.oidcConfig,
+                                        new JsonObject(userInfo.getJsonObject().toString()));
                             }
                             OidcUtils.setBlockinApiAttribute(builder, vertxContext);
                             OidcUtils.setTenantIdAttribute(builder, resolvedContext.oidcConfig);
@@ -219,11 +231,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
     private static JsonObject getRolesJson(RoutingContext vertxContext, TenantConfigContext resolvedContext,
             TokenCredential tokenCred,
-            JsonObject tokenJson, JsonObject userInfo) {
+            JsonObject tokenJson, UserInfo userInfo) {
         JsonObject rolesJson = tokenJson;
         if (resolvedContext.oidcConfig.roles.source.isPresent()) {
             if (resolvedContext.oidcConfig.roles.source.get() == Source.userinfo) {
-                rolesJson = userInfo;
+                rolesJson = new JsonObject(userInfo.getJsonObject().toString());
             } else if (tokenCred instanceof IdTokenCredential
                     && resolvedContext.oidcConfig.roles.source.get() == Source.accesstoken) {
                 rolesJson = ((TokenVerificationResult) vertxContext.get(CODE_ACCESS_TOKEN_RESULT)).localVerificationResult;
@@ -282,7 +294,33 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<TokenVerificationResult> introspectTokenUni(TenantConfigContext resolvedContext, String token) {
-        return resolvedContext.provider.introspectToken(token);
+        TokenIntrospectionCache tokenIntrospectionCache = tenantResolver.getTokenIntrospectionCache();
+        Uni<TokenIntrospection> tokenIntrospectionUni = tokenIntrospectionCache == null ? null
+                : tokenIntrospectionCache
+                        .getIntrospection(token, resolvedContext.oidcConfig, getIntrospectionRequestContext);
+        if (tokenIntrospectionUni == null) {
+            tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token);
+        } else {
+            tokenIntrospectionUni = tokenIntrospectionUni.onItem().ifNull()
+                    .switchTo(newTokenIntrospectionUni(resolvedContext, token));
+        }
+        return tokenIntrospectionUni.onItem().transform(t -> new TokenVerificationResult(null, t));
+    }
+
+    private Uni<TokenIntrospection> newTokenIntrospectionUni(TenantConfigContext resolvedContext, String token) {
+        Uni<TokenIntrospection> tokenIntrospectionUni = resolvedContext.provider.introspectToken(token);
+        if (tenantResolver.getTokenIntrospectionCache() == null || !resolvedContext.oidcConfig.allowTokenIntrospectionCache) {
+            return tokenIntrospectionUni;
+        } else {
+            return tokenIntrospectionUni.call(new Function<TokenIntrospection, Uni<?>>() {
+
+                @Override
+                public Uni<?> apply(TokenIntrospection introspection) {
+                    return tenantResolver.getTokenIntrospectionCache().addIntrospection(token, introspection,
+                            resolvedContext.oidcConfig, uniVoidOidcContext);
+                }
+            });
+        }
     }
 
     private static Uni<SecurityIdentity> validateTokenWithoutOidcServer(TokenAuthenticationRequest request,
@@ -298,13 +336,46 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         }
     }
 
-    private Uni<JsonObject> getUserInfoUni(RoutingContext vertxContext, TokenAuthenticationRequest request,
+    private Uni<UserInfo> getUserInfoUni(RoutingContext vertxContext, TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
-        if (resolvedContext.oidcConfig.authentication.isUserInfoRequired()) {
-            return resolvedContext.provider.getUserInfo(vertxContext, request);
+        String accessToken = vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
+        if (accessToken == null) {
+            accessToken = request.getToken().getToken();
+        }
+
+        UserInfoCache userInfoCache = tenantResolver.getUserInfoCache();
+        Uni<UserInfo> userInfoUni = userInfoCache == null ? null
+                : userInfoCache.getUserInfo(accessToken, resolvedContext.oidcConfig, getUserInfoRequestContext);
+        if (userInfoUni == null) {
+            userInfoUni = newUserInfoUni(resolvedContext, accessToken);
         } else {
-            return NULL_USER_INFO_UNI;
+            userInfoUni = userInfoUni.onItem().ifNull()
+                    .switchTo(newUserInfoUni(resolvedContext, accessToken));
+        }
+        return userInfoUni;
+    }
+
+    private Uni<UserInfo> newUserInfoUni(TenantConfigContext resolvedContext, String accessToken) {
+        Uni<UserInfo> userInfoUni = resolvedContext.provider.getUserInfo(accessToken);
+        if (tenantResolver.getUserInfoCache() == null || !resolvedContext.oidcConfig.allowUserInfoCache) {
+            return userInfoUni;
+        } else {
+            return userInfoUni.call(new Function<UserInfo, Uni<?>>() {
+
+                @Override
+                public Uni<?> apply(UserInfo userInfo) {
+                    return tenantResolver.getUserInfoCache().addUserInfo(accessToken, userInfo,
+                            resolvedContext.oidcConfig, uniVoidOidcContext);
+                }
+            });
         }
     }
 
+    private static class GetIntrospectionRequestContext extends AbstractBlockingTaskRunner<TokenIntrospection>
+            implements OidcContext<TokenIntrospection> {
+    }
+
+    private static class GetUserInfoRequestContext extends AbstractBlockingTaskRunner<UserInfo>
+            implements OidcContext<UserInfo> {
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -12,6 +12,7 @@ import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.OidcEndpointAccessException;
@@ -55,7 +56,7 @@ public class OidcProviderClient implements Closeable {
                 .transform(resp -> getJsonWebKeySet(resp));
     }
 
-    public Uni<JsonObject> getUserInfo(String token) {
+    public Uni<UserInfo> getUserInfo(String token) {
         return client.getAbs(metadata.getUserInfoUri())
                 .putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + token)
                 .send().onItem().transform(resp -> getUserInfo(resp));
@@ -126,8 +127,8 @@ public class OidcProviderClient implements Closeable {
         return new AuthorizationCodeTokens(idToken, accessToken, refreshToken);
     }
 
-    private JsonObject getUserInfo(HttpResponse<Buffer> resp) {
-        return getJsonObject(resp);
+    private UserInfo getUserInfo(HttpResponse<Buffer> resp) {
+        return new UserInfo(getString(resp));
     }
 
     private TokenIntrospection getTokenIntrospection(HttpResponse<Buffer> resp) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -38,6 +38,10 @@ public class OidcRecorder {
 
     private static final Map<String, TenantConfigContext> dynamicTenantsConfig = new ConcurrentHashMap<>();
 
+    public Supplier<DefaultTokenIntrospectionUserInfoCache> setupTokenCache(OidcConfig config, Supplier<Vertx> vertx) {
+        return () -> new DefaultTokenIntrospectionUserInfoCache(config, vertx.get());
+    }
+
     public Supplier<TenantConfigBean> setup(OidcConfig config, Supplier<Vertx> vertx, TlsConfig tlsConfig) {
         final Vertx vertxValue = vertx.get();
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -142,7 +142,7 @@ public final class OidcUtils {
 
     static QuarkusSecurityIdentity validateAndCreateIdentity(
             RoutingContext vertxContext, TokenCredential credential,
-            TenantConfigContext resolvedContext, JsonObject tokenJson, JsonObject rolesJson, JsonObject userInfo) {
+            TenantConfigContext resolvedContext, JsonObject tokenJson, JsonObject rolesJson, UserInfo userInfo) {
 
         OidcTenantConfig config = resolvedContext.oidcConfig;
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
@@ -195,9 +195,9 @@ public final class OidcUtils {
         builder.addAttribute(TENANT_ID_ATTRIBUTE, config.tenantId.orElse("Default"));
     }
 
-    public static void setSecurityIdentityUserInfo(QuarkusSecurityIdentity.Builder builder, JsonObject userInfo) {
+    public static void setSecurityIdentityUserInfo(QuarkusSecurityIdentity.Builder builder, UserInfo userInfo) {
         if (userInfo != null) {
-            builder.addAttribute(USER_INFO_ATTRIBUTE, new UserInfo(userInfo.encode()));
+            builder.addAttribute(USER_INFO_ATTRIBUTE, userInfo);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/UniVoidOidcContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/UniVoidOidcContext.java
@@ -1,0 +1,6 @@
+package io.quarkus.oidc.runtime;
+
+import io.quarkus.oidc.OidcContext;
+
+public class UniVoidOidcContext extends AbstractBlockingTaskRunner<Void> implements OidcContext<Void> {
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/UniVoidOidcContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/UniVoidOidcContext.java
@@ -1,6 +1,0 @@
-package io.quarkus.oidc.runtime;
-
-import io.quarkus.oidc.OidcContext;
-
-public class UniVoidOidcContext extends AbstractBlockingTaskRunner<Void> implements OidcContext<Void> {
-}

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CacheResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CacheResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("cache")
+public class CacheResource {
+
+    @Inject
+    CustomIntrospectionUserInfoCache tokenCache;
+
+    @POST
+    @Path("clear")
+    public int clear() {
+        tokenCache.clearCache();
+        return tokenCache.getCacheSize();
+    }
+
+    @GET
+    @Path("size")
+    public int size() {
+        return tokenCache.getCacheSize();
+    }
+}

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomIntrospectionUserInfoCache.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomIntrospectionUserInfoCache.java
@@ -4,7 +4,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.quarkus.arc.AlternativePriority;
-import io.quarkus.oidc.OidcContext;
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.TokenIntrospectionCache;
@@ -21,26 +21,26 @@ public class CustomIntrospectionUserInfoCache implements TokenIntrospectionCache
 
     @Override
     public Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcConfig,
-            OidcContext<Void> requestContext) {
+            OidcRequestContext<Void> requestContext) {
         return tokenCache.addIntrospection(token, introspection, oidcConfig, requestContext);
     }
 
     @Override
     public Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
-            OidcContext<TokenIntrospection> requestContext) {
+            OidcRequestContext<TokenIntrospection> requestContext) {
         return tokenCache.getIntrospection(token, oidcConfig, requestContext);
     }
 
     @Override
     public Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcConfig,
-            OidcContext<Void> requestContext) {
+            OidcRequestContext<Void> requestContext) {
         return requestContext
                 .runBlocking(() -> tokenCache.addUserInfo(token, userInfo, oidcConfig, requestContext).await().indefinitely());
     }
 
     @Override
     public Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig,
-            OidcContext<UserInfo> requestContext) {
+            OidcRequestContext<UserInfo> requestContext) {
         return tokenCache.getUserInfo(token, oidcConfig, requestContext);
     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomIntrospectionUserInfoCache.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomIntrospectionUserInfoCache.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.keycloak;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.quarkus.arc.AlternativePriority;
+import io.quarkus.oidc.OidcContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.oidc.TokenIntrospectionCache;
+import io.quarkus.oidc.UserInfo;
+import io.quarkus.oidc.UserInfoCache;
+import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+@AlternativePriority(1)
+public class CustomIntrospectionUserInfoCache implements TokenIntrospectionCache, UserInfoCache {
+    @Inject
+    DefaultTokenIntrospectionUserInfoCache tokenCache;
+
+    @Override
+    public Uni<Void> addIntrospection(String token, TokenIntrospection introspection, OidcTenantConfig oidcConfig,
+            OidcContext<Void> requestContext) {
+        return tokenCache.addIntrospection(token, introspection, oidcConfig, requestContext);
+    }
+
+    @Override
+    public Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
+            OidcContext<TokenIntrospection> requestContext) {
+        return tokenCache.getIntrospection(token, oidcConfig, requestContext);
+    }
+
+    @Override
+    public Uni<Void> addUserInfo(String token, UserInfo userInfo, OidcTenantConfig oidcConfig,
+            OidcContext<Void> requestContext) {
+        return requestContext
+                .runBlocking(() -> tokenCache.addUserInfo(token, userInfo, oidcConfig, requestContext).await().indefinitely());
+    }
+
+    @Override
+    public Uni<UserInfo> getUserInfo(String token, OidcTenantConfig oidcConfig,
+            OidcContext<UserInfo> requestContext) {
+        return tokenCache.getUserInfo(token, oidcConfig, requestContext);
+    }
+
+    public int getCacheSize() {
+        return tokenCache.getCacheSize();
+    }
+
+    public void clearCache() {
+        tokenCache.clearCache();
+    }
+}

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -36,6 +36,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.getCredentials().setSecret("secret");
                     config.getToken().setIssuer(getIssuerUrl() + "/realms/quarkus-d");
                     config.getAuthentication().setUserInfoRequired(true);
+                    config.setAllowUserInfoCache(false);
                     return config;
                 } else if ("tenant-oidc".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
@@ -46,6 +47,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                             : uri.replace("/tenant/tenant-oidc/api/user", "/oidc");
                     config.setAuthServerUrl(authServerUri);
                     config.setClientId("client");
+                    config.setAllowTokenIntrospectionCache(false);
                     return config;
                 } else if ("tenant-oidc-no-discovery".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
@@ -66,14 +68,21 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.token.setAllowJwtIntrospection(false);
                     config.setClientId("client");
                     return config;
-                } else if ("tenant-oidc-introspection-only".equals(tenantId)) {
+                } else if ("tenant-oidc-introspection-only".equals(tenantId)
+                        || "tenant-oidc-introspection-only-cache".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-oidc-introspection-only");
+                    config.setTenantId(tenantId);
                     String uri = context.request().absoluteURI();
-                    String authServerUri = uri.replace("/tenant/tenant-oidc-introspection-only/api/user", "/oidc");
+                    String authServerUri = uri.replace("/tenant/" + tenantId + "/api/user", "/oidc");
                     config.setAuthServerUrl(authServerUri);
                     config.setDiscoveryEnabled(false);
+                    config.authentication.setUserInfoRequired(true);
+                    if ("tenant-oidc-introspection-only".equals(tenantId)) {
+                        config.setAllowTokenIntrospectionCache(false);
+                        config.setAllowUserInfoCache(false);
+                    }
                     config.setIntrospectionPath("introspect");
+                    config.setUserInfoPath("userinfo");
                     config.setClientId("client");
                     return config;
                 } else if ("tenant-oidc-no-opaque-token".equals(tenantId)) {
@@ -93,6 +102,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.getCredentials().setSecret("secret");
                     config.getAuthentication().setUserInfoRequired(true);
                     config.getRoles().setSource(Source.userinfo);
+                    config.setAllowUserInfoCache(false);
                     config.setApplicationType(ApplicationType.WEB_APP);
                     return config;
                 }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
@@ -15,7 +16,7 @@ import io.vertx.ext.web.RoutingContext;
 public class CustomTenantConfigResolver implements TenantConfigResolver {
 
     @Override
-    public Uni<OidcTenantConfig> resolve(RoutingContext context, TenantConfigRequestContext requestContext) {
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         return requestContext.runBlocking(new Supplier<OidcTenantConfig>() {
             @Override
             public OidcTenantConfig get() {

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -25,6 +25,7 @@ public class OidcResource {
     private volatile boolean rotate;
     private volatile int jwkEndpointCallCount;
     private volatile int introspectionEndpointCallCount;
+    private volatile int userInfoEndpointCallCount;
 
     @PostConstruct
     public void init() throws Exception {
@@ -42,6 +43,7 @@ public class OidcResource {
         return "{" +
                 "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
                 "   \"introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
+                "   \"userinfo_endpoint\":" + "\"" + baseUri + "/userinfo\"," +
                 "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
                 "  }";
     }
@@ -98,6 +100,30 @@ public class OidcResource {
                 "   \"scope\": \"user\"," +
                 "   \"email\": \"user@gmail.com\"," +
                 "   \"username\": \"alice\"" +
+                "  }";
+    }
+
+    @GET
+    @Path("userinfo-endpoint-call-count")
+    public int userInfoEndpointCallCount() {
+        return userInfoEndpointCallCount;
+    }
+
+    @POST
+    @Path("userinfo-endpoint-call-count")
+    public int resetUserInfoEndpointCallCount() {
+        userInfoEndpointCallCount = 0;
+        return userInfoEndpointCallCount;
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path("userinfo")
+    public String userinfo() {
+        userInfoEndpointCallCount++;
+
+        return "{" +
+                "   \"preferred_username\": \"alice\"" +
                 "  }";
     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -29,6 +29,9 @@ public class TenantResource {
     AccessTokenCredential accessTokenCred;
 
     @Inject
+    CustomIntrospectionUserInfoCache tokenCache;
+
+    @Inject
     @IdToken
     JsonWebToken idToken;
 
@@ -48,7 +51,12 @@ public class TenantResource {
                 name = name + "." + userInfo.getString(Claims.preferred_username.name());
             }
         }
-        return tenant + ":" + name;
+
+        String response = tenant + ":" + name;
+        if (tenant.startsWith("tenant-oidc-introspection-only")) {
+            response += (":" + tokenCache.getCacheSize());
+        }
+        return response;
     }
 
     @GET

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.http.cors=true
 
+quarkus.oidc.token-cache.max-size=3
+
 # Default Tenant
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus-a
 quarkus.oidc.client-id=quarkus-app-a
@@ -22,6 +24,8 @@ quarkus.oidc.tenant-b-no-discovery.auth-server-url=${keycloak.url}/realms/quarku
 quarkus.oidc.tenant-b-no-discovery.discovery-enabled=false
 quarkus.oidc.tenant-b-no-discovery.user-info-path=/protocol/openid-connect/userinfo
 quarkus.oidc.tenant-b-no-discovery.introspection-path=protocol/openid-connect/token/introspect
+quarkus.oidc.tenant-b-no-discovery.allow-token-introspection-cache=false
+quarkus.oidc.tenant-b-no-discovery.allow-user-info-cache=false
 quarkus.oidc.tenant-b-no-discovery.client-id=quarkus-app-b
 quarkus.oidc.tenant-b-no-discovery.credentials.secret=secret
 quarkus.oidc.tenant-b-no-discovery.application-type=service
@@ -41,6 +45,7 @@ quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
 quarkus.oidc.tenant-web-app.authentication.user-info-required=true
 quarkus.oidc.tenant-web-app.roles.source=userinfo
+quarkus.oidc.tenant-web-app.allow-user-info-cache=false
 
 # Tenant Web App No Discovery (Introspection + User Info)
 quarkus.oidc.tenant-web-app-no-discovery.auth-server-url=${keycloak.url}/realms/quarkus-webapp
@@ -49,12 +54,13 @@ quarkus.oidc.tenant-web-app-no-discovery.authorization-path=/protocol/openid-con
 quarkus.oidc.tenant-web-app-no-discovery.token-path=/protocol/openid-connect/token
 quarkus.oidc.tenant-web-app-no-discovery.user-info-path=/protocol/openid-connect/userinfo
 quarkus.oidc.tenant-web-app-no-discovery.introspection-path=protocol/openid-connect/token/introspect
-#quarkus.oidc.tenant-web-app-no-discovery.jwks-path=/protocol/openid-connect/certs
+quarkus.oidc.tenant-web-app-no-discovery.allow-token-introspection-cache=false
 quarkus.oidc.tenant-web-app-no-discovery.client-id=quarkus-app-webapp
 quarkus.oidc.tenant-web-app-no-discovery.credentials.secret=secret
 quarkus.oidc.tenant-web-app-no-discovery.application-type=web-app
 quarkus.oidc.tenant-web-app-no-discovery.authentication.user-info-required=true
 quarkus.oidc.tenant-web-app-no-discovery.roles.source=userinfo
+quarkus.oidc.tenant-web-app-no-discovery.allow-user-info-cache=false
 
 # Tenant Web App2
 quarkus.oidc.tenant-web-app2.auth-server-url=${keycloak.url}/realms/quarkus-webapp2
@@ -95,3 +101,4 @@ quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCg
 smallrye.jwt.sign.key.location=/privateKey.pem
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.http.auth.proactive=false


### PR DESCRIPTION
Fixes #12800.

The problem of the performance being possibly affected due to up to 2 remote calls per every incoming access token (one for the access token introspection - opaque bearer access token or access token returned with the code flow response if it is configured to be the source of roles with non Keycloak providers plus a user info call if required for all the providers) has been known for a while and several users are waiting for a fix, in some cases SLAs can be affected.  I believe @stianst and @pedroigor have also mentioned before the possibility of caching the token introspection results for a short configurable period of time.

So this PR does the following:
- introduces Uni friendly `TokenIntrospectionCache` and `UserInfoCache` interfaces
- Minor updates to `TokenIntrospection` and `UserInfo` for the custom cache implementations be able to recreate them either from String or `javax.json.JsonObject`
- Minor update to the way `UserInfo` is prepared - earlier, Vertx `JsonObject` was created first and then later it was converted to `javax.json.JsonObject` and now it is the other way around but only if `UserInfo` is the source of roles since Vertx `JsonObject` is used for it which is rare enough - so it s a bit more effective now and fits better with the new interfaces.
- Updates `OidcIdentityProvider` to check  `TokenIntrospectionCache` and `UserInfoCache` and try to add a new entry but only if the current tenant allows to cache.
- Simple default token cache implementing both `TokenIntrospectionCache` and `UserInfoCache` is provided - in the vast majority of cases it will be the same token which is introspected and/or used to get `UserInfo` - so this cache uses a single cache entry to hold both objects (one of them can be null), enforces a max number of entries and optionally starts a clean up timer. It is a fairly basic  implementation which might be tweaked a bit further but it should be good enough to handle the cases where up to say 3K requests are coming nearly at the same time. Users can register custom ones of course.
- Tests verifying the default cache behaves correctly have been added
- Docs have been updated
