### PR TITLE
Micrometer: ignore null suppliers

### DIFF
--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -235,7 +235,7 @@ public class MicrometerProcessor {
         // RootMeterRegistryBuildItem is present to indicate we call this after the root registry has been initialized
 
         for (MetricsFactoryConsumerBuildItem item : metricsFactoryConsumerBuildItems) {
-            if (item.executionTime() == ExecutionTime.STATIC_INIT) {
+            if (item != null && item.executionTime() == ExecutionTime.STATIC_INIT) {
                 recorder.registerMetrics(item.getConsumer());
             }
         }
@@ -261,7 +261,7 @@ public class MicrometerProcessor {
         recorder.configureRegistries(config, typeClasses, shutdownContextBuildItem);
 
         for (MetricsFactoryConsumerBuildItem item : metricsFactoryConsumerBuildItems) {
-            if (item.executionTime() == ExecutionTime.RUNTIME_INIT) {
+            if (item != null && item.executionTime() == ExecutionTime.RUNTIME_INIT) {
                 recorder.registerMetrics(item.getConsumer());
             }
         }


### PR DESCRIPTION
Resolves #20350 

There was a limitation: neo4j metrics is a runtime provided value. Micrometer needs to be guarded against the empty supplier (which was assumed to be the case)