### PR TITLE
Update to Apicurio Registry 2.1.1.Final and use Vert.x HTTP client

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -201,7 +201,8 @@
         <log4j2-jboss-logmanager.version>1.0.0.Final</log4j2-jboss-logmanager.version>
         <log4j-jboss-logmanager.version>1.2.2.Final</log4j-jboss-logmanager.version>
         <avro.version>1.11.0</avro.version>
-        <apicurio-registry.version>2.0.1.Final</apicurio-registry.version>
+        <apicurio-registry.version>2.1.1.Final</apicurio-registry.version>
+        <apicurio-common-rest-client.version>0.0.9.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <jacoco.version>0.8.7</jacoco.version>
         <testcontainers.version>1.16.2</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.2.12</docker-java.version> <!-- must be the version Testcontainers use -->
@@ -3045,6 +3046,11 @@
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
                 <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-common-rest-client-vertx</artifactId>
+                <version>${apicurio-common-rest-client.version}</version>
             </dependency>
 
             <dependency>

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -392,7 +392,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.0.1.Final
+    image: apicurio/apicurio-registry-mem:2.1.1.Final
     ports:
       - 8081:8080
     depends_on:
@@ -607,7 +607,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
     @Override
     public Map<String, String> start() {
         kafka.start();
-        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.0.1.Final")
+        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.1.1.Final")
                 .withExposedPorts(8080)
                 .withEnv("QUARKUS_PROFILE", "prod");
         registry.start();

--- a/extensions/apicurio-registry-avro/deployment/pom.xml
+++ b/extensions/apicurio-registry-avro/deployment/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient-deployment</artifactId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
+++ b/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
@@ -3,9 +3,12 @@ package io.quarkus.apicurio.registry.avro;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.vertx.deployment.VertxBuildItem;
 
 public class ApicurioRegistryAvroProcessor {
     @BuildStep
@@ -35,10 +38,11 @@ public class ApicurioRegistryAvroProcessor {
                 "io.apicurio.registry.serde.Legacy4ByteIdHandler",
                 "io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider",
                 "io.apicurio.registry.serde.headers.DefaultHeadersHandler"));
+    }
 
-        // Apicurio Registry 2.x uses the JDK 11 HTTP client, which unconditionally requires SSL
-        // TODO when the new HTTP client SPI in Apicurio Registry client appears, this will no longer be needed
-        //  (but we'll have to make sure that the Vert.x HTTP client is used)
-        sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.APICURIO_REGISTRY_AVRO));
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void apicurioRegistryClient(VertxBuildItem vertx, ApicurioRegistryClient client) {
+        client.setup(vertx.getVertx());
     }
 }

--- a/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryDevServicesBuildTimeConfig.java
+++ b/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryDevServicesBuildTimeConfig.java
@@ -29,7 +29,7 @@ public class ApicurioRegistryDevServicesBuildTimeConfig {
      * The Apicurio Registry image to use.
      * Note that only Apicurio Registry 2.x images are supported.
      */
-    @ConfigItem(defaultValue = "apicurio/apicurio-registry-mem:2.0.1.Final")
+    @ConfigItem(defaultValue = "apicurio/apicurio-registry-mem:2.1.1.Final")
     public String imageName;
 
     /**

--- a/extensions/apicurio-registry-avro/runtime/pom.xml
+++ b/extensions/apicurio-registry-avro/runtime/pom.xml
@@ -17,6 +17,16 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.apicurio</groupId>
+                    <artifactId>apicurio-common-rest-client-jdk</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-common-rest-client-vertx</artifactId>
         </dependency>
 
         <dependency>
@@ -27,10 +37,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-avro</artifactId>
         </dependency>
-        <!-- Apicurio Registry libraries use Keycloak client, which requires Apache HTTP Client -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/apicurio-registry-avro/runtime/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryClient.java
+++ b/extensions/apicurio-registry-avro/runtime/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryClient.java
@@ -1,0 +1,14 @@
+package io.quarkus.apicurio.registry.avro;
+
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.rest.client.VertxHttpClientProvider;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Vertx;
+
+@Recorder
+public class ApicurioRegistryClient {
+    public void setup(RuntimeValue<Vertx> vertx) {
+        RegistryClientFactory.setProvider(new VertxHttpClientProvider(vertx.getValue()));
+    }
+}

--- a/integration-tests/kafka-avro-apicurio2/pom.xml
+++ b/integration-tests/kafka-avro-apicurio2/pom.xml
@@ -22,7 +22,7 @@
       -->
 
     <properties>
-        <apicurio.version>2.0.1.Final</apicurio.version>
+        <apicurio.version>2.1.1.Final</apicurio.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAndSchemaRegistryTestResource.java
+++ b/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAndSchemaRegistryTestResource.java
@@ -29,7 +29,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
     @Override
     public Map<String, String> start() {
         kafka.start();
-        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.0.1.Final")
+        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.1.1.Final")
                 .withExposedPorts(8080)
                 .withEnv("QUARKUS_PROFILE", "prod");
         registry.start();

--- a/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
+++ b/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
@@ -1,10 +1,20 @@
 package io.quarkus.it.kafka;
 
+import org.junit.jupiter.api.BeforeAll;
+
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.rest.client.VertxHttpClientProvider;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.vertx.core.Vertx;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(KafkaAndSchemaRegistryTestResource.class)
 public class KafkaAvroIT extends KafkaAvroTest {
+    @BeforeAll
+    public static void setUp() {
+        // this is for the test JVM, which also uses Kafka client, which in turn also interacts with the registry
+        RegistryClientFactory.setProvider(new VertxHttpClientProvider(Vertx.vertx()));
+    }
 
 }


### PR DESCRIPTION
We (the Apicurio Team) released a new version of Registry recently. This PR updates the usage of Registry to the new version.