### PR TITLE
Add Kotlin deps to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,6 +123,10 @@ updates:
       - dependency-name: io.grpc:*
       # jaeger
       - dependency-name: io.jaegertracing:*
+      # Kotlin
+      - dependency-name: org.jetbrains.kotlin:*
+      - dependency-name: org.jetbrains.kotlinx:*
+      - dependency-name: org.jetbrains.dokka:*
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/integration-tests/gradle"


### PR DESCRIPTION
I've become tired of bumping kotlin stuff, given that I'm not even a kotlin user. 😉

PS: I guess we will see cases where the bot will bump kotlin to a next major (or similar), breaking compatibility with e.g. coroutines.
But that's what reviews are for, right?