### PR TITLE
Catch Kotlin 1.5.30 references dependabot missed

### DIFF
--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -33,7 +33,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
         <scala.version>2.12.13</scala.version>
         <scala-plugin.version>4.4.0</scala-plugin.version>
 

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -25,7 +25,7 @@ compileJava {
     options.compilerArgs << '-parameters'
 }
 
-// This is a fix as kotlin 1.5.30 does not support Java 17 yet
+// This is a fix as kotlin 1.5.31 does not support Java 17 yet
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     tasks.quarkusDev {
         compilerArgs = ["-jvm-target", "16"]

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("jvm")
 }
 
-// This is a fix as kotlin 1.5.30 does not support Java 17 yet
+// This is a fix as kotlin 1.5.31 does not support Java 17 yet
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     tasks.quarkusDev {
         compilerArgs = listOf("-jvm-target", "16")

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
this is mostly to make it easier to find all the places to update to 1.6