### PR TITLE
Dev services container locator constructs service address with docker-host:host-port

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -46,7 +46,8 @@ public class ContainerLocator {
                     .flatMap(container -> getMappedPort(container, port)
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
                                     .map(port -> {
-                                        final ContainerAddress containerAddress = new ContainerAddress(containerPort.getIp(),
+                                        final ContainerAddress containerAddress = new ContainerAddress(
+                                                DockerClientFactory.instance().dockerHostIpAddress(),
                                                 containerPort.getPublicPort());
                                         log.infof("Dev Services container found: %s (%s). Connecting to: %s.",
                                                 container.getId(),


### PR DESCRIPTION
Multiple applications can share some dev services by locating previously launched containers based on labels.

The current container locator constructs the service address using exposed port host IP (0.0.0.0 by default) and host port.
This doesn't work when the Docker host is on another IP than localhost.

This change uses the Docker host as the service host.