### PR TITLE
Fix intermittent failure

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -48,6 +48,7 @@ public abstract class AbstractTransactionLifecycleTest {
             // Expect no warnings (in particular from Agroal)
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
                     // Ignore these particular warnings: they are not relevant to this test.
+                    && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
                     && !record.getMessage().contains("Using Java versions older than 11 to build Quarkus applications")
                     && !record.getMessage().contains("Agroal does not support detecting if a connection is still usable")
                     && !record.getMessage().contains("Netty DefaultChannelId initialization"))


### PR DESCRIPTION
Failure seen here: https://github.com/quarkusio/quarkus/pull/20558#issuecomment-938322771

CI just has a very slow moment, causing the blocked thread detector to trigger. This causes the test to fail as it break the log assertion.