### PR TITLE
DevTools: annotation consistency in CLI; BuildTool discovery for existing projects

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -15,7 +15,7 @@ import picocli.CommandLine.Unmatched;
         CreateExtension.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class Create implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -16,7 +16,6 @@ import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "app", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Create a Quarkus application project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory", footer = { "%n"
@@ -24,7 +23,7 @@ import picocli.CommandLine.Mixin;
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class CreateApp extends BaseCreateCommand {
-    @Mixin
+    @CommandLine.Mixin
     TargetGAVGroup gav = new TargetGAVGroup();
 
     @CommandLine.Option(order = 1, paramLabel = "EXTENSION", names = { "-x",

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -16,7 +16,6 @@ import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "cli", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Create a Quarkus command-line project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory.", footer = { "%n"
@@ -24,7 +23,7 @@ import picocli.CommandLine.Mixin;
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class CreateCli extends BaseCreateCommand {
-    @Mixin
+    @CommandLine.Mixin
     TargetGAVGroup gav = new TargetGAVGroup();
 
     @CommandLine.Option(order = 1, paramLabel = "EXTENSION", names = { "-x",

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -17,7 +17,6 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "extension", sortOptions = false, mixinStandardHelpOptions = false, showDefaultValues = true, header = "Create a Quarkus extension project", description = "%n"
         + "Quarkus extensions are built from multiple modules: runtime, deployment, integration-test and "
@@ -72,7 +71,7 @@ public class CreateExtension extends BaseCreateCommand {
     @CommandLine.Spec
     protected CommandLine.Model.CommandSpec spec;
 
-    @Mixin
+    @CommandLine.Mixin
     ExtensionGAVMixin gav = new ExtensionGAVMixin();
 
     @CommandLine.ArgGroup(order = 1, heading = "%nQuarkus version:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
@@ -17,7 +17,7 @@ import picocli.CommandLine.Unmatched;
                 ProjectExtensionsRemove.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
 public class ProjectExtensions implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
     @CommandLine.Spec

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
@@ -10,12 +10,11 @@ import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "add", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Add extension(s) to this project.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<Integer> {
 
-    @Mixin
+    @CommandLine.Mixin
     RunModeOption runMode;
 
     @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
@@ -17,12 +17,11 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.registry.RegistryResolutionException;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "categories", aliases = "cat", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List extension categories.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class ProjectExtensionsCategories extends BaseBuildCommand implements Callable<Integer> {
 
-    @Mixin
+    @CommandLine.Mixin
     RunModeOption runMode;
 
     @CommandLine.ArgGroup(heading = "%nOutput format:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -17,7 +17,6 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.registry.RegistryResolutionException;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "list", aliases = "ls", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List platforms and extensions. ", footer = {
         "%nList modes:%n",
@@ -29,7 +28,7 @@ import picocli.CommandLine.Mixin;
                 "The CLI release will be used if this command is invoked outside of a project and no other release is specified.%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class ProjectExtensionsList extends BaseBuildCommand implements Callable<Integer> {
 
-    @Mixin
+    @CommandLine.Mixin
     RunModeOption runMode;
 
     @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version (absolute):%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
@@ -10,12 +10,11 @@ import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 
 @CommandLine.Command(name = "remove", aliases = "rm", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Remove extension(s) from this project.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class ProjectExtensionsRemove extends BaseBuildCommand implements Callable<Integer> {
 
-    @Mixin
+    @CommandLine.Mixin
     RunModeOption runMode;
 
     @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.")

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -16,7 +16,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Help;
 import picocli.CommandLine.IHelpSectionRenderer;
 import picocli.CommandLine.IParameterExceptionHandler;
-import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.UsageMessageSpec;
 import picocli.CommandLine.ParameterException;
@@ -35,7 +34,7 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     @Inject
     CommandLine.IFactory factory;
 
-    @Mixin
+    @CommandLine.Mixin(name = "output")
     OutputOptionMixin output;
 
     @CommandLine.Spec

--- a/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
@@ -7,7 +7,6 @@ import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Unmatched;
 
 @CommandLine.Command(name = "registry", sortOptions = false, mixinStandardHelpOptions = false, header = "Configure Quarkus registry client", subcommands = {
         RegistryListCommand.class,
@@ -15,7 +14,7 @@ import picocli.CommandLine.Unmatched;
         RegistryRemoveCommand.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class Registry implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
     @CommandLine.Mixin
@@ -24,7 +23,7 @@ public class Registry implements Callable<Integer> {
     @CommandLine.Spec
     protected CommandLine.Model.CommandSpec spec;
 
-    @Unmatched // avoids throwing errors for unmatched arguments
+    @CommandLine.Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
 
     public Integer call() throws Exception {

--- a/devtools/cli/src/main/java/io/quarkus/cli/Version.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Version.java
@@ -12,25 +12,23 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.smallrye.common.classloader.ClassPathUtils;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 @CommandLine.Command(name = "version", sortOptions = false, header = "Display version information.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
 public class Version implements CommandLine.IVersionProvider, Callable<Integer> {
 
     private static String version;
 
-    @Mixin
+    @CommandLine.Mixin(name = "output")
     OutputOptionMixin output;
 
-    @Mixin
+    @CommandLine.Mixin
     HelpOption helpOption;
 
     @CommandLine.ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
-    @Spec
+    @CommandLine.Spec
     CommandSpec spec;
 
     @CommandLine.Option(order = 3, names = {

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
@@ -15,7 +15,7 @@ public class BaseBuildCommand {
     @CommandLine.Spec
     protected CommandLine.Model.CommandSpec spec;
 
-    @CommandLine.Mixin
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
@@ -36,7 +36,7 @@ public class OutputOptionMixin implements MessageWriter {
         testProjectRoot = Paths.get(path).toAbsolutePath();
     }
 
-    @Spec(Spec.Target.MIXEE)
+    @CommandLine.Spec(CommandLine.Spec.Target.MIXEE)
     CommandSpec mixee;
 
     ColorScheme scheme;

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/BaseCreateCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/BaseCreateCommand.java
@@ -26,19 +26,19 @@ import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
 public class BaseCreateCommand implements Callable<Integer> {
-    @Mixin
+    @CommandLine.Mixin
     protected RunModeOption runMode;
 
-    @Mixin
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @Mixin
+    @CommandLine.Mixin
     ToggleRegistryClientMixin registryClient;
 
     @CommandLine.Mixin
     protected HelpOption helpOption;
 
-    @Spec
+    @CommandLine.Spec
     protected CommandSpec spec;
 
     @CommandLine.Option(paramLabel = "OUTPUT-DIR", names = { "-o",

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
@@ -5,22 +5,20 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import picocli.CommandLine;
-import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 public class BaseRegistryCommand implements Callable<Integer> {
 
-    @Mixin(name = "output")
+    @CommandLine.Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @Mixin
+    @CommandLine.Mixin
     protected RegistryClientMixin registryClient;
 
     @CommandLine.Mixin
     protected HelpOption helpOption;
 
-    @Spec
+    @CommandLine.Spec
     protected CommandSpec spec;
 
     @Override

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -14,7 +14,6 @@ import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistriesConfigLocator;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 public class QuarkusProjectHelper {
 
@@ -41,21 +40,7 @@ public class QuarkusProjectHelper {
     }
 
     public static BuildTool detectExistingBuildTool(Path projectDirPath) {
-        if (projectDirPath.resolve("pom.xml").toFile().exists()) {
-            return BuildTool.MAVEN;
-        } else if (projectDirPath.resolve("build.gradle").toFile().exists()) {
-            return BuildTool.GRADLE;
-        } else if (projectDirPath.resolve("build.gradle.kts").toFile().exists()) {
-            return BuildTool.GRADLE_KOTLIN_DSL;
-        } else if (projectDirPath.resolve("jbang").toFile().exists()) {
-            return BuildTool.JBANG;
-        } else if (projectDirPath.resolve("src").toFile().isDirectory()) {
-            String[] files = projectDirPath.resolve("src").toFile().list();
-            if (files != null && Arrays.asList(files).stream().anyMatch(x -> x.contains(".java"))) {
-                return BuildTool.JBANG;
-            }
-        }
-        return null;
+        return BuildTool.fromProject(projectDirPath);
     }
 
     public static QuarkusProject getProject(Path projectDir) {


### PR DESCRIPTION
Ship some isolated changes: consistent use of annotations in CLI.
Move detection of a project build tool to the build tool enum