### PR TITLE
Only use `objcopy` in Linux environments

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalRunner.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.SystemUtils;
+
 public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
 
     private final String nativeImageExecutable;
@@ -34,6 +36,10 @@ public class NativeImageBuildLocalRunner extends NativeImageBuildRunner {
 
     @Override
     protected boolean objcopyExists() {
+        if (!SystemUtils.IS_OS_LINUX) {
+            return false;
+        }
+
         // System path
         String systemPath = System.getenv("PATH");
         if (systemPath != null) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.util.ProcessUtil;
@@ -75,12 +76,10 @@ public abstract class NativeImageBuildRunner {
                     // Strip debug symbols regardless, because the underlying JDK might contain them
                     objcopy("--strip-debug", resultingExecutableName);
                 }
-            } else {
-                if (!debugSymbolsEnabled) {
-                    log.warn(
-                            "objcopy executable not found in PATH. Debug symbols will therefore not be separated from the executable.");
-                    log.warn("That also means that resulting native executable is larger as it embeds the debug symbols.");
-                }
+            } else if (SystemUtils.IS_OS_LINUX) {
+                log.warn(
+                        "objcopy executable not found in PATH. Debug symbols will therefore not be separated from the executable.");
+                log.warn("That also means that resulting native executable is larger as it embeds the debug symbols.");
             }
             return new Result(0, objcopyExists);
         } finally {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -223,12 +223,7 @@ public class NativeImageBuildStep {
                     Path finalSymbolsPath = outputTargetBuildItem.getOutputDirectory().resolve(symbolsName);
                     IoUtils.copy(generatedSymbols, finalSymbolsPath);
                     Files.delete(generatedSymbols);
-                } else {
-                    log.warn(
-                            "objcopy executable not found in PATH. Debug symbols therefore cannot be placed into the dedicated directory.");
-                    log.warn("That also means that resulting native executable is larger as it embeds the debug symbols.");
                 }
-
             }
             System.setProperty("native.image.path", finalExecutablePath.toAbsolutePath().toString());
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -703,7 +703,7 @@ Depending on what the final desired output of the CI/CD pipeline is, the generat
 
 Starting with Oracle GraalVM 20.2 or Mandrel 20.1,
 debug symbols for native executables can be generated for Linux environments
-(Windows support is still under development).
+(Windows support is still under development, macOS is not supported).
 These symbols can be used to debug native executables with tools such as `gdb`.
 
 To generate debug symbols,
@@ -713,7 +713,7 @@ You will find the debug symbols for the native executable in a `.debug` file nex
 [NOTE]
 ====
 The generation of the `.debug` file depends on `objcopy`.
-On common Linux distributions and macOS you will need to install the `binutils` package:
+On common Linux distributions you will need to install the `binutils` package:
 
 [source,bash]
 ----
@@ -721,9 +721,6 @@ On common Linux distributions and macOS you will need to install the `binutils` 
 sudo dnf install binutils
 # Debian-based distributions
 sudo apt-get install binutils
-# macOS
-brew install binutils
-export PATH=/usr/local/opt/binutils/bin:$PATH
 ----
 
 When `objcopy` is not available debug symbols are embedded in the executable.


### PR DESCRIPTION
Addresses macOS issues in #13856.

* `objcopy` invocations in macOS make the executable crash on startup.
* Debug info is only available for Linux,
so avoid `objcopy` altogether on macOS,
even if present in PATH.
* Updated documentation to avoid confusion.