### PR TITLE
Externalize Gradle model builder in a module

### DIFF
--- a/devtools/gradle/gradle-application-plugin/build.gradle
+++ b/devtools/gradle/gradle-application-plugin/build.gradle
@@ -2,6 +2,8 @@ dependencies {
     implementation "io.quarkus:quarkus-devtools-common:${version}"
     implementation "io.quarkus:quarkus-core-deployment:${version}"
 
+    implementation project(":gradle-model")
+
     testImplementation "io.quarkus:quarkus-project-core-extension-codestarts:${version}"
     testImplementation "io.quarkus:quarkus-devmode-test-utils:${version}"
     testImplementation "io.quarkus:quarkus-devtools-testing:${version}"

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -30,7 +30,6 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.util.GradleVersion;
 
-import io.quarkus.gradle.builder.GradleApplicationModelBuilder;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
 import io.quarkus.gradle.dependency.ConditionalDependenciesEnabler;
 import io.quarkus.gradle.dependency.ExtensionDependency;
@@ -48,6 +47,7 @@ import io.quarkus.gradle.tasks.QuarkusRemoveExtension;
 import io.quarkus.gradle.tasks.QuarkusTest;
 import io.quarkus.gradle.tasks.QuarkusTestConfig;
 import io.quarkus.gradle.tasks.QuarkusTestNative;
+import io.quarkus.gradle.tooling.GradleApplicationModelBuilder;
 
 public class QuarkusPlugin implements Plugin<Project> {
 
@@ -67,7 +67,6 @@ public class QuarkusPlugin implements Plugin<Project> {
     public static final String QUARKUS_REMOTE_DEV_TASK_NAME = "quarkusRemoteDev";
     public static final String QUARKUS_TEST_TASK_NAME = "quarkusTest";
     public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
-    public static final String ANNOTATION_PROCESSOR_CONFIGURATION_NAME = "quarkusAnnotationProcessor";
 
     @Deprecated
     public static final String BUILD_NATIVE_TASK_NAME = "buildNative";

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -28,8 +28,8 @@ import io.quarkus.bootstrap.model.gradle.ModelParameter;
 import io.quarkus.bootstrap.model.gradle.impl.ModelParameterImpl;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.gradle.AppModelGradleResolver;
-import io.quarkus.gradle.builder.GradleApplicationModelBuilder;
 import io.quarkus.gradle.tasks.QuarkusGradleUtils;
+import io.quarkus.gradle.tooling.GradleApplicationModelBuilder;
 import io.quarkus.runtime.LaunchMode;
 
 public class QuarkusPluginExtension {

--- a/devtools/gradle/gradle-model/build.gradle
+++ b/devtools/gradle/gradle-model/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation "io.quarkus:quarkus-core-deployment:${version}"
+    testImplementation "io.quarkus:quarkus-devtools-testing:${version}"
+}

--- a/devtools/gradle/gradle-model/pom.xml
+++ b/devtools/gradle/gradle-model/pom.xml
@@ -10,43 +10,21 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>io.quarkus.gradle.plugin</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-gradle-model</artifactId>
     <packaging>pom</packaging>
-    <name>Quarkus - Gradle Plugin</name>
-    <description>Quarkus - Gradle Plugin</description>
+    <name>Quarkus - Gradle Model</name>
+    <description>Quarkus - Gradle Model</description>
 
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-gradle-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bootstrap-core</artifactId>
-        </dependency>
+        <!-- Compile -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devtools-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devmode-test-utils</artifactId>
+            <artifactId>quarkus-devtools-testing</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -96,16 +74,16 @@
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}.jar</file>
+                                    <file>build/libs/gradle-model-${project.version}.jar</file>
                                     <type>jar</type>
                                 </artifact>
                                 <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}-javadoc.jar</file>
+                                    <file>build/libs/gradle-model-${project.version}-javadoc.jar</file>
                                     <type>jar</type>
                                     <classifier>javadoc</classifier>
                                 </artifact>
                                 <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}-sources.jar</file>
+                                    <file>build/libs/gradle-model-${project.version}-sources.jar</file>
                                     <type>jar</type>
                                     <classifier>sources</classifier>
                                 </artifact>
@@ -117,5 +95,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -1,4 +1,4 @@
-package io.quarkus.gradle.builder;
+package io.quarkus.gradle.tooling;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -49,9 +49,6 @@ import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.workspace.DefaultProcessedSources;
 import io.quarkus.bootstrap.workspace.DefaultWorkspaceModule;
 import io.quarkus.bootstrap.workspace.ProcessedSources;
-import io.quarkus.gradle.QuarkusPlugin;
-import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
-import io.quarkus.gradle.dependency.DependencyUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACT;
@@ -82,7 +79,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
             }
 
             return project.getConfigurations().create(CLASSPATH_CONFIGURATION).extendsFrom(
-                    project.getConfigurations().getByName(QuarkusPlugin.DEV_MODE_CONFIGURATION_NAME),
+                    project.getConfigurations().getByName(ToolingUtils.DEV_MODE_CONFIGURATION_NAME),
                     project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME),
                     project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         }
@@ -99,7 +96,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
         deploymentConfiguration = project.getConfigurations().create(DEPLOYMENT_CONFIGURATION)
                 .withDependencies(ds -> ds.addAll(platforms));
-        Configuration implementationDeployment = project.getConfigurations().findByName(ApplicationDeploymentClasspathBuilder
+        Configuration implementationDeployment = project.getConfigurations().findByName(ToolingUtils
                 .toDeploymentConfigurationName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
         if (implementationDeployment != null) {
             deploymentConfiguration.extendsFrom(implementationDeployment);
@@ -107,7 +104,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
         if (LaunchMode.TEST.equals(mode)) {
             Configuration testDeploymentConfiguration = project.getConfigurations()
-                    .findByName(ApplicationDeploymentClasspathBuilder
+                    .findByName(ToolingUtils
                             .toDeploymentConfigurationName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
             if (testDeploymentConfiguration != null) {
                 deploymentConfiguration.extendsFrom(testDeploymentConfiguration);
@@ -115,8 +112,8 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         }
         if (LaunchMode.DEVELOPMENT.equals(mode)) {
             Configuration devDeploymentConfiguration = project.getConfigurations()
-                    .findByName(ApplicationDeploymentClasspathBuilder
-                            .toDeploymentConfigurationName(QuarkusPlugin.DEV_MODE_CONFIGURATION_NAME));
+                    .findByName(ToolingUtils
+                            .toDeploymentConfigurationName(ToolingUtils.DEV_MODE_CONFIGURATION_NAME));
             if (devDeploymentConfiguration != null) {
                 deploymentConfiguration.extendsFrom(devDeploymentConfiguration);
             }
@@ -146,7 +143,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
     public Object buildAll(String modelName, ModelParameter parameter, Project project) {
         final LaunchMode mode = LaunchMode.valueOf(parameter.getMode());
 
-        final List<org.gradle.api.artifacts.Dependency> deploymentDeps = DependencyUtils.getEnforcedPlatforms(project);
+        final List<org.gradle.api.artifacts.Dependency> deploymentDeps = ToolingUtils.getEnforcedPlatforms(project);
         final PlatformImports platformImports = resolvePlatformImports(project, deploymentDeps);
 
         final ResolvedDependency appArtifact = getProjectArtifact(project, mode);
@@ -383,7 +380,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
                 final String classifier = a.getClassifier();
                 if (classifier == null || classifier.isEmpty()) {
-                    final IncludedBuild includedBuild = DependencyUtils.includedBuild(project.getRootProject(), a.getName());
+                    final IncludedBuild includedBuild = ToolingUtils.includedBuild(project.getRootProject(), a.getName());
                     if (includedBuild != null) {
                         final PathList.Builder pathBuilder = PathList.builder();
                         addSubstitutedProject(pathBuilder, includedBuild.getProjectDir());

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -1,0 +1,55 @@
+package io.quarkus.gradle.tooling;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.Project;
+import org.gradle.api.UnknownDomainObjectException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.plugins.JavaPlugin;
+
+public class ToolingUtils {
+
+    private static final String DEPLOYMENT_CONFIGURATION_SUFFIX = "Deployment";
+    public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
+
+    public static String toDeploymentConfigurationName(String baseConfigurationName) {
+        return baseConfigurationName + DEPLOYMENT_CONFIGURATION_SUFFIX;
+    }
+
+    public static List<Dependency> getEnforcedPlatforms(Project project) {
+        final List<org.gradle.api.artifacts.Dependency> directExtension = new ArrayList<>();
+        final Configuration impl = project.getConfigurations()
+                .getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
+
+        for (Dependency d : impl.getAllDependencies()) {
+            if (!(d instanceof ModuleDependency)) {
+                continue;
+            }
+            final ModuleDependency module = (ModuleDependency) d;
+            if (isEnforcedPlatform(module)) {
+                directExtension.add(d);
+            }
+        }
+        return directExtension;
+    }
+
+    public static boolean isEnforcedPlatform(ModuleDependency module) {
+        final Category category = module.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
+        return category != null && (Category.ENFORCED_PLATFORM.equals(category.getName())
+                || Category.REGULAR_PLATFORM.equals(category.getName()));
+    }
+
+    public static IncludedBuild includedBuild(final Project project, final String projectName) {
+        try {
+            return project.getGradle().includedBuild(projectName);
+        } catch (UnknownDomainObjectException ignore) {
+            return null;
+        }
+    }
+
+}

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilderTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilderTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.gradle.builder;
+package io.quarkus.gradle.tooling;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
@@ -9,7 +9,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.junit.jupiter.api.Test;
 
-public class QuarkusModelBuilderTest {
+public class GradleApplicationModelBuilderTest {
 
     @Test
     void testToAppDependency() {

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -10,8 +10,10 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>io.quarkus</groupId>
     <artifactId>io.quarkus.gradle.plugin.parent</artifactId>
     <packaging>pom</packaging>
+    <version>999-SNAPSHOT</version>
     <name>Quarkus - Gradle Plugin - Parent</name>
     <description>Quarkus - Gradle Plugin</description>
 
@@ -22,9 +24,20 @@
     </properties>
 
     <modules>
+        <module>gradle-model</module>
         <module>gradle-application-plugin</module>
         <module>gradle-extension-plugin</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-gradle-model</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/devtools/gradle/settings.gradle
+++ b/devtools/gradle/settings.gradle
@@ -13,4 +13,4 @@ gradleEnterprise {
 }
 
 rootProject.name = 'quarkus-gradle-plugins'
-include 'gradle-application-plugin', 'gradle-extension-plugin'
+include 'gradle-application-plugin', 'gradle-extension-plugin', 'gradle-model'


### PR DESCRIPTION
This externalize the gradle model into a common module. This will be useful in both plugin in order to be able to serialize the app model. 