### PR TITLE
Bump Netty to 4.1.69.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -130,7 +130,7 @@
         <infinispan.version>12.1.7.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <netty.version>4.1.68.Final</netty.version>
+        <netty.version>4.1.69.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.2.Final</jboss-logging.version>
         <mutiny.version>1.1.1</mutiny.version>


### PR DESCRIPTION
This is related to this PR https://github.com/quarkusio/quarkus/pull/20619. 

Now Netty 4.1.69.Final has been officially released, thus the update is possible