### PR TITLE
Raise dependabot open-pull-requests-limit to 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
       time: "23:00"
       timezone: Europe/Paris
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 6
     labels:
       - area/dependencies
     allow:


### PR DESCRIPTION
We often have a couple of update PRs open for while and so the limit of 4 is reached very quickly.

Also, PRs are created in the night where CI is not that loaded.