### PR TITLE
Fix broken link

### DIFF
--- a/extensions/micrometer-registry-prometheus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer-registry-prometheus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,7 +7,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "stable"


### PR DESCRIPTION
Fix the link to the guide of MicroProfile extension in the extension metadata