### PR TITLE
Fix some gradle-extension-plugin apply bugs

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -65,11 +65,11 @@ public class QuarkusExtensionPluginTest {
 
     @Test
     public void pluginShouldAddAnnotationProcessor() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent());
+        TestUtils.createExtensionProject(testProjectDir);
         BuildResult dependencies = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir)
-                .withArguments("dependencies", "--configuration", "annotationProcessor")
+                .withArguments("build", ":runtime:dependencies", "--configuration", "annotationProcessor")
                 .build();
 
         assertThat(dependencies.getOutput()).contains(QuarkusExtensionPlugin.QUARKUS_ANNOTATION_PROCESSOR);
@@ -81,7 +81,7 @@ public class QuarkusExtensionPluginTest {
         BuildResult dependencies = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir)
-                .withArguments(":deployment:dependencies", "--configuration", "annotationProcessor")
+                .withArguments("build", ":deployment:dependencies", "--configuration", "annotationProcessor")
                 .build();
         assertThat(dependencies.getOutput()).contains(QuarkusExtensionPlugin.QUARKUS_ANNOTATION_PROCESSOR);
     }

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
@@ -41,6 +41,23 @@ public class TestUtils {
                 "}\n";
     }
 
+    public static String getDefaultDeploymentBuildFileContent() throws IOException {
+        return "plugins {\n" +
+                "id 'java'\n" +
+                "}\n" +
+                "group 'org.acme'\n" +
+                "version '1.0.0'\n" +
+                "repositories { \n" +
+                "mavenCentral()\n" +
+                "mavenLocal()\n" +
+                "}\n" +
+                "dependencies {\n" +
+                "implementation enforcedPlatform(\"io.quarkus:quarkus-bom:" + getCurrentQuarkusVersion() + "\")\n" +
+                "implementation \"io.quarkus:quarkus-arc\" \n" +
+                "implementation project(\":runtime\")" +
+                "}\n";
+    }
+
     public static BuildResult runExtensionDescriptorTask(File testProjectDir) {
         BuildResult extensionDescriptorResult = GradleRunner.create()
                 .withPluginClasspath()
@@ -57,10 +74,16 @@ public class TestUtils {
         File runtimeModule = new File(testProjectDir, "runtime");
         runtimeModule.mkdir();
         writeFile(new File(runtimeModule, "build.gradle"), getDefaultGradleBuildFileContent());
+        File runtimeTestFile = new File(runtimeModule, "src/main/java/runtime/Test.java");
+        runtimeTestFile.getParentFile().mkdirs();
+        writeFile(runtimeTestFile, "package runtime; public class Test {}");
 
         File deploymentModule = new File(testProjectDir, "deployment");
         deploymentModule.mkdir();
-        writeFile(new File(deploymentModule, "build.gradle"), "plugins { id 'java'}");
+        writeFile(new File(deploymentModule, "build.gradle"), getDefaultDeploymentBuildFileContent());
+        File deploymentTestFile = new File(deploymentModule, "src/main/java/deployment/Test.java");
+        deploymentTestFile.getParentFile().mkdirs();
+        writeFile(deploymentTestFile, "package deployment; public class Test {}");
 
         writeFile(new File(testProjectDir, "settings.gradle"), "include 'runtime', 'deployment'");
 


### PR DESCRIPTION
This PR fixes a few bugs with the gradle-extension-plugin as follows:
- ~~JavaPluginConvention is deprecated so I replaced it with it's successor JavaPluginExtension~~
- The deployment module configuration is read before configuration is applied making the module fixed to the default name. I changed it to trigger on `afterEvaluate`.
- The annotation processor can't be resolved without providing an explicit version. I've changed it to detect the current version of the plugin and set the annotation processor to the same one.

These changes are based on issues I ran into during usage in my own environment using Gradle 7.2. I'm not a Gradle expert. @glefloch If there is anything that doesn't fit well with your plans, let me know and I can make changes or close this PR.