### PR TITLE
Prefer workspace paths only for artifacts that are not extensions or their dependencies

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -28,6 +28,7 @@ public interface BootstrapConstants {
     String META_INF = "META-INF";
 
     String DESCRIPTOR_PATH = META_INF + '/' + DESCRIPTOR_FILE_NAME;
+    String BUILD_STEPS_PATH = META_INF + "/quarkus-build-steps.list";
 
     String PROP_DEPLOYMENT_ARTIFACT = "deployment-artifact";
     String PROP_PROVIDES_CAPABILITIES = "provides-capabilities";


### PR DESCRIPTION
This fixes GRPC dev mode tests in the deployment module.
The issue was caused by the bootstrap refactoring PR which preferred local workspace paths (classes dirs) to the JARs as the resolved artifact paths in dev mode and tests.
This PR makes sure extension artifacts and their dependencies are resolved as JARs, like before.