### PR TITLE
Update MongoDB and MongoDB with Panache guides

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -70,11 +70,11 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=mongodb-panache-quickstart \
     -DclassName="org.acme.mongodb.panache.PersonResource" \
     -Dpath="/persons" \
-    -Dextensions="resteasy,resteasy-jackson,mongodb-panache"
+    -Dextensions="resteasy-reactive-jackson,mongodb-panache"
 cd mongodb-panache-quickstart
 ----
 
-This command generates a Maven structure importing the RESTEasy/JAX-RS, Jackson and MongoDB with Panache extensions.
+This command generates a Maven structure importing the RESTEasy Reactive Jackson and MongoDB with Panache extensions.
 After this, the `quarkus-mongodb-panache` extension has been added to your `pom.xml`.
 
 If you don't want to generate a new project, add the dependency in your `pom.xml`:
@@ -416,7 +416,7 @@ The repository pattern examples have been omitted for brevity.
 
 == Writing a JAX-RS resource
 
-First, include one of the RESTEasy extensions to enable JAX-RS endpoints, for example, add the `io.quarkus:quarkus-resteasy-jackson` dependency for JAX-RS and JSON support.
+First, include one of the RESTEasy extensions to enable JAX-RS endpoints, for example, add the `io.quarkus:quarkus-resteasy-reactive-jackson` dependency for JAX-RS and JSON support.
 
 Then, you can create the following resource to create/read/update/delete your Person entity:
 

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -48,12 +48,12 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=mongodb-quickstart \
     -DclassName="org.acme.mongodb.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy,resteasy-jackson,mongodb-client,resteasy-mutiny,context-propagation"
+    -Dextensions="resteasy-reactive-jackson,mongodb-client"
 cd mongodb-quickstart
 ----
 
-This command generates a Maven structure importing the RESTEasy/JAX-RS, Jackson, Mutiny, Context Propagation and MongoDB Client extensions.
-After this, the quarkus-mongodb-client extension has been added to your `pom.xml`.
+This command generates a Maven structure importing the RESTEasy Reactive Jackson and MongoDB Client extensions.
+After this, the `quarkus-mongodb-client` extension has been added to your `pom.xml`.
 
 If you already have your Quarkus project configured, you can add the `mongodb-client` extension
 to your project by running the following command in your project base directory:


### PR DESCRIPTION
Updates reflect changes in related Quickstarts:
- `mongodb-quickstart`
- `mongodb-panache-quickstart`

In both cases, RESTEasy dependencies were replaced with RESTEasy
Reactive ones. Also, other redundant dependencies were deleted.