### PR TITLE
Upgrade ASM to 9.2 and add ASM to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: com.jcraft:jzlib
       - dependency-name: org.jboss.logging:*
       - dependency-name: org.jboss.logmanager:*
+      - dependency-name: org.ow2.asm:*
       # Quarkus
       - dependency-name: io.quarkus.gizmo:gizmo
       - dependency-name: io.quarkus.http:*

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -76,7 +76,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
-        <asm.version>9.1</asm.version>
+        <asm.version>9.2</asm.version>
         <commons-io.version>2.11.0</commons-io.version>
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>


### PR DESCRIPTION
This should fix various test failures in the EA job that is already running java 18-ea.

https://asm.ow2.io/versions.html

PS: Gizmo was udated here, but wasn't released yet: https://github.com/quarkusio/gizmo/pull/83