### PR TITLE
Fix gdb debugging with GraalVM/Mandrel >=21.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -223,11 +223,6 @@ public class NativeImageBuildStep {
                     Path finalSymbolsPath = outputTargetBuildItem.getOutputDirectory().resolve(symbolsName);
                     IoUtils.copy(generatedSymbols, finalSymbolsPath);
                     Files.delete(generatedSymbols);
-                    final String sources = "sources";
-                    final Path generatedSources = outputDir.resolve(sources);
-                    final Path finalSources = outputTargetBuildItem.getOutputDirectory().resolve(sources);
-                    IoUtils.copy(generatedSources, finalSources);
-                    IoUtils.recursiveDelete(generatedSources);
                 } else {
                     log.warn(
                             "objcopy executable not found in PATH. Debug symbols therefore cannot be placed into the dedicated directory.");


### PR DESCRIPTION
As of 21.1 (https://github.com/oracle/graal/commit/dee66ca6e28fd519cef061130d20e28ec35d1a1f)
dwarf info contain absolute paths to the source-cache. As a result
moving the sources breaks gdb.

The move was performed to make sure the sources are next to the binary,
in an effort to ease debugging on remote hosts by copying the binary and
the sources in the same directory.  As discussed in
https://github.com/oracle/graal/pull/3828 this is not expected to be the
common case, so it's better to favour the local debugging experience by
leaving the sources where they were placed by GraalVM/Mandrel.

Reverts: #12351
Closes: #20321 