### PR TITLE
Qute parser - use standard error report for invalid virtual methods

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import io.quarkus.qute.TemplateNode.Origin;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,20 +31,20 @@ public final class Expressions {
         return value.substring(0, start);
     }
 
-    public static List<String> parseVirtualMethodParams(String value) {
+    public static List<String> parseVirtualMethodParams(String value, Origin origin, String exprValue) {
         int start = value.indexOf(LEFT_BRACKET);
         if (start != -1 && value.endsWith(RIGHT_BRACKET)) {
             String params = value.substring(start + 1, value.length() - 1);
             return splitParts(params, PARAMS_SPLIT_CONFIG);
         }
-        throw new IllegalArgumentException("Not a virtual method: " + value);
+        throw Parser.parserError("invalid virtual method in {" + exprValue + "}", origin);
     }
 
-    public static String parseBracketContent(String value) {
+    public static String parseBracketContent(String value, Origin origin, String exprValue) {
         if (value.endsWith(SQUARE_RIGHT_BRACKET)) {
             return value.substring(1, value.length() - 1);
         }
-        throw new IllegalArgumentException("Not a bracket notation expression: " + value);
+        throw Parser.parserError("invalid bracket notation expression in {" + exprValue + "}", origin);
     }
 
     public static String buildVirtualMethodSignature(String name, List<String> params) {

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -355,6 +355,18 @@ public class ParserTest {
                 "Parser error on line 1: empty expression found {data:}", 1);
     }
 
+    @Test
+    public void testInvalidVirtualMethod() {
+        assertParserError("{foo.baz()(}",
+                "Parser error on line 1: invalid virtual method in {foo.baz()(}", 1);
+    }
+
+    @Test
+    public void testInvalidBracket() {
+        assertParserError("{foo.baz[}",
+                "Parser error on line 1: invalid bracket notation expression in {foo.baz[}", 1);
+    }
+
     public static class Foo {
 
         public List<Item> getItems() {


### PR DESCRIPTION
- resolves #20567

The error should look like: `Parser error in template [hello.html] on line 8: invalid virtual method in {name.foo()(}`.