### PR TITLE
Make sure compile classpath is resolved before test classpath

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -28,10 +28,11 @@ public class ApplicationDeploymentClasspathBuilder {
 
         DependencyHandler dependencies = project.getDependencies();
         for (ExtensionDependency extension : extensions) {
+            if (commonExtensions.contains(extension)) {
+                continue;
+            }
             if (common) {
                 commonExtensions.add(extension);
-            } else if (commonExtensions.contains(extension)) {
-                continue;
             }
             extension.createDeploymentVariant(dependencies);
             requireDeploymentDependency(deploymentConfigurationName, extension, dependencies);


### PR DESCRIPTION
Adds an explicit dependency between `generateCode` and `generateCodeTest` tasks to make sure the compile classpath is resolve before the test classpath. That will avoid to have duplicate variant of dependencies.

close #20315 