### PR TITLE
Hibernate Validator: Correctly detect custom ValueExtractor beans

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/ApplicationScopedCustomValueExtractorTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/ApplicationScopedCustomValueExtractorTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.validator.test.valueextractor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotBlank;
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@Disabled("Reproduces https://github.com/quarkusio/quarkus/issues/20375, not yet fixed")
+public class ApplicationScopedCustomValueExtractorTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestBean.class, Container.class, ApplicationScopedContainerValueExtractor.class));
+
+    @Test
+    public void testApplicationScopedCustomValueExtractor() {
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(1);
+    }
+
+    public static class TestBean {
+        public Container<@NotBlank String> constrainedContainer;
+
+        public TestBean() {
+            Container<String> invalidContainer = new Container<>();
+            invalidContainer.value = "   ";
+
+            this.constrainedContainer = invalidContainer;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ApplicationScopedContainerValueExtractor
+            implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+        @Override
+        public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+            receiver.value("someName", originalValue.value);
+        }
+    }
+
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/Container.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/Container.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.validator.test.valueextractor;
 
 // TODO for some reason, this must be a top-level type, not a nested/inner type,
 //  in order for annotations on type parameters to be detected.
+//  See NestedContainerTypeCustomValueExtractorTest
 public class Container<T> {
 
     public T value;

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/Container.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/Container.java
@@ -1,0 +1,9 @@
+package io.quarkus.hibernate.validator.test.valueextractor;
+
+// TODO for some reason, this must be a top-level type, not a nested/inner type,
+//  in order for annotations on type parameters to be detected.
+public class Container<T> {
+
+    public T value;
+
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/NestedContainerTypeCustomValueExtractorTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/NestedContainerTypeCustomValueExtractorTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.hibernate.validator.test.valueextractor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotBlank;
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@Disabled("Reproduces https://github.com/quarkusio/quarkus/issues/20377, not yet fixed")
+public class NestedContainerTypeCustomValueExtractorTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestBean.class, NestedContainerType.class, NestedContainerClassValueExtractor.class));
+
+    @Test
+    public void testNestedContainerTypeValueExtractor() {
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(1);
+    }
+
+    public static class TestBean {
+        public NestedContainerType<@NotBlank String> constrainedContainer;
+
+        public TestBean() {
+            NestedContainerType<String> invalidContainer = new NestedContainerType<>();
+            invalidContainer.value = "   ";
+
+            this.constrainedContainer = invalidContainer;
+        }
+    }
+
+    public static class NestedContainerType<T> {
+
+        public T value;
+
+    }
+
+    @Singleton
+    public static class NestedContainerClassValueExtractor
+            implements ValueExtractor<NestedContainerType<@ExtractedValue ?>> {
+
+        @Override
+        public void extractValues(NestedContainerType<?> originalValue, ValueReceiver receiver) {
+            receiver.value("someName", originalValue.value);
+        }
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/SingletonCustomValueExtractorTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/valueextractor/SingletonCustomValueExtractorTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.validator.test.valueextractor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotBlank;
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SingletonCustomValueExtractorTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestBean.class, Container.class, SingletonContainerValueExtractor.class));
+
+    @Test
+    public void testSingletonCustomValueExtractor() {
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(1);
+    }
+
+    public static class TestBean {
+        public Container<@NotBlank String> constrainedContainer;
+
+        public TestBean() {
+            Container<String> invalidContainer = new Container<>();
+            invalidContainer.value = "   ";
+
+            this.constrainedContainer = invalidContainer;
+        }
+    }
+
+    @Singleton
+    public static class SingletonContainerValueExtractor
+            implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+        @Override
+        public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+            receiver.value("someName", originalValue.value);
+        }
+    }
+
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.validator.runtime;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.enterprise.util.TypeLiteral;
 import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -31,6 +32,9 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HibernateValidatorRecorder {
+
+    private static final TypeLiteral<ValueExtractor<?>> TYPE_LITERAL_VALUE_EXTRACTOR_WITH_WILDCARD = new TypeLiteral<ValueExtractor<?>>() {
+    };
 
     public BeanContainerListener initializeValidatorFactory(Set<Class<?>> classesToBeValidated,
             Set<String> detectedBuiltinConstraints,
@@ -132,7 +136,10 @@ public class HibernateValidatorRecorder {
 
                 // Automatically add all the values extractors declared as beans
                 for (ValueExtractor<?> valueExtractor : Arc.container().beanManager().createInstance()
-                        .select(ValueExtractor.class)) {
+                        // Apparently passing ValueExtractor.class
+                        // won't match beans implementing ValueExtractor<NotAWildcard>,
+                        // so we need a type literal here.
+                        .select(TYPE_LITERAL_VALUE_EXTRACTOR_WITH_WILDCARD)) {
                     configuration.addValueExtractor(valueExtractor);
                 }
 


### PR DESCRIPTION
Fixes #20347 , though not completely: there are still limitations, reported as #20375 and #20377 .

So for now, custom `ValueExtractor` beans will only work properly if they are annotated with `@Singleton`, and perhaps `@Dependent`; they definitely won't work if annotated with `@ApplicationScoped` (because of #20375).