### PR TITLE
Remove usage of deprecated method in Neo4j extension

### DIFF
--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -52,7 +52,8 @@ public class Neo4jFunctionalityTest {
                 .body("status", is("UP"),
                         "checks.status", containsInAnyOrder("UP"),
                         "checks.name", containsInAnyOrder("Neo4j connection health check"),
-                        "checks.data.server", containsInAnyOrder(matchesRegex("Neo4j/.*@.*:\\d*")));
+                        "checks.data.server", containsInAnyOrder(matchesRegex("Neo4j/.*@.*:\\d*")),
+                        "checks.data.edition", containsInAnyOrder(is(notNullValue())));
     }
 
     @Test


### PR DESCRIPTION
`dbms.components` will be used to retrieve the correct kernel version instead of `ServerInfo#version`.