### PR TITLE
Adds processor to annotation JsonAutoDetect

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -18,6 +18,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Type;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -54,6 +55,8 @@ public class JacksonProcessor {
     private static final DotName JSON_DESERIALIZE = DotName.createSimple(JsonDeserialize.class.getName());
 
     private static final DotName JSON_SERIALIZE = DotName.createSimple(JsonSerialize.class.getName());
+
+    private static final DotName JSON_AUTO_DETECT = DotName.createSimple(JsonAutoDetect.class.getName());
 
     private static final DotName JSON_CREATOR = DotName.createSimple("com.fasterxml.jackson.annotation.JsonCreator");
 
@@ -165,6 +168,14 @@ public class JacksonProcessor {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
                 reflectiveClass
                         .produce(new ReflectiveClassBuildItem(false, false, nullsUsingValue.asClass().name().toString()));
+            }
+        }
+
+        for (AnnotationInstance creatorInstance : index.getAnnotations(JSON_AUTO_DETECT)) {
+            if (creatorInstance.target().kind().equals(CLASS)) {
+                reflectiveClass
+                        .produce(
+                                new ReflectiveClassBuildItem(true, true, creatorInstance.target().asClass().name().toString()));
             }
         }
 


### PR DESCRIPTION
This pr adds the processor to Jackson `JsonAutoDetect` annotation (currently needed for records usage);

Bug:
This error happens in the endpoint's response serialization (mode native):
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Failed to access RecordComponents of type `com.netodevel.money_transfer.dto.MoneyTransferResponse`
```

How to Reproduce?

**clone repository**
git clone https://github.com/netodevel/money-transfer-service

**build native image**
mvn clean install -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:21.2.0-java16 -DskipTests

**run postgresql local**
docker-compose up -d 

**execute binary**
./target/money-transfer-service-1.0.0-SNAPSHOT-runner 

** execute request **
[POST]  url: http://localhost:8080/api/money-transfer

```json
{
  "fromAccount": "999",
  "toAccount": "777",
  "amount": 50
}
```





