### PR TITLE
Set mininal gradle version to 6.1

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -271,8 +271,8 @@ public class QuarkusPlugin implements Plugin<Project> {
     }
 
     private void verifyGradleVersion() {
-        if (GradleVersion.current().compareTo(GradleVersion.version("5.0")) < 0) {
-            throw new GradleException("Quarkus plugin requires Gradle 5.0 or later. Current version is: " +
+        if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) < 0) {
+            throw new GradleException("Quarkus plugin requires Gradle 6.1 or later. Current version is: " +
                     GradleVersion.current());
         }
     }


### PR DESCRIPTION
I tried to use gradle 5.6 but the current project generation and api we are using require gradle 6.1. 