### PR TITLE
Preserve cause of Jackson encoding exception when using Vert.x

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/QuarkusJacksonJsonCodec.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/QuarkusJacksonJsonCodec.java
@@ -144,7 +144,7 @@ class QuarkusJacksonJsonCodec implements JsonCodec {
             ObjectMapper mapper = pretty ? prettyMapper() : QuarkusJacksonJsonCodec.mapper;
             return mapper.writeValueAsString(object);
         } catch (Exception e) {
-            throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+            throw new EncodeException("Failed to encode as JSON: " + e.getMessage(), e);
         }
     }
 
@@ -154,7 +154,7 @@ class QuarkusJacksonJsonCodec implements JsonCodec {
             ObjectMapper mapper = pretty ? prettyMapper() : QuarkusJacksonJsonCodec.mapper;
             return Buffer.buffer(mapper.writeValueAsBytes(object));
         } catch (Exception e) {
-            throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+            throw new EncodeException("Failed to encode as JSON: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Relates to: #20490