### PR TITLE
Allow to disable MP ConfigProperties and ConfigMapping

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -248,6 +248,7 @@ public class ConfigBuildStep {
     @BuildStep
     void generateConfigClasses(
             CombinedIndexBuildItem combinedIndex,
+            BuildExclusionsBuildItem exclusionsBuildItem,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ConfigClassBuildItem> configClasses) {
@@ -258,6 +259,9 @@ public class ConfigBuildStep {
 
         for (AnnotationInstance instance : mappingAnnotations) {
             AnnotationTarget target = instance.target();
+            if (exclusionsBuildItem.isExcluded(target)) {
+                continue;
+            }
             AnnotationValue annotationPrefix = instance.value("prefix");
 
             if (target.kind().equals(FIELD)) {

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/profile/IfBuildProfileTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/profile/IfBuildProfileTest.java
@@ -17,6 +17,7 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -26,9 +27,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.config.ConfigPrefix;
-import io.quarkus.arc.config.ConfigProperties;
 import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigMapping;
 
 public class IfBuildProfileTest {
 
@@ -37,12 +38,17 @@ public class IfBuildProfileTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Producer.class, OtherProducer.class, AnotherProducer.class,
                             TestInterceptor.class, ProdInterceptor.class, Logging.class, DummyTestBean.class,
-                            DummyProdBean.class)
+                            DummyProdBean.class, BarTestBean.class, BarProdBean.class, FooTestBean.class,
+                            FooProdBean.class)
                     .addAsResource(
                             new StringAsset(
                                     "%test.dummy.message=Hi from Test\n" +
                                             "%test.dummy.complex.message=Hi from complex Test\n" +
-                                            "%test.dummy.complex.bis.message=Hi from complex bis Test\n"),
+                                            "%test.dummy.complex.bis.message=Hi from complex bis Test\n" +
+                                            "%test.bar.message=Hi from Test\n" +
+                                            "%test.bar.complex.message=Hi from complex Test\n" +
+                                            "%test.foo.message=Hi from Test\n" +
+                                            "%test.foo.complex.message=Hi from complex Test\n"),
                             "application.properties"));
     @Inject
     Hello hello;
@@ -55,6 +61,18 @@ public class IfBuildProfileTest {
 
     @Inject
     Instance<DummyProdBean> dummyProd;
+
+    @Inject
+    BarTestBean barTest;
+
+    @Inject
+    Instance<BarProdBean> barProd;
+
+    @Inject
+    FooTestBean fooTest;
+
+    @Inject
+    Instance<FooProdBean> fooProd;
 
     @Test
     public void testInjection() {
@@ -75,6 +93,16 @@ public class IfBuildProfileTest {
         assertTrue(dummyProd.isUnsatisfied());
         assertTrue(hello.dummyAbsent().isUnsatisfied());
         assertTrue(hello.dummyAbsentBis().isUnsatisfied());
+        assertEquals("Hi from Test", barTest.message);
+        assertEquals("Hi from Test", barTest.bar.message);
+        assertEquals("Hi from complex Test", barTest.barComplex.message);
+        assertTrue(barTest.barProd.isUnsatisfied());
+        assertTrue(barProd.isUnsatisfied());
+        assertEquals("Hi from Test", fooTest.message);
+        assertEquals("Hi from Test", fooTest.foo.message());
+        assertEquals("Hi from complex Test", fooTest.fooComplex.message());
+        assertTrue(fooTest.fooProd.isUnsatisfied());
+        assertTrue(fooProd.isUnsatisfied());
     }
 
     @Test
@@ -82,7 +110,7 @@ public class IfBuildProfileTest {
         assertEquals("hello from test. Foo is: foo from test", CDI.current().select(GreetingBean.class).get().greet());
     }
 
-    @ConfigProperties
+    @io.quarkus.arc.config.ConfigProperties
     public static class Dummy {
         public String message;
     }
@@ -107,7 +135,7 @@ public class IfBuildProfileTest {
     }
 
     @IfBuildProfile("prod")
-    @ConfigProperties(prefix = "dummy.prod")
+    @io.quarkus.arc.config.ConfigProperties(prefix = "dummy.prod")
     public static class DummyProd {
         public String message;
     }
@@ -127,6 +155,78 @@ public class IfBuildProfileTest {
         public void setDummyAbsentBis(@ConfigPrefix("dummy.absent.bis") Dummy dummyAbsentBis) { // Should not make it fail as excluded by the IfBuildProfile annotation
             this.dummyAbsentBis = dummyAbsentBis;
         }
+    }
+
+    @ConfigProperties(prefix = "bar")
+    public static class Bar {
+        public String message;
+    }
+
+    @Singleton
+    @IfBuildProfile("test")
+    static class BarTestBean {
+        @ConfigProperty(name = "bar.message")
+        String message;
+        @ConfigProperties(prefix = "bar")
+        Bar bar;
+        @ConfigProperties(prefix = "bar.complex")
+        Bar barComplex;
+        @Inject
+        Instance<BarProd> barProd;
+    }
+
+    @IfBuildProfile("prod")
+    @ConfigProperties(prefix = "bar.prod")
+    public static class BarProd {
+        public String message;
+    }
+
+    @Singleton
+    @IfBuildProfile("prod")
+    static class BarProdBean {
+        @ConfigProperty(name = "bar.message")
+        String message;
+        @ConfigProperties(prefix = "bar.absent") // Should not make it fail as excluded by the IfBuildProfile annotation
+        Bar barAbsent;
+        @Inject
+        BarProd barProd;
+    }
+
+    @ConfigMapping(prefix = "foo")
+    public interface Foo {
+        String message();
+    }
+
+    @Singleton
+    @IfBuildProfile("test")
+    static class FooTestBean {
+        @ConfigProperty(name = "foo.message")
+        String message;
+        @Inject
+        Foo foo;
+        @Inject
+        @ConfigMapping(prefix = "foo.complex")
+        Foo fooComplex;
+        @Inject
+        Instance<FooProd> fooProd;
+    }
+
+    @IfBuildProfile("prod")
+    @ConfigMapping(prefix = "foo.prod")
+    public interface FooProd {
+        String message();
+    }
+
+    @Singleton
+    @IfBuildProfile("prod")
+    static class FooProdBean {
+        @ConfigProperty(name = "foo.message")
+        String message;
+        @Inject
+        @ConfigMapping(prefix = "foo.absent") // Should not make it fail as excluded by the IfBuildProfile annotation
+        Foo fooAbsent;
+        @Inject
+        BarProd barProd;
     }
 
     @Logging


### PR DESCRIPTION
fixes #20275

## Motivation

The annotation `@ConfigProperties` and `@ConfigMapping` cannot be disabled once used which can be a problem when it maps an optional part of the configuration.

## Modifications

* Relies on `BuildExclusionsBuildItem#isExcluded` to potentially exclude what has been annotated with `@ConfigProperties` and `@ConfigMapping` 
* Adds tests to validate that we can exclude what has been annotated with `@ConfigProperties` or `@ConfigMapping`.
