### PR TITLE
Link to SwaggerUi and GraphQLUi in Dev UI for Keycloak when testing with all the supported grants

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -218,6 +218,11 @@ Follow the link and you'll be able log in to your provider, get the tokens and t
 
 If you work with other providers then a Dev UI experience described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section might differ slightly. For example, an access token may not be in a JWT format so it won't be possibe to show its internal content, though all providers should return an ID Token as JWT.
 
+[NOTE]
+====
+The current access token is used by default to test the service with `Swagger UI` or `GrapghQL UI`. If the provider (other than Keycloak) returns a binary access token then it will be used with `Swagger UI` or `GrapghQL UI` only if this provider has a token introspection endpoint otherwise an `IdToken` which is always in a JWT format will be passed to `Swagger UI` or `GrapghQL UI`. In such cases you can verify with the manual Dev UI test that `401` will always be returned for the current binary access token. Also note that using `IdToken` as a fallback with either of these UIs is only possible with the authorization code flow.
+====
+
 Some providers such as `Auth0` do not support a standard RP initiated logout so a logout option will also be hidden.
 
 At the moment `Dev UI for all OpenId Connect Providers` only supports an authorization code grant. More grants may be supported in the future, similarly to how it is done with `Dev Services for Keycloak`.

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
@@ -17,7 +17,8 @@ public abstract class AbstractDevConsoleProcessor {
             String clientSecret,
             String authorizationUrl,
             String tokenUrl,
-            String logoutUrl) {
+            String logoutUrl,
+            boolean introspectionIsAvailable) {
         if (oidcProviderName != null) {
             devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("oidcProviderName", oidcProviderName));
         }
@@ -38,6 +39,7 @@ public abstract class AbstractDevConsoleProcessor {
         if (capabilities.isPresent(Capability.SMALLRYE_GRAPHQL)) {
             devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("graphqlIsAvailable", true));
         }
+        devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("introspectionIsAvailable", introspectionIsAvailable));
     }
 
     protected void produceDevConsoleRouteItems(BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsolePostHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsolePostHandler.java
@@ -45,8 +45,13 @@ public class KeycloakDevConsolePostHandler extends DevConsolePostHandler {
                         form.get("clientSecret"),
                         KeycloakDevServicesProcessor.capturedDevServicesConfiguration.webClienTimeout);
             }
-
-            testServiceInternal(event, client, form.get("serviceUrl"), token);
+            LOG.infof("Test token: %s", token);
+            if (form.get("serviceUrl") != null) {
+                testServiceInternal(event, client, form.get("serviceUrl"), token);
+            } else {
+                // only token is required
+                event.put("result", token);
+            }
         } catch (Throwable t) {
             LOG.errorf("Token can not be acquired from Keycloak: %s", t.toString());
         } finally {
@@ -56,7 +61,6 @@ public class KeycloakDevConsolePostHandler extends DevConsolePostHandler {
 
     private void testServiceInternal(RoutingContext event, WebClient client, String serviceUrl, String token) {
         try {
-            LOG.infof("Test token: %s", token);
             LOG.infof("Sending token to '%s'", serviceUrl);
             int statusCode = client.getAbs(serviceUrl)
                     .putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + token).send().await().indefinitely()

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -41,7 +41,8 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     (String) configProps.get().getProperties().get("quarkus.oidc.credentials.secret"),
                     realmUrl + "/protocol/openid-connect/auth",
                     realmUrl + "/protocol/openid-connect/token",
-                    realmUrl + "/protocol/openid-connect/logout");
+                    realmUrl + "/protocol/openid-connect/logout",
+                    true);
 
         }
     }

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -136,39 +136,19 @@ var port = {config:property('quarkus.http.port')};
     }
 
     function navigateToSwaggerUi(){
-        {#if info:swaggerIsAvailable??}
-        var url = "{config:http-path('quarkus.swagger-ui.path')}";
-        
-        var authorizedValue = {
-            "SecurityScheme":{
-                "schema":{
-                    "flow":"implicit",
-                    "authorizationUrl":"{info:authorizationUrl}",
-                    "tokenUrl":"{info:tokenUrl}",
-                    "type":"oauth2",
-                    "description":"Authentication"
-                },
-                "clientId":"{info:clientId}",
-                "name":"SecurityScheme",
-                "token":{
-                    "access_token":accessToken,
-                    "token_type":"Bearer",
-                    "expires_in":"900"
-                }
-            }
-        };
-        
-        localStorage.setItem('authorized', JSON.stringify(authorizedValue));
-        window.open(url, '_blank').focus();
-        {/if}
+        navigateToSwaggerUiWithToken(getTokenForNavigation())
     }
     
     function navigateToGraphQLUi(){
-        {#if info:graphqlIsAvailable??}
-            var url = "{config:http-path('quarkus.smallrye-graphql.ui.root-path')}";
-            var headerJson = '{"authorization": "Bearer ' + accessToken + '"}';
-            url = url + '/?' + encodeURIComponent('headers') + '=' + encodeURIComponent(headerJson);
-            window.open(url, '_blank').focus();
+        navigateToGraphQLUiWithToken(getTokenForNavigation())
+    }
+    
+    function getTokenForNavigation(){
+        {#if info:introspectionIsAvailable??}
+            return accessToken;
+        {#else}
+            var parts = accessToken.split(".");
+            return parts.length == 3 ? accessToken : idToken;
         {/if}
     }
     
@@ -269,6 +249,34 @@ var port = {config:property('quarkus.http.port')};
               printResponseData(data, "User: " + userName + ", " + "service path: " + servicePath);
             });
     }
+    
+    function testServiceWithPasswordInSwaggerUi(userName){
+        $.post("testService",
+            {
+              tokenUrl: '{info:tokenUrl}',
+              client: '{info:clientId}',
+              clientSecret: '{info:clientSecret}',
+              user: userName,
+              grant: '{info:oidcGrantType}'
+            },
+            function(data, status){
+              navigateToSwaggerUiWithToken(data);
+            });
+    }
+    
+    function testServiceWithPasswordInGraphQLUi(userName){
+        $.post("testService",
+            {
+              tokenUrl: '{info:tokenUrl}',
+              client: '{info:clientId}',
+              clientSecret: '{info:clientSecret}',
+              user: userName,
+              grant: '{info:oidcGrantType}'
+            },
+            function(data, status){
+              navigateToGraphQLUiWithToken(data);
+            });
+    }
 {/if}
 
 {#if info:oidcGrantType is 'client_credentials'}
@@ -285,7 +293,69 @@ var port = {config:property('quarkus.http.port')};
               printResponseData(data, "Service path: " + servicePath);
             });
     }
+    function testServiceWithClientCredentialsInSwaggerUi(){
+        $.post("testService",
+            {
+              tokenUrl: '{info:tokenUrl}',
+              client: '{info:clientId}',
+              clientSecret: '{info:clientSecret}',
+              grant: '{info:oidcGrantType}'
+            },
+            function(data, status){
+              navigateToSwaggerUiWithToken(data);
+            });
+    }
+    
+    function testServiceWithClientCredentialsInGraphQLUi(){
+        $.post("testService",
+            {
+              tokenUrl: '{info:tokenUrl}',
+              client: '{info:clientId}',
+              clientSecret: '{info:clientSecret}',
+              grant: '{info:oidcGrantType}'
+            },
+            function(data, status){
+              navigateToGraphQLUiWithToken(data);
+            });
+    }
 {/if}
+
+function navigateToSwaggerUiWithToken(token){
+    {#if info:swaggerIsAvailable??}
+    var url = "{config:http-path('quarkus.swagger-ui.path')}";
+    
+    var authorizedValue = {
+        "SecurityScheme":{
+            "schema":{
+                "flow":"implicit",
+                "authorizationUrl":"{info:authorizationUrl}",
+                "tokenUrl":"{info:tokenUrl}",
+                "type":"oauth2",
+                "description":"Authentication"
+            },
+            "clientId":"{info:clientId}",
+            "name":"SecurityScheme",
+            "token":{
+                "access_token":token,
+                "token_type":"Bearer",
+                "expires_in":"900"
+            }
+        }
+    };
+    
+    localStorage.setItem('authorized', JSON.stringify(authorizedValue));
+    window.open(url, '_blank').focus();
+    {/if}
+}
+
+function navigateToGraphQLUiWithToken(token){
+    {#if info:graphqlIsAvailable??}
+        var url = "{config:http-path('quarkus.smallrye-graphql.ui.root-path')}";
+        var headerJson = '{"authorization": "Bearer ' + token + '"}';
+        url = url + '/?' + encodeURIComponent('headers') + '=' + encodeURIComponent(headerJson);
+        window.open(url, '_blank').focus();
+    {/if}
+}
 
 function printResponseData(data, message){
     if(data.startsWith("2")){
@@ -480,6 +550,18 @@ function signInToService(servicePath) {
                     <div class="col offset-md-2">
                         <button onclick="testServiceWithPassword($('#userName').val(), $('#servicePath').val());" class="btn btn-primary btn-block" title="Test service">Test service</button>
                     </div>
+                    <div class="float-right">
+	                    {#if info:swaggerIsAvailable??}
+	                    <a onclick="testServiceWithPasswordInSwaggerUi($('#userName').val());" class="btn btn-link" title="Test in Swagger UI">
+	                        <i class="fas fa-external-link-alt"></i> Swagger UI
+	                    </a>
+	                    {/if}
+	                    {#if info:graphqlIsAvailable??}
+	                    <a onclick="testServiceWithPasswordInGraphQLUi($('#userName').val());" class="btn btn-link" title="Test in GraphQL UI">
+	                        <i class="fas fa-external-link-alt"></i> GraphQL UI
+	                    </a>
+	                    {/if}
+	                </div>
                 </div>    
 
                 <br/>
@@ -506,6 +588,18 @@ function signInToService(servicePath) {
                     <div class="col offset-md-2">
                         <button onclick="testServiceWithClientCredentials($('#servicePath').val());" class="btn btn-primary btn-block" title="Test service">Test service</button>
                     </div>
+                    <div class="float-right">
+	                    {#if info:swaggerIsAvailable??}
+	                    <a onclick="testServiceWithClientCredentialsInSwaggerUi();" class="btn btn-link" title="Test in Swagger UI">
+	                        <i class="fas fa-external-link-alt"></i> Swagger UI
+	                    </a>
+	                    {/if}
+	                    {#if info:graphqlIsAvailable??}
+	                    <a onclick="testServiceWithClientCredentialsInGraphQLUi();" class="btn btn-link" title="Test in GraphQL UI">
+	                        <i class="fas fa-external-link-alt"></i> GraphQL UI
+	                    </a>
+	                    {/if}
+	                </div>
                 </div>    
 
                 <br/>


### PR DESCRIPTION
This PR:

- Has SwaggerUi and GraphQLUi used for the password and client creds grants as well (Keycloak only for now)
- When SwaggerUi and GraphQLUi are used to test the code flow - then the access token is used only if it is JWT or if it can be introspected, otherwise IdToken is used - this mainly applies to testing non-Keycloak providers, ex, with Auth0 it can be a binary token but no introspection endpoint is available, so using it with Swagge UI will always return 401 so at least with Id Token which is always JWT, there is a chance to get some non 401 result, 200 or 403.
- Minor updates to OIDC dev console processor to try and recognize more provider names 
- Also relaxed OidcDevConsole to support service apps only, web-apps, same as with keycloak is also possible, though as mentioned at #20286 for the moment it is a bit limited