### PR TITLE
gRPC Dev UI - propagate parsing errors to UI

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleWebSocketListener.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleWebSocketListener.java
@@ -180,7 +180,12 @@ public class GrpcDevConsoleWebSocketListener implements GrpcWebSocketProxy.WebSo
                                     }
                                 }
                             } catch (Exception e) {
-                                throw new IllegalStateException(e);
+                                websocketData.responseConsumer
+                                        .accept(jsonResponse(id, "ERROR").put("body",
+                                                e.getMessage() + "\nCheck application log for more details")
+                                                .encode());
+                                grpcCall.incomingStream = null;
+                                log.error("Failure returned by gRPC service", e);
                             }
                         }
                     }


### PR DESCRIPTION
The result:

![image](https://user-images.githubusercontent.com/3901322/136387664-e15ca6af-0c16-4587-9edc-1e6423f421ba.png)

![image](https://user-images.githubusercontent.com/3901322/136387723-e6ad7513-7936-44ac-b0aa-72b750cb279f.png)
