### PR TITLE
Remove integration-tests/gradle from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -136,16 +136,6 @@ updates:
         update-types: ["version-update:semver-major"]
     rebase-strategy: disabled
   - package-ecosystem: gradle
-    directory: "/integration-tests/gradle"
-    schedule:
-      interval: daily
-      time: "21:00"
-      timezone: Europe/Paris
-    open-pull-requests-limit: 4
-    labels:
-      - area/dependencies
-    rebase-strategy: disabled
-  - package-ecosystem: gradle
     directory: "/devtools/gradle"
     schedule:
       interval: daily


### PR DESCRIPTION
Doesn't make sense anymore after #18849 and in fact the bot complains:
![screenshot](https://user-images.githubusercontent.com/22860528/135353271-ba34055f-6b85-4007-86e1-c8910b9a3f6b.png)

...or do we want to run updates in the nested test projects?