### PR TITLE
Swap put and post methods

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -369,28 +369,28 @@ quarkus.locales=en-US,es-ES,fr-FR
 It's sometimes necessary to enable different validation constraints
 for the same class when it's passed to a different method.
 
-For example, a `Book` may need to have a `null` identifier when passed to the `put` method
+For example, a `Book` may need to have a `null` identifier when passed to the `post` method
 (because the identifier will be generated),
-but a non-`null` identifier when passed to the `post` method
+but a non-`null` identifier when passed to the `put` method
 (because the method needs the identifier to know what to update).
 
 To address this, you can take advantage of validation groups.
 Validation groups are markers that you put on your constraints in order to enable or disable them at will.
 
-First, define the `Put` and `Post` groups, which are just Java interfaces.
+First, define the `Post` and `Put` groups, which are just Java interfaces.
 
 [source, java]
 ----
 public interface ValidationGroups {
-    interface Put extends Default { // <1>
-    }
     interface Post extends Default { // <1>
+    }
+    interface Put extends Default { // <1>
     }
 }
 ----
 <1> Make the custom groups extend the `Default` group.
 This means that whenever these groups are enabled, the `Default` group is also enabled.
-This is useful if you have constraints that you want validated in both the `Put` and `Post` method:
+This is useful if you have constraints that you want validated in both the `Post` and `Put` method:
 you can simply use the default group on those constraints, like on the `title` property below.
 
 Then add the relevant constraints to `Book`, assigning the right group to each constraint:
@@ -399,8 +399,8 @@ Then add the relevant constraints to `Book`, assigning the right group to each c
 ----
 public class Book {
 
-    @Null(groups = ValidationGroups.Put.class)
-    @NotNull(groups = ValidationGroups.Post.class)
+    @Null(groups = ValidationGroups.Post.class)
+    @NotNull(groups = ValidationGroups.Put.class)
     public Long id;
 
     @NotBlank
@@ -414,24 +414,24 @@ Finally, add a `@ConvertGroup` annotation next to your `@Valid` annotation in yo
 [source, java]
 ----
 @Path("/")
-@PUT
+@POST
 @Consumes(MediaType.APPLICATION_JSON)
-public void put(@Valid @ConvertGroup(to = ValidationGroups.Put.class) Book book) { // <1>
+public void post(@Valid @ConvertGroup(to = ValidationGroups.Post.class) Book book) { // <1>
     // ...
 }
 
 @Path("/")
-@POST
+@PUT
 @Consumes(MediaType.APPLICATION_JSON)
-public void post(@Valid @ConvertGroup(to = ValidationGroups.Post.class) Book book) { // <2>
+public void put(@Valid @ConvertGroup(to = ValidationGroups.Put.class) Book book) { // <2>
     // ...
 }
 ----
-<1> Enable the `Put` group, meaning only constraints assigned to the `Put` (and `Default`) groups
-will be validated for the `book` parameter of the `put` method.
-In this case, it means `Book.id` must be `null` and `Book.title` must not be blank.
-<2> Enable the `Post` group, meaning only constraints assigned to the `Post` (and `Default`) groups
+<1> Enable the `Post` group, meaning only constraints assigned to the `Post` (and `Default`) groups
 will be validated for the `book` parameter of the `post` method.
+In this case, it means `Book.id` must be `null` and `Book.title` must not be blank.
+<2> Enable the `Put` group, meaning only constraints assigned to the `Put` (and `Default`) groups
+will be validated for the `book` parameter of the `put` method.
 In this case, it means `Book.id` must not be `null` and `Book.title` must not be blank.
 
 [[configuration-reference]]

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -263,21 +263,21 @@ public class HibernateValidatorTestResource
         return "FAILED";
     }
 
-    @PUT
-    @Path("/rest-end-point-validation-groups/")
-    @Produces(MediaType.TEXT_PLAIN)
-    @Consumes(MediaType.APPLICATION_JSON)
-    public String testRestEndPointValidationGroups_Put(
-            @Valid @ConvertGroup(to = ValidationGroups.Put.class) MyBeanWithGroups bean) {
-        return "passed";
-    }
-
     @POST
     @Path("/rest-end-point-validation-groups/")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.APPLICATION_JSON)
     public String testRestEndPointValidationGroups_Post(
             @Valid @ConvertGroup(to = ValidationGroups.Post.class) MyBeanWithGroups bean) {
+        return "passed";
+    }
+
+    @PUT
+    @Path("/rest-end-point-validation-groups/")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public String testRestEndPointValidationGroups_Put(
+            @Valid @ConvertGroup(to = ValidationGroups.Put.class) MyBeanWithGroups bean) {
         return "passed";
     }
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/MyBeanWithGroups.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/MyBeanWithGroups.java
@@ -7,14 +7,14 @@ import javax.validation.constraints.Null;
 
 public class MyBeanWithGroups {
 
-    @Null(groups = ValidationGroups.Put.class)
-    @NotNull(groups = { ValidationGroups.Post.class, ValidationGroups.Get.class, ValidationGroups.Delete.class })
+    @Null(groups = ValidationGroups.Post.class)
+    @NotNull(groups = { ValidationGroups.Put.class, ValidationGroups.Get.class, ValidationGroups.Delete.class })
     private Long id;
 
     @NotNull
     private String name;
 
-    @AssertFalse(groups = { ValidationGroups.Put.class, ValidationGroups.Post.class, ValidationGroups.Get.class })
+    @AssertFalse(groups = { ValidationGroups.Post.class, ValidationGroups.Put.class, ValidationGroups.Get.class })
     @AssertTrue(groups = ValidationGroups.Delete.class)
     private boolean deleted;
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/ValidationGroups.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/groups/ValidationGroups.java
@@ -3,10 +3,10 @@ package io.quarkus.it.hibernate.validator.groups;
 import javax.validation.groups.Default;
 
 public interface ValidationGroups {
-    interface Put extends Default {
+    interface Post extends Default {
     }
 
-    interface Post extends Default {
+    interface Put extends Default {
     }
 
     interface Get extends Default {

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -353,12 +353,12 @@ public class HibernateValidatorFunctionalityTest {
 
     @Test
     public void testRestEndPointValidationGroups_parameters() {
-        // PUT: input id must be null
+        // POST: input id must be null
         RestAssured.given()
                 .contentType(ContentType.JSON)
                 .body("{\"id\": 1, \"name\": \"b\"}")
                 .when()
-                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(400)
                 .body(containsString("must be null"));
@@ -366,17 +366,17 @@ public class HibernateValidatorFunctionalityTest {
                 .contentType(ContentType.JSON)
                 .body("{\"name\": \"b\"}")
                 .when()
-                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(200)
                 .body(containsString("passed"));
 
-        // POST: input id must not be null
+        // PUT: input id must not be null
         RestAssured.given()
                 .contentType(ContentType.JSON)
                 .body("{\"name\": \"b\"}")
                 .when()
-                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(400)
                 .body(containsString("must not be null"));
@@ -384,7 +384,7 @@ public class HibernateValidatorFunctionalityTest {
                 .contentType(ContentType.JSON)
                 .body("{\"id\": 1, \"name\": \"b\"}")
                 .when()
-                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(200)
                 .body(containsString("passed"));
@@ -394,7 +394,7 @@ public class HibernateValidatorFunctionalityTest {
                 .contentType(ContentType.JSON)
                 .body("{}")
                 .when()
-                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(400)
                 .body(containsString("must not be null"));
@@ -402,7 +402,7 @@ public class HibernateValidatorFunctionalityTest {
                 .contentType(ContentType.JSON)
                 .body("{\"id\":1}")
                 .when()
-                .post("/hibernate-validator/test/rest-end-point-validation-groups/")
+                .put("/hibernate-validator/test/rest-end-point-validation-groups/")
                 .then()
                 .statusCode(400)
                 .body(containsString("must not be null"));


### PR DESCRIPTION
I swap put and post methods in validation guide. I think it makes more sense this way. Put method is idempotent and returns the same result when used with update. Instead, post method returns a new instance with a new id, so it isn't idempotent.