### PR TITLE
Don't load the target class in the generated Bean class

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerConfig.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerConfig.java
@@ -118,4 +118,11 @@ public class JaegerConfig {
     @ConfigItem(defaultValue = "true")
     public Boolean logTraceContext;
 
+    /**
+     * Whether or not the registration of tracer as the global tracer should be disabled.
+     * This setting should only be turned on in tests that need to install a mock tracer.
+     */
+    @ConfigItem(defaultValue = "false")
+    public Boolean disableTracerRegistration;
+
 }

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -58,7 +58,7 @@ public class JaegerDeploymentRecorder {
         // Usually the tracer will be registered only here, although consumers
         // could register a different tracer in the code which runs before this class.
         // This is also used in tests.
-        if (!GlobalTracer.isRegistered()) {
+        if (!GlobalTracer.isRegistered() && !jaeger.disableTracerRegistration) {
             log.debugf("Registering tracer to GlobalTracer %s", quarkusTracer);
             GlobalTracer.register(quarkusTracer);
         }

--- a/extensions/mongodb-client/deployment/src/test/resources/application-tracing-mongo.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-tracing-mongo.properties
@@ -3,6 +3,7 @@ quarkus.mongodb.tracing.enabled=true
 
 
 quarkus.jaeger.enabled=true
+quarkus.jaeger.disable-tracer-registration=true
 quarkus.jaeger.service-name=tracing-test
 quarkus.jaeger.sampler-param=1
 quarkus.jaeger.sampler-type=const

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTracingTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTracingTest.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,7 @@ public class GraphQLTracingTest extends AbstractGraphQLTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestResource.class, TestPojo.class, TestRandom.class, TestGenericsPojo.class,
                             BusinessException.class)
+                    .addAsResource(new StringAsset("quarkus.jaeger.disable-tracer-registration=true"), "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
     static MockTracer mockTracer = new MockTracer();

--- a/extensions/smallrye-opentracing/deployment/src/test/resources/application.properties
+++ b/extensions/smallrye-opentracing/deployment/src/test/resources/application.properties
@@ -8,3 +8,5 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 
+quarkus.jaeger.disable-tracer-registration=true
+

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -215,7 +215,7 @@ public final class Types {
                     .invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
             tccl = creator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
         }
-        return creator.invokeStaticMethod(MethodDescriptors.CL_FOR_NAME, creator.load(className), creator.load(true), tccl);
+        return creator.invokeStaticMethod(MethodDescriptors.CL_FOR_NAME, creator.load(className), creator.load(false), tccl);
     }
 
     static Type getProviderType(ClassInfo classInfo) {


### PR DESCRIPTION
This is done in order to avoid loading classes
that potentially won't be used at all (the most prominent
of which is Jackson's `ObjectMapper`)

See [original discussion](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Arc.20-.20somewhat.20advanced.20questions/near/257994308) for more information

Co-authored-by: Ladislav Thon

P.S. for a hello world style application that uses `quarkus-vertx-http` transitively but does not use the `ObjectMapper` in any way, this saves around `60ms` of startup on my machine and some heap space as well.