### PR TITLE
Datasource "health-exclude" property should apply to reactive pools too

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.agroal.deployment;
 
-import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
-
 import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +33,6 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecks;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -336,15 +333,8 @@ class AgroalProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
-    HealthBuildItem addHealthCheck(Capabilities capabilities, DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
-            AgroalRecorder recorder, BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+    HealthBuildItem addHealthCheck(Capabilities capabilities, DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
         if (capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
-            syntheticBeans.produce(SyntheticBeanBuildItem.configure(DataSourcesExcludedFromHealthChecks.class)
-                    .scope(Singleton.class)
-                    .unremovable()
-                    .supplier(recorder.dataSourcesExcludedFromHealthChecks(dataSourcesBuildTimeConfig))
-                    .done());
             return new HealthBuildItem("io.quarkus.agroal.runtime.health.DataSourceHealthCheck",
                     dataSourcesBuildTimeConfig.healthEnabled);
         } else {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
@@ -1,15 +1,8 @@
 package io.quarkus.agroal.runtime;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 import io.agroal.api.AgroalDataSource;
-import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecks;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -32,26 +25,6 @@ public class AgroalRecorder {
             @Override
             public AgroalDataSource get() {
                 return agroalDataSource;
-            }
-        };
-    }
-
-    public Supplier<DataSourcesExcludedFromHealthChecks> dataSourcesExcludedFromHealthChecks(
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
-        return new Supplier<DataSourcesExcludedFromHealthChecks>() {
-            @Override
-            public DataSourcesExcludedFromHealthChecks get() {
-                List<String> excludedNames = new ArrayList<>();
-                if (dataSourcesBuildTimeConfig.defaultDataSource.healthExclude) {
-                    excludedNames.add(DataSourceUtil.DEFAULT_DATASOURCE_NAME);
-                }
-                for (Map.Entry<String, DataSourceBuildTimeConfig> dataSource : dataSourcesBuildTimeConfig.namedDataSources
-                        .entrySet()) {
-                    if (dataSource.getValue().healthExclude) {
-                        excludedNames.add(dataSource.getKey());
-                    }
-                }
-                return new DataSourcesExcludedFromHealthChecks(excludedNames);
             }
         };
     }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
@@ -3,7 +3,6 @@ package io.quarkus.agroal.runtime.health;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,7 +31,7 @@ public class DataSourceHealthCheck implements HealthCheck {
         Set<Bean<?>> beans = Arc.container().beanManager().getBeans(DataSource.class);
         DataSourcesExcludedFromHealthChecks excluded = Arc.container().instance(DataSourcesExcludedFromHealthChecks.class)
                 .get();
-        List<String> excludedNames = excluded.getExcludedNames();
+        Set<String> excludedNames = excluded.getExcludedNames();
         for (Bean<?> bean : beans) {
             if (bean.getName() == null) {
                 if (!excludedNames.contains(DataSourceUtil.DEFAULT_DATASOURCE_NAME)) {

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/DataSourcesExcludedFromHealthChecksProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/DataSourcesExcludedFromHealthChecksProcessor.java
@@ -1,0 +1,34 @@
+package io.quarkus.datasource.deployment;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+
+import javax.inject.Singleton;
+
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
+import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecks;
+import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecksRecorder;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+
+public class DataSourcesExcludedFromHealthChecksProcessor {
+
+    @BuildStep
+    @Record(STATIC_INIT)
+    void produceBean(
+            Capabilities capabilities,
+            DataSourcesExcludedFromHealthChecksRecorder recorder,
+            DataSourcesBuildTimeConfig config,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+        if (capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            syntheticBeans.produce(SyntheticBeanBuildItem.configure(DataSourcesExcludedFromHealthChecks.class)
+                    .scope(Singleton.class)
+                    .unremovable()
+                    .runtimeValue(recorder.configureDataSourcesExcludedFromHealthChecks(config))
+                    .done());
+        }
+    }
+}

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesExcludedFromHealthChecks.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesExcludedFromHealthChecks.java
@@ -1,16 +1,16 @@
 package io.quarkus.datasource.runtime;
 
-import java.util.List;
+import java.util.Set;
 
 public class DataSourcesExcludedFromHealthChecks {
 
-    private List<String> excludedNames;
+    private final Set<String> excludedNames;
 
-    public DataSourcesExcludedFromHealthChecks(List<String> names) {
-        this.excludedNames = names;
+    public DataSourcesExcludedFromHealthChecks(Set<String> excludedNames) {
+        this.excludedNames = excludedNames;
     }
 
-    public List<String> getExcludedNames() {
+    public Set<String> getExcludedNames() {
         return excludedNames;
     }
 }

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesExcludedFromHealthChecksRecorder.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesExcludedFromHealthChecksRecorder.java
@@ -1,0 +1,30 @@
+package io.quarkus.datasource.runtime;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class DataSourcesExcludedFromHealthChecksRecorder {
+
+    public RuntimeValue<DataSourcesExcludedFromHealthChecks> configureDataSourcesExcludedFromHealthChecks(
+            DataSourcesBuildTimeConfig config) {
+        Stream.Builder<String> builder = Stream.builder();
+        if (config.defaultDataSource.healthExclude) {
+            builder.add(DataSourceUtil.DEFAULT_DATASOURCE_NAME);
+        }
+        for (Map.Entry<String, DataSourceBuildTimeConfig> dataSource : config.namedDataSources.entrySet()) {
+            if (dataSource.getValue().healthExclude) {
+                builder.add(dataSource.getKey());
+            }
+        }
+        Set<String> excludedNames = builder.build().collect(toUnmodifiableSet());
+        return new RuntimeValue<>(new DataSourcesExcludedFromHealthChecks(excludedNames));
+    }
+}

--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHa
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -93,11 +95,16 @@ class ReactiveDB2ClientProcessor {
      */
     @BuildStep
     void addHealthCheck(
+            Capabilities capabilities,
             BuildProducer<HealthBuildItem> healthChecks,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (!capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            return;
+        }
+
         if (!hasPools(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, defaultDataSourceDbKindBuildItems,
                 curateOutcomeBuildItem)) {
             return;

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHa
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -90,11 +92,16 @@ class ReactiveMSSQLClientProcessor {
      */
     @BuildStep
     void addHealthCheck(
+            Capabilities capabilities,
             BuildProducer<HealthBuildItem> healthChecks,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (!capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            return;
+        }
+
         if (!hasPools(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, defaultDataSourceDbKindBuildItems,
                 curateOutcomeBuildItem)) {
             return;

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DataSourceHealthCheckExclusionTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DataSourceHealthCheckExclusionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.mssql.client;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DataSourceHealthCheckExclusionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .withConfigurationResource("application-datasources-with-health.properties");
+
+    @Test
+    public void testDataSourceHealthCheckExclusion() {
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"));
+    }
+
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
@@ -1,0 +1,11 @@
+quarkus.datasource.db-kind=mssql
+quarkus.datasource.username=sa
+quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.reactive.url=${reactive-mssql.url}
+# this data source is broken, but will be excluded from the health check, so the overall check should pass
+quarkus.datasource."broken".db-kind=mssql
+quarkus.datasource."broken".username=BROKEN
+quarkus.datasource."broken".password=A_Str0ng_Required_Password
+quarkus.datasource."broken".reactive.url=${reactive-mssql.url}
+quarkus.datasource."broken".health-exclude=true
+quarkus.datasource.health.enabled=true

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/health/ReactiveMSSQLDataSourcesHealthCheck.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/health/ReactiveMSSQLDataSourcesHealthCheck.java
@@ -1,5 +1,7 @@
 package io.quarkus.reactive.mssql.client.runtime.health;
 
+import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
@@ -7,7 +9,9 @@ import javax.enterprise.inject.Any;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecks;
 import io.quarkus.reactive.datasource.runtime.ReactiveDatasourceHealthCheck;
 import io.vertx.mssqlclient.MSSQLPool;
 
@@ -21,8 +25,14 @@ class ReactiveMSSQLDataSourcesHealthCheck extends ReactiveDatasourceHealthCheck 
 
     @PostConstruct
     protected void init() {
-        for (InstanceHandle<MSSQLPool> handle : Arc.container().select(MSSQLPool.class, Any.Literal.INSTANCE).handles()) {
-            addPool(getPoolName(handle.getBean()), handle.get());
+        ArcContainer container = Arc.container();
+        DataSourcesExcludedFromHealthChecks excluded = container.instance(DataSourcesExcludedFromHealthChecks.class).get();
+        Set<String> excludedNames = excluded.getExcludedNames();
+        for (InstanceHandle<MSSQLPool> handle : container.select(MSSQLPool.class, Any.Literal.INSTANCE).handles()) {
+            String poolName = getPoolName(handle.getBean());
+            if (!excludedNames.contains(poolName)) {
+                addPool(poolName, handle.get());
+            }
         }
     }
 

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHa
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -93,11 +95,16 @@ class ReactiveMySQLClientProcessor {
      */
     @BuildStep
     void addHealthCheck(
+            Capabilities capabilities,
             BuildProducer<HealthBuildItem> healthChecks,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (!capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            return;
+        }
+
         if (!hasPools(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, defaultDataSourceDbKindBuildItems,
                 curateOutcomeBuildItem)) {
             return;

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DataSourceHealthCheckExclusionTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DataSourceHealthCheckExclusionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.mysql.client;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DataSourceHealthCheckExclusionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .withConfigurationResource("application-datasources-with-health.properties");
+
+    @Test
+    public void testDataSourceHealthCheckExclusion() {
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"));
+    }
+
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/application-datasources-with-health.properties
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/application-datasources-with-health.properties
@@ -1,0 +1,11 @@
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive.url=${reactive-mysql.url}
+# this data source is broken, but will be excluded from the health check, so the overall check should pass
+quarkus.datasource."broken".db-kind=mysql
+quarkus.datasource."broken".username=BROKEN
+quarkus.datasource."broken".password=hibernate_orm_test
+quarkus.datasource."broken".reactive.url=${reactive-mysql.url}
+quarkus.datasource."broken".health-exclude=true
+quarkus.datasource.health.enabled=true

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/health/ReactiveMySQLDataSourcesHealthCheck.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/health/ReactiveMySQLDataSourcesHealthCheck.java
@@ -1,5 +1,7 @@
 package io.quarkus.reactive.mysql.client.runtime.health;
 
+import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
@@ -7,7 +9,9 @@ import javax.enterprise.inject.Any;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.datasource.runtime.DataSourcesExcludedFromHealthChecks;
 import io.quarkus.reactive.datasource.runtime.ReactiveDatasourceHealthCheck;
 import io.vertx.mysqlclient.MySQLPool;
 
@@ -21,8 +25,14 @@ class ReactiveMySQLDataSourcesHealthCheck extends ReactiveDatasourceHealthCheck 
 
     @PostConstruct
     protected void init() {
-        for (InstanceHandle<MySQLPool> handle : Arc.container().select(MySQLPool.class, Any.Literal.INSTANCE).handles()) {
-            addPool(getPoolName(handle.getBean()), handle.get());
+        ArcContainer container = Arc.container();
+        DataSourcesExcludedFromHealthChecks excluded = container.instance(DataSourcesExcludedFromHealthChecks.class).get();
+        Set<String> excludedNames = excluded.getExcludedNames();
+        for (InstanceHandle<MySQLPool> handle : container.select(MySQLPool.class, Any.Literal.INSTANCE).handles()) {
+            String poolName = getPoolName(handle.getBean());
+            if (!excludedNames.contains(poolName)) {
+                addPool(poolName, handle.get());
+            }
         }
     }
 

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -15,6 +15,8 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHa
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -95,11 +97,16 @@ class ReactivePgClientProcessor {
      */
     @BuildStep
     void addHealthCheck(
+            Capabilities capabilities,
             BuildProducer<HealthBuildItem> healthChecks,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (!capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            return;
+        }
+
         if (!hasPools(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, defaultDataSourceDbKindBuildItems,
                 curateOutcomeBuildItem)) {
             return;

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DataSourceHealthCheckExclusionTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DataSourceHealthCheckExclusionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.pg.client;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DataSourceHealthCheckExclusionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .withConfigurationResource("application-datasources-with-health.properties");
+
+    @Test
+    public void testDataSourceHealthCheckExclusion() {
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"));
+    }
+
+}

--- a/extensions/reactive-pg-client/deployment/src/test/resources/application-datasources-with-health.properties
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/application-datasources-with-health.properties
@@ -1,0 +1,13 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive.url=${reactive-postgres.url}
+quarkus.datasource.reactive.postgresql.pipelining-limit=10
+# this data source is broken, but will be excluded from the health check, so the overall check should pass
+quarkus.datasource."broken".db-kind=postgresql
+quarkus.datasource."broken".username=BROKEN
+quarkus.datasource."broken".password=hibernate_orm_test
+quarkus.datasource."broken".reactive.url=${reactive-postgres.url}
+quarkus.datasource."broken".reactive.postgresql.pipelining-limit=7
+quarkus.datasource."broken".health-exclude=true
+quarkus.datasource.health.enabled=true


### PR DESCRIPTION
Closes #20059

In #13375, we got a way to exclude a datasource from health-checks.
Yet the implementation for reactive datasources was missing.