### PR TITLE
Add "works with openjdk" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
 [![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17-brightgreen.svg?style=for-the-badge&logo=Java)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
 
+<a href="https://foojay.io/today/works-with-openjdk"><img align="left" src="https://github.com/foojayio/badges/raw/main/works_with_openjdk/Works-with-OpenJDK.png" width="100"></a>
+<br><br><br>
+----
+
 # Quarkus - Supersonic Subatomic Java
 
 Quarkus is a Cloud Native, (Linux) Container First framework for writing Java applications.


### PR DESCRIPTION
OpenJDK powers millions of applications and services around the globe. The OpenJDK project is where Java is developed and maintained and provides the reference implementation for Java SE specifications. A multitude of reputable, compatible, and interchangeable OpenJDK distributions are available to power Java applications that work with OpenJDK.

Use the "Works with OpenJDK" badge to indicate that your project, library, application, or service is known to work with OpenJDK. Or uses OpenJDK. Or is tested on OpenJDK. Or is generally happy with or likes OpenJDK.

Let's celebrate OpenJDK!