### PR TITLE
Handle dependency constraint in gradle conditional dependency resolution

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -51,6 +51,7 @@ public class DependencyUtils {
         configurationCopy.getDependencies().addAll(boms);
 
         for (Configuration toDuplicate : toDuplicates) {
+            configurationCopy.getDependencyConstraints().addAll(toDuplicate.getAllDependencyConstraints());
             for (Dependency dependency : toDuplicate.getAllDependencies()) {
                 if (includedBuild(project, dependency.getName()) != null) {
                     continue;

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+group = 'com.quarkus.demo'
+version = '1.0'
+
+repositories {
+    mavenCentral()
+    if (System.properties.containsKey('maven.repo.local')) {
+        maven {
+            url System.properties.get('maven.repo.local')
+        }
+    } else {
+        mavenLocal()
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    constraints {
+        implementation 'javax.json.bind:javax.json.bind-api:1.0'
+    }
+
+    implementation 'javax.json.bind:javax.json.bind-api'
+}
+

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        if (System.properties.containsKey('maven.repo.local')) {
+            maven {
+                url System.properties.get('maven.repo.local')
+            }
+        } else {
+            mavenLocal()
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'quarkus-dependency-constraint'
+
+

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,17 @@
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyConstraintsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyConstraintsTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class DependencyConstraintsTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void shoudBuildProjectWithDependencyConstraint() throws Exception {
+        File projectDir = getProjectDir("dependency-constraints-project");
+
+        BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=mutable-jar");
+
+        assertThat(buildResult.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+
+        final File buildDir = new File(projectDir, "build");
+        final Path mainLib = buildDir.toPath().resolve("quarkus-app").resolve("lib").resolve("main");
+
+        assertThat(mainLib.resolve("javax.json.bind.javax.json.bind-api-1.0.jar")).exists();
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/DependencyConstraintsDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/DependencyConstraintsDevModeTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyConstraintsDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "dependency-constraints-project";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hello");
+    }
+}


### PR DESCRIPTION
Dependency constraint were ignored while duplicating configuration. This branch adds a copy of constraint when we duplicate configuration.

close #20419 