### PR TITLE
Allow to do a blocking smallrye-jwt authentication

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtBuildTimeConfig.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtBuildTimeConfig.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * deployment configuration
  */
 @ConfigRoot(name = "smallrye-jwt")
-public class SmallRyeJWTConfig {
+public class SmallRyeJwtBuildTimeConfig {
 
     /**
      * The MP-JWT configuration object

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -57,7 +57,7 @@ class SmallRyeJwtProcessor {
     private static final DotName CLAIM_NAME = DotName.createSimple(Claim.class.getName());
     private static final DotName CLAIMS_NAME = DotName.createSimple(Claims.class.getName());
 
-    SmallRyeJWTConfig config;
+    SmallRyeJwtBuildTimeConfig config;
 
     @BuildStep(onlyIf = IsEnabled.class)
     ExtensionSslNativeSupportBuildItem enableSslInNative() {
@@ -175,7 +175,7 @@ class SmallRyeJwtProcessor {
     }
 
     public static class IsEnabled implements BooleanSupplier {
-        SmallRyeJWTConfig config;
+        SmallRyeJwtBuildTimeConfig config;
 
         public boolean getAsBoolean() {
             return config.enabled;

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsCustomFactoryUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsCustomFactoryUnitTest.java
@@ -27,7 +27,8 @@ public class DefaultGroupsCustomFactoryUnitTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(testClasses)
                     .addAsResource("privateKey.pem")
-                    .addAsResource("TokenUserGroup.json"));
+                    .addAsResource("TokenUserGroup.json")
+                    .addAsResource("applicationCustomFactory.properties", "application.properties"));
 
     @BeforeEach
     public void generateToken() throws Exception {

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestJWTCallerPrincipalFactory.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestJWTCallerPrincipalFactory.java
@@ -6,7 +6,6 @@ import java.util.Base64;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.jose4j.jwt.JwtClaims;
-import org.jose4j.jwt.consumer.InvalidJwtException;
 
 import io.quarkus.arc.AlternativePriority;
 import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
@@ -22,9 +21,10 @@ public class TestJWTCallerPrincipalFactory extends JWTCallerPrincipalFactory {
     @Override
     public JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException {
         try {
+            Thread.sleep(5000);
             String json = new String(Base64.getUrlDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8);
             return new DefaultJWTCallerPrincipal(JwtClaims.parse(json));
-        } catch (InvalidJwtException ex) {
+        } catch (Exception ex) {
             throw new ParseException(ex.getMessage());
         }
     }

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
@@ -31,7 +31,7 @@ public class TokenRealmUnitTest {
         PublicKey pk1 = keyPair.getPublic();
         PrivateKey pk1Priv = keyPair.getPrivate();
         JWTAuthContextInfo contextInfo = new JWTAuthContextInfo((RSAPublicKey) pk1, "https://server.example.com");
-        MpJwtValidator jwtValidator = new MpJwtValidator(new DefaultJWTParser(contextInfo));
+        MpJwtValidator jwtValidator = new MpJwtValidator(new DefaultJWTParser(contextInfo), null);
         QuarkusIdentityProviderManagerImpl authenticator = QuarkusIdentityProviderManagerImpl.builder()
                 .addProvider(new AnonymousIdentityProvider())
                 .setBlockingExecutor(new Executor() {

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationCustomFactory.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationCustomFactory.properties
@@ -1,0 +1,1 @@
+quarkus.smallrye-jwt.blocking-authentication=true

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.jwt.runtime.auth;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "smallrye-jwt", phase = ConfigPhase.RUN_TIME)
+public class SmallRyeJwtConfig {
+
+    /**
+     * Enable this property if fetching the remote keys can be a time consuming operation.
+     * Do not enable it if you use the local keys.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean blockingAuthentication;
+}


### PR DESCRIPTION
It is related to https://github.com/smallrye/smallrye-jwt/issues/511.

`smallrye-jwt` uses an internal blocking Jose4j HTTP client and if the keys have to be fetched from a remote endpoint then it is done at the 1st request time and if the remote keys endpoint is slow or unavailable then the problems like #511 will happen.

As far as `smallrye-jwt` is concerned, the best effort can be made there to read the keys early. However even in that case, when dealing with the JWK keys, they will have to be refreshed now and then remotely, so a risk of blocking will remain.

So, at the quarkus level it makes sense IMHO to let users control that a blocking authentication has to be performed in case of the slow/unstable remote key endpoints.

This is not a problem at the `quarkus-oidc` level but since we do not control the client at the smallrye-jwt level, we have to find a workaround. Longer term, 1) making smallrye-jwt reactive - the issue exists 2) making Jose4J HTTPS handler accept a client interface as opposed to its Simple HTTP client for Quarkus to register Vertx client will make it work as well but it may take awhile.

If would be good if it could make it to 2.4.0.CR1, CC @aloubyansky 

thanks