### PR TITLE
Add http response content length to OTEL tracing

### DIFF
--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/VertxOpenTelemetryTest.java
@@ -4,6 +4,8 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_CLIENT_IP;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_FLAVOR;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_HOST;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_SCHEME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
@@ -52,9 +54,10 @@ public class VertxOpenTelemetryTest {
 
     @Test
     void trace() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        String expectedResponse = "Hello Tracer!";
         RestAssured.when().get("/tracer").then()
                 .statusCode(200)
-                .body(is("Hello Tracer!"));
+                .body(is(expectedResponse));
 
         List<SpanData> spans = testSpanExporter.getFinishedSpanItems();
 
@@ -71,6 +74,8 @@ public class VertxOpenTelemetryTest {
         assertEquals("http", spans.get(1).getAttributes().get(HTTP_SCHEME));
         assertEquals("localhost:8081", spans.get(1).getAttributes().get(HTTP_HOST));
         assertEquals("127.0.0.1", spans.get(1).getAttributes().get(HTTP_CLIENT_IP));
+        assertEquals(0, spans.get(1).getAttributes().get(HTTP_REQUEST_CONTENT_LENGTH));
+        assertEquals(expectedResponse.length(), spans.get(1).getAttributes().get(HTTP_RESPONSE_CONTENT_LENGTH));
         assertThat(textMapPropagators, arrayContainingInAnyOrder(W3CTraceContextPropagator.getInstance(),
                 W3CBaggagePropagator.getInstance()));
         assertThat(idGenerator, instanceOf(IdGenerator.random().getClass()));

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/restclient/ClientTracingFilter.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/restclient/ClientTracingFilter.java
@@ -9,6 +9,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
@@ -83,6 +84,13 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
             }
 
             clientSpan.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, responseContext.getStatus());
+            clientSpan.setAttribute(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, responseContext.getLength());
+
+            String requestContentLength = requestContext.getHeaderString(HttpHeaders.CONTENT_LENGTH);
+
+            if (requestContentLength != null && requestContentLength.length() > 0 && Long.parseLong(requestContentLength) > 0) {
+                clientSpan.setAttribute(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, Long.valueOf(requestContentLength));
+            }
 
             if (!responseContext.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL)) {
                 // TODO Is this ok as we don't have an exception to call recordException() with?


### PR DESCRIPTION
We were missing content length from requests and on http client.
This PR adds the missing attributes to the spans created by Quarkus.