### PR TITLE
Upgrade Hibernate ORM to 5.6.0.CR1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.0.Beta2</hibernate-orm.version>
+        <hibernate-orm.version>5.6.0.CR1</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR9</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>


### PR DESCRIPTION
No meaningful changes compared to previous Beta2:
 - https://in.relation.to/2021/09/29/hibernate-orm-560-CR1-release/