### PR TITLE
Fix issue with default beans resolution

### DIFF
--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckDefaultScopeTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckDefaultScopeTest.java
@@ -6,6 +6,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 import java.lang.annotation.Retention;
@@ -41,11 +42,11 @@ public class HealthCheckDefaultScopeTest {
             when().get("/q/health/live").then()
                     .body("status", is("UP"),
                             "checks.status", contains("UP", "UP"),
-                            "checks.name", contains("noScope", "noScopeStereotype"));
+                            "checks.name", containsInAnyOrder("noScope", "noScopeStereotype"));
             when().get("/q/health/live").then()
                     .body("status", is("DOWN"),
                             "checks.status", contains("DOWN", "DOWN"),
-                            "checks.name", contains("noScope", "noScopeStereotype"));
+                            "checks.name", containsInAnyOrder("noScope", "noScopeStereotype"));
         } finally {
             RestAssured.reset();
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
+import java.util.Iterator;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.util.TypeLiteral;
@@ -32,5 +33,20 @@ public interface InjectableInstance<T> extends Instance<T> {
      * @see WithCaching
      */
     void clearCache();
+
+    /**
+     * This method attempts to resolve ambiguities.
+     * <p>
+     * In general, if multiple beans are eligible then the container eliminates all beans that are:
+     * <ul>
+     * <li>not alternatives, except for producer methods and fields of beans that are alternatives,</li>
+     * <li>default beans.</li>
+     * </ul>
+     * 
+     * @return an iterator over the contextual references of the disambiguated beans
+     * @see DefaultBean
+     */
+    @Override
+    Iterator<T> iterator();
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -569,13 +569,14 @@ public class ArcContainerImpl implements ArcContainer {
         }
 
         // Try to resolve the ambiguity
-        List<InjectableBean<?>> resolved = new ArrayList<>(matching);
+        List<InjectableBean<?>> nonDefault = new ArrayList<>(matching);
 
-        resolved.removeIf(InjectableBean::isDefaultBean);
-        if (resolved.size() == 1) {
-            return Collections.singleton(resolved.get(0));
+        nonDefault.removeIf(InjectableBean::isDefaultBean);
+        if (nonDefault.size() == 1) {
+            return Collections.singleton(nonDefault.get(0));
         }
 
+        List<InjectableBean<?>> resolved = new ArrayList<>(nonDefault);
         resolved.removeIf(not(ArcContainerImpl::isAlternativeOrDeclaredOnAlternative));
         if (resolved.size() == 1) {
             return Collections.singleton(resolved.get(0));
@@ -587,8 +588,10 @@ public class ArcContainerImpl implements ArcContainer {
             if (resolved.size() == 1) {
                 return Collections.singleton(resolved.get(0));
             }
+            return new HashSet<>(resolved);
         }
-        return new HashSet<>(matching);
+        //return all non-default beans
+        return new HashSet<>(nonDefault);
     }
 
     private static boolean isAlternativeOrDeclaredOnAlternative(InjectableBean<?> bean) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -565,33 +565,38 @@ public class ArcContainerImpl implements ArcContainer {
         if (matching.isEmpty()) {
             return Collections.emptySet();
         } else if (matching.size() == 1) {
-            return Collections.singleton(matching.get(0));
+            return Set.of(matching.get(0));
         }
+        // Try to resolve the ambiguity and return the set of disambiguated beans
 
-        // Try to resolve the ambiguity
+        // First remove the default beans
         List<InjectableBean<?>> nonDefault = new ArrayList<>(matching);
-
         nonDefault.removeIf(InjectableBean::isDefaultBean);
-        if (nonDefault.size() == 1) {
-            return Collections.singleton(nonDefault.get(0));
+        if (nonDefault.isEmpty()) {
+            // All the matching beans were default
+            return Set.copyOf(matching);
+        } else if (nonDefault.size() == 1) {
+            return Set.of(nonDefault.get(0));
         }
 
-        List<InjectableBean<?>> resolved = new ArrayList<>(nonDefault);
-        resolved.removeIf(not(ArcContainerImpl::isAlternativeOrDeclaredOnAlternative));
-        if (resolved.size() == 1) {
-            return Collections.singleton(resolved.get(0));
-        } else if (resolved.size() > 1) {
-            resolved.sort(ArcContainerImpl::compareAlternativeBeans);
-            // Keep only the highest priorities
-            Integer highest = getAlternativePriority(resolved.get(0));
-            resolved.removeIf(injectableBean -> !highest.equals(getAlternativePriority(injectableBean)));
-            if (resolved.size() == 1) {
-                return Collections.singleton(resolved.get(0));
+        // More than one non-default bean remains - eliminate beans that don't have a priority
+        List<InjectableBean<?>> priorityBeans = new ArrayList<>(nonDefault);
+        priorityBeans.removeIf(not(ArcContainerImpl::isAlternativeOrDeclaredOnAlternative));
+        if (priorityBeans.isEmpty()) {
+            // No alternative/priority beans are present
+            return Set.copyOf(nonDefault);
+        } else if (priorityBeans.size() == 1) {
+            return Set.of(priorityBeans.get(0));
+        } else {
+            // Keep only the highest priorities 
+            priorityBeans.sort(ArcContainerImpl::compareAlternativeBeans);
+            Integer highest = getAlternativePriority(priorityBeans.get(0));
+            priorityBeans.removeIf(bean -> !highest.equals(getAlternativePriority(bean)));
+            if (priorityBeans.size() == 1) {
+                return Set.of(priorityBeans.get(0));
             }
-            return new HashSet<>(resolved);
+            return Set.copyOf(priorityBeans);
         }
-        //return all non-default beans
-        return new HashSet<>(nonDefault);
     }
 
     private static boolean isAlternativeOrDeclaredOnAlternative(InjectableBean<?> bean) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
@@ -6,10 +6,12 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -17,13 +19,21 @@ public class DefaultClassBeanTest {
 
     @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class,
-            GreetingBean.class, Hello.class, PingBean.class);
+            GreetingBean.class, Hello.class, PingBean.class, Author.class, SciFi.class, Fantasy.class, Detective.class);
 
     @Test
     public void testInjection() {
         Hello hello = Arc.container().instance(Hello.class).get();
         assertEquals("hello", hello.hello());
         assertEquals("pong", hello.ping());
+        var result = hello.instance();
+        StringBuilder sb = new StringBuilder();
+        for (var i : result) {
+            i.write(sb);
+        }
+        Assertions.assertTrue(sb.toString().contains("SciFi"));
+        Assertions.assertTrue(sb.toString().contains("Fantasy"));
+        Assertions.assertFalse(sb.toString().contains("Detective"));
     }
 
     @Test
@@ -40,6 +50,9 @@ public class DefaultClassBeanTest {
         @Inject
         PingBean ping;
 
+        @Inject
+        Instance<Author> instance;
+
         String hello() {
             return bean.greet();
         }
@@ -48,6 +61,9 @@ public class DefaultClassBeanTest {
             return ping.ping();
         }
 
+        public Instance<Author> instance() {
+            return instance;
+        }
     }
 
     @DefaultBean // This one is overriden by Producer.greetingBean()
@@ -85,4 +101,35 @@ public class DefaultClassBeanTest {
 
     }
 
+    interface Author {
+        void write(StringBuilder sb);
+    }
+
+    @Singleton
+    static class SciFi implements Author {
+
+        @Override
+        public void write(StringBuilder sb) {
+            sb.append("SciFi");
+        }
+    }
+
+    @Singleton
+    static class Fantasy implements Author {
+
+        @Override
+        public void write(StringBuilder sb) {
+            sb.append("Fantasy");
+        }
+    }
+
+    @Singleton
+    @DefaultBean
+    static class Detective implements Author {
+
+        @Override
+        public void write(StringBuilder sb) {
+            sb.append("Detective");
+        }
+    }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.test.ArcTestContainer;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
@@ -34,6 +36,9 @@ public class DefaultClassBeanTest {
         Assertions.assertTrue(sb.toString().contains("SciFi"));
         Assertions.assertTrue(sb.toString().contains("Fantasy"));
         Assertions.assertFalse(sb.toString().contains("Detective"));
+        Set<Detective> detectives = Arc.container().beanManager().createInstance().select(Detective.class).stream()
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(1, detectives.size());
     }
 
     @Test
@@ -61,7 +66,7 @@ public class DefaultClassBeanTest {
             return ping.ping();
         }
 
-        public Instance<Author> instance() {
+        Instance<Author> instance() {
             return instance;
         }
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerFieldTest.java
@@ -1,11 +1,15 @@
 package io.quarkus.arc.test.defaultbean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.test.ArcTestContainer;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
@@ -17,7 +21,7 @@ public class DefaultProducerFieldTest {
 
     @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class,
-            GreetingBean.class, Hello.class);
+            GreetingBean.class, Hello.class, Fantasy.class);
 
     @Test
     public void testInjection() {
@@ -29,14 +33,30 @@ public class DefaultProducerFieldTest {
         assertEquals("hola", CDI.current().select(GreetingBean.class).get().greet());
     }
 
+    @Test
+    public void testInstanceIterator() {
+        List<Author> authors = Arc.container().instance(Hello.class).get().instance().stream().collect(Collectors.toList());
+        assertEquals(2, authors.size());
+        String result = authors.stream().map(Author::get).collect(Collectors.joining());
+        assertTrue(result.contains("SciFi"));
+        assertTrue(result.contains("Fantasy"));
+    }
+
     @ApplicationScoped
     static class Hello {
 
         @Inject
         GreetingBean bean;
 
+        @Inject
+        Instance<Author> instance;
+
         String hello() {
             return bean.greet();
+        }
+
+        Instance<Author> instance() {
+            return instance;
         }
 
     }
@@ -63,6 +83,31 @@ public class DefaultProducerFieldTest {
 
         };
 
+        @Produces
+        @Singleton
+        @DefaultBean
+        Author sciFi = new Author() {
+
+            @Override
+            public String get() {
+                return "SciFi";
+            }
+        };
+
+    }
+
+    interface Author {
+        String get();
+    }
+
+    @Singleton
+    @DefaultBean
+    static class Fantasy implements Author {
+
+        @Override
+        public String get() {
+            return "Fantasy";
+        }
     }
 
 }


### PR DESCRIPTION
If there is more than one Foo for Instance<Foo> then default beans are
included in the result list. This result in HTTP basic auth always being
enabled if there is more than one authenticator.