### PR TITLE
Enhance OidcClient to pass custom headers to the token endpoint

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -159,6 +159,12 @@ public class OidcClientConfig extends OidcCommonConfig {
     @ConfigItem(defaultValue = "true")
     public boolean earlyTokensAcquisition = true;
 
+    /**
+     * Custom HTTP headers which have to be sent to the token endpoint
+     */
+    @ConfigItem
+    public Map<String, String> headers;
+
     public Optional<String> getId() {
         return id;
     }
@@ -197,5 +203,13 @@ public class OidcClientConfig extends OidcCommonConfig {
 
     public void setRefreshTokenTimeSkew(Duration refreshTokenTimeSkew) {
         this.refreshTokenTimeSkew = Optional.of(refreshTokenTimeSkew);
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -88,6 +88,11 @@ public class OidcClientImpl implements OidcClient {
                 HttpRequest<Buffer> request = client.postAbs(tokenRequestUri);
                 request.putHeader(HttpHeaders.CONTENT_TYPE.toString(),
                         HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
+                if (oidcConfig.headers != null) {
+                    for (Map.Entry<String, String> headerEntry : oidcConfig.headers.entrySet()) {
+                        request.putHeader(headerEntry.getKey(), headerEntry.getValue());
+                    }
+                }
                 if (clientSecretBasicAuthScheme != null) {
                     request.putHeader(AUTHORIZATION_HEADER, clientSecretBasicAuthScheme);
                 } else if (clientJwtKey != null) {

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -5,10 +5,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
 import io.smallrye.mutiny.Uni;
@@ -24,6 +27,10 @@ public class FrontendResource {
     Tokens tokens;
 
     @Inject
+    @NamedOidcClient("non-standard-response-without-header")
+    OidcClient tokensWithoutHeader;
+
+    @Inject
     OidcClients clients;
 
     @GET
@@ -35,7 +42,18 @@ public class FrontendResource {
     @GET
     @Path("echoTokenNonStandardResponse")
     public String echoTokenNonStandardResponse() {
-        return tokens.getAccessToken() + " " + tokens.getRefreshToken();
+        try {
+            return tokens.getAccessToken() + " " + tokens.getRefreshToken();
+        } catch (OidcClientException ex) {
+            throw new WebApplicationException(401);
+        }
+    }
+
+    @GET
+    @Path("echoTokenNonStandardResponseWithoutHeader")
+    public Uni<Tokens> echoTokenNonStandardResponseWithoutHeader() {
+        return tokensWithoutHeader.getTokens().onFailure(OidcClientException.class)
+                .transform(t -> new WebApplicationException(401));
     }
 
     @GET

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -18,6 +18,19 @@ quarkus.oidc-client.non-standard-response.grant.refresh-token-property=refreshTo
 quarkus.oidc-client.non-standard-response.grant.expires-in-property=expiresIn
 quarkus.oidc-client.non-standard-response.grant-options.password.username=alice
 quarkus.oidc-client.non-standard-response.grant-options.password.password=alice
+quarkus.oidc-client.non-standard-response.headers.X-Custom=XCustomHeaderValue
+
+quarkus.oidc-client.non-standard-response-without-header.auth-server-url=${keycloak.url}
+quarkus.oidc-client.non-standard-response-without-header.discovery-enabled=false
+quarkus.oidc-client.non-standard-response-without-header.token-path=/non-standard-tokens
+quarkus.oidc-client.non-standard-response-without-header.client-id=quarkus-app
+quarkus.oidc-client.non-standard-response-without-header.credentials.secret=secret
+quarkus.oidc-client.non-standard-response-without-header.grant.type=password
+quarkus.oidc-client.non-standard-response-without-header.grant.access-token-property=accessToken
+quarkus.oidc-client.non-standard-response-without-header.grant.refresh-token-property=refreshToken
+quarkus.oidc-client.non-standard-response-without-header.grant.expires-in-property=expiresIn
+quarkus.oidc-client.non-standard-response-without-header.grant-options.password.username=alice
+quarkus.oidc-client.non-standard-response-without-header.grant-options.password.password=alice
 
 quarkus.oidc-client.refresh.auth-server-url=${keycloak.url}
 quarkus.oidc-client.refresh.discovery-enabled=false

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -36,6 +36,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withBody(
                                 "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
         server.stubFor(WireMock.post("/non-standard-tokens")
+                .withHeader("X-Custom", matching("XCustomHeaderValue"))
                 .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
                 .willReturn(WireMock
                         .aResponse()

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -62,6 +62,13 @@ public class OidcClientTest {
     }
 
     @Test
+    public void testEchoTokensNonStandardResponseWithoutHeader() {
+        RestAssured.when().get("/frontend/echoTokenNonStandardResponseWithoutHeader")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testEchoTokensRefreshTokenOnly() {
         RestAssured.given().queryParam("refreshToken", "shared_refresh_token")
                 .when().get("/frontend/echoRefreshTokenOnly")


### PR DESCRIPTION
Fixes #20835.

This PR simply updates `OidcClient` to add the custom headers to the token request if configured.

`integrations/oidc-client-wiremock` tests have been updated to assert that one test passes only if a custom header is provided while the other with the identical configuration but without the custom header fails.

Would be nice to have it in 2.4.0.Final, if it is not too late, in which case 2.4.1.Final would be fine