### PR TITLE
Remove dependency management for google-http-client

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -187,7 +187,6 @@
         <checker-qual.version>2.5.2</checker-qual.version>
         <error-prone-annotations.version>2.2.0</error-prone-annotations.version>
         <jib-core.version>0.20.0</jib-core.version>
-        <google-http-client.version>1.34.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.40.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
@@ -5266,11 +5265,6 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.http-client</groupId>
-                <artifactId>google-http-client</artifactId>
-                <version>${google-http-client.version}</version>
             </dependency>
 
             <!-- gRPC additional dependencies (the rest is managed by the BOM) -->


### PR DESCRIPTION
The right version is used by JIB without the dependency management part, but this cause an issue for Google Cloud Services that needs a more recent version.

The version was downgraded by #20398 due to issues with JIB and the latest version.

As the Quarkus BOM is included before the Google Cloud Services one, there is no way to override the version on the Google Cloud Services side.

Keep in mind that now, JIB and Google Cloud Services are incompatible extensions.

Another solution would be to revert #20398.