### PR TITLE
Qute - introduce TemplateData#namespace()

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1569,11 +1569,42 @@ class Item {
 
 [source,html]
 ----
-{#each items} <1>
+{#each items}
   {it.price.setScale(2, rounding)} <1>
 {/each}
 ----
 <1> The generated value resolver knows how to invoke the `BigDecimal.setScale()` method.
+
+==== Accessing Static Fields and Methods
+
+If `@TemplateData#namespace()` is set to a non-empty value then a namespace resolver is automatically generated to access static fields and methods of the target class.
+By default, the namespace is the FQCN of the target class where dots and dollar signs are replaced by underscores.
+For example, the namespace for a class with name `org.acme.Foo` is `org_acme_Foo`.
+The static field `Foo.AGE` can be accessed via `{org_acme_Foo:AGE}`.
+The static method `Foo.computeValue(int number)` can be accessed via `{org_acme_Foo:computeValue(10)}`.
+ 
+NOTE: A namespace can only consist of alphanumeric characters and underscores.
+
+.Enum Annotated With `@TemplateData`
+[source,java]
+----
+package model;
+
+@TemplateData <1>
+public enum Status {
+    ON,
+    OFF
+}
+----
+<1> A name resolver with the namespace `model_Status` is generated automatically.
+
+.Template Accessing Enum Constants
+[source,html]
+----
+{#if machine.status == model_Status:ON}
+  The machine is ON!
+{/if}
+----
 
 [[native_executables]]
 === Native Executables

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -914,6 +914,9 @@ public class QuteProcessor {
                     idx = name.lastIndexOf(ExtensionMethodGenerator.SUFFIX);
                 }
                 if (idx == -1) {
+                    idx = name.lastIndexOf(ValueResolverGenerator.NAMESPACE_SUFFIX);
+                }
+                if (idx == -1) {
                     idx = name.lastIndexOf(ValueResolverGenerator.SUFFIX);
                 }
                 String className = name.substring(0, idx);

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeCheckExcludeBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeCheckExcludeBuildItem.java
@@ -49,7 +49,7 @@ public final class TypeCheckExcludeBuildItem extends MultiBuildItem {
         public final int numberOfParameters;
 
         public TypeCheck(String name, ClassInfo clazz, int parameters) {
-            this.name = name;
+            this.name = Objects.requireNonNull(name, "Name must not be null");
             this.clazz = clazz;
             this.numberOfParameters = parameters;
         }
@@ -68,7 +68,7 @@ public final class TypeCheckExcludeBuildItem extends MultiBuildItem {
         }
 
         public boolean classNameEquals(DotName name) {
-            return clazz.name().equals(name);
+            return clazz != null ? clazz.name().equals(name) : false;
         }
 
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
@@ -11,13 +11,22 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark a target type for which a value resolver should be automatically generated. Note that
  * non-public members, constructors, static initializers, static, synthetic and void methods are always ignored.
+ * <p>
+ * If the {@link #namespace()} is set to a non-empty value then a namespace resolver is automatically generated to access static
+ * fields and methos of the target class.
  * 
  * @see ValueResolver
+ * @see NamespaceResolver
  */
 @Target(TYPE)
 @Retention(RUNTIME)
 @Repeatable(Container.class)
 public @interface TemplateData {
+
+    /**
+     * Constant value for {@link #key()} indicating that the annotated element's name should be used as-is.
+     */
+    String UNDERSCORED_FQCN = "<<undescored fqcn>>";
 
     /**
      * The class a value resolver should be generated for. By default, the annotated type.
@@ -38,6 +47,17 @@ public @interface TemplateData {
      * If set to true include only properties: instance fields and methods without params.
      */
     boolean properties() default false;
+
+    /**
+     * If set to a non-empty value then a namespace resolver is automatically generated to access static fields and methos of
+     * the target class.
+     * <p>
+     * By default, the namespace is the FQCN of the target class where dots and dollar signs are replaced by underscores, for
+     * example the namespace for a class with name {@code org.acme.Foo} is {@code org_acme_Foo}.
+     * <p>
+     * Note that a namespace can only consist of alphanumeric characters and underscores.
+     */
+    String namespace() default UNDERSCORED_FQCN;
 
     @Retention(RUNTIME)
     @Target(TYPE)

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyEnum.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyEnum.java
@@ -1,0 +1,19 @@
+package io.quarkus.qute.generator;
+
+import io.quarkus.qute.TemplateData;
+
+@TemplateData(namespace = "MyEnum")
+public enum MyEnum {
+
+    ONE,
+    BAR,
+    CHARLIE;
+
+    MyEnum() {
+    }
+
+    public String getName() {
+        return this.toString().toLowerCase();
+    }
+
+}

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyService.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyService.java
@@ -99,4 +99,8 @@ public class MyService {
         return "ok";
     }
 
+    public static int getDummy(int val) {
+        return val * 2;
+    }
+
 }


### PR DESCRIPTION
- and make it possible to access static fields and methos of the target
class

For now the expressions that start with a namespace coming from a `@TemplateData` are ignored during type-safe validation  - I will create a follow-up issue to address this shortage.

To use it with an enum:
```java
package model;

@TemplateData // the default namespace is the FQCN of the target class with dots and dollar signs replaced with underscores
public enum Status {
    ON,
    OFF
}
```

and use it like this:
```
{#if machine.status == model_Status:ON}
  The machine is ON!
{/if}
```