### PR TITLE
Upgrade jib-core to 0.20.0 and add to dependabot, align google-http-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
       - dependency-name: org.jboss.logging:*
       - dependency-name: org.jboss.logmanager:*
       - dependency-name: org.ow2.asm:*
+      - dependency-name: com.google.cloud.tools:jib-core
       # Quarkus
       - dependency-name: io.quarkus.gizmo:gizmo
       - dependency-name: io.quarkus.http:*

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -186,8 +186,8 @@
         <jzlib.version>1.1.3</jzlib.version>
         <checker-qual.version>2.5.2</checker-qual.version>
         <error-prone-annotations.version>2.2.0</error-prone-annotations.version>
-        <jib-core.version>0.17.0</jib-core.version>
-        <google-http-client.version>1.38.0</google-http-client.version>
+        <jib-core.version>0.20.0</jib-core.version>
+        <google-http-client.version>1.34.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.40.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
Downgrade of `google-http-client` due to: https://github.com/GoogleContainerTools/jib/issues/3416