### PR TITLE
Leverage docker executable name in docker check

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -16,6 +16,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.console.StartupLogCompressor;
@@ -125,20 +126,23 @@ public class IsDockerWorking implements BooleanSupplier {
     private static class DockerBinaryStrategy implements Strategy {
 
         private final boolean silent;
+        private final String binary;
 
         private DockerBinaryStrategy(boolean silent) {
             this.silent = silent;
+            this.binary = ConfigProvider.getConfig().getOptionalValue("quarkus.docker.executable-name", String.class)
+                    .orElse("docker");
         }
 
         @Override
         public Result get() {
             try {
-                if (!ExecUtil.execSilent("docker", "-v")) {
-                    LOGGER.warn("'docker -v' returned an error code. Make sure your Docker binary is correct");
+                if (!ExecUtil.execSilent(binary, "-v")) {
+                    LOGGER.warnf("'%s -v' returned an error code. Make sure your Docker binary is correct", binary);
                     return Result.UNKNOWN;
                 }
             } catch (Exception e) {
-                LOGGER.warnf("No Docker binary found or general error: %s", e);
+                LOGGER.warnf("No %s binary found or general error: %s", binary, e);
                 return Result.UNKNOWN;
             }
 


### PR DESCRIPTION
Leverage the binary provided by `quarkus.docker.executable-name` property in order to validate the `IsDockerRunning` check. 

Resolves #20128 