### PR TITLE
Make getParent() return null from QuarkusClassLoader

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -182,7 +182,7 @@ public class TestSupport implements TestController {
                             .setDisableClasspathCache(false)
                             .setIsolateDeployment(true)
                             .setExistingModel(null)
-                            .setBaseClassLoader(getClass().getClassLoader().getParent())
+                            .setBaseClassLoader(ClassLoader.getSystemClassLoader())
                             .setTest(true)
                             .setAuxiliaryApplication(true)
                             .setHostApplicationIsTestOnly(devModeType == DevModeType.TEST_ONLY)

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -86,7 +86,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     private volatile boolean driverLoaded;
 
     private QuarkusClassLoader(Builder builder) {
-        super(builder.parent);
+        super(builder.parent instanceof QuarkusClassLoader ? builder.parent : null);
         this.name = builder.name;
         this.elements = builder.elements;
         this.bannedElements = builder.bannedElements;


### PR DESCRIPTION
If the module path is set returning the application ClassLoader from
getParent() will break the ClassLoader isolation, as the module based
service lookup will be used.

Fixes #20190