### PR TITLE
Integrate OIDC DevUI with SwaggerUi and 'web-app' applications

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -57,8 +57,8 @@ public class OidcBuildStep {
     public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
         // TODO: By default quarkus.oidc.application-type = service
         // Also look at other options (web-app, hybrid)
-        securityInformationProducer
-                .produce(SecurityInformationBuildItem.OPENIDCONNECT("quarkus.oidc.auth-server-url"));
+        //securityInformationProducer
+        //        .produce(SecurityInformationBuildItem.OPENIDCONNECT("quarkus.oidc.auth-server-url"));
     }
 
     @BuildStep(onlyIf = IsEnabled.class)

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -357,6 +357,13 @@ function navigateToGraphQLUiWithToken(token){
     {/if}
 }
 
+function navigateToSwaggerUiWithoutToken(){
+    {#if info:swaggerIsAvailable??}
+    var url = "{config:http-path('quarkus.swagger-ui.path')}";
+    window.open(url, '_blank').focus();
+    {/if}
+}
+
 function printResponseData(data, message){
     if(data.startsWith("2")){
         $('#results').append("<i class='far fa-check-circle text-success px-2'></i>");
@@ -624,6 +631,13 @@ function signInToService(servicePath) {
                 <div class="col offset-md-2">
                     <button onclick="signInToService($('#servicePath').val());" class="btn btn-success btn-block" title="Log into your Web Application">Log into your Web Application</button>
                 </div>
+                <div class="float-right">
+	                    {#if info:swaggerIsAvailable??}
+	                    <a onclick="navigateToSwaggerUiWithoutToken();" class="btn btn-link" title="Test in Swagger UI">
+	                        <i class="fas fa-external-link-alt"></i> Swagger UI
+	                    </a>
+	                    {/if}
+	                </div>
             </div>
         </div>
     </div> 


### PR DESCRIPTION
This is a draft PR to make it easy to experiment with using SwaggerUI for testing the `quarkus.oidc.application-type=web-app` applications.
As noted at #20286, current OIDC Dev UI and Swagger UI integration makes it super easy to test `quarkus.oidc.application-type=service` applications because in this case, after irrespectively of how Swagger UI gets its token, it submits it to Quarkus with `HTTP Authorization Bearer` which is exactly what `quarkus.oidc.application-type=service` expects.

However when we have  `quarkus.oidc.application-type=web-app` , it does not know what `HTTP Authorization Bearer` is, as it itself initiates an authorization code flow.

This is why in this draft PR I temporarily update `OidcBuildStep` not to ask Swagger to do any authentication itself when accessing a secure Quarkus endpoint - this endpoint will authenticate any request from the browser itself.

And this is where the problem is when Swagger UI is hitting the CORS problem - I've verified with both Keycloak and Auth0, the OIDC provider authorization endpoints seem not to like it at all (I did configure CORS in Auth0 to expect a `localhost:8080` origin...).

The good news is that
1) Entering a service path manually and using Dev UI `Test Service` works fine as CORS is not a problem in this case
2) it is not a Swagger UI only specific problem. It is to do with it using JavaScipt to access the service endpoints (Fetch or XMLHttpRequest) and this is where CORS restriction is applied
3) 2) is not a big problem as 1) works 

Fixing it would be a nice to to have improvement but it is not a blocker.
The problem can be reproduced with this PR and this config:

```
quarkus.oidc.application-type=web-app

quarkus.http.auth.permission.swagger-ui.paths=/q/swagger-ui
quarkus.http.auth.permission.swagger-ui.policy=permit
quarkus.http.auth.permission.openapi.paths=/q/openapi
quarkus.http.auth.permission.openapi.policy=permit

quarkus.http.cors=true
```

and then `mvn:quarkus-dev` and choose `SwaggerUI` instead of the manual test.

In the Browser Console you'll see a CORS error after invoking any of the secured service methods from Swagger Ui.

The question is how to fix it if it is possible at all. This is what we suggest if JavaScript is used to drive the access to `web-app` service resources: https://quarkus.io/guides/security-openid-connect-web-authentication#single-page-applications

This Java script needs to set a header, `X-Requested-With=JavaScript` and if Quarkus is configured with `quarkus.oidc.authentication.java-script-auto-redirect=false` then this JavaScript will get `499` and at this point all it has to do is to delegate to the browser itself: `window.location.assign(servicePath);`

It is very easy to do for a custom script - but can Quarkus SwaggerUI be somehow customized to do it, that is the problem