### PR TITLE
CI: Increase 'JVM Tests' timeout by 30 minutes

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -234,7 +234,7 @@ jobs:
     needs: [build-jdk11, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
-    timeout-minutes: 240
+    timeout-minutes: 270
     env:
       MAVEN_OPTS: ${{ matrix.java.maven_opts }}
     strategy:


### PR DESCRIPTION
Short term remedy. I did not go higher because TBH 4 hours are already well beyond bearable, IMO.

We need to work on efficiency and the number of modules (but reducing the number of modules alone won't help much if those are not adding much to the overall runtime).
See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/CI.20JVM.20tests.20timeouts