### PR TITLE
Add `vertx-mutiny-generator` to BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1655,6 +1655,11 @@
                 <artifactId>quarkus-grpc-codegen</artifactId>
                 <version>${project.version}</version>
             </dependency>
+             <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>vertx-mutiny-generator</artifactId>
+                <version>${smallrye-mutiny-vertx-binding.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-grpc-stubs</artifactId>


### PR DESCRIPTION
Dependency `vertx-mutiny-generator` is required in order to generate mutiny stubs from a Quarkus/Vertx core implementation. 

For example, if you have the following handler:

```
public class MustContainsRolesImpl implements MustContainsRoles {

    private List<String> expectedRoles;

    public MustContainsRolesImpl(List<String> expectedRoles) {
        this.expectedRoles = expectedRoles;
    }

    @Override
    public void handle(RoutingContext ctx) {
        final String authorization = ctx.request().headers().get(AUTHORIZATION);
        if (authorization != null && authorization.toLowerCase().startsWith(BEARER.toLowerCase())) {
            var user = ctx.user();
            var roles = retrieveRoles(user);
            for (var expectedRole : expectedRoles) {
                if (!roles.contains(expectedRole)) {
                    ctx.fail(new HttpException(401, "Missing required role"));
                    break;
                }
            }
        }

        ctx.next();
    }

    private JsonArray retrieveRoles(final User user) {
        return user.principal().getJsonArray(ROLES);
    }
}
```

You could add the following interface in order to generate a Mutiny facade:

```
@MutinyGen(com.micifuz.commons.handlers.MustContainsRoles.class)
public interface MustContainsRoles extends Handler<RoutingContext> {

    String ROLES = "roles";
    String AUTHORIZATION = "Authorization";
    String BEARER = "bearer";

    static MustContainsRoles create(List<String> expectedRoles) {
        return new MustContainsRolesImpl(expectedRoles);
    }
}
```

This dependency is doing the same job as `io.vertx:vertx-codegen` does with RxJava. 
