### PR TITLE
Fix gRPC code gen test

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -190,7 +190,8 @@ public class DeploymentInjectingDependencyVisitor {
             if (resolver.getProjectModuleResolver() != null) {
                 module = resolver.getProjectModuleResolver().getProjectModule(artifact.getGroupId(), artifact.getArtifactId());
             }
-            newRtDep = toAppArtifact(artifact, module, preferWorkspacePaths)
+            //if a classifier is set we never prefer workspace paths
+            newRtDep = toAppArtifact(artifact, module, preferWorkspacePaths && artifact.getClassifier().isEmpty())
                     .setRuntimeCp()
                     .setDeploymentCp()
                     .setOptional(node.getDependency().isOptional())


### PR DESCRIPTION
If an artifact has a classifier don't resolve it from the workspace, as
the classes directory does not correspond to this artifact.