### PR TITLE
Upgrade to Hibernate Reactive 1.0.0.CR10

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.6.0.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.CR9</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.CR10</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>
         <narayana.version>5.12.0.Final</narayana.version>

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionProducer.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionProducer.java
@@ -7,6 +7,7 @@ import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
+import org.hibernate.reactive.common.spi.MutinyImplementor;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.arc.DefaultBean;
@@ -20,7 +21,7 @@ public class ReactiveSessionProducer {
     @RequestScoped
     @DefaultBean
     public Mutiny.Session createMutinySession() {
-        return mutinySessionFactory.openSession();
+        return ((MutinyImplementor) mutinySessionFactory).newSession();
     }
 
     public void disposeMutinySession(@Disposes Mutiny.Session reactiveSession) {


### PR DESCRIPTION

In this version, all methods which "open a session" have been made reactive.

To make it simpler for ourselves to implement the CDI producer of a Session, we introduced a non-API method on `org.hibernate.reactive.common.spi.MutinyImplementor`.

We plan to create some follow ups which will eventually get rid of the need to open a session in blocking mode, but this was getting hairy - so this approach will allow us to split the problem and face the migration in smaller steps.

Upgrading the migration guide soon.