### PR TITLE
Add maven-publish plugin to fix gradle plugin names

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -5,6 +5,7 @@ plugins {
 subprojects {
     apply plugin: 'java-gradle-plugin'
     apply plugin: 'com.gradle.plugin-publish'
+    apply plugin: 'maven-publish'
 
     if (JavaVersion.current().isJava9Compatible()) {
         compileJava.options.compilerArgs.addAll(['--release', '11'])


### PR DESCRIPTION
This branch adds the `maven-publish` plugin. 

As mention in the message from the gradle team, this should make sure the group id is not prefixes with `gradle.plugin`.
This looks to be the recommended setup. but there is no way to test it before submitting the plugin :/ 

> ## Group shouldn't start with gradle.plugin
> Under certain circumstances (read on for details), the publishing plugin will use the project group, prefixed with gradle.plugin as the maven coordinate group for your plugin. For example, if your project has group com.foo, the maven coordinate group of the plugin will be gradle.plugin.com.foo. We no longer accept the usage of the gradle.plugin prefix in group values.

> The plugin-publish plugin will not do the prefixing described above in case it's used in collaboration with the maven-publish plugin. This is now the recommended setup (see Gradle docs for plugin publishing), so prefixing should no longer happen.

> Another way of disabling the automatic prefixing is setting the group via a mavenCoordinates block. See the Full Example below. We will reject plugins if they have a group starting with gradle.plugin so you need to adapt the legacy setup.
