### PR TITLE
Add support for multiple sql load scripts

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.deployment;
 
 import java.nio.charset.Charset;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -70,7 +71,7 @@ public class HibernateOrmConfigPersistenceUnit {
      */
     // @formatter:on
     @ConfigItem(defaultValueDocumentation = "import.sql in DEV, TEST ; no-file otherwise")
-    public Optional<String> sqlLoadScript;
+    public Optional<List<String>> sqlLoadScript;
 
     /**
      * The size of the batches used when loading entities and collections.

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportMultipleSqlLoadScriptsFileAbsentTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportMultipleSqlLoadScriptsFileAbsentTestCase.java
@@ -1,0 +1,29 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ImportMultipleSqlLoadScriptsFileAbsentTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(ConfigurationError.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application-import-multiple-load-scripts-test.properties", "application.properties")
+                    .addAsResource("import-multiple-load-scripts-1.sql", "import-1.sql"));
+
+    @Test
+    public void testImportMultipleSqlLoadScriptsTest() {
+        // should not be called, deployment exception should happen first:
+        // it's illegal to have Hibernate sql-load-script configuration property set
+        // to an absent file
+        Assertions.fail();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportMultipleSqlLoadScriptsTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportMultipleSqlLoadScriptsTestCase.java
@@ -1,0 +1,30 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ImportMultipleSqlLoadScriptsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application-import-multiple-load-scripts-test.properties", "application.properties")
+                    .addAsResource("import-multiple-load-scripts-1.sql", "import-1.sql")
+                    .addAsResource("import-multiple-load-scripts-2.sql", "import-2.sql"));
+
+    @Test
+    public void testImportMultipleSqlLoadScriptsTest() {
+        String name1 = "import-1.sql load script entity";
+        String name2 = "import-2.sql load script entity";
+
+        RestAssured.when().get("/orm-sql-load-script/1").then().body(Matchers.is(name1));
+        RestAssured.when().get("/orm-sql-load-script/2").then().body(Matchers.is(name2));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-import-multiple-load-scripts-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-import-multiple-load-scripts-test.properties
@@ -1,0 +1,7 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+#quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import-1.sql,import-2.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-multiple-load-scripts-1.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-multiple-load-scripts-1.sql
@@ -1,0 +1,1 @@
+INSERT INTO MyEntity(id, name) VALUES(1, 'import-1.sql load script entity');

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-multiple-load-scripts-2.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-multiple-load-scripts-2.sql
@@ -1,0 +1,1 @@
+INSERT INTO MyEntity(id, name) VALUES(2, 'import-2.sql load script entity');


### PR DESCRIPTION
This PR fixes the issue #20177.
The property "quarkus.hibernate-orm.sql-load-script" can now take a comma separated list of SQL load scripts.