### PR TITLE
Try to prevent path failure during 'Upload gc.log' in Windows job

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -329,7 +329,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "GC log - JDK ${{matrix.java.name}}"
-          path: "**/windows-java-11.txt"
+          path: |
+            **/windows-java-11.txt
+            !**/build/tmp/**
 
   maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}


### PR DESCRIPTION
Should (hopefully) prevent failures like:
```
Error: ENOENT: no such file or directory, realpath 'D:\a\quarkus\quarkus\devtools\gradle\gradle-extension-plugin\build\tmp\test\work\.gradle-test-kit\caches\modules-2\metadata-2.97\descriptors\org.eclipse.microprofile.context-propagation\microprofile-context-propagation-parent\1.2\a8be1fe3b3911d3d3425fe720cf42835'
```

See also:
- https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
- https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Upload.20gc-log.20failures.20in.20CI