### PR TITLE
Reintroduce lost tests in mongodb-client (2.2 backport)

### DIFF
--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativePojoResourceIT.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativePojoResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.mongodb;
+
+import io.quarkus.it.mongodb.pojo.PojoResource;
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativePojoResourceIT extends PojoResource {
+}

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativeVehicleResourceIT.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativeVehicleResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.mongodb;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeVehicleResourceIT extends VehicleResourceTest {
+}

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/PojoResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/PojoResourceTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.mongodb;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.it.mongodb.pojo.Pojo;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoTestResource;
+
+@QuarkusTest
+@QuarkusTestResource(MongoTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class PojoResourceTest {
+    @Test
+    public void testPojoEndpoint() {
+        Pojo pojo = new Pojo();
+        pojo.description = "description";
+        pojo.optionalString = Optional.of("optional");
+        given().header("Content-Type", "application/json").body(pojo)
+                .when().post("/pojos")
+                .then().statusCode(201);
+
+        given().get("/pojos").then().statusCode(200).body("size()", is(1));
+    }
+}

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/VehicleResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/VehicleResourceTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.mongodb;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.it.mongodb.discriminator.Car;
+import io.quarkus.it.mongodb.discriminator.Moto;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoTestResource;
+
+@QuarkusTest
+@QuarkusTestResource(MongoTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class VehicleResourceTest {
+    @Test
+    public void testVehicleEndpoint() {
+        Car car = new Car();
+        car.name = "Renault Clio";
+        car.type = "CAR";
+        car.seatNumber = 5;
+        given().header("Content-Type", "application/json").body(car)
+                .when().post("/vehicles")
+                .then().statusCode(201);
+
+        Moto moto = new Moto();
+        moto.name = "Harley Davidson Sportster";
+        moto.type = "MOTO";
+        given().header("Content-Type", "application/json").body(moto)
+                .when().post("/vehicles")
+                .then().statusCode(201);
+
+        given().get("/vehicles").then().statusCode(200).body("size()", is(2));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/20139.

Backport of https://github.com/quarkusio/quarkus/pull/20146.