### PR TITLE
Add annotation processor in extension modules

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -1,0 +1,97 @@
+package io.quarkus.extension.gradle;
+
+import java.util.List;
+
+import org.gradle.api.Project;
+
+public class QuarkusExtensionConfiguration {
+
+    private String deploymentArtifact;
+    private String deploymentModule;
+    private List<String> excludedArtifacts;
+    private List<String> parentFirstArtifacts;
+    private List<String> runnerParentFirstArtifacts;
+    private List<String> lesserPriorityArtifacts;
+    private List<String> conditionalDependencies;
+    private List<String> dependencyCondition;
+
+    private Project project;
+
+    public QuarkusExtensionConfiguration(Project project) {
+        this.project = project;
+    }
+
+    public String getDeploymentArtifact() {
+        return deploymentArtifact;
+    }
+
+    public void setDeploymentArtifact(String deploymentArtifact) {
+        this.deploymentArtifact = deploymentArtifact;
+    }
+
+    public String getDeploymentModule() {
+        return deploymentModule;
+    }
+
+    public void setDeploymentModule(String deploymentModule) {
+        this.deploymentModule = deploymentModule;
+    }
+
+    public List<String> getExcludedArtifacts() {
+        return excludedArtifacts;
+    }
+
+    public void setExcludedArtifacts(List<String> excludedArtifacts) {
+        this.excludedArtifacts = excludedArtifacts;
+    }
+
+    public List<String> getParentFirstArtifacts() {
+        return parentFirstArtifacts;
+    }
+
+    public void setParentFirstArtifacts(List<String> parentFirstArtifacts) {
+        this.parentFirstArtifacts = parentFirstArtifacts;
+    }
+
+    public List<String> getRunnerParentFirstArtifacts() {
+        return runnerParentFirstArtifacts;
+    }
+
+    public void setRunnerParentFirstArtifacts(List<String> runnerParentFirstArtifacts) {
+        this.runnerParentFirstArtifacts = runnerParentFirstArtifacts;
+    }
+
+    public List<String> getLesserPriorityArtifacts() {
+        return lesserPriorityArtifacts;
+    }
+
+    public void setLesserPriorityArtifacts(List<String> lesserPriorityArtifacts) {
+        this.lesserPriorityArtifacts = lesserPriorityArtifacts;
+    }
+
+    public List<String> getConditionalDependencies() {
+        return conditionalDependencies;
+    }
+
+    public void setConditionalDependencies(List<String> conditionalDependencies) {
+        this.conditionalDependencies = conditionalDependencies;
+    }
+
+    public List<String> getDependencyConditions() {
+        return dependencyCondition;
+    }
+
+    public void setDependencyConditions(List<String> dependencyCondition) {
+        this.dependencyCondition = dependencyCondition;
+    }
+
+    public String getDefaultDeployementArtifactName() {
+        String projectName = project.getName();
+        if (project.getParent() != null && projectName.equals("runtime")) {
+            projectName = project.getParent().getName();
+        }
+        return String.format("%s:%s-deployment:%s", project.getGroup(), projectName,
+                project.getVersion());
+    }
+
+}

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -1,32 +1,92 @@
 package io.quarkus.extension.gradle;
 
+import java.io.File;
+
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 
 import io.quarkus.extension.gradle.tasks.ExtensionDescriptorTask;
 
 public class QuarkusExtensionPlugin implements Plugin<Project> {
 
+    public static final String DEFAULT_DEPLOYMENT_PROJECT_NAME = "deployment";
+    public static final String EXTENSION_CONFIGURATION_NAME = "quarkusExtension";
     public static final String EXTENSION_DESCRIPTOR_TASK_NAME = "extensionDescriptor";
+
+    public static final String QUARKUS_ANNOTATION_PROCESSOR = "io.quarkus:quarkus-extension-processor";
 
     @Override
     public void apply(Project project) {
-        registerTasks(project);
+        final QuarkusExtensionConfiguration quarkusExt = project.getExtensions().create(EXTENSION_CONFIGURATION_NAME,
+                QuarkusExtensionConfiguration.class);
+        registerTasks(project, quarkusExt);
     }
 
-    private void registerTasks(Project project) {
+    private void registerTasks(Project project, QuarkusExtensionConfiguration quarkusExt) {
         TaskContainer tasks = project.getTasks();
         ExtensionDescriptorTask extensionDescriptorTask = tasks.create(EXTENSION_DESCRIPTOR_TASK_NAME,
-                ExtensionDescriptorTask.class);
+                ExtensionDescriptorTask.class, task -> {
+                    JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+                    File resourcesDir = convention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput()
+                            .getResourcesDir();
+                    task.setResourcesDir(resourcesDir);
+                    task.setQuarkusExtensionConfiguration(quarkusExt);
+                });
 
         project.getPlugins().withType(
                 JavaPlugin.class,
                 javaPlugin -> {
                     Task jarTask = tasks.getByName(JavaPlugin.JAR_TASK_NAME);
                     jarTask.dependsOn(extensionDescriptorTask);
+
+                    Configuration annotationProcessorConfiguration = project.getConfigurations()
+                            .getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME);
+                    addAnnotationProcessorDependency(annotationProcessorConfiguration, project.getDependencies());
+                });
+
+        Project deploymentProject = findDeploymentProject(project, quarkusExt);
+        if (deploymentProject != null) {
+            deploymentProject.getPlugins().withType(
+                    JavaPlugin.class,
+                    javaPlugin -> {
+                        Configuration deploymentAnnotationProcessorConfiguration = deploymentProject.getConfigurations()
+                                .getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME);
+                        addAnnotationProcessorDependency(deploymentAnnotationProcessorConfiguration,
+                                deploymentProject.getDependencies());
+                    });
+        }
+    }
+
+    private void addAnnotationProcessorDependency(Configuration configuration, DependencyHandler dependencyHandler) {
+        configuration
+                .withDependencies(dependencies -> {
+                    Dependency annotationProcessor = dependencyHandler.create(QUARKUS_ANNOTATION_PROCESSOR);
+                    dependencies.add(annotationProcessor);
                 });
     }
+
+    private Project findDeploymentProject(Project project, QuarkusExtensionConfiguration configuration) {
+
+        String deploymentProjectName = configuration.getDeploymentModule();
+        if (deploymentProjectName == null) {
+            deploymentProjectName = DEFAULT_DEPLOYMENT_PROJECT_NAME;
+        }
+
+        Project deploymentProject = project.getRootProject().findProject(deploymentProjectName);
+        if (deploymentProject == null) {
+            project.getLogger().warn("Unable to find deployment project with name: " + deploymentProjectName
+                    + ". You can configure the deployment project name by setting the 'deploymentProject' property in the plugin extension.");
+        }
+
+        return deploymentProject;
+    }
+
 }

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -10,132 +10,49 @@ import java.util.Properties;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.extension.gradle.QuarkusExtensionConfiguration;
 
 /**
  * Task that generates extension descriptor files.
  */
 public class ExtensionDescriptorTask extends DefaultTask {
 
-    private String deployment;
-    private List<String> excludedArtifacts;
-    private List<String> parentFirstArtifacts;
-    private List<String> runnerParentFirstArtifacts;
-    private List<String> lesserPriorityArtifacts;
-    private List<String> conditionalDependencies;
-    private List<String> dependencyCondition;
+    private QuarkusExtensionConfiguration quarkusExtensionConfiguration;
+    private File resourcesDir;
 
     public ExtensionDescriptorTask() {
         setDescription("Generate extension descriptor file");
         setGroup("quarkus");
     }
 
-    @Input
-    public String getDeployment() {
-        if (deployment == null) {
-            String projectName = getProject().getName();
-            if (getProject().getParent() != null && projectName.equals("runtime")) {
-                projectName = getProject().getParent().getName();
-            }
-            return String.format("%s:%s-deployment:%s", getProject().getGroup(), projectName,
-                    getProject().getVersion());
-        }
-        return deployment;
-    }
-
-    @Option(option = "deployment", description = "GAV of the deployment module")
-    public void setDeployment(String deployment) {
-        this.deployment = deployment;
-    }
-
-    @Input
-    @Optional
-    public List<String> getExcludedArtifacts() {
-        return excludedArtifacts;
-    }
-
-    @Option(option = "excludedArtifacts", description = "Artifacts that should be excluded from the final build")
-    public void setExcludedArtifacts(List<String> excludedArtifacts) {
-        this.excludedArtifacts = excludedArtifacts;
-    }
-
-    @Input
-    @Optional
-    public List<String> getParentFirstArtifacts() {
-        return parentFirstArtifacts;
-    }
-
-    @Option(option = "parentFirstArtifacts", description = "Artifacts that should be loaded first when running in dev or test mode")
-    public void setParentFirstArtifacts(List<String> parentFirstArtifacts) {
-        this.parentFirstArtifacts = parentFirstArtifacts;
-    }
-
-    @Input
-    @Optional
-    public List<String> getRunnerParentFirstArtifacts() {
-        return runnerParentFirstArtifacts;
-    }
-
-    @Option(option = "runnerParentFirstArtifacts", description = "Artifacts that should be loaded first when the fast-jar is  used")
-    public void setRunnerParentFirstArtifacts(List<String> runnerParentFirstArtifacts) {
-        this.runnerParentFirstArtifacts = runnerParentFirstArtifacts;
-    }
-
-    @Input
-    @Optional
-    public List<String> getLesserPriorityArtifacts() {
-        return lesserPriorityArtifacts;
-    }
-
-    @Option(option = "lesserPriorityArtifacts", description = "Artifacts that should be loaded in case no other normal element exists")
-    public void setLesserPriorityArtifacts(List<String> lesserPriorityArtifacts) {
-        this.lesserPriorityArtifacts = lesserPriorityArtifacts;
-    }
-
-    @Input
-    @Optional
-    public List<String> getConditionalDependencies() {
-        return conditionalDependencies;
-    }
-
-    @Option(option = "conditionalDependencies", description = "Artifacts that could be conditionally loaded")
-    public void setConditionalDependencies(List<String> conditionalDependencies) {
-        this.conditionalDependencies = conditionalDependencies;
-    }
-
-    @Input
-    @Optional
-    public List<String> getDependencyCondition() {
-        return dependencyCondition;
-    }
-
-    @Option(option = "dependencyCondition", description = "Conditions that should enable this extension (in case this extension is loaded as a conditional dependency)")
-    public void setDependencyCondition(List<String> dependencyCondition) {
-        this.dependencyCondition = dependencyCondition;
-    }
-
     @TaskAction
     public void generateExtensionDescriptor() {
-        JavaPluginConvention convention = getProject().getConvention().getPlugin(JavaPluginConvention.class);
-        File resourcesDir = convention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getResourcesDir();
-
         generateQuarkusExtensionProperties(resourcesDir);
+    }
+
+    public void setResourcesDir(File resourcesDir) {
+        this.resourcesDir = resourcesDir;
+    }
+
+    public void setQuarkusExtensionConfiguration(QuarkusExtensionConfiguration quarkusExtensionConfiguration) {
+        this.quarkusExtensionConfiguration = quarkusExtensionConfiguration;
     }
 
     private void generateQuarkusExtensionProperties(File outputDir) {
         final Properties props = new Properties();
-        props.setProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, getDeployment());
+        String deploymentArtifact = quarkusExtensionConfiguration.getDeploymentArtifact();
+        if (quarkusExtensionConfiguration.getDeploymentArtifact() == null) {
+            deploymentArtifact = quarkusExtensionConfiguration.getDefaultDeployementArtifactName();
+        }
+        props.setProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, deploymentArtifact);
 
+        List<String> conditionalDependencies = quarkusExtensionConfiguration.getConditionalDependencies();
         if (conditionalDependencies != null && !conditionalDependencies.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             int i = 0;
@@ -145,30 +62,37 @@ public class ExtensionDescriptorTask extends DefaultTask {
             }
             props.setProperty(BootstrapConstants.CONDITIONAL_DEPENDENCIES, buf.toString());
         }
-        if (dependencyCondition != null && !dependencyCondition.isEmpty()) {
+
+        List<String> dependencyConditions = quarkusExtensionConfiguration.getDependencyConditions();
+        if (dependencyConditions != null && !dependencyConditions.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             int i = 0;
-            buf.append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
-            while (i < dependencyCondition.size()) {
-                buf.append(' ').append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
+            buf.append(AppArtifactKey.fromString(dependencyConditions.get(i++)).toGacString());
+            while (i < dependencyConditions.size()) {
+                buf.append(' ').append(AppArtifactKey.fromString(dependencyConditions.get(i++)).toGacString());
             }
             props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
         }
+
+        List<String> parentFirstArtifacts = quarkusExtensionConfiguration.getParentFirstArtifacts();
         if (parentFirstArtifacts != null && !parentFirstArtifacts.isEmpty()) {
             String val = String.join(",", parentFirstArtifacts);
             props.put(AppModel.PARENT_FIRST_ARTIFACTS, val);
         }
 
+        List<String> runnerParentFirstArtifacts = quarkusExtensionConfiguration.getRunnerParentFirstArtifacts();
         if (runnerParentFirstArtifacts != null && !runnerParentFirstArtifacts.isEmpty()) {
             String val = String.join(",", runnerParentFirstArtifacts);
             props.put(AppModel.RUNNER_PARENT_FIRST_ARTIFACTS, val);
         }
 
+        List<String> excludedArtifacts = quarkusExtensionConfiguration.getExcludedArtifacts();
         if (excludedArtifacts != null && !excludedArtifacts.isEmpty()) {
             String val = String.join(",", excludedArtifacts);
             props.put(AppModel.EXCLUDED_ARTIFACTS, val);
         }
 
+        List<String> lesserPriorityArtifacts = quarkusExtensionConfiguration.getLesserPriorityArtifacts();
         if (lesserPriorityArtifacts != null && !lesserPriorityArtifacts.isEmpty()) {
             String val = String.join(",", lesserPriorityArtifacts);
             props.put(AppModel.LESSER_PRIORITY_ARTIFACTS, val);

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.util.ZipUtils;
 
-public class QuarkusPluginTest {
+public class QuarkusExtensionPluginTest {
 
     @TempDir
     File testProjectDir;
@@ -61,5 +61,28 @@ public class QuarkusPluginTest {
                 Assertions.fail("Unable to read jar file");
             }
         });
+    }
+
+    @Test
+    public void pluginShouldAddAnnotationProcessor() throws IOException {
+        TestUtils.writeFile(buildFile, TestUtils.DEFAULT_BUILD_GRADLE_CONTENT);
+        BuildResult dependencies = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments("dependencies", "--configuration", "annotationProcessor")
+                .build();
+
+        assertThat(dependencies.getOutput()).contains(QuarkusExtensionPlugin.QUARKUS_ANNOTATION_PROCESSOR);
+    }
+
+    @Test
+    public void pluginShouldAddAnnotationProcessorToDeploymentModule() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir);
+        BuildResult dependencies = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(":deployment:dependencies", "--configuration", "annotationProcessor")
+                .build();
+        assertThat(dependencies.getOutput()).contains(QuarkusExtensionPlugin.QUARKUS_ANNOTATION_PROCESSOR);
     }
 }

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
@@ -36,6 +36,19 @@ public class TestUtils {
         return extensionDescriptorResult;
     }
 
+    public static void createExtensionProject(File testProjectDir) throws IOException {
+        File runtimeModule = new File(testProjectDir, "runtime");
+        runtimeModule.mkdir();
+        writeFile(new File(runtimeModule, "build.gradle"), DEFAULT_BUILD_GRADLE_CONTENT);
+
+        File deploymentModule = new File(testProjectDir, "deployment");
+        deploymentModule.mkdir();
+        writeFile(new File(deploymentModule, "build.gradle"), "plugins { id 'java'}");
+
+        writeFile(new File(testProjectDir, "settings.gradle"), "include 'runtime', 'deployment'");
+
+    }
+
     public static void writeFile(File destination, String content) throws IOException {
         BufferedWriter output = null;
         try {

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.quarkus.extension.gradle.QuarkusExtensionPlugin;
 import io.quarkus.extension.gradle.TestUtils;
 
-public class ExtensionDescriptorTest {
+public class ExtensionDescriptorTaskTest {
 
     @TempDir
     File testProjectDir;
@@ -43,8 +43,8 @@ public class ExtensionDescriptorTest {
     @Test
     public void shouldUseCustomDeploymentArtifactName() throws IOException {
         String buildFileContent = TestUtils.DEFAULT_BUILD_GRADLE_CONTENT
-                + QuarkusExtensionPlugin.EXTENSION_DESCRIPTOR_TASK_NAME + " { " +
-                "deployment = 'custom.group:custom-deployment-artifact:0.1.0'" +
+                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
+                "deploymentArtifact = 'custom.group:custom-deployment-artifact:0.1.0'" +
                 "}";
         TestUtils.writeFile(buildFile, buildFileContent);
         TestUtils.runExtensionDescriptorTask(testProjectDir);
@@ -59,7 +59,7 @@ public class ExtensionDescriptorTest {
     @Test
     public void shouldContainsConditionalDependencies() throws IOException {
         String buildFileContent = TestUtils.DEFAULT_BUILD_GRADLE_CONTENT
-                + QuarkusExtensionPlugin.EXTENSION_DESCRIPTOR_TASK_NAME + " { " +
+                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
                 "conditionalDependencies= ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
                 "}";
         TestUtils.writeFile(buildFile, buildFileContent);
@@ -77,7 +77,7 @@ public class ExtensionDescriptorTest {
     @Test
     public void shouldContainsParentFirstArtifacts() throws IOException {
         String buildFileContent = TestUtils.DEFAULT_BUILD_GRADLE_CONTENT
-                + QuarkusExtensionPlugin.EXTENSION_DESCRIPTOR_TASK_NAME + " { " +
+                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
                 "parentFirstArtifacts = ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
                 "}";
         TestUtils.writeFile(buildFile, buildFileContent);

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -543,8 +543,10 @@ Please refer to https://github.com/quarkusio/quarkus/blob/{quarkus-version}/devt
 
 ==== Using Gradle
 
-You will need to apply the `io.quarkus.extension` plugin and enable annotation processor `io.quarkus:quarkus-extension-processor` in the `runtime` module of your extension project.
+You will need to apply the `io.quarkus.extension` plugin in the `runtime` module of your extension project.
 The plugin includes the `extensionDescriptor` task that will generate the `META-INF/quarkus-extension.properties` file.
+The plugin also enables the `io.quarkus:quarkus-extension-processor` annotation processor in both `deployment` and `runtime` modules.
+The name of the deployment module can be configured in the plugin by setting the `deploymentModule` property. The property is set to `deployment` by default:
 
 [source,groovy,subs=attributes+]
 ----
@@ -553,23 +555,12 @@ plugins {
     id 'io.quarkus.extensions'
 }
 
-dependencies {
-    implementation platform('io.quarkus:quarkus-bom:{quarkus-version}')
-    annotationProcessor 'io.quarkus:quarkus-extension-processor'
-}
-----
-
-In your deployment module, you will need to enable only the annotation processor `io.quarkus:quarkus-extension-processor`:
-
-[source,groovy,subs=attributes+]
-----
-plugins {
-    id 'java'
+quarkusExtension {
+    deploymentModule = 'deployment'
 }
 
 dependencies {
     implementation platform('io.quarkus:quarkus-bom:{quarkus-version}')
-    annotationProcessor 'io.quarkus:quarkus-extension-processor'
 }
 ----
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/runtime/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     api("io.quarkus:quarkus-hibernate-reactive-panache")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-a-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-a-deployment:1.0-SNAPSHOT"
     conditionalDependencies = ["org.acme:ext-b::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/runtime/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-b-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-c::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-b-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-c::jar"]
     conditionalDependencies = ["org.acme:ext-e::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-c-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-c-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-d-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-d-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/runtime/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-e-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-c::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-e-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-c::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/runtime/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation project(':ext-g:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-f-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-f-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-g-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-g-deployment:1.0-SNAPSHOT"
     conditionalDependencies = ["org.acme:ext-h::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/runtime/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     implementation project(':ext-k:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-h-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-i::jar", "org.acme:ext-j::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-h-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-i::jar", "org.acme:ext-j::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-i-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-i-deployment:1.0-SNAPSHOT"
     conditionalDependencies = ["org.acme:ext-o::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-j-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-j-deployment:1.0-SNAPSHOT"
     conditionalDependencies = ["org.acme:ext-p::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/runtime/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation project(':ext-t:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-k-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-k-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/runtime/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation project(':ext-j:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-l-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-l-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-m-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-m-deployment:1.0-SNAPSHOT"
     conditionalDependencies = ["org.acme:ext-n::jar:1.0-SNAPSHOT", "org.acme:ext-r::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/runtime/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     implementation project(':ext-i:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-n-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-k::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-n-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-k::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/runtime/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-o-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-h::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-o-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-h::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/runtime/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-p-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-o::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-p-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-o::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/runtime/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-r-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-i::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-r-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-i::jar"]
     conditionalDependencies = ["org.acme:ext-s::jar:1.0-SNAPSHOT"]
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/runtime/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     implementation project(':ext-u:runtime')
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-s-deployment:1.0-SNAPSHOT"
-    dependencyCondition = ["org.acme:ext-t::jar"]
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-s-deployment:1.0-SNAPSHOT"
+    dependencyConditions = ["org.acme:ext-t::jar"]
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-t-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-t-deployment:1.0-SNAPSHOT"
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/runtime/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 }
 
-extensionDescriptor {
-    deployment = "org.acme:ext-u-deployment:1.0-SNAPSHOT"
+quarkusExtension {
+    deploymentArtifact = "org.acme:ext-u-deployment:1.0-SNAPSHOT"
 }
 
 publishing {


### PR DESCRIPTION
This branch: 

- Moves configuration from task to extension (will be globally available)
- Rename tests class to match tested classes
- Adds `io.quarkus:quarkus-extension-processor` automatically in `deployment`/`runtime` modules.