### PR TITLE
Fix lambda maven archtetypes, startup bugs, and docs

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -60,8 +60,6 @@ Copy the build.gradle, gradle.properties and settings.gradle into the above gene
 
 Execute: gradle wrapper to setup the gradle wrapper (recommended).
 
-The dependency for `quarkus-test-amazon-lambda` will also need to be added to your build.gradle.
-
 For full Gradle details <<gradle, see below>>.
 ====
 
@@ -300,8 +298,8 @@ call must set a specific environment variable:
 
 == Examine the POM and Gradle build
 
-There is nothing special about the POM other than the inclusion of the `quarkus-amazon-lambda` and `quarkus-test-amazon-lambda` extensions
-as a dependencies.  The extension automatically generates everything you might need for your lambda deployment.
+There is nothing special about the POM other than the inclusion of the `quarkus-amazon-lambda` extension
+as a dependency.  The extension automatically generates everything you might need for your lambda deployment.
 
 NOTE: In previous versions of this extension you had to set up your pom or gradle
 to zip up your executable for native deployments, but this is not the case anymore.
@@ -309,8 +307,7 @@ to zip up your executable for native deployments, but this is not the case anymo
 [[gradle]]
 == Gradle build
 
-Similarly for Gradle projects, you also just have to add the `quarkus-amazon-lambda` and
-`quarkus-test-amazon-lambda` dependencies.  The extension automatically generates everything you might need
+Similarly for Gradle projects, you also just have to add the `quarkus-amazon-lambda` dependency.  The extension automatically generates everything you might need
 for your lambda deployment.
 
 Example Gradle dependencies:
@@ -321,8 +318,6 @@ dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-amazon-lambda'
-
-    testImplementation  "io.quarkus:quarkus-test-amazon-lambda"
 
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'

--- a/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
@@ -235,8 +235,8 @@ call must set a specific environment variable:
 
 == Examine the POM
 
-There is nothing special about the POM other than the inclusion of the `quarkus-funqy-amazon-lambda` and `quarkus-test-amazon-lambda` extensions
-as a dependencies.  The extension automatically generates everything you might need for your lambda deployment.
+There is nothing special about the POM other than the inclusion of the `quarkus-funqy-amazon-lambda` extension
+as a dependency.  The extension automatically generates everything you might need for your lambda deployment.
 
 == Integration Testing
 

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -105,6 +105,29 @@
                     <name>native</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
@@ -1,0 +1,7 @@
+package ${package};
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class GreetingIT extends GreetingTest {
+}

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -105,6 +105,29 @@
                     <name>native</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
@@ -1,0 +1,7 @@
+package ${package};
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class GreetingIT extends GreetingTest {
+}

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -49,12 +49,12 @@ public abstract class AbstractLambdaPollLoop {
             @Override
             public void run() {
                 try {
-                    if (!LambdaHotReplacementRecorder.enabled && launchMode == LaunchMode.DEVELOPMENT) {
+                    if (!LambdaHotReplacementRecorder.enabled
+                            && (launchMode == LaunchMode.DEVELOPMENT || launchMode == LaunchMode.NORMAL)) {
                         // when running with continuous testing, this method fails
                         // because currentApplication is not set when running as an
                         // auxiliary application.  So, just skip it if hot replacement enabled.
-                        // this is only needed in lambda JVM mode anyways to make sure
-                        // quarkus has started.
+                        // This method is called to determine if Quarkus is started and ready to receive requests.
                         checkQuarkusBootstrapped();
                     }
                     URL requestUrl = AmazonLambdaApi.invocationNext(baseUrl);

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -84,6 +84,29 @@
                     <name>native</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerIT.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerIT.java
@@ -1,0 +1,7 @@
+package ${package};
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class LambdaHandlerIT extends LambdaHandlerTest {
+}

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerTest.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerTest.java
@@ -15,8 +15,9 @@ public class LambdaHandlerTest {
         // you test your lambas by invoking on http://localhost:8081
         // this works in dev mode too
 
-        Person in = new Person();
+        InputObject in = new InputObject();
         in.setName("Stu");
+        in.setGreeting("Hello");
         given()
                 .contentType("application/json")
                 .accept("application/json")

--- a/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -74,6 +74,29 @@
                     <name>native</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>


### PR DESCRIPTION
The live coding/testing merge a few weeks ago broke the maven archtetypes and introduced some startup bugs.  Specifically, the poll loop would start before Quarkus had fully initiliazed and would process a request before quarkus was fully started and initialized.

Fixes #20745 
Fixes #20689 
Fixes #20674 
Fixes #20665 
Fixes #20633 
