### PR TITLE
gradlew.bat/mvnw.bat should NOT be executable

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -2,7 +2,6 @@ name: gradle-wrapper
 type: tooling
 output-strategy:
   "gradlew": "executable"
-  "gradlew.bat": "executable"
 language:
   base:
     data:

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
@@ -2,7 +2,6 @@ name: maven-wrapper
 type: tooling
 output-strategy:
   "mvnw": "executable"
-  "mvnw.cmd": "executable"
 language:
   base:
     data:

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/compress/QuarkusProjectCompress.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/compress/QuarkusProjectCompress.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.zip.UnixStat;
@@ -17,11 +15,7 @@ import org.apache.commons.compress.archivers.zip.ZipLong;
 
 public final class QuarkusProjectCompress {
 
-    private static final List<String> EXECUTABLES = Collections.unmodifiableList(Arrays.asList(
-            "gradlew",
-            "gradlew.bat",
-            "mvnw",
-            "mvnw.bat"));
+    private static final List<String> EXECUTABLES = List.of("gradlew", "mvnw");
 
     // Visible for testing
     static final int DIR_UNIX_MODE = UnixStat.DIR_FLAG | UnixStat.DEFAULT_DIR_PERM;


### PR DESCRIPTION
If the gradle project is generated, the root directory listing has these gradle-wrapper related files:
```
ls -la demo/gradlew*
-rwxr-xr-x@ 1 morph  staff  8070 Oct  2 21:47 demo/gradlew
-rwxr-xr-x@ 1 morph  staff  2763 Oct  2 21:47 demo/gradlew.bat
```
The problem is that the second one, the bat file should not be executable, because it is auto-suggested in the shell to be executed, it raises inconvenience and requires manual fixing (via chmod). You can ensure and just list e.g. root directory of quarkus:
```
ls -la quarkus/mvnw*
-rwxr-xr-x  1 morph  staff  10069 Oct  3 19:50 quarkus/mvnw
-rw-r--r--  1 morph  staff   6607 Oct  3 19:50 quarkus/mvnw.cmd
```
The first file for *nix has the executable flag, the second file for Windows - does not.

This PR addresses the issue.

The same for maven wrapper bat executable.