### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Be sure to test your pull request in:
 If you have not done so on this machine, you need to:
  
 * Install Git and configure your GitHub access
-* Install Java SDK 8 or 11+ (OpenJDK recommended)
+* Install Java SDK 11+ (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:
     * Linux


### PR DESCRIPTION
Small correction to the contributing guide, we need Java 11 now.

I made the change from the Github UI and it creates a branch on the quarkus main repo not on my fork, sorry for that, I'll delete the branch when merged.