### PR TITLE
Upgrade to Hibernate ORM 5.5.8.Final - 2.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.5.7.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.5.8.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.CR9</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>


### PR DESCRIPTION

@gsmet is it ok for me to target the 2.2 branch directly for such cases, or do you prefer a different workflow?

We don't want to have this in `main` as it transitioned to 5.6 - as we discussed earlier.