### PR TITLE
Update to Kotlin 1.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -147,7 +147,7 @@
         <awssdk.version>2.17.82</awssdk.version>
         <aws-alexa-sdk.version>2.41.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <kotlin.coroutine.version>1.5.2</kotlin.coroutine.version>
         <dekorate.version>2.6.0</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <dokka.version>1.5.31</dokka.version>
         <scala.version>2.12.13</scala.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
@@ -873,7 +873,6 @@
                 <property>
                     <name>dokka</name>
                 </property>
-                <jdk>(,16)</jdk>
                 <file>
                     <exists>src/main/kotlin</exists>
                 </file>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -115,6 +115,18 @@
                             <goal>test-compile</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>kapt</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessors>
+                                <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                            </annotationProcessors>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -173,37 +185,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Execute kapt, but not on Java 16 or higher due to
-            - https://youtrack.jetbrains.com/issue/KT-45545 (Java 16+)
-            - https://youtrack.jetbrains.com/issue/KT-47583 (Java 17+) -->
-        <profile>
-            <id>kapt-not-on-jdk16</id>
-            <activation>
-                <jdk>(,16)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>kapt</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>kapt</goal>
-                                </goals>
-                                <configuration>
-                                    <annotationProcessors>
-                                        <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
-                                    </annotationProcessors>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -33,7 +33,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <scala.version>2.12.13</scala.version>
         <scala-plugin.version>4.4.0</scala-plugin.version>
 

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -25,9 +25,9 @@ compileJava {
     options.compilerArgs << '-parameters'
 }
 
-// This is a fix as kotlin 1.5.31 does not support Java 17 yet
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+// This is a fix as kotlin 1.6.0 does not support Java 18 yet
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
     tasks.quarkusDev {
-        compilerArgs = ["-jvm-target", "16"]
+        compilerArgs = ["-jvm-target", "17"]
     }
 }

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/build.gradle.kts
@@ -3,12 +3,13 @@ plugins {
     kotlin("jvm")
 }
 
-// This is a fix as kotlin 1.5.31 does not support Java 17 yet
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+// This is a fix as kotlin 1.6.0 does not support Java 18 yet
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
     tasks.quarkusDev {
-        compilerArgs = listOf("-jvm-target", "16")
+        compilerArgs = listOf("-jvm-target", "17")
     }
 }
+
 dependencies {
     implementation(project(":port"))
     implementation(project(":domain"))

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This is actually bumping to 1.6.0-RC for now.  This is to start getting the pieces in place for the eventual release.  I'm filing the PR now to make sure we get all the workarounds removed for Kotlin on Java 16.  It obviously can't be merged until 1.6.0 is final.