### PR TITLE
Exclude javax.xml.bind:jaxb-api from the quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -73,8 +73,6 @@
         <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <jaxb-runtime.version>2.3.3-b02</jaxb-runtime.version>
-        <!-- just for test dependency convergence -->
-        <jaxb-api.version>2.3.1</jaxb-api.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
         <asm.version>9.2</asm.version>
@@ -3099,11 +3097,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -16,6 +16,9 @@
     <description>Dependency management for integration tests. Importable by third party extension developers.</description>
 
     <properties>
+        <!-- just for test dependency convergence -->
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+
         <rxjava1.version>1.3.8</rxjava1.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>
@@ -52,6 +55,12 @@
                         <artifactId>docker-java-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Moving the `javax.xml.bind:jaxb-api` constraint to the test BOM.