### PR TITLE
Upgrade Hibernate Reactive to 1.0.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.6.0.Final</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.CR10</hibernate-reactive.version>
+        <hibernate-reactive.version>1.0.0.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.6.Final</hibernate-search.version>
         <narayana.version>5.12.0.Final</narayana.version>


### PR DESCRIPTION
Compared to CR10, it only contains a minor change that shouldn't affect Quarkus: https://github.com/hibernate/hibernate-reactive/issues/1001