### PR TITLE
Improve Security Search in Quarkus Guides

### DIFF
--- a/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,9 +7,9 @@ metadata:
   - "jwt"
   - "json-web-token"
   - "rbac"
+  - "security"
   guide: "https://quarkus.io/guides/security-jwt"
   categories:
-  - "web"
   - "security"
   status: "stable"
   config:


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/20622 and https://github.com/quarkusio/quarkusio.github.io/pull/1167

* removed the web category for the security-jwt guide (Using JWT RBAC)
* added the "security" keyword for the same guide

Signed-off-by: Nathan Erwin <nathan.d.erwin@gmail.com>