### PR TITLE
Move awt runtime package definitions out of core

### DIFF
--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
@@ -1,4 +1,4 @@
-package io.quarkus.runtime.graal;
+package io.quarkus.awt.runtime.graal;
 
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -6,18 +6,6 @@ import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 
-/**
- * Technically, this should live in extensions/awt,
- * but currently all code that relies on JAXB
- * requires at the very least sun.java2d package to be runtime initialized.
- *
- * Having sun.java2d code initialized at build time caused issues,
- * which is why a substitution was set in place to avoid such code making it to the binary:
- * https://github.com/quarkusio/quarkus/commit/ef87e5567cf3ac462a3f12aad4b5b530d9220223
- *
- * So, as long as JAXB graphics code has not been excluded completely from JAXB,
- * it is safer to define all image related packages to be runtime initialized directly in core.
- */
 @AutomaticFeature
 public class AwtFeature implements Feature {
     @Override

--- a/extensions/jaxb/deployment/pom.xml
+++ b/extensions/jaxb/deployment/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-awt-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -26,6 +26,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-awt</artifactId>
+        </dependency>
         <!-- Don't rely on the JDK impl to be present as it's not present in JDK 11+ -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
This PR attempts to reduce the blast radius of #20681.

Defining awt/image packages as runtime init, means that there are some compilation/linking steps that are derived from the clinit code within those packages. E.g. loading `awt` library. As a result of this, extra compilation/linking parameters are added, some of which don't fully work on Windows.

So, this PR tries to reduce the blast radius of this, by moving the awt/image runtime init package definitions to `extensions/awt` and then, making `jaxb` depend on it. So, those quickstarts that depend on `awt` on windows will still encounter the issue, but that should be a smaller number.