### PR TITLE
Fix formatting of warnings for legacy beans annotated with @PersistenceUnit

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitUtil.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitUtil.java
@@ -70,7 +70,7 @@ public class PersistenceUnitUtil {
                             + " This is deprecated usage and will not work in future versions of Quarkus."
                             + " Annotate this bean with @%2$s(\"%4$s\") instead of @%3$s(\"%4$s\") to make it future-proof.",
                             beanType.getName(), PersistenceUnitExtension.class.getSimpleName(),
-                            PersistenceUnit.class.getSimpleName());
+                            PersistenceUnit.class.getSimpleName(), persistenceUnitName);
                 }
             }
         }


### PR DESCRIPTION
Fixes #20581

The tests weren't failing because the exception happens inside the logger, and the logger never throws exceptions: it just logs them.

The main purpose of the test is to check that legacy annotations still work, and it does that job well, so I didn't change it. I don't think it's worth the effort to add a test to check that the warnings are properly logged; I've checked manually, it works. If you want to check too, just build Quarkus, then run this:

```sh
 mvn clean install -f integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/ -Dtest-containers -Dstart-containers
```