### PR TITLE
Extract test-only dependencies from the bootstrap-bom

### DIFF
--- a/independent-projects/bootstrap/app-model/pom.xml
+++ b/independent-projects/bootstrap/app-model/pom.xml
@@ -22,6 +22,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/independent-projects/bootstrap/bom-test/pom.xml
+++ b/independent-projects/bootstrap/bom-test/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-bootstrap-bom-test</artifactId>
+    <name>Quarkus - Bootstrap - Test BOM</name>
+    <description>This BOM contains only test scoped dependencies for the bootstrap project's testsuite</description>
+    <packaging>pom</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-depchain</artifactId>
+                <type>pom</type>
+                <scope>test</scope>
+                <version>${shrinkwrap-depchain.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -10,37 +10,6 @@
     <artifactId>quarkus-bootstrap-bom</artifactId>
     <name>Quarkus - Bootstrap - BOM</name>
     <packaging>pom</packaging>
-    <properties>
-        <!-- Versions -->
-        <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
-        <jboss-logging.version>3.4.2.Final</jboss-logging.version>
-        <junit.jupiter.version>5.8.1</junit.jupiter.version>
-        <maven-core.version>3.8.1</maven-core.version><!-- Keep in sync with sisu.version -->
-        <sisu.version>0.3.4</sisu.version><!-- Keep in sync with maven-core.version -->
-        <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
-        <maven-resolver.version>1.6.2</maven-resolver.version>
-        <maven-shared-utils.version>3.3.3</maven-shared-utils.version> <!-- changed from the original version due to https://snyk.io/vuln/maven:org.apache.maven.shared:maven-shared-utils@3.2.1 -->
-        <maven-wagon.version>3.4.3</maven-wagon.version>
-        <httpcore.version>4.4.14</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
-        <plexus-cypher.version>1.7</plexus-cypher.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson.version>2.12.5</jackson.version>
-        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
-        <jakarta.inject-api.version>1.0</jakarta.inject-api.version>
-        <commons-lang.version>3.12.0</commons-lang.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager-embedded.version>1.0.9</jboss-logmanager-embedded.version>
-        <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
-        <slf4j-api.version>1.7.30</slf4j-api.version>
-        <graal-sdk.version>21.2.0</graal-sdk.version>
-        <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
-        <smallrye-common.version>1.6.0</smallrye-common.version>
-        <gradle-tooling.version>7.2</gradle-tooling.version>
-    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -345,28 +314,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.jupiter.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-depchain</artifactId>
-                <type>pom</type>
-                <scope>test</scope>
-                <version>${shrinkwrap-depchain.version}</version>
-            </dependency>
-             <!-- Jackson dependencies, imported as a BOM -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
             <!-- Smallrye Common dependencies, imported as a BOM -->
             <dependency>

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -22,6 +22,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -22,6 +22,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -59,6 +59,21 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Jackson dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -22,6 +22,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -108,12 +115,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-depchain</artifactId>
-            <type>pom</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -27,10 +27,40 @@
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 
+        <!-- Dependency versions -->
         <assertj.version>3.21.0</assertj.version>
+        <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
+        <jboss-logging.version>3.4.2.Final</jboss-logging.version>
+        <junit.jupiter.version>5.8.1</junit.jupiter.version>
+        <maven-core.version>3.8.1</maven-core.version><!-- Keep in sync with sisu.version -->
+        <sisu.version>0.3.4</sisu.version><!-- Keep in sync with maven-core.version -->
+        <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
+        <maven-resolver.version>1.6.2</maven-resolver.version>
+        <maven-shared-utils.version>3.3.3</maven-shared-utils.version> <!-- changed from the original version due to https://snyk.io/vuln/maven:org.apache.maven.shared:maven-shared-utils@3.2.1 -->
+        <maven-wagon.version>3.4.3</maven-wagon.version>
+        <httpcore.version>4.4.14</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
+        <plexus-cypher.version>1.7</plexus-cypher.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
+        <jackson.version>2.12.5</jackson.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
+        <jakarta.inject-api.version>1.0</jakarta.inject-api.version>
+        <commons-lang.version>3.12.0</commons-lang.version>
+        <guava.version>30.1.1-jre</guava.version>
+        <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
+        <jboss-logmanager-embedded.version>1.0.9</jboss-logmanager-embedded.version>
+        <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
+        <slf4j-api.version>1.7.30</slf4j-api.version>
+        <graal-sdk.version>21.2.0</graal-sdk.version>
+        <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <smallrye-common.version>1.6.0</smallrye-common.version>
+        <gradle-tooling.version>7.2</gradle-tooling.version>
     </properties>
     <modules>
         <module>bom</module>
+        <module>bom-test</module>
         <module>app-model</module>
         <module>maven-resolver</module>
         <module>core</module>
@@ -38,15 +68,6 @@
         <module>runner</module>
         <module>gradle-resolver</module>
     </modules>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>

--- a/independent-projects/bootstrap/runner/pom.xml
+++ b/independent-projects/bootstrap/runner/pom.xml
@@ -27,6 +27,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <gitflow-incremental-builder.version>3.14.3</gitflow-incremental-builder.version>
-        <quarkus-platform-bom-plugin.version>0.0.22</quarkus-platform-bom-plugin.version>
+        <quarkus-platform-bom-plugin.version>0.0.31</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Given that the `quarkus-bootstrap-bom` gets imported into the `quarkus-bom`, it'd be better to keep dependency constraints that are used only for testing of the bootstrap modules out of the `quarkus-bootstrap-bom`.