### PR TITLE
Upgrade docker-maven-plugin to 0.37.0 and add to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,7 @@ updates:
       - dependency-name: com.thoughtworks.xstream:xstream
       - dependency-name: org.jacoco:*
       # Maven plugins
+      - dependency-name: io.fabric8:docker-maven-plugin
       - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
       - dependency-name: net.revelc.code:impsort-maven-plugin
       # Narayana

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -578,7 +578,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.31.0</version>
+                    <version>0.37.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
I've seen some strange job timeouts after stopping DB2 container (via this plugin) and maybe this improves things.
Even if not, keeping up to date makes sense anyway.

https://github.com/fabric8io/docker-maven-plugin/releases