### PR TITLE
Discard providers without annotation when there are only excluded classes

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/BuildProfileTest.java
@@ -60,6 +60,7 @@ class BuildProfileTest {
                 .header("X-RF-4", nullValue())
                 .header("X-RF-5", notNullValue())
                 .header("X-RF-6", nullValue())
+                .header("X-RF-7", notNullValue())
                 .body(Matchers.is("ok1"));
     }
 
@@ -176,6 +177,21 @@ class BuildProfileTest {
         }
     }
 
+    public static class ResponseFilter7 implements ContainerResponseFilter {
+
+        private final String value;
+
+        public ResponseFilter7(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            responseContext.getHeaders().add("X-RF-7", value);
+        }
+    }
+
     @IfBuildProfile("test")
     @Provider
     public static class Feature1 implements Feature {
@@ -225,6 +241,7 @@ class BuildProfileTest {
         @Override
         public void configure(ResourceInfo resourceInfo, FeatureContext context) {
             context.register(ResponseFilter5.class);
+            context.register(new ResponseFilter7("Value"));
         }
     }
 

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ApplicationScanningResult.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ApplicationScanningResult.java
@@ -32,14 +32,16 @@ public final class ApplicationScanningResult {
 
     public KeepProviderResult keepProvider(ClassInfo providerClass) {
         if (filterClasses) {
-            // we don't care about provider annotations, they're manually registered (but for the server only)
             if (allowedClasses.isEmpty()) {
-                // we only have only classes to exclude
-                return excludedClasses.contains(providerClass.name().toString()) ? KeepProviderResult.DISCARD
-                        : KeepProviderResult.SERVER_ONLY;
+                // we have only classes to exclude
+                if (excludedClasses.contains(providerClass.name().toString())) {
+                    return KeepProviderResult.DISCARD;
+                }
+            } else {
+                // we don't care about provider annotations, they're manually registered (but for the server only)
+                return allowedClasses.contains(providerClass.name().toString()) ? KeepProviderResult.SERVER_ONLY
+                        : KeepProviderResult.DISCARD;
             }
-            return allowedClasses.contains(providerClass.name().toString()) ? KeepProviderResult.SERVER_ONLY
-                    : KeepProviderResult.DISCARD;
         }
         return providerClass.classAnnotation(ResteasyReactiveDotNames.PROVIDER) != null ? KeepProviderResult.NORMAL
                 : KeepProviderResult.DISCARD;
@@ -48,7 +50,7 @@ public final class ApplicationScanningResult {
     public boolean keepClass(String className) {
         if (filterClasses) {
             if (allowedClasses.isEmpty()) {
-                // we only have only classes to exclude
+                // we have only classes to exclude
                 return !excludedClasses.contains(className);
             }
             return allowedClasses.contains(className);


### PR DESCRIPTION
fixes #20441

## Motivation

Avoid getting potentially `UnsatisfiedResolutionException` when we exclude providers thanks to build time conditions.

## Modifications:

* Make sure that the annotation is present when we have excluded classes
* Add the corresponding test case