### PR TITLE
Avoid allocating an iterator when using Arc contexts

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -2,7 +2,7 @@ package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -34,7 +34,7 @@ public interface ArcContainer {
      * @param scopeType
      * @return the matching context objects, never null
      */
-    Collection<InjectableContext> getContexts(Class<? extends Annotation> scopeType);
+    List<InjectableContext> getContexts(Class<? extends Annotation> scopeType);
 
     /**
      * 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -78,7 +78,7 @@ public class ArcContainerImpl implements ArcContainer {
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
     private final Map<String, Set<String>> qualifierNonbindingMembers;
 
-    private final Map<Class<? extends Annotation>, Collection<InjectableContext>> contexts;
+    private final Map<Class<? extends Annotation>, List<InjectableContext>> contexts;
     private final ManagedContext requestContext;
     private final InjectableContext applicationContext;
     private final InjectableContext singletonContext;
@@ -162,7 +162,7 @@ public class ArcContainerImpl implements ArcContainer {
     private void putContext(InjectableContext context) {
         Collection<InjectableContext> values = contexts.get(context.getScope());
         if (values == null) {
-            contexts.put(context.getScope(), Collections.singleton(context));
+            contexts.put(context.getScope(), Collections.singletonList(context));
         } else {
             List<InjectableContext> multi = new ArrayList<>(values.size() + 1);
             multi.addAll(values);
@@ -216,7 +216,7 @@ public class ArcContainerImpl implements ArcContainer {
     }
 
     @Override
-    public Collection<InjectableContext> getContexts(Class<? extends Annotation> scopeType) {
+    public List<InjectableContext> getContexts(Class<? extends Annotation> scopeType) {
         requireRunning();
         return contexts.getOrDefault(scopeType, Collections.emptyList());
     }


### PR DESCRIPTION
Allocation of these iterators can be on the hot path,
so bets avoid their use.

The following screenshot (from YourKit) shows the issue the PR addresses:

![Screenshot from 2021-10-14 12-27-06](https://user-images.githubusercontent.com/4374975/137290268-c0aa6760-d144-434b-801f-693214e42de0.png)


