### PR TITLE
In CI swap Java 16 with 17 and in EA job swap 17-ea with 18-ea

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -249,8 +249,8 @@ jobs:
             os-name: "ubuntu-latest"
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "17",
+            java-version: 17,
             maven_args: "$JVM_TEST_MAVEN_ARGS",
             maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
             os-name: "ubuntu-latest"

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -10,10 +10,17 @@ on:
         description: 'JDK version'
         required: true
         # make sure to keep the default of JDK_VERSION in sync!
-        default: '17-ea'
+        default: '18-ea'
+      jdkDistribution:
+        description: 'JDK distribution'
+        required: true
+        # make sure to keep the default of JDK_DIST in sync!
+        # use zulu until temurin dist is available
+        default: 'zulu'
 
 env:
-  JDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdkVersion || '17-ea' }}
+  JDK_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdkVersion || '18-ea' }}
+  JDK_DIST: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdkDistribution || 'zulu' }}
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
   JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Dformat.skip"
@@ -34,7 +41,7 @@ jobs:
         # AdoptOpenJDK does not seem to provide EA builds, so use the standard action which provides a Zulu JDK
         uses: actions/setup-java@v2
         with:
-          distribution: temurin
+          distribution: ${{ env.JDK_DIST }}
           java-version: ${{ env.JDK_VERSION }}
       - name: Print Java version
         shell: bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions Status](<https://img.shields.io/github/workflow/status/QuarkusIO/quarkus/Quarkus CI?logo=GitHub&style=for-the-badge>)](https://github.com/quarkusio/quarkus/actions?query=workflow%3A%22Quarkus+CI%22)
 [![License](https://img.shields.io/github/license/quarkusio/quarkus?style=for-the-badge&logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
-[![Supported JVM Versions](https://img.shields.io/badge/JVM-11--16-brightgreen.svg?style=for-the-badge&logo=Java)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
+[![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17-brightgreen.svg?style=for-the-badge&logo=Java)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
 
 # Quarkus - Supersonic Subatomic Java
 


### PR DESCRIPTION
Resolves #20215

Unfortunately, I don't have time ATM for:
> Ironically, the EA job has more >11 coverage than regular CI so it might be worthwhile to have a nightly "EA" run, but with 17 (additionally to the normal EA run with 18-ea).

I'll put that higher on my list (and create yet another housekeeping issue for that).