### PR TITLE
ArC - build time resolution improvement

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
@@ -83,9 +83,7 @@ class BeanResolverImpl implements BeanResolver {
     private List<BeanInfo> findMatching(TypeAndQualifiers typeAndQualifiers) {
         List<BeanInfo> resolved = new ArrayList<>();
         //optimisation for the simple class case
-        Collection<BeanInfo> potentialBeans = typeAndQualifiers.type.kind() == CLASS
-                ? beanDeployment.getBeansByType(typeAndQualifiers.type)
-                : beanDeployment.getBeans();
+        Collection<BeanInfo> potentialBeans = potentialBeans(typeAndQualifiers.type);
         for (BeanInfo b : potentialBeans) {
             if (Beans.matches(b, typeAndQualifiers)) {
                 resolved.add(b);
@@ -97,14 +95,20 @@ class BeanResolverImpl implements BeanResolver {
     List<BeanInfo> findTypeMatching(Type type) {
         List<BeanInfo> resolved = new ArrayList<>();
         //optimisation for the simple class case
-        Collection<BeanInfo> potentialBeans = type.kind() == CLASS ? beanDeployment.getBeansByType(type)
-                : beanDeployment.getBeans();
+        Collection<BeanInfo> potentialBeans = potentialBeans(type);
         for (BeanInfo b : potentialBeans) {
             if (Beans.matchesType(b, type)) {
                 resolved.add(b);
             }
         }
         return resolved.isEmpty() ? Collections.emptyList() : resolved;
+    }
+
+    Collection<BeanInfo> potentialBeans(Type type) {
+        if ((type.kind() == CLASS || type.kind() == PARAMETERIZED_TYPE) && !type.name().equals(DotNames.OBJECT)) {
+            return beanDeployment.getBeansByRawType(type.name());
+        }
+        return beanDeployment.getBeans();
     }
 
     boolean matches(Type requiredType, Type beanType) {

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -59,6 +59,7 @@ public class TypesTest {
                 ParameterizedType fooType = t.asParameterizedType();
                 assertEquals("T", fooType.arguments().get(0).asTypeVariable().identifier());
                 assertEquals(DotNames.OBJECT, fooType.arguments().get(0).asTypeVariable().bounds().get(0).name());
+                assertTrue(Types.containsTypeVariable(fooType));
             }
         }
         ClassInfo producerClass = index.getClassByName(producerName);


### PR DESCRIPTION
This PR follows-up on https://github.com/quarkusio/quarkus/pull/20290

The main improvements are:
- do not cache results for java.lang.Object - every bean has this type
- use optimized immutable structures; in most cases there will be a
single bean for a given type
- the key of the map is DotName (i.e. raw type name) so that it can be
used for parameterized types as well