### PR TITLE
Take advantage of RestEasy-specific endpoint validation in Spring Web

### DIFF
--- a/extensions/spring-web/deployment/pom.xml
+++ b/extensions/spring-web/deployment/pom.xml
@@ -28,6 +28,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-server-common-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -56,6 +56,7 @@ import io.quarkus.resteasy.reactive.server.spi.AnnotationsTransformerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
 import io.quarkus.resteasy.reactive.spi.AdditionalResourceClassBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodAnnotationsBuildItem;
 import io.quarkus.spring.web.runtime.ResponseEntityHandler;
 import io.quarkus.spring.web.runtime.ResponseStatusExceptionMapper;
 import io.quarkus.spring.web.runtime.ResponseStatusHandler;
@@ -144,7 +145,15 @@ public class SpringWebProcessor {
     }
 
     @BuildStep
-    public void methodAnnotationsTransformer(BuildProducer<AnnotationsTransformerBuildItem> producer) {
+    public void methodAnnotationsTransformer(BuildProducer<AnnotationsTransformerBuildItem> producer,
+            BuildProducer<AdditionalJaxRsResourceMethodAnnotationsBuildItem> additionalJaxRsMethodProducer) {
+        // This is useful mainly to let Hibernate Validator know that methods annotated with these annotations
+        // are to be validated differently,
+        // e.g. by yielding HTTP status 400 instead of 500 on constraint violation for a method parameter.
+        // The effect on RestEasy itself is negligible: it will only register the annotated methods for reflection,
+        // which we already do.
+        additionalJaxRsMethodProducer.produce(new AdditionalJaxRsResourceMethodAnnotationsBuildItem(MAPPING_ANNOTATIONS));
+
         producer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
 
             @Override


### PR DESCRIPTION
This should fix the test failure we've been having on CI since #20141 was merged.

In short, this makes sure that constraint violations on parameters of Spring controller methods lead to a HTTP status 400 (bad request) instead of the default 500 (internal error) for other constraint validations.

#20141 introduced a new type of exception (`ResteasyReactiveViolationException`) to distingish between those violations, but due to incomplete metadata, Spring controller methods were not using the correct interceptor that throws this exception, and were thus considered as internal components, whose parameters thus trigger a HTTP status 500 when they violate constraints.