### PR TITLE
Allow retries on Vault MP Config Source initialization

### DIFF
--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
@@ -132,7 +132,7 @@ public class DevServicesVaultProcessor {
 
         boolean needToStart = !ConfigUtils.isPropertyPresent(URL_CONFIG_KEY);
         if (!needToStart) {
-            log.debug("Not starting devservices for default Vault client as url have been provided");
+            log.debug("Not starting devservices for default Vault client as url has been provided");
             return null;
         }
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultIOException.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultIOException.java
@@ -1,0 +1,26 @@
+package io.quarkus.vault.runtime;
+
+import io.quarkus.vault.VaultException;
+
+public class VaultIOException extends VaultException {
+
+    public VaultIOException() {
+    }
+
+    public VaultIOException(String message) {
+        super(message);
+    }
+
+    public VaultIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public VaultIOException(Throwable cause) {
+        super(cause);
+    }
+
+    public VaultIOException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
@@ -33,7 +33,7 @@ public class VaultBootstrapConfig {
     public static final String DEFAULT_SECRET_CONFIG_CACHE_PERIOD = "10M";
     public static final String KUBERNETES_CACERT = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
     public static final String DEFAULT_CONNECT_TIMEOUT = "5S";
-    public static final String DEFAULT_READ_TIMEOUT = "1S";
+    public static final String DEFAULT_READ_TIMEOUT = "5S";
     public static final String DEFAULT_TLS_USE_KUBERNETES_CACERT = "true";
     public static final String DEFAULT_KUBERNETES_AUTH_MOUNT_PATH = "auth/kubernetes";
 
@@ -140,6 +140,12 @@ public class VaultBootstrapConfig {
     @ConfigItem(name = "secret-config-kv-path")
     @ConfigDocMapKey("prefix")
     public Map<String, KvPathConfig> secretConfigKvPathPrefix;
+
+    /**
+     * Maximum number of attempts when fetching MP Config properties on the initial connection.
+     */
+    @ConfigItem(defaultValue = "1")
+    public int mpConfigInitialAttempts;
 
     /**
      * Used to hide confidential infos, for logging in particular.

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUnableToConnectITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUnableToConnectITCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.vault;
+
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@Disabled // test is expected to fail on quarkus app startup
+public class VaultUnableToConnectITCase {
+
+    // start the test with no vault listening on 4850
+    // the application startup should fail with the following debug logs 3 times:
+    // attempt ... to fetch secrets from vault failed with: ...
+    // retrying to fetch secrets
+    // ...
+    // you can also validate the retry on read timeout by starting a server that answers
+    // POSTs on http://localhost:4850/v1/auth/userpass/login/{user} and sleeps more than 10 secs
+    // again you are expected to see several attempts in the logs
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-unable-to-connect.properties", "application.properties"));
+
+    @ConfigProperty(name = PASSWORD_PROPERTY_NAME)
+    String someSecret;
+
+    @Test
+    void test() {
+        // we will not reach that point
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-unable-to-connect.properties
+++ b/integration-tests/vault/src/test/resources/application-unable-to-connect.properties
@@ -1,0 +1,13 @@
+quarkus.vault.url=http://localhost:4850
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+quarkus.vault.secret-config-kv-path=config
+
+quarkus.vault.read-timeout=10S
+quarkus.vault.mp-config-initial-attempts=3
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+
+#quarkus.log.level=DEBUG
+quarkus.log.min-level=DEBUG
+quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
@@ -12,8 +12,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-approle.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle.properties
@@ -12,8 +12,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
@@ -11,10 +11,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG
-
-

--- a/integration-tests/vault/src/test/resources/application-vault-enterprise.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-enterprise.properties
@@ -3,5 +3,3 @@ quarkus.vault.enterprise.namespace=accounting
 quarkus.vault.authentication.client-token=123
 quarkus.vault.kv-secret-engine-version=1
 quarkus.tls.trust-all=true
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
@@ -12,8 +12,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -5,6 +5,3 @@ quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
 quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
 
 quarkus.tls.trust-all=true
-
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-pki.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-pki.properties
@@ -8,6 +8,3 @@ quarkus.vault.log-confidentiality-level=low
 quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
-
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-totp.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-totp.properties
@@ -3,6 +3,3 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 
 quarkus.vault.tls.skip-verify=true
-
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
@@ -15,8 +15,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
@@ -12,8 +12,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -20,8 +20,5 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
-# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
-quarkus.vault.read-timeout=5S
-
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG


### PR DESCRIPTION
During the initialization of the Vault Config Source, vault (or one specific replica) might be temporarily unavailable.
In that case the rest call through the vertx web client will throw a mutiny timeout exception, which will make the application fail at startup.
Retrying, sometimes just once, may be enough to successfully fetch the secrets from the Vault (or a good replica) after an initial failure, which will allow for the application to continue its initialization, and avoid a crash and a restart.
Ideally the remote service should always be up. But this can't be guaranteed, and since it is on the critical path of application startup, it is fair to add some resiliency.
This PR provides a way to allow some retries during the very first time secrets get fetched by the vault config source.
Once fetched successfully once, the retries will not be used again. Instead we will rely on the internal cache.
Retries are used only in the context of the vault config source. In particular it is not being used by the different programmatic interfaces for the supported engines.
To summarize it is only used by the vault config source, and only on the very first access.