### PR TITLE
Only apply gradle publish plugin to plugin modules

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 subprojects {
-    apply plugin: 'java-gradle-plugin'
-    apply plugin: 'com.gradle.plugin-publish'
+
+    apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
     if (JavaVersion.current().isJava9Compatible()) {
@@ -55,12 +55,6 @@ subprojects {
 
     javadoc {
         options.addStringOption('encoding', 'UTF-8')
-    }
-
-    pluginBundle {
-        website = 'https://quarkus.io/'
-        vcsUrl = 'https://github.com/quarkusio/quarkus'
-        tags = ['quarkus', 'quarkusio', 'graalvm']
     }
 }
 

--- a/devtools/gradle/gradle-application-plugin/build.gradle
+++ b/devtools/gradle/gradle-application-plugin/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish'
+}
+
 dependencies {
     implementation "io.quarkus:quarkus-devtools-common:${version}"
     implementation "io.quarkus:quarkus-core-deployment:${version}"
@@ -20,4 +25,10 @@ gradlePlugin {
             description = 'Builds a Quarkus application, and provides helpers to launch dev-mode, the Quarkus CLI, building of native images'
         }
     }
+}
+
+pluginBundle {
+    website = 'https://quarkus.io/'
+    vcsUrl = 'https://github.com/quarkusio/quarkus'
+    tags = ['quarkus', 'quarkusio', 'graalvm']
 }

--- a/devtools/gradle/gradle-extension-plugin/build.gradle
+++ b/devtools/gradle/gradle-extension-plugin/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish'
+}
+
 dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
@@ -14,4 +19,10 @@ gradlePlugin {
             description = 'Builds a Quarkus extension'
         }
     }
+}
+
+pluginBundle {
+    website = 'https://quarkus.io/'
+    vcsUrl = 'https://github.com/quarkusio/quarkus'
+    tags = ['quarkus', 'quarkusio', 'graalvm']
 }

--- a/devtools/gradle/gradle-model/build.gradle
+++ b/devtools/gradle/gradle-model/build.gradle
@@ -2,3 +2,18 @@ dependencies {
     implementation "io.quarkus:quarkus-core-deployment:${version}"
     testImplementation "io.quarkus:quarkus-devtools-testing:${version}"
 }
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}


### PR DESCRIPTION
This branch removes the gradle-plugin from the `gradle-model` module.