### PR TITLE
Fix resolution of MediaType when validation errors using Accept headers

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/JaxrsEndPointValidationInterceptor.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/JaxrsEndPointValidationInterceptor.java
@@ -34,7 +34,7 @@ public class JaxrsEndPointValidationInterceptor extends AbstractMethodValidation
         try {
             return super.validateMethodInvocation(ctx);
         } catch (ConstraintViolationException e) {
-            throw new ResteasyViolationExceptionImpl(e.getConstraintViolations(), getAccept(ctx.getMethod()));
+            throw new ResteasyViolationExceptionImpl(e.getConstraintViolations(), getProduces(ctx.getMethod()));
         }
     }
 
@@ -44,7 +44,7 @@ public class JaxrsEndPointValidationInterceptor extends AbstractMethodValidation
         super.validateConstructorInvocation(ctx);
     }
 
-    private List<MediaType> getAccept(Method method) {
+    private List<MediaType> getProduces(Method method) {
         MediaType[] producedMediaTypes = MediaTypeHelper.getProduces(method.getDeclaringClass(), method);
 
         if (producedMediaTypes == null) {

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionImpl.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionImpl.java
@@ -23,8 +23,8 @@ public class ResteasyViolationExceptionImpl extends ResteasyViolationException {
     private static final long serialVersionUID = 657697354453281559L;
 
     public ResteasyViolationExceptionImpl(final Set<? extends ConstraintViolation<?>> constraintViolations,
-            final List<MediaType> accept) {
-        super(constraintViolations, accept);
+            final List<MediaType> produces) {
+        super(constraintViolations, produces);
     }
 
     @Override

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.validator.runtime.jaxrs;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Utility class to deal with MediaTypes in JAX-RS endpoints.
+ */
+public final class ValidatorMediaTypeUtil {
+
+    private static final List<MediaType> SUPPORTED_MEDIA_TYPES = Arrays.asList(MediaType.APPLICATION_XML_TYPE,
+            MediaType.APPLICATION_JSON_TYPE, MediaType.TEXT_PLAIN_TYPE);
+
+    private ValidatorMediaTypeUtil() {
+
+    }
+
+    /**
+     * Look up the right media type taking into account the HTTP request and the media types defined in the `@Produces`
+     * annotation.
+     *
+     * @param mediaTypesFromRequest list of media types in the HTTP request.
+     * @param mediaTypesFromProducesAnnotation list of media types set in the `@Produces` annotation.
+     * @return one supported media type from either the HTTP request or the annotation.
+     */
+    public static Optional<MediaType> getAcceptMediaType(List<MediaType> mediaTypesFromRequest,
+            List<MediaType> mediaTypesFromProducesAnnotation) {
+
+        Optional<MediaType> mediaType = mediaTypesFromRequest.stream()
+                // It's supported
+                .filter(SUPPORTED_MEDIA_TYPES::contains)
+                // It's included in the `@Produces` annotation
+                .filter(mediaTypesFromProducesAnnotation::contains)
+                .findFirst()
+                // if none is found, then return the first from the annotation
+                .or(mediaTypesFromProducesAnnotation.stream()::findFirst);
+
+        return mediaType;
+    }
+}

--- a/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
+++ b/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
@@ -8,6 +8,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.resteasy.annotations.providers.jaxb.WrappedMap;
+import org.jboss.resteasy.api.validation.ConstraintType;
 
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -23,11 +24,13 @@ public class ResteasyJaxbProcessor {
             WrappedMap.class);
 
     @BuildStep
-    void processAnnotations(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    void addReflectiveClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             CombinedIndexBuildItem combinedIndexBuildItem) {
-        IndexView index = combinedIndexBuildItem.getIndex();
+        // Handle RESTEasy Validation API classes
+        addReflectiveClass(reflectiveClass, true, true, ConstraintType.Type.class.getName());
 
         // Handle RESTEasy annotations usage.
+        IndexView index = combinedIndexBuildItem.getIndex();
         for (Class annotationClazz : RESTEASY_JAXB_ANNOTATIONS) {
             DotName annotation = DotName.createSimple(annotationClazz.getName());
 

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
@@ -136,6 +140,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -139,7 +139,7 @@ public class HibernateValidatorTestResource
 
     @GET
     @Path("/rest-end-point-validation/{id}/")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") String id) {
         return id;
     }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -152,7 +152,7 @@ public class HibernateValidatorFunctionalityTest {
         // are user errors and should be reported as such.
 
         // Bad request
-        RestAssured.when()
+        RestAssured.given()
                 .get("/hibernate-validator/test/rest-end-point-validation/plop/")
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
@@ -165,10 +165,44 @@ public class HibernateValidatorFunctionalityTest {
                     .isEmpty();
         }
 
-        RestAssured.when()
+        // Should be ok
+        RestAssured.given()
                 .get("/hibernate-validator/test/rest-end-point-validation/42/")
                 .then()
                 .body(is("42"));
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingTextMediaType() {
+        RestAssured.given()
+                .accept(ContentType.TEXT)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.TEXT)
+                .body(containsString("numeric value out of bounds"));
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingJsonMediaType() {
+        RestAssured.given()
+                .accept(ContentType.JSON)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.JSON)
+                .body("parameterViolations[0].message", containsString("numeric value out of bounds"));
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingXmlMediaType() {
+        RestAssured.given()
+                .accept(ContentType.XML)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.XML)
+                .body("violationReport.parameterViolations.message", containsString("numeric value out of bounds"));
     }
 
     @Test
@@ -264,6 +298,7 @@ public class HibernateValidatorFunctionalityTest {
                 .get("/hibernate-validator/test/no-produces/plop/")
                 .then()
                 .statusCode(400)
+                .contentType(ContentType.JSON)
                 .body(containsString("numeric value out of bounds"));
     }
 


### PR DESCRIPTION
The solution is to inject the HttpHeaders to have access to the HTTP headers in the exception mappers for Resteasy Classic and Reactive:

```java
@Context
HttpHeaders headers;
```

And then use a new utility that I called `ValidatorMediaTypeUtil` with some share functionality to get the list of media types from the `@Produces` annotation and to find the matching media type to serialize the validation reports.

Fix https://github.com/quarkusio/quarkus/issues/20859