### PR TITLE
Fix gradle tests

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -76,7 +76,7 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         return project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
     }
 
-    private static Configuration deploymentClasspathConfig(Project project, LaunchMode mode,
+    private static synchronized Configuration deploymentClasspathConfig(Project project, LaunchMode mode,
             Collection<org.gradle.api.artifacts.Dependency> platforms) {
 
         Configuration deploymentConfiguration = project.getConfigurations().findByName(DEPLOYMENT_CONFIGURATION);


### PR DESCRIPTION
generateCode and generateTestCode can be run concurrently, and this
method is not thread safe. I think in some situations dependnecies get
added to a Configuration twice, which cases the failures we are seeing.