### PR TITLE
A build step must be a non-static method

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -476,16 +476,16 @@ public final class ExtensionLoader {
         // now iterate the methods
         final List<Method> methods = getMethods(clazz);
         for (Method method : methods) {
-            final int mods = method.getModifiers();
-            if (Modifier.isStatic(mods)) {
+            final BuildStep buildStep = method.getAnnotation(BuildStep.class);
+            if (buildStep == null) {
                 continue;
             }
-            if (!method.isAnnotationPresent(BuildStep.class))
-                continue;
-            if (!Modifier.isPublic(mods) || !Modifier.isPublic(method.getDeclaringClass().getModifiers())) {
+            if (Modifier.isStatic(method.getModifiers())) {
+                throw new RuntimeException("A build step must be a non-static method: " + method);
+            }
+            if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isPublic(method.getDeclaringClass().getModifiers())) {
                 method.setAccessible(true);
             }
-            final BuildStep buildStep = method.getAnnotation(BuildStep.class);
             final Class<? extends BooleanSupplier>[] onlyIf = buildStep.onlyIf();
             final Class<? extends BooleanSupplier>[] onlyIfNot = buildStep.onlyIfNot();
             final Parameter[] methodParameters = method.getParameters();

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -23,7 +23,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ConfigClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -38,7 +37,6 @@ public class ConfigMappingUtils {
     private ConfigMappingUtils() {
     }
 
-    @BuildStep
     public static void generateConfigClasses(
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -578,9 +578,8 @@ to produce the final build artifact(s).
 
 ==== Build steps
 
-A _build step_ is a method which is annotated with the `@io.quarkus.deployment.annotations.BuildStep` annotation.  Each
-build step may <<consuming-values,consume>> items that are produced by earlier stages, and <<producing-values,produce>> items
-that can be consumed by later stages. Build steps are normally only run when they produce a build item that is
+A _build step_ is a non-static method which is annotated with the `@io.quarkus.deployment.annotations.BuildStep` annotation.  
+Each build step may <<consuming-values,consume>> items that are produced by earlier stages, and <<producing-values,produce>> items that can be consumed by later stages. Build steps are normally only run when they produce a build item that is
 ultimately consumed by another step.
 
 Build steps are normally placed on plain classes within an extension's deployment module.  The classes are automatically


### PR DESCRIPTION
- previously all static methods annotated with BuildStep were silently
ignored