### PR TITLE
Fix misleading exception message on @Transactional(Transactional.TxType.NEVER)

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorNever.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorNever.java
@@ -10,8 +10,6 @@ import javax.transaction.TransactionManager;
 import javax.transaction.Transactional;
 import javax.transaction.TransactionalException;
 
-import com.arjuna.ats.jta.logging.jtaLogger;
-
 /**
  * @author paul.robinson@redhat.com 25/05/2013
  */
@@ -33,7 +31,7 @@ public class TransactionalInterceptorNever extends TransactionalInterceptorBase 
     @Override
     protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
         if (tx != null) {
-            throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new InvalidTransactionException());
+            throw new TransactionalException("Transaction is not allowed for invocation", new InvalidTransactionException());
         }
         return invokeInNoTx(ic);
     }


### PR DESCRIPTION
Fixes #16448

`jtaLogger.i18NLogger` doesn't have a proper message for this, which could be considered an upstream issue at narayana. (/cc @mmusgrov)
But better have a clear message without i18N and ARJUNA-code than a misleading one.