### PR TITLE
Report throwable on write

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
@@ -69,7 +69,14 @@ public class VertxBlockingOutput implements VertxOutput {
     public void write(ByteBuf data, boolean last) throws IOException {
         if (last && data == null) {
             request.response().end();
+            //if there is a problem we still try and end, but then throw to report to the caller
+            if (throwable != null) {
+                throw new IOException(throwable);
+            }
             return;
+        }
+        if (throwable != null) {
+            throw new IOException(throwable);
         }
         try {
             //do all this in the same lock


### PR DESCRIPTION
Note that we don't wait for the write operation for performance reasons
to allow vert.x to buffer the response. The failure will be reported at
some point before/during close.

Fixes #20458