### PR TITLE
Add HTTP config parameter to control the content type of unexpected error responses

### DIFF
--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -78,6 +78,16 @@
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -231,6 +231,16 @@ public class HttpConfiguration {
     @ConfigItem
     public boolean enableDecompression;
 
+    /**
+     * Provides a hint (optional) for the contents type of responses generated for
+     * the errors not handled by the application.
+     * <p>
+     * When unset, Quarkus will decide which contents type to use based on request headers.
+     * </p>
+     */
+    @ConfigItem
+    public Optional<PayloadHint> unhandledErrorContentsType;
+
     public ProxyConfig proxy;
 
     public int determinePort(LaunchMode launchMode) {
@@ -245,5 +255,10 @@ public class HttpConfiguration {
         ENABLED,
         REDIRECT,
         DISABLED;
+    }
+
+    public enum PayloadHint {
+        JSON,
+        HTML,
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -308,7 +308,8 @@ public class VertxHttpRecorder {
             defaultRouteHandler.accept(httpRouteRouter.route().order(DEFAULT_ROUTE_ORDER));
         }
 
-        httpRouteRouter.route().last().failureHandler(new QuarkusErrorHandler(launchMode.isDevOrTest()));
+        httpRouteRouter.route().last().failureHandler(
+                new QuarkusErrorHandler(launchMode.isDevOrTest(), httpConfiguration.unhandledErrorContentsType));
 
         if (requireBodyHandler) {
             //if this is set then everything needs the body handler installed

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
@@ -2,11 +2,26 @@ package io.quarkus.vertx.http.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.core.json.Json;
+import io.vertx.ext.web.RoutingContext;
 
+@ExtendWith(MockitoExtension.class)
 class QuarkusErrorHandlerTest {
+
+    private static final Throwable testError = new IllegalStateException("test123");
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    RoutingContext routingContext;
 
     @Test
     public void string_with_tab_should_be_correctly_escaped() {
@@ -32,4 +47,30 @@ class QuarkusErrorHandlerTest {
         assertEquals(initial, parsed);
     }
 
+    @Test
+    public void json_content_type_hint_should_be_respected() {
+        QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, Optional.of(HttpConfiguration.PayloadHint.JSON));
+        Mockito.when(routingContext.failure()).thenReturn(testError);
+        errorHandler.handle(routingContext);
+        Mockito.verify(routingContext.response().headers()).set(HttpHeaderNames.CONTENT_TYPE,
+                "application/json; charset=utf-8");
+    }
+
+    @Test
+    public void content_type_should_default_to_json_if_accepted() {
+        QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, Optional.empty());
+        Mockito.when(routingContext.failure()).thenReturn(testError);
+        Mockito.when(routingContext.request().getHeader("Accept")).thenReturn("application/json");
+        errorHandler.handle(routingContext);
+        Mockito.verify(routingContext.response().headers()).set(HttpHeaderNames.CONTENT_TYPE,
+                "application/json; charset=utf-8");
+    }
+
+    @Test
+    public void html_content_type_hint_should_be_respected() {
+        QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, Optional.of(HttpConfiguration.PayloadHint.HTML));
+        Mockito.when(routingContext.failure()).thenReturn(testError);
+        errorHandler.handle(routingContext);
+        Mockito.verify(routingContext.response().headers()).set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
+    }
 }


### PR DESCRIPTION
Applications do not always control the context of unexpected
exceptions and may not be able to provide exception mappers in
all cases.

QuarkusErrorHandler previously replied on the `Accept` HTTP header
to decide whether to format the error response as JSON or HTML.

RFC6839 defines the `+json` media type suffix that may be used
by applications to create custom media types compatible with
the JSON format. For example: `application/my-app+json`

In those cases QuarkusErrorHandler cannot reasonably be able to
produce the exact expected response contents type because its
specification is application-dependent. However, it may still be
preferable to return a generic `applicaiton/json` response as
opposed to HTML in those cases.

The new (optional) configuration setting allows applications to
request a specific contents type for formatting unexpected error
responses.

The default Quarkus behaviour remains unchanged. QuarkusErrorHandler
will use the `Accept` header for determining the response contents
type.

----

If this PR is accepted, please backport to v2.2.x.