### PR TITLE
Fix setting class reader options

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -101,7 +101,9 @@ public class ClassTransformingBuildStep {
             if (!i.isCacheable()) {
                 nonCacheable.add(i.getClassToTransform());
             }
-            classReaderOptions.put(i.getClassToTransform(), i.getClassReaderOptions());
+            classReaderOptions.merge(i.getClassToTransform(), i.getClassReaderOptions(),
+                    // class reader options are bit flags (see org.objectweb.asm.ClassReader)
+                    (oldValue, newValue) -> oldValue | newValue);
         }
         QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
         Map<String, Path> transformedToArchive = new ConcurrentHashMap<>();

--- a/integration-tests/logging-panache/pom.xml
+++ b/integration-tests/logging-panache/pom.xml
@@ -20,6 +20,16 @@
             <artifactId>quarkus-arc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+          - this dependency is enough to test that the Logging with Panache
+          - and Hibernate ORM with Panache class transformations do not collide
+          - on setting the class reader options (issue #20569)
+          -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
@@ -43,6 +53,19 @@
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>


### PR DESCRIPTION
When multiple class transformations are registered, the class reader
options used to be overwritten by each transformation registration.
The last class transformation registered would control the class
reader options for all transformations of the same class. This caused
an issue for Logging with Panache, which requires the `EXPAND_FRAMES`
option.

This commit fixes that by merging the class reader options values,
so that all options that at least one transformation requires are set.
Since the class reader options are bit flags, merging them is a simple
bitwise OR.

Fixes #20569