### PR TITLE
Bump kotlin-coroutines to 1.5.2, dokka to 1.5.30

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -149,7 +149,7 @@
         <aws-alexa-sdk.version>2.40.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
         <kotlin.version>1.5.30</kotlin.version>
-        <kotlin.coroutine.version>1.5.1</kotlin.coroutine.version>
+        <kotlin.coroutine.version>1.5.2</kotlin.coroutine.version>
         <dekorate.version>2.5.0</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,7 +21,7 @@
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.5.30</kotlin.version>
-        <dokka.version>1.5.0</dokka.version>
+        <dokka.version>1.5.30</dokka.version>
         <scala.version>2.12.13</scala.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
         <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->


### PR DESCRIPTION
Unsurprisingly, no improvements in terms of "add-opens" for dokka.