### PR TITLE
Qute type-safe validation fix

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1708,6 +1708,7 @@ public class QuteProcessor {
     private static AnnotationTarget findProperty(String name, ClassInfo clazz, IndexView index) {
         Set<DotName> interfaceNames = new HashSet<>();
         while (clazz != null) {
+            addInterfaces(clazz, index, interfaceNames);
             interfaceNames.addAll(clazz.interfaceNames());
             // Fields
             for (FieldInfo field : clazz.fields()) {
@@ -1756,6 +1757,19 @@ public class QuteProcessor {
         return null;
     }
 
+    private static void addInterfaces(ClassInfo clazz, IndexView index, Set<DotName> interfaceNames) {
+        if (clazz == null) {
+            return;
+        }
+        List<DotName> names = clazz.interfaceNames();
+        if (!names.isEmpty()) {
+            interfaceNames.addAll(names);
+            for (DotName name : names) {
+                addInterfaces(index.getClassByName(name), index, interfaceNames);
+            }
+        }
+    }
+
     /**
      * Find a non-static non-synthetic method with the given name, matching number of params and assignable parameter types.
      *
@@ -1771,7 +1785,7 @@ public class QuteProcessor {
             IndexView index, Function<String, String> templateIdToPathFun, Map<String, Match> results) {
         Set<DotName> interfaceNames = new HashSet<>();
         while (clazz != null) {
-            interfaceNames.addAll(clazz.interfaceNames());
+            addInterfaces(clazz, index, interfaceNames);
             for (MethodInfo method : clazz.methods()) {
                 if (Modifier.isPublic(method.flags()) && !Modifier.isStatic(method.flags())
                         && !ValueResolverGenerator.isSynthetic(method.flags())

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/InterfaceValidationSuccessTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/InterfaceValidationSuccessTest.java
@@ -20,7 +20,7 @@ public class InterfaceValidationSuccessTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(Metrics.class, Count.class, Wrapper.class)
+                    .addClasses(Metrics.class, Count.class, Wrapper.class, NumericWrapper.class)
                     .addAsResource(new StringAsset("{@java.util.List list}"
                             + "{list.empty}:{list.toString}"),
                             "templates/list.html")
@@ -76,7 +76,10 @@ public class InterfaceValidationSuccessTest {
         String name(int age);
     }
 
-    public interface Count extends Wrapper<Integer> {
+    public interface NumericWrapper extends Wrapper<Integer> {
+    }
+
+    public interface Count extends NumericWrapper {
     }
 
     public interface Metrics {


### PR DESCRIPTION
- also include all methods from the interfaces extended by other
interfaces (not only from those implemented directly by any class in the
hierarchy)
- resolves #20512