### PR TITLE
Do not fail with 401 if OIDC token does not have a custom role claim

### DIFF
--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -151,12 +151,8 @@ public class OidcUtilsTest {
     public void testTokenWithCustomRolesWrongPath() throws Exception {
         OidcTenantConfig.Roles rolesCfg = OidcTenantConfig.Roles.fromClaimPath("application-card/embedded/roles");
         InputStream is = getClass().getResourceAsStream("/tokenCustomPath.json");
-        try {
-            OidcUtils.findRoles(null, rolesCfg, read(is));
-            fail("Exception expected at the wrong path");
-        } catch (Exception ex) {
-            // expected
-        }
+        List<String> roles = OidcUtils.findRoles(null, rolesCfg, read(is));
+        assertEquals(0, roles.size());
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -12,16 +12,25 @@ import io.quarkus.security.identity.SecurityIdentity;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@Path("/api/admin/bearer")
+@Path("/api/admin")
 public class AdminResource {
 
     @Inject
     SecurityIdentity identity;
 
+    @Path("bearer")
     @GET
     @RolesAllowed("admin")
     @Produces(MediaType.APPLICATION_JSON)
     public String admin() {
+        return "granted:" + identity.getRoles();
+    }
+
+    @Path("bearer-wrong-role-path")
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String adminWrongRolePath() {
         return "granted:" + identity.getRoles();
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -17,6 +17,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("bearer")) {
             return "bearer";
         }
+        if (path.endsWith("bearer-wrong-role-path")) {
+            return "bearer-wrong-role-path";
+        }
         return null;
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -36,4 +36,12 @@ public class UsersResource {
     public User preferredUserName() {
         return new User(((JsonWebToken) identity.getPrincipal()).getClaim("preferred_username"));
     }
+
+    @GET
+    @Path("/preferredUserName/bearer-wrong-role-path")
+    @RolesAllowed("user")
+    @Produces(MediaType.APPLICATION_JSON)
+    public User preferredUserNameWrongRolePath() {
+        return new User(((JsonWebToken) identity.getPrincipal()).getClaim("preferred_username"));
+    }
 }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -15,6 +15,13 @@ quarkus.oidc.bearer.credentials.secret=secret
 quarkus.oidc.bearer.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer.token.audience=https://service.example.com
 
+quarkus.oidc.bearer-wrong-role-path.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer-wrong-role-path.client-id=quarkus-app
+quarkus.oidc.bearer-wrong-role-path.credentials.secret=secret
+quarkus.oidc.bearer-wrong-role-path.authentication.scopes=profile,email,phone
+quarkus.oidc.bearer-wrong-role-path.token.audience=https://service.example.com
+quarkus.oidc.bearer-wrong-role-path.roles.role-claim-path=path
+
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -49,6 +49,24 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testSecureAccessSuccessPreferredUsernameWrongRolePath() {
+        for (String username : Arrays.asList("alice", "admin")) {
+            RestAssured.given().auth().oauth2(getAccessToken(username, new HashSet<>(Arrays.asList("user", "admin"))))
+                    .when().get("/api/users/preferredUserName/bearer-wrong-role-path")
+                    .then()
+                    .statusCode(403);
+        }
+    }
+
+    @Test
+    public void testAccessAdminResourceWrongRolePath() {
+        RestAssured.given().auth().oauth2(getAccessToken("admin", new HashSet<>(Arrays.asList("admin"))))
+                .when().get("/api/admin/bearer-wrong-role-path")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
     public void testAccessAdminResourceAudienceArray() {
         RestAssured.given().auth().oauth2(getAccessTokenAudienceArray("admin", new HashSet<>(Arrays.asList("admin"))))
                 .when().get("/api/admin/bearer")


### PR DESCRIPTION
Fixes #20694

All this PR does is ensures that if the custom claim containing the roles is missing then it is logged as opposed to breaking the flow with 401, the test has been added to confirm a proper 403 will be reported if needed. (that test suite also has tests confirming 200 is returned with the default role claim)