### PR TITLE
Apply min-level logging config to root logger

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -89,7 +89,14 @@ public class LoggingSetupRecorder {
         final LogContext logContext = LogContext.getLogContext();
         final Logger rootLogger = logContext.getLogger("");
 
-        rootLogger.setLevel(config.level);
+        if (config.level.intValue() < buildConfig.minLevel.intValue()) {
+            log.warnf("Root log level %s set below minimum logging level %s, promoting it to %s",
+                    config.level, buildConfig.minLevel, buildConfig.minLevel);
+
+            rootLogger.setLevel(buildConfig.minLevel);
+        } else {
+            rootLogger.setLevel(config.level);
+        }
 
         ErrorManager errorManager = new OnlyOnceErrorManager();
         final Map<String, CleanupFilterConfig> filters = config.filters;

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and only messages at same runtime log level or above are shown.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
 public class LoggingMinLevelAboveTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and there's no applicable runtime log level override.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
 public class LoggingMinLevelByDefaultTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelGlobalTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelGlobalTest.java
@@ -9,20 +9,17 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
- * This test verifies that log levels are promoted to min-level when set below the default min-level.
- * 
- * So given the default min-level is DEBUG,
- * so if log level is set to TRACE,
- * it will be automatically promoted to DEBUG.
+ * Tests that logging works as expected when min-level is default,
+ * and the global log level is below it.
  */
 @QuarkusTest
-@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
-public class LoggingMinLevelPromoteTest {
+@QuarkusTestResource(SetGlobalRuntimeLogLevel.class)
+public class LoggingMinLevelGlobalTest {
 
     @Test
     public void testInfo() {
         given()
-                .when().get("/log/promote/info")
+                .when().get("/log/bydefault/info")
                 .then()
                 .statusCode(200)
                 .body(is("true"));
@@ -31,7 +28,7 @@ public class LoggingMinLevelPromoteTest {
     @Test
     public void testWarn() {
         given()
-                .when().get("/log/promote/warn")
+                .when().get("/log/bydefault/warn")
                 .then()
                 .statusCode(200)
                 .body(is("true"));
@@ -40,7 +37,7 @@ public class LoggingMinLevelPromoteTest {
     @Test
     public void testNotTrace() {
         given()
-                .when().get("/log/promote/not-trace")
+                .when().get("/log/bydefault/not-trace")
                 .then()
                 .statusCode(200)
                 .body(is("true"));

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetCategoryRuntimeLogLevels.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetCategoryRuntimeLogLevels.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-public final class SetRuntimeLogLevels implements QuarkusTestResourceLifecycleManager {
+public final class SetCategoryRuntimeLogLevels implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetGlobalRuntimeLogLevel.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/SetGlobalRuntimeLogLevel.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.logging.minlevel.unset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public final class SetGlobalRuntimeLogLevel implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        final Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.put("quarkus.log.level", "TRACE");
+        return systemProperties;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+}


### PR DESCRIPTION
Closes #20066

The issue is fixed by applying min-level to the root logger. Category loggers were already handled.