### PR TITLE
Add a JTA aware variant of the Neo4j driver

### DIFF
--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -505,6 +505,42 @@ It exposes its API based on http://www.reactive-streams.org[Reactive Streams], m
 Those can be used directly, but we found it easier and more expressive to wrap them in reactive types such as the one provided by Mutiny.
 Typically, in the previous code, the session is closed when the stream completes, fails or the subscriber cancels.
 
+== Participating in managed transactions
+
+The Neo4j database offers ACID transactions out of the box and exposes them through the driver. All examples above use
+transactions managed locally by the driver.
+
+However, if you follow <<transaction#using-transactions-in-quarkus,the guide about JTA transactions>>
+and put `io.quarkus:quarkus-narayana-jta` on the classpath, imperative methods using the Neo4j driver will participate
+in ongoing JTA transactions when annotated with `@Transactional`.
+
+In an ongoing JTA transaction only calls to the `Session` interface are allowed using one of the various `#run` overloads like this
+
+[source,java]
+----
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import org.neo4j.driver.Driver;
+
+public class AService {
+
+	@Inject Driver driver;
+
+	@Transactional
+    public void doThingsTransactional(String externalId) {
+		try (Session session = driver.session()) {
+			session.run(
+				"CREATE (f:Framework {name: $name, id: $id}) - [:CAN_USE {transactional: 'of course'}] -> (n:Database {name: 'Neo4j'})",
+                Values.parameters("name", "Quarkus", "id", externalId)
+            );
+		}
+	}
+}
+----
+
+What has been an autocommit-transaction before is now a fully managed JTA transaction and will commit or rollback with
+accordingly.
+
 == Configuration Reference
 
 include::{generated-dir}/config/quarkus-neo4j.adoc[opts=optional, leveloffset=+1]

--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
@@ -22,6 +22,16 @@ import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 class Neo4jDriverProcessor {
 
+    boolean hasJTA() {
+        try {
+            Class.forName("javax.transaction.Transactional", false, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+        }
+
+        return false;
+    }
+
     @BuildStep
     FeatureBuildItem createFeature(BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport) {
 
@@ -38,7 +48,7 @@ class Neo4jDriverProcessor {
             Neo4jConfiguration configuration,
             ShutdownContextBuildItem shutdownContext) {
 
-        RuntimeValue<Driver> driverHolder = recorder.initializeDriver(configuration, shutdownContext);
+        RuntimeValue<Driver> driverHolder = recorder.initializeDriver(configuration, shutdownContext, hasJTA());
         syntheticBeans
                 .produce(SyntheticBeanBuildItem.configure(Driver.class).runtimeValue(driverHolder).setRuntimeInit().done());
 

--- a/extensions/neo4j/runtime/pom.xml
+++ b/extensions/neo4j/runtime/pom.xml
@@ -34,6 +34,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareDriver.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareDriver.java
@@ -1,0 +1,166 @@
+package io.quarkus.neo4j.runtime;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Metrics;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.async.AsyncSession;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.types.TypeSystem;
+import org.neo4j.driver.util.Experimental;
+
+import io.quarkus.arc.Arc;
+
+final class JTAAwareDriver implements Driver {
+
+    private static final Object SESSION_KEY = new Object();
+    private final Driver delegate;
+
+    JTAAwareDriver(Driver delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return delegate.isEncrypted();
+    }
+
+    @Override
+    public Session session() {
+
+        return this.session(SessionConfig.defaultConfig());
+    }
+
+    @Override
+    public Session session(SessionConfig sessionConfig) {
+
+        var synchronizationRegistryHandle = Arc.container().instance(TransactionSynchronizationRegistry.class);
+        if (synchronizationRegistryHandle.isAvailable()) {
+
+            var synchronizationRegistry = synchronizationRegistryHandle.get();
+            if (synchronizationRegistry.getTransactionStatus() == Status.STATUS_ACTIVE) {
+
+                var session = (Session) synchronizationRegistry.getResource(SESSION_KEY);
+                if (session != null) {
+                    return session;
+                }
+
+                return createAndRegisterJTAAwareSession(synchronizationRegistry, sessionConfig);
+            }
+        }
+
+        return this.delegate.session(sessionConfig);
+    }
+
+    Session createAndRegisterJTAAwareSession(TransactionSynchronizationRegistry synchronizationRegistry,
+            SessionConfig sessionConfig) {
+
+        var configBuilder = SessionConfig.builder();
+        // We will use write mode by default here… We have no way to determine this from the transactional annotation
+        // If this is unwanted, make sure you use @Transactional(NEVER) and create a config on you own.
+        configBuilder = configBuilder.withDefaultAccessMode(AccessMode.WRITE)
+                .withBookmarks(sessionConfig.bookmarks());
+        configBuilder = sessionConfig.database().map(configBuilder::withDatabase).orElse(configBuilder);
+        configBuilder = sessionConfig.fetchSize().map(configBuilder::withFetchSize).orElse(configBuilder);
+
+        var session = new JTAAwareSession(this.delegate.session(configBuilder.build()));
+
+        synchronizationRegistry.putResource(SESSION_KEY, session);
+        synchronizationRegistry.registerInterposedSynchronization(new Synchronization() {
+            @Override
+            public void beforeCompletion() {
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+
+                switch (status) {
+                    case Status.STATUS_ROLLEDBACK:
+                        session.rollbackAndClose();
+                        break;
+                    case Status.STATUS_COMMITTED:
+                        session.commitAndClose();
+                        break;
+                    default:
+                        throw new RuntimeException("Don't know how to deal with transaction status " + status);
+                }
+            }
+        });
+        return session;
+    }
+
+    @Override
+    public RxSession rxSession() {
+        return delegate.rxSession();
+    }
+
+    @Override
+    public RxSession rxSession(SessionConfig sessionConfig) {
+        return delegate.rxSession(sessionConfig);
+    }
+
+    @Override
+    public AsyncSession asyncSession() {
+        return delegate.asyncSession();
+    }
+
+    @Override
+    public AsyncSession asyncSession(SessionConfig sessionConfig) {
+        return delegate.asyncSession(sessionConfig);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public CompletionStage<Void> closeAsync() {
+        return delegate.closeAsync();
+    }
+
+    @Override
+    @Experimental
+    public Metrics metrics() {
+        return delegate.metrics();
+    }
+
+    @Override
+    @Experimental
+    public boolean isMetricsEnabled() {
+        return delegate.isMetricsEnabled();
+    }
+
+    @Override
+    @Experimental
+    public TypeSystem defaultTypeSystem() {
+        return delegate.defaultTypeSystem();
+    }
+
+    @Override
+    public void verifyConnectivity() {
+        delegate.verifyConnectivity();
+    }
+
+    @Override
+    public CompletionStage<Void> verifyConnectivityAsync() {
+        return delegate.verifyConnectivityAsync();
+    }
+
+    @Override
+    public boolean supportsMultiDb() {
+        return delegate.supportsMultiDb();
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsMultiDbAsync() {
+        return delegate.supportsMultiDbAsync();
+    }
+}

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareDriver.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareDriver.java
@@ -76,20 +76,14 @@ final class JTAAwareDriver implements Driver {
         synchronizationRegistry.registerInterposedSynchronization(new Synchronization() {
             @Override
             public void beforeCompletion() {
+                session.commitAndClose();
             }
 
             @Override
             public void afterCompletion(int status) {
 
-                switch (status) {
-                    case Status.STATUS_ROLLEDBACK:
-                        session.rollbackAndClose();
-                        break;
-                    case Status.STATUS_COMMITTED:
-                        session.commitAndClose();
-                        break;
-                    default:
-                        throw new RuntimeException("Don't know how to deal with transaction status " + status);
+                if (status == Status.STATUS_ROLLEDBACK || status == Status.STATUS_MARKED_ROLLBACK) {
+                    session.rollbackAndClose();
                 }
             }
         });

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareSession.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareSession.java
@@ -1,0 +1,147 @@
+package io.quarkus.neo4j.runtime;
+
+import java.util.Map;
+
+import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.TransactionConfig;
+import org.neo4j.driver.TransactionWork;
+import org.neo4j.driver.Value;
+
+final class JTAAwareSession implements Session {
+
+    private final Session delegate;
+    private final Transaction currentTransaction;
+
+    JTAAwareSession(Session delegate) {
+
+        this.delegate = delegate;
+        this.currentTransaction = this.delegate.beginTransaction();
+    }
+
+    @Override
+    public Transaction beginTransaction() {
+
+        return this.beginTransaction(TransactionConfig.empty());
+    }
+
+    @Override
+    public Transaction beginTransaction(TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Unmanaged transactions are not supported in a managed (JTA) environment.");
+    }
+
+    @Override
+    public <T> T readTransaction(TransactionWork<T> work) {
+
+        return readTransaction(work, TransactionConfig.empty());
+    }
+
+    @Override
+    public <T> T readTransaction(TransactionWork<T> work, TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Transaction functions are not supported in a managed (JTA) environment.");
+    }
+
+    @Override
+    public <T> T writeTransaction(TransactionWork<T> work) {
+
+        return writeTransaction(work, TransactionConfig.empty());
+    }
+
+    @Override
+    public <T> T writeTransaction(TransactionWork<T> work, TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Transaction functions are not supported in a managed (JTA) environment.");
+    }
+
+    @Override
+    public Result run(String query, TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Cannot use a different transaction configuration in a managed (JTA) environment.");
+    }
+
+    @Override
+    public Result run(String query, Map<String, Object> parameters, TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Cannot use a different transaction configuration in a managed (JTA) environment.");
+    }
+
+    @Override
+    public Result run(Query query, TransactionConfig config) {
+
+        throw new UnsupportedOperationException(
+                "Cannot use a different transaction configuration in a managed (JTA) environment.");
+    }
+
+    @Override
+    public Bookmark lastBookmark() {
+
+        return this.delegate.lastBookmark();
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("A reset is not supported in a managed (JTA) environment.");
+    }
+
+    @Override
+    public void close() {
+        // NO-OP in a managed environment
+    }
+
+    @Override
+    public Result run(String query, Value parameters) {
+        return currentTransaction.run(query, parameters);
+    }
+
+    @Override
+    public Result run(String query, Map<String, Object> parameters) {
+        return currentTransaction.run(query, parameters);
+    }
+
+    @Override
+    public Result run(String query, Record parameters) {
+        return currentTransaction.run(query, parameters);
+    }
+
+    @Override
+    public Result run(String query) {
+        return currentTransaction.run(query);
+    }
+
+    @Override
+    public Result run(Query query) {
+        return currentTransaction.run(query);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    void commitAndClose() {
+        try {
+            this.currentTransaction.commit();
+        } finally {
+            this.delegate.close();
+        }
+    }
+
+    void rollbackAndClose() {
+        try {
+            this.currentTransaction.rollback();
+        } finally {
+            this.delegate.close();
+        }
+    }
+}

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareSession.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/JTAAwareSession.java
@@ -139,7 +139,9 @@ final class JTAAwareSession implements Session {
 
     void rollbackAndClose() {
         try {
-            this.currentTransaction.rollback();
+            if (this.currentTransaction.isOpen()) {
+                this.currentTransaction.rollback();
+            }
         } finally {
             this.delegate.close();
         }

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
@@ -28,7 +28,8 @@ public class Neo4jDriverRecorder {
 
     private static final Logger log = Logger.getLogger(Neo4jDriverRecorder.class);
 
-    public RuntimeValue<Driver> initializeDriver(Neo4jConfiguration configuration, ShutdownContext shutdownContext) {
+    public RuntimeValue<Driver> initializeDriver(Neo4jConfiguration configuration, ShutdownContext shutdownContext,
+            boolean jtaPresent) {
 
         String uri = configuration.uri;
         AuthToken authToken = AuthTokens.none();
@@ -41,6 +42,9 @@ public class Neo4jDriverRecorder {
         configurePoolSettings(configBuilder, configuration.pool);
 
         Driver driver = GraphDatabase.driver(uri, authToken, configBuilder.build());
+        if (jtaPresent) {
+            driver = new JTAAwareDriver(driver);
+        }
         shutdownContext.addShutdownTask(driver::close);
         return new RuntimeValue<>(driver);
     }

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
@@ -29,7 +29,7 @@ public class Neo4jDriverRecorder {
     private static final Logger log = Logger.getLogger(Neo4jDriverRecorder.class);
 
     public RuntimeValue<Driver> initializeDriver(Neo4jConfiguration configuration, ShutdownContext shutdownContext,
-            boolean jtaPresent) {
+            boolean transactionsPresent) {
 
         String uri = configuration.uri;
         AuthToken authToken = AuthTokens.none();
@@ -42,7 +42,7 @@ public class Neo4jDriverRecorder {
         configurePoolSettings(configBuilder, configuration.pool);
 
         Driver driver = GraphDatabase.driver(uri, authToken, configBuilder.build());
-        if (jtaPresent) {
+        if (transactionsPresent) {
             driver = new JTAAwareDriver(driver);
         }
         shutdownContext.addShutdownTask(driver::close);

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -52,6 +52,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta</artifactId>
+        </dependency>
 
         <!-- Project reactor makes it easier to deal with reactive streams -->
         <dependency>

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -121,6 +121,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/neo4j/src/main/java/io/quarkus/it/neo4j/Neo4jResource.java
+++ b/integration-tests/neo4j/src/main/java/io/quarkus/it/neo4j/Neo4jResource.java
@@ -4,8 +4,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
-import reactor.core.publisher.Flux;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
@@ -32,6 +30,8 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
 
 @Path("/neo4j")
 public class Neo4jResource {
@@ -62,12 +62,14 @@ public class Neo4jResource {
     @Path("/transactional")
     @Produces(TEXT_PLAIN)
     @Transactional
-    public String doThingsTransactional(@QueryParam("externalId") String externalId, @QueryParam("causeAScene") @DefaultValue("false") boolean causeAScene) {
+    public String doThingsTransactional(@QueryParam("externalId") String externalId,
+            @QueryParam("causeAScene") @DefaultValue("false") boolean causeAScene) {
         try (Session session = driver.session()) {
-            session.run("CREATE (f:Framework {name: $name, id: $id}) - [:CAN_USE {transactional: 'of course'}] -> (n:Database {name: 'Neo4j'})",
-                Values.parameters("name", "Quarkus", "id", externalId));
+            session.run(
+                    "CREATE (f:Framework {name: $name, id: $id}) - [:CAN_USE {transactional: 'of course'}] -> (n:Database {name: 'Neo4j'})",
+                    Values.parameters("name", "Quarkus", "id", externalId));
         }
-        if(causeAScene) {
+        if (causeAScene) {
             throw new SomeException("On purpose.");
         }
         return "OK";
@@ -82,7 +84,7 @@ public class Neo4jResource {
             // Will use an explicit tx
             createNodes(driver);
         } catch (Exception e) {
-           throw new SomeException(e.getMessage());
+            throw new SomeException(e.getMessage());
         }
         return "OK";
     }
@@ -100,8 +102,8 @@ public class Neo4jResource {
         public Response toResponse(SomeException exception) {
 
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .entity(exception.getMessage())
-                .build();
+                    .entity(exception.getMessage())
+                    .build();
         }
     }
 

--- a/integration-tests/neo4j/src/main/java/io/quarkus/it/neo4j/Neo4jResource.java
+++ b/integration-tests/neo4j/src/main/java/io/quarkus/it/neo4j/Neo4jResource.java
@@ -81,9 +81,9 @@ public class Neo4jResource {
     @Transactional
     public String mixingUpTxConcepts() {
         try (Session session = driver.session();
-            Transaction transaction = session.beginTransaction()) {
+                Transaction transaction = session.beginTransaction()) {
             transaction.run("CREATE (f:Framework {name: $name}) - [:CAN_USE] -> (n:Database {name: 'Neo4j'})",
-                Values.parameters("name", "Quarkus"));
+                    Values.parameters("name", "Quarkus"));
             transaction.commit();
         } catch (Exception e) {
             throw new SomeException(e.getMessage());
@@ -139,14 +139,13 @@ public class Neo4jResource {
         }), RxSession::close).doOnNext(System.out::println);
     }
 
-
     @GET
     @Path("/countNodesWith")
     @Produces(TEXT_PLAIN)
     public long countNodesWith(@QueryParam("externalId") String externalId) {
         try (var session = driver.session()) {
             return session.run("MATCH (n:Framework {id: $id}) RETURN count(n)", Values.parameters("id", externalId))
-                .single().get(0).asLong();
+                    .single().get(0).asLong();
         }
     }
 

--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -3,16 +3,10 @@ package io.quarkus.it.neo4j;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -25,6 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Values;
 
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
 /**
  * Test connecting via Neo4j Java-Driver to Neo4j.
  * Can quickly start a matching database with:
@@ -36,7 +34,8 @@ import org.neo4j.driver.Values;
 @QuarkusTest
 public class Neo4jFunctionalityTest {
 
-    @Inject Driver driver;
+    @Inject
+    Driver driver;
 
     // This creates nodes as well and uses an unmanaged tx. It is therefore also testing that the
     // JTA aware driver behaves just like the normal one when not managed
@@ -49,8 +48,8 @@ public class Neo4jFunctionalityTest {
     public void testTransactionalNeo4jFunctionalityCommiting() {
         var externalId = UUID.randomUUID().toString();
         RestAssured.given().when()
-            .queryParam("externalId", externalId)
-            .get("/neo4j/transactional").then().body(is("OK"));
+                .queryParam("externalId", externalId)
+                .get("/neo4j/transactional").then().body(is("OK"));
 
         assertEquals(1L, numberOfFrameworkNodesWithId(externalId));
     }
@@ -59,12 +58,12 @@ public class Neo4jFunctionalityTest {
     public void testTransactionalNeo4jFunctionalityRollback() {
         var externalId = UUID.randomUUID().toString();
         RestAssured.given().when()
-            .queryParam("externalId", externalId)
-            .queryParam("causeAScene", true)
-            .get("/neo4j/transactional")
-            .then().log().all()
-            .statusCode(500)
-            .body(is(equalTo("On purpose.")));
+                .queryParam("externalId", externalId)
+                .queryParam("causeAScene", true)
+                .get("/neo4j/transactional")
+                .then().log().all()
+                .statusCode(500)
+                .body(is(equalTo("On purpose.")));
 
         assertEquals(0L, numberOfFrameworkNodesWithId(externalId));
     }
@@ -72,16 +71,16 @@ public class Neo4jFunctionalityTest {
     @Test
     public void testItShouldNotBeAllowedToUseJTAAndLocalTX() {
         RestAssured.given().when()
-            .get("/neo4j/not-allowed-to-use-jta-and-local-tx")
-            .then().log().all()
-            .statusCode(500)
-            .body(is(equalTo("Unmanaged transactions are not supported in a managed (JTA) environment.")));
+                .get("/neo4j/not-allowed-to-use-jta-and-local-tx")
+                .then().log().all()
+                .statusCode(500)
+                .body(is(equalTo("Unmanaged transactions are not supported in a managed (JTA) environment.")));
     }
 
     private long numberOfFrameworkNodesWithId(String externalId) {
         try (var session = driver.session()) {
             return session.run("MATCH (n:Framework {id: $id}) RETURN count(n)", Values.parameters("id", externalId))
-                .single().get(0).asLong();
+                    .single().get(0).asLong();
         }
     }
 

--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -72,11 +72,11 @@ public class Neo4jFunctionalityTest {
 
     private long numberOfFrameworkNodesWithId(String externalId) {
         return Long.parseLong(RestAssured.given().when()
-            .queryParam("externalId", externalId)
-            .get("/neo4j/countNodesWith")
-            .then()
-            .statusCode(200)
-            .extract().asString());
+                .queryParam("externalId", externalId)
+                .get("/neo4j/countNodesWith")
+                .then()
+                .statusCode(200)
+                .extract().asString());
     }
 
     @Test

--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -1,16 +1,29 @@
 package io.quarkus.it.neo4j;
 
-import static org.hamcrest.Matchers.*;
-
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.hamcrest.Matcher;
-import org.junit.jupiter.api.Test;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Values;
 
 /**
  * Test connecting via Neo4j Java-Driver to Neo4j.
@@ -23,9 +36,53 @@ import io.restassured.http.ContentType;
 @QuarkusTest
 public class Neo4jFunctionalityTest {
 
+    @Inject Driver driver;
+
+    // This creates nodes as well and uses an unmanaged tx. It is therefore also testing that the
+    // JTA aware driver behaves just like the normal one when not managed
     @Test
     public void testBlockingNeo4jFunctionality() {
         RestAssured.given().when().get("/neo4j/blocking").then().body(is("OK"));
+    }
+
+    @Test
+    public void testTransactionalNeo4jFunctionalityCommiting() {
+        var externalId = UUID.randomUUID().toString();
+        RestAssured.given().when()
+            .queryParam("externalId", externalId)
+            .get("/neo4j/transactional").then().body(is("OK"));
+
+        assertEquals(1L, numberOfFrameworkNodesWithId(externalId));
+    }
+
+    @Test
+    public void testTransactionalNeo4jFunctionalityRollback() {
+        var externalId = UUID.randomUUID().toString();
+        RestAssured.given().when()
+            .queryParam("externalId", externalId)
+            .queryParam("causeAScene", true)
+            .get("/neo4j/transactional")
+            .then().log().all()
+            .statusCode(500)
+            .body(is(equalTo("On purpose.")));
+
+        assertEquals(0L, numberOfFrameworkNodesWithId(externalId));
+    }
+
+    @Test
+    public void testItShouldNotBeAllowedToUseJTAAndLocalTX() {
+        RestAssured.given().when()
+            .get("/neo4j/not-allowed-to-use-jta-and-local-tx")
+            .then().log().all()
+            .statusCode(500)
+            .body(is(equalTo("Unmanaged transactions are not supported in a managed (JTA) environment.")));
+    }
+
+    private long numberOfFrameworkNodesWithId(String externalId) {
+        try (var session = driver.session()) {
+            return session.run("MATCH (n:Framework {id: $id}) RETURN count(n)", Values.parameters("id", externalId))
+                .single().get(0).asLong();
+        }
     }
 
     @Test


### PR DESCRIPTION
This driver is aware of ongoing JTA transaction. If it detects an ongoing transaction, a session will be created accordingly that particpates in the tx.

To disable this in a bigger scenario (i.e. when an outer transactional method is calling a repo method that should independently commit), the standard means of `@Transactional(NOT_SUPPORTED)` (or `NEVER`) can be applied.