### PR TITLE
Resilient enum for extension metadata & remove 'code' tag from resteasy-reactive-xxx

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,3 +10,11 @@ metadata:
   categories:
   - "web"
   status: "stable"
+  codestart:
+    name: "resteasy-reactive"
+    kind: "core"
+    languages:
+      - "java"
+      - "kotlin"
+      - "scala"
+    artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,6 +17,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,6 +16,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,6 +12,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -13,6 +13,7 @@ metadata:
   status: "experimental"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,6 +16,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,7 @@ metadata:
   status: "stable"
   codestart:
     name: "resteasy-reactive"
+    kind: "core"
     languages:
       - "java"
       - "kotlin"

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/MetadataValue.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/MetadataValue.java
@@ -72,7 +72,11 @@ final class MetadataValue {
         if (name == null) {
             return defaultValue;
         }
-        return T.valueOf(clazz, name.toUpperCase(Locale.ROOT).replace('-', '_'));
+        try {
+            return T.valueOf(clazz, name.toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            return defaultValue;
+        }
     }
 
 }


### PR DESCRIPTION
- Adding new enum values in the extension metadata will not break compatibility after this change, it will now use the default if an invalid value is found.

- Currently, in code.quarkus.io all the resteasy-reactive extensions have the `code` tag. This is because we needed a way to avoid having the classic resteasy starter code with those extensions. As a workaround we used the `core` kind which isn't showing the `code` tag but still referencing the codestart. In a few versions we will be able to introduce `default-codestart` without much risk.


