### PR TITLE
Revert "Port rest-data-panache to RESTEasy Reactive"

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -50,9 +50,6 @@ public interface Capability {
 
     String RESTEASY_MUTINY = RESTEASY + ".mutiny";
     String RESTEASY_REACTIVE = RESTEASY + ".reactive";
-    String RESTEASY_REACTIVE_JSON = RESTEASY_REACTIVE + ".json";
-    String RESTEASY_REACTIVE_JSON_JACKSON = RESTEASY_REACTIVE_JSON + ".jackson";
-    String RESTEASY_REACTIVE_JSON_JSONB = RESTEASY_REACTIVE_JSON + ".jsonb";
 
     String JWT = QUARKUS_PREFIX + "jwt";
 

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -5,8 +5,6 @@ import static io.quarkus.deployment.Feature.HIBERNATE_ORM_REST_DATA_PANACHE;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
-import javax.ws.rs.Priorities;
-
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -25,10 +23,9 @@ import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.jta.TransactionalUpdateExecutor;
-import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
-import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 class HibernateOrmPanacheRestProcessor {
 
@@ -44,9 +41,8 @@ class HibernateOrmPanacheRestProcessor {
     }
 
     @BuildStep
-    ExceptionMapperBuildItem registerRestDataPanacheExceptionMapper() {
-        return new ExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName(),
-                RestDataPanacheException.class.getName(), Priorities.USER + 100, false);
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/pom.xml
@@ -22,10 +22,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
+++ b/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
@@ -5,8 +5,6 @@ import static io.quarkus.deployment.Feature.MONGODB_REST_DATA_PANACHE;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
-import javax.ws.rs.Priorities;
-
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -29,10 +27,9 @@ import io.quarkus.mongodb.rest.data.panache.PanacheMongoEntityResource;
 import io.quarkus.mongodb.rest.data.panache.PanacheMongoRepositoryResource;
 import io.quarkus.mongodb.rest.data.panache.runtime.NoopUpdateExecutor;
 import io.quarkus.mongodb.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
-import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
-import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 class MongoPanacheRestProcessor {
 
@@ -48,9 +45,8 @@ class MongoPanacheRestProcessor {
     }
 
     @BuildStep
-    ExceptionMapperBuildItem registerRestDataPanacheExceptionMapper() {
-        return new ExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName(),
-                RestDataPanacheException.class.getName(), Priorities.USER + 100, false);
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     @BuildStep

--- a/extensions/panache/rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/rest-data-panache/deployment/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
@@ -3,12 +3,17 @@ package io.quarkus.rest.data.panache.deployment;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jboss.resteasy.links.impl.EL;
+
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
@@ -24,8 +29,6 @@ import io.quarkus.rest.data.panache.runtime.hal.HalEntityWrapperJsonbSerializer;
 import io.quarkus.rest.data.panache.runtime.hal.HalLink;
 import io.quarkus.rest.data.panache.runtime.hal.HalLinkJacksonSerializer;
 import io.quarkus.rest.data.panache.runtime.hal.HalLinkJsonbSerializer;
-import io.quarkus.resteasy.reactive.server.deployment.GeneratedJaxRsResourceGizmoAdaptor;
-import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceBuildItem;
 
 public class RestDataProcessor {
 
@@ -37,8 +40,8 @@ public class RestDataProcessor {
     @BuildStep
     void implementResources(CombinedIndexBuildItem index, List<RestDataResourceBuildItem> resourceBuildItems,
             List<ResourcePropertiesBuildItem> resourcePropertiesBuildItems, Capabilities capabilities,
-            BuildProducer<GeneratedJaxRsResourceBuildItem> implementationsProducer) {
-        ClassOutput classOutput = new GeneratedJaxRsResourceGizmoAdaptor(implementationsProducer);
+            BuildProducer<GeneratedBeanBuildItem> implementationsProducer) {
+        ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
         JaxRsResourceImplementor jaxRsResourceImplementor = new JaxRsResourceImplementor(hasValidatorCapability(capabilities));
         ResourcePropertiesProvider resourcePropertiesProvider = new ResourcePropertiesProvider(index.getIndex());
 
@@ -74,6 +77,11 @@ public class RestDataProcessor {
                 HalLinkJsonbSerializer.class.getName()));
     }
 
+    @BuildStep
+    RuntimeInitializedClassBuildItem el() {
+        return new RuntimeInitializedClassBuildItem(EL.class.getCanonicalName());
+    }
+
     private ResourceProperties getResourceProperties(ResourcePropertiesProvider resourcePropertiesProvider,
             ResourceMetadata resourceMetadata, List<ResourcePropertiesBuildItem> resourcePropertiesBuildItems) {
         for (ResourcePropertiesBuildItem resourcePropertiesBuildItem : resourcePropertiesBuildItems) {
@@ -90,7 +98,7 @@ public class RestDataProcessor {
     }
 
     private boolean hasHalCapability(Capabilities capabilities) {
-        return capabilities.isPresent(Capability.RESTEASY_REACTIVE_JSON_JSONB)
-                || capabilities.isPresent(Capability.RESTEASY_REACTIVE_JSON_JACKSON);
+        return capabilities.isPresent(Capability.RESTEASY_JSON_JSONB)
+                || capabilities.isPresent(Capability.RESTEASY_JSON_JACKSON);
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -12,7 +12,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 
-import org.jboss.logging.Logger;
+import org.jboss.resteasy.links.LinkResource;
 
 import io.quarkus.gizmo.AnnotatedElement;
 import io.quarkus.gizmo.AnnotationCreator;
@@ -25,14 +25,11 @@ import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.rest.data.panache.runtime.sort.SortQueryParamValidator;
-import io.quarkus.resteasy.reactive.links.RestLink;
 
 /**
  * A standard JAX-RS method implementor.
  */
 public abstract class StandardMethodImplementor implements MethodImplementor {
-
-    private static final Logger LOGGER = Logger.getLogger(StandardMethodImplementor.class);
 
     /**
      * Implement exposed JAX-RS method.
@@ -81,15 +78,9 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
     }
 
     protected void addLinksAnnotation(AnnotatedElement element, String entityClassName, String rel) {
-        AnnotationCreator linkResource = element.addAnnotation(RestLink.class);
-        Class<?> entityClass;
-        try {
-            entityClass = Thread.currentThread().getContextClassLoader().loadClass(entityClassName);
-            linkResource.addValue("entityType", entityClass);
-            linkResource.addValue("rel", rel);
-        } catch (ClassNotFoundException e) {
-            LOGGER.error("Unable to create links for entity: '" + entityClassName + "'", e);
-        }
+        AnnotationCreator linkResource = element.addAnnotation(LinkResource.class);
+        linkResource.addValue("entityClassName", entityClassName);
+        linkResource.addValue("rel", rel);
     }
 
     protected void addPathAnnotation(AnnotatedElement element, String value) {

--- a/extensions/panache/rest-data-panache/runtime/pom.xml
+++ b/extensions/panache/rest-data-panache/runtime/pom.xml
@@ -19,7 +19,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-links</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
@@ -1,51 +1,41 @@
 package io.quarkus.rest.data.panache.runtime.resource;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.Link;
-
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
-import io.quarkus.resteasy.reactive.links.RestLinksProvider;
+import org.jboss.resteasy.links.LinksProvider;
+import org.jboss.resteasy.links.RESTServiceDiscovery;
 
 public final class ResourceLinksProvider {
 
     private static final String SELF_REF = "self";
 
     public Map<String, String> getClassLinks(Class<?> className) {
-        return linksToMap(restLinksProvider().getTypeLinks(className));
+        RESTServiceDiscovery links = LinksProvider
+                .getClassLinksProvider()
+                .getLinks(className, Thread.currentThread().getContextClassLoader());
+        return linksToMap(links);
     }
 
     public Map<String, String> getInstanceLinks(Object instance) {
-        return linksToMap(restLinksProvider().getInstanceLinks(instance));
+        RESTServiceDiscovery links = LinksProvider
+                .getObjectLinksProvider()
+                .getLinks(instance, Thread.currentThread().getContextClassLoader());
+        return linksToMap(links);
     }
 
     public String getSelfLink(Object instance) {
-        Collection<Link> links = restLinksProvider().getInstanceLinks(instance);
-        for (Link link : links) {
-            if (SELF_REF.equals(link.getRel())) {
-                return link.getUri().toString();
-            }
-        }
-        return null;
+        RESTServiceDiscovery.AtomLink link = LinksProvider.getObjectLinksProvider()
+                .getLinks(instance, Thread.currentThread().getContextClassLoader())
+                .getLinkForRel(SELF_REF);
+        return link == null ? null : link.getHref();
     }
 
-    private RestLinksProvider restLinksProvider() {
-        InstanceHandle<RestLinksProvider> instance = Arc.container().instance(RestLinksProvider.class);
-        if (instance.isAvailable()) {
-            return instance.get();
+    private Map<String, String> linksToMap(RESTServiceDiscovery serviceDiscovery) {
+        Map<String, String> links = new HashMap<>(serviceDiscovery.size());
+        for (RESTServiceDiscovery.AtomLink atomLink : serviceDiscovery) {
+            links.put(atomLink.getRel(), atomLink.getHref());
         }
-        throw new IllegalStateException("Invalid use of '" + this.getClass().getName()
-                + "'. No request scope bean found for type '" + ResourceLinksProvider.class.getName() + "'");
-    }
-
-    private Map<String, String> linksToMap(Collection<Link> links) {
-        Map<String, String> result = new HashMap<>();
-        for (Link link : links) {
-            result.put(link.getRel(), link.getUri().toString());
-        }
-        return result;
+        return links;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/pom.xml
@@ -29,12 +29,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <configuration>
-                    <capabilities>
-                        <provides>io.quarkus.rest.jackson</provides>
-                        <provides>io.quarkus.resteasy.reactive.json.jackson</provides>
-                    </capabilities>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/pom.xml
@@ -29,12 +29,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <configuration>
-                    <capabilities>
-                        <provides>io.quarkus.rest.jsonb</provides>
-                        <provides>io.quarkus.resteasy.reactive.json.jsonb</provides>
-                    </capabilities>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.links.runtime;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.ws.rs.core.Link;
@@ -33,9 +34,8 @@ final class RestLinksProviderImpl implements RestLinksProvider {
     public Collection<Link> getTypeLinks(Class<?> elementType) {
         verifyInit();
 
-        List<LinkInfo> linkInfoList = linksContainer.getForClass(elementType);
-        List<Link> links = new ArrayList<>(linkInfoList.size());
-        for (LinkInfo linkInfo : linkInfoList) {
+        List<Link> links = new LinkedList<>();
+        for (LinkInfo linkInfo : linksContainer.getForClass(elementType)) {
             if (linkInfo.getPathParameters().size() == 0) {
                 links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
                         .rel(linkInfo.getRel())
@@ -49,9 +49,8 @@ final class RestLinksProviderImpl implements RestLinksProvider {
     public <T> Collection<Link> getInstanceLinks(T instance) {
         verifyInit();
 
-        List<LinkInfo> linkInfoList = linksContainer.getForClass(instance.getClass());
-        List<Link> links = new ArrayList<>(linkInfoList.size());
-        for (LinkInfo linkInfo : linkInfoList) {
+        List<Link> links = new LinkedList<>();
+        for (LinkInfo linkInfo : linksContainer.getForClass(instance.getClass())) {
             links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
                     .rel(linkInfo.getRel())
                     .build(getPathParameterValues(linkInfo, instance)));

--- a/extensions/spring-data-rest/deployment/pom.xml
+++ b/extensions/spring-data-rest/deployment/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
@@ -7,8 +7,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.ws.rs.Priorities;
-
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -26,11 +24,10 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.rest.data.panache.deployment.properties.ResourcePropertiesBuildItem;
-import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.spring.data.rest.deployment.crud.CrudMethodsImplementor;
 import io.quarkus.spring.data.rest.deployment.crud.CrudPropertiesProvider;
 import io.quarkus.spring.data.rest.deployment.paging.PagingAndSortingMethodsImplementor;
@@ -58,9 +55,8 @@ class SpringDataRestProcessor {
     }
 
     @BuildStep
-    ExceptionMapperBuildItem registerRestDataPanacheExceptionMapper() {
-        return new ExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName(),
-                RestDataPanacheException.class.getName(), Priorities.USER + 100, false);
+    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
+        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
     }
 
     @BuildStep

--- a/extensions/spring-data-rest/runtime/pom.xml
+++ b/extensions/spring-data-rest/runtime/pom.xml
@@ -27,10 +27,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-data-rest-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
@@ -237,8 +237,8 @@ class HibernateOrmRestDataPanacheTest {
                 .and().body(book.toString())
                 .when().post("/books")
                 .then().statusCode(400)
-                .and().body("violations[0].field", equalTo("add.arg0.title"))
-                .and().body("violations[0].message", equalTo("must not be blank"));
+                .and().body("parameterViolations[0].path", equalTo("add.arg0.title"))
+                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
     }
 
     @Test
@@ -307,7 +307,7 @@ class HibernateOrmRestDataPanacheTest {
                 .and().body(book.toString())
                 .when().put("/books/" + CRIME_AND_PUNISHMENT_ID)
                 .then().statusCode(400)
-                .and().body("violations[0].field", equalTo("update.arg1.title"))
-                .and().body("violations[0].message", equalTo("must not be blank"));
+                .and().body("parameterViolations[0].path", equalTo("update.arg1.title"))
+                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
     }
 }

--- a/integration-tests/mongodb-rest-data-panache/pom.xml
+++ b/integration-tests/mongodb-rest-data-panache/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <!-- Service Binding - This isn't necessary to any Kafka functionality, but we want to test that Quarkus provides the proper config from a mock service binding -->
         <dependency>
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
@@ -172,8 +172,8 @@ class SpringDataRestTest {
                 .and().body(book.toString())
                 .when().post("/books")
                 .then().statusCode(400)
-                .and().body("violations[0].field", equalTo("add.arg0.title"))
-                .and().body("violations[0].message", equalTo("must not be blank"));
+                .and().body("parameterViolations[0].path", equalTo("add.arg0.title"))
+                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
     }
 
     @Test
@@ -242,7 +242,7 @@ class SpringDataRestTest {
                 .and().body(book.toString())
                 .when().put("/books/" + CRIME_AND_PUNISHMENT_ID)
                 .then().statusCode(400)
-                .and().body("violations[0].field", equalTo("update.arg1.title"))
-                .and().body("violations[0].message", equalTo("must not be blank"));
+                .and().body("parameterViolations[0].path", equalTo("update.arg1.title"))
+                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
     }
 }


### PR DESCRIPTION
This reverts commit 149bf56e

This is done because it was discovered that this change could break applications that use Camel and Kogito. 
The plan is to make the extension work with both RESTEasy Reactive and RESTEasy Classic for `2.4`

~~P.S. Another similar PR for the case of Spring Web will follow soon.~~ PR is https://github.com/quarkusio/quarkus/pull/20399