### PR TITLE
Default to new SQLServer2016Dialect

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -35,7 +35,7 @@ public final class Dialects {
             return "org.hibernate.dialect.DerbyTenSevenDialect";
         }
         if (DatabaseKind.isMsSQL(resolvedDbKind)) {
-            return "org.hibernate.dialect.SQLServer2012Dialect";
+            return "org.hibernate.dialect.SQLServer2016Dialect";
         }
 
         String error = "Hibernate extension could not guess the dialect from the database kind '" + resolvedDbKind

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
@@ -9,7 +9,7 @@ import org.hibernate.dialect.DerbyTenSevenDialect;
 import org.hibernate.dialect.MariaDB103Dialect;
 import org.hibernate.dialect.MySQL8Dialect;
 import org.hibernate.dialect.Oracle12cDialect;
-import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.dialect.SQLServer2016Dialect;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ public class ConstantsTest {
         assertDialectMatch(DatabaseKind.MARIADB, MariaDB103Dialect.class);
         assertDialectMatch(DatabaseKind.MYSQL, MySQL8Dialect.class);
         assertDialectMatch(DatabaseKind.DERBY, DerbyTenSevenDialect.class);
-        assertDialectMatch(DatabaseKind.MSSQL, SQLServer2012Dialect.class);
+        assertDialectMatch(DatabaseKind.MSSQL, SQLServer2016Dialect.class);
         assertDialectMatch(DatabaseKind.ORACLE, Oracle12cDialect.class);
     }
 


### PR DESCRIPTION
`Dialects#guessDialect()` should default to the latest version for every dialect.