### PR TITLE
Honor explicit container-build=false when container-runtime is set

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -171,13 +171,17 @@ public class NativeConfig {
      * used by default. If docker is not available or is an alias to podman, podman will be used instead as the default.
      */
     @ConfigItem
-    public boolean containerBuild;
+    public Optional<Boolean> containerBuild;
 
     /**
      * If this build is done using a remote docker daemon.
      */
     @ConfigItem
     public boolean remoteContainerBuild;
+
+    public boolean isContainerBuild() {
+        return containerBuild.orElse(containerRuntime.isPresent() || remoteContainerBuild);
+    }
 
     /**
      * The docker image to use to do the image build

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -254,7 +254,7 @@ public class KafkaProcessor {
 
         String root = "org/xerial/snappy/native/";
         // add linux64 native lib when targeting containers
-        if (nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild) {
+        if (nativeConfig.isContainerBuild()) {
             String dir = "Linux/x86_64";
             String snappyNativeLibraryName = "libsnappyjava.so";
             String path = root + dir + "/" + snappyNativeLibraryName;

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -32,7 +32,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.steps.NativeImageBuildStep;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsProducer;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRecorder;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
@@ -123,7 +122,7 @@ class KafkaStreamsProcessor {
 
     private void addSupportForRocksDbLib(BuildProducer<NativeImageResourceBuildItem> nativeLibs, NativeConfig nativeConfig) {
         // for RocksDB, either add linux64 native lib when targeting containers
-        if (NativeImageBuildStep.isContainerBuild(nativeConfig)) {
+        if (nativeConfig.isContainerBuild()) {
             nativeLibs.produce(new NativeImageResourceBuildItem("librocksdbjni-linux64.so"));
         }
         // otherwise the native lib of the platform this build runs on


### PR DESCRIPTION
Makes -Dquarkus.native.container-runtime=docker not imply
-Dquarkus.native.container-build=true when the latter is explicitly set
to false.  Additionally makes isContainerBuild checks consistent.

I.e. if -Dquarkus.native.container-runtime=podman
-Dquarkus.native.container-build=false are passed as parameters Quarkus
will not use a builder image.

Closes: #20258