### PR TITLE
Decouple rest-data-panache from RESTEasy Classic

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4211,6 +4211,10 @@
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -50,6 +50,9 @@ public interface Capability {
 
     String RESTEASY_MUTINY = RESTEASY + ".mutiny";
     String RESTEASY_REACTIVE = RESTEASY + ".reactive";
+    String RESTEASY_REACTIVE_JSON = RESTEASY_REACTIVE + ".json";
+    String RESTEASY_REACTIVE_JSON_JACKSON = RESTEASY_REACTIVE_JSON + ".jackson";
+    String RESTEASY_REACTIVE_JSON_JSONB = RESTEASY_REACTIVE_JSON + ".jsonb";
 
     String JWT = QUARKUS_PREFIX + "jwt";
 

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
@@ -41,6 +41,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -5,6 +5,8 @@ import static io.quarkus.deployment.Feature.HIBERNATE_ORM_REST_DATA_PANACHE;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
+import javax.ws.rs.Priorities;
+
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -23,9 +25,11 @@ import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.jta.TransactionalUpdateExecutor;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
+import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 
 class HibernateOrmPanacheRestProcessor {
 
@@ -41,8 +45,14 @@ class HibernateOrmPanacheRestProcessor {
     }
 
     @BuildStep
-    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
-        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
+    void registerRestDataPanacheExceptionMapper(
+            BuildProducer<ResteasyJaxrsProviderBuildItem> resteasyJaxrsProviderBuildItemBuildProducer,
+            BuildProducer<ExceptionMapperBuildItem> exceptionMapperBuildItemBuildProducer) {
+        resteasyJaxrsProviderBuildItemBuildProducer
+                .produce(new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName()));
+        exceptionMapperBuildItemBuildProducer
+                .produce(new ExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName(),
+                        RestDataPanacheException.class.getName(), Priorities.USER + 100, false));
     }
 
     @BuildStep

--- a/extensions/panache/rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/rest-data-panache/deployment/pom.xml
@@ -23,8 +23,13 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common-spi</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-spi</artifactId>

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -35,17 +35,17 @@ class JaxRsResourceImplementor {
 
     private final List<MethodImplementor> methodImplementors;
 
-    JaxRsResourceImplementor(boolean withValidation) {
+    JaxRsResourceImplementor(boolean withValidation, boolean isResteasyClassic) {
         this.methodImplementors = Arrays.asList(
-                new GetMethodImplementor(),
-                new GetHalMethodImplementor(),
-                new ListMethodImplementor(),
-                new ListHalMethodImplementor(),
-                new AddMethodImplementor(withValidation),
-                new AddHalMethodImplementor(withValidation),
-                new UpdateMethodImplementor(withValidation),
-                new UpdateHalMethodImplementor(withValidation),
-                new DeleteMethodImplementor());
+                new GetMethodImplementor(isResteasyClassic),
+                new GetHalMethodImplementor(isResteasyClassic),
+                new ListMethodImplementor(isResteasyClassic),
+                new ListHalMethodImplementor(isResteasyClassic),
+                new AddMethodImplementor(withValidation, isResteasyClassic),
+                new AddHalMethodImplementor(withValidation, isResteasyClassic),
+                new UpdateMethodImplementor(withValidation, isResteasyClassic),
+                new UpdateHalMethodImplementor(withValidation, isResteasyClassic),
+                new DeleteMethodImplementor(isResteasyClassic));
     }
 
     /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -25,7 +25,8 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
 
     private final boolean withValidation;
 
-    public AddMethodImplementor(boolean withValidation) {
+    public AddMethodImplementor(boolean withValidation, boolean isResteasyClassic) {
+        super(isResteasyClassic);
         this.withValidation = withValidation;
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -23,6 +23,10 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "remove";
 
+    public DeleteMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Generate JAX-RS DELETE method that exposes {@link RestDataResource#delete(Object)}.
      * Generated code looks more or less like this:

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -23,6 +23,10 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "self";
 
+    public GetMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Generate JAX-RS GET method that exposes {@link RestDataResource#get(Object)}.
      * Generated code looks more or less like this:

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -36,6 +36,10 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
+    public ListMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Generate JAX-RS GET method that exposes {@link RestDataResource#list(Page, Sort)}.
      * Generated pseudo-code with enabled pagination is shown below. If pagination is disabled pageIndex and pageSize

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -38,7 +38,8 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
 
     private final boolean withValidation;
 
-    public UpdateMethodImplementor(boolean withValidation) {
+    public UpdateMethodImplementor(boolean withValidation, boolean isResteasyClassic) {
+        super(isResteasyClassic);
         this.withValidation = withValidation;
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/AddHalMethodImplementor.java
@@ -23,7 +23,8 @@ public final class AddHalMethodImplementor extends HalMethodImplementor {
 
     private final boolean withValidation;
 
-    public AddHalMethodImplementor(boolean withValidation) {
+    public AddHalMethodImplementor(boolean withValidation, boolean isResteasyClassic) {
+        super(isResteasyClassic);
         this.withValidation = withValidation;
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/GetHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/GetHalMethodImplementor.java
@@ -22,6 +22,10 @@ public final class GetHalMethodImplementor extends HalMethodImplementor {
 
     private static final String RESOURCE_METHOD_NAME = "get";
 
+    public GetHalMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Expose {@link RestDataResource#get(Object)} via HAL JAX-RS method.
      * Generated code looks more or less like this:

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
@@ -18,6 +18,10 @@ import io.quarkus.rest.data.panache.runtime.hal.HalEntityWrapper;
  */
 abstract class HalMethodImplementor extends StandardMethodImplementor {
 
+    HalMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Implement a method if it is exposed and hal is enabled.
      */

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -36,6 +36,10 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
+    public ListHalMethodImplementor(boolean isResteasyClassic) {
+        super(isResteasyClassic);
+    }
+
     /**
      * Expose {@link RestDataResource#list(Page, Sort)} via HAL JAX-RS method.
      * Generated pseudo-code with enabled pagination is shown below. If pagination is disabled pageIndex and pageSize

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/UpdateHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/UpdateHalMethodImplementor.java
@@ -36,7 +36,8 @@ public final class UpdateHalMethodImplementor extends HalMethodImplementor {
 
     private final boolean withValidation;
 
-    public UpdateHalMethodImplementor(boolean withValidation) {
+    public UpdateHalMethodImplementor(boolean withValidation, boolean isResteasyClassic) {
+        super(isResteasyClassic);
         this.withValidation = withValidation;
     }
 

--- a/extensions/panache/rest-data-panache/runtime/pom.xml
+++ b/extensions/panache/rest-data-panache/runtime/pom.xml
@@ -18,18 +18,22 @@
             <artifactId>quarkus-panache-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-links</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-links</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/RestEasyHalLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/RestEasyHalLinksProvider.java
@@ -3,20 +3,20 @@ package io.quarkus.rest.data.panache.runtime.hal;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.rest.data.panache.runtime.resource.ResourceLinksProvider;
 
 final class RestEasyHalLinksProvider implements HalLinksProvider {
 
-    private final ResourceLinksProvider linksProvider = new ResourceLinksProvider();
-
     @Override
     public Map<String, HalLink> getLinks(Class<?> entityClass) {
-        return toHalLinkMap(linksProvider.getClassLinks(entityClass));
+        return toHalLinkMap(restLinksProvider().getClassLinks(entityClass));
     }
 
     @Override
     public Map<String, HalLink> getLinks(Object entity) {
-        return toHalLinkMap(linksProvider.getInstanceLinks(entity));
+        return toHalLinkMap(restLinksProvider().getInstanceLinks(entity));
     }
 
     private Map<String, HalLink> toHalLinkMap(Map<String, String> links) {
@@ -25,5 +25,13 @@ final class RestEasyHalLinksProvider implements HalLinksProvider {
             halLinks.put(entry.getKey(), new HalLink(entry.getValue()));
         }
         return halLinks;
+    }
+
+    private ResourceLinksProvider restLinksProvider() {
+        InstanceHandle<ResourceLinksProvider> instance = Arc.container().instance(ResourceLinksProvider.class);
+        if (instance.isAvailable()) {
+            return instance.get();
+        }
+        throw new IllegalStateException("No bean of type '" + ResourceLinksProvider.class.getName() + "' found.");
     }
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/RESTEasyClassicResourceLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/RESTEasyClassicResourceLinksProvider.java
@@ -1,0 +1,41 @@
+package io.quarkus.rest.data.panache.runtime.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.resteasy.links.LinksProvider;
+import org.jboss.resteasy.links.RESTServiceDiscovery;
+
+public final class RESTEasyClassicResourceLinksProvider implements ResourceLinksProvider {
+
+    private static final String SELF_REF = "self";
+
+    public Map<String, String> getClassLinks(Class<?> className) {
+        RESTServiceDiscovery links = LinksProvider
+                .getClassLinksProvider()
+                .getLinks(className, Thread.currentThread().getContextClassLoader());
+        return linksToMap(links);
+    }
+
+    public Map<String, String> getInstanceLinks(Object instance) {
+        RESTServiceDiscovery links = LinksProvider
+                .getObjectLinksProvider()
+                .getLinks(instance, Thread.currentThread().getContextClassLoader());
+        return linksToMap(links);
+    }
+
+    public String getSelfLink(Object instance) {
+        RESTServiceDiscovery.AtomLink link = LinksProvider.getObjectLinksProvider()
+                .getLinks(instance, Thread.currentThread().getContextClassLoader())
+                .getLinkForRel(SELF_REF);
+        return link == null ? null : link.getHref();
+    }
+
+    private Map<String, String> linksToMap(RESTServiceDiscovery serviceDiscovery) {
+        Map<String, String> links = new HashMap<>(serviceDiscovery.size());
+        for (RESTServiceDiscovery.AtomLink atomLink : serviceDiscovery) {
+            links.put(atomLink.getRel(), atomLink.getHref());
+        }
+        return links;
+    }
+}

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/RESTEasyReactiveResourceLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/RESTEasyReactiveResourceLinksProvider.java
@@ -1,0 +1,51 @@
+package io.quarkus.rest.data.panache.runtime.resource;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Link;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.resteasy.reactive.links.RestLinksProvider;
+
+public class RESTEasyReactiveResourceLinksProvider implements ResourceLinksProvider {
+
+    private static final String SELF_REF = "self";
+
+    public Map<String, String> getClassLinks(Class<?> className) {
+        return linksToMap(restLinksProvider().getTypeLinks(className));
+    }
+
+    public Map<String, String> getInstanceLinks(Object instance) {
+        return linksToMap(restLinksProvider().getInstanceLinks(instance));
+    }
+
+    public String getSelfLink(Object instance) {
+        Collection<Link> links = restLinksProvider().getInstanceLinks(instance);
+        for (Link link : links) {
+            if (SELF_REF.equals(link.getRel())) {
+                return link.getUri().toString();
+            }
+        }
+        return null;
+    }
+
+    private RestLinksProvider restLinksProvider() {
+        InstanceHandle<RestLinksProvider> instance = Arc.container().instance(RestLinksProvider.class);
+        if (instance.isAvailable()) {
+            return instance.get();
+        }
+        throw new IllegalStateException("Invalid use of '" + this.getClass().getName()
+                + "'. No request scope bean found for type '" + RESTEasyReactiveResourceLinksProvider.class.getName() + "'");
+    }
+
+    private Map<String, String> linksToMap(Collection<Link> links) {
+        Map<String, String> result = new HashMap<>();
+        for (Link link : links) {
+            result.put(link.getRel(), link.getUri().toString());
+        }
+        return result;
+    }
+}

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/resource/ResourceLinksProvider.java
@@ -1,41 +1,13 @@
 package io.quarkus.rest.data.panache.runtime.resource;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import org.jboss.resteasy.links.LinksProvider;
-import org.jboss.resteasy.links.RESTServiceDiscovery;
+public interface ResourceLinksProvider {
 
-public final class ResourceLinksProvider {
+    Map<String, String> getClassLinks(Class<?> className);
 
-    private static final String SELF_REF = "self";
+    Map<String, String> getInstanceLinks(Object instance);
 
-    public Map<String, String> getClassLinks(Class<?> className) {
-        RESTServiceDiscovery links = LinksProvider
-                .getClassLinksProvider()
-                .getLinks(className, Thread.currentThread().getContextClassLoader());
-        return linksToMap(links);
-    }
-
-    public Map<String, String> getInstanceLinks(Object instance) {
-        RESTServiceDiscovery links = LinksProvider
-                .getObjectLinksProvider()
-                .getLinks(instance, Thread.currentThread().getContextClassLoader());
-        return linksToMap(links);
-    }
-
-    public String getSelfLink(Object instance) {
-        RESTServiceDiscovery.AtomLink link = LinksProvider.getObjectLinksProvider()
-                .getLinks(instance, Thread.currentThread().getContextClassLoader())
-                .getLinkForRel(SELF_REF);
-        return link == null ? null : link.getHref();
-    }
-
-    private Map<String, String> linksToMap(RESTServiceDiscovery serviceDiscovery) {
-        Map<String, String> links = new HashMap<>(serviceDiscovery.size());
-        for (RESTServiceDiscovery.AtomLink atomLink : serviceDiscovery) {
-            links.put(atomLink.getRel(), atomLink.getHref());
-        }
-        return links;
-    }
+    @SuppressWarnings("unused")
+    String getSelfLink(Object instance);
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/GeneratedJaxRsResourceGizmoAdaptor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/GeneratedJaxRsResourceGizmoAdaptor.java
@@ -1,8 +1,7 @@
-package io.quarkus.resteasy.reactive.server.deployment;
+package io.quarkus.resteasy.reactive.spi;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceBuildItem;
 
 public class GeneratedJaxRsResourceGizmoAdaptor implements ClassOutput {
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/pom.xml
@@ -29,6 +29,12 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.rest.jackson</provides>
+                        <provides>io.quarkus.resteasy.reactive.json.jackson</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/runtime/pom.xml
@@ -29,6 +29,12 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.rest.jsonb</provides>
+                        <provides>io.quarkus.resteasy.reactive.json.jsonb</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
@@ -2,7 +2,6 @@ package io.quarkus.resteasy.reactive.links.runtime;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.ws.rs.core.Link;
@@ -34,8 +33,9 @@ final class RestLinksProviderImpl implements RestLinksProvider {
     public Collection<Link> getTypeLinks(Class<?> elementType) {
         verifyInit();
 
-        List<Link> links = new LinkedList<>();
-        for (LinkInfo linkInfo : linksContainer.getForClass(elementType)) {
+        List<LinkInfo> linkInfoList = linksContainer.getForClass(elementType);
+        List<Link> links = new ArrayList<>(linkInfoList.size());
+        for (LinkInfo linkInfo : linkInfoList) {
             if (linkInfo.getPathParameters().size() == 0) {
                 links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
                         .rel(linkInfo.getRel())
@@ -49,8 +49,9 @@ final class RestLinksProviderImpl implements RestLinksProvider {
     public <T> Collection<Link> getInstanceLinks(T instance) {
         verifyInit();
 
-        List<Link> links = new LinkedList<>();
-        for (LinkInfo linkInfo : linksContainer.getForClass(instance.getClass())) {
+        List<LinkInfo> linkInfoList = linksContainer.getForClass(instance.getClass());
+        List<Link> links = new ArrayList<>(linkInfoList.size());
+        for (LinkInfo linkInfo : linkInfoList) {
             links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
                     .rel(linkInfo.getRel())
                     .build(getPathParameterValues(linkInfo, instance)));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/generatedresource/GeneratedJaxRsResourceTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/generatedresource/GeneratedJaxRsResourceTest.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceGizmoAdaptor;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -18,7 +19,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.resteasy.reactive.server.deployment.GeneratedJaxRsResourceGizmoAdaptor;
 import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceBuildItem;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/generatedresource/GeneratedJaxRsResourceTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/generatedresource/GeneratedJaxRsResourceTest.java
@@ -7,7 +7,6 @@ import java.util.function.Consumer;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceGizmoAdaptor;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -20,6 +19,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceBuildItem;
+import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceGizmoAdaptor;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class GeneratedJaxRsResourceTest {

--- a/extensions/spring-data-rest/deployment/pom.xml
+++ b/extensions/spring-data-rest/deployment/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>quarkus-spring-data-jpa-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.ws.rs.Priorities;
+
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -24,10 +26,12 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.rest.data.panache.deployment.properties.ResourcePropertiesBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
+import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.spring.data.rest.deployment.crud.CrudMethodsImplementor;
 import io.quarkus.spring.data.rest.deployment.crud.CrudPropertiesProvider;
 import io.quarkus.spring.data.rest.deployment.paging.PagingAndSortingMethodsImplementor;
@@ -55,8 +59,14 @@ class SpringDataRestProcessor {
     }
 
     @BuildStep
-    ResteasyJaxrsProviderBuildItem registerRestDataPanacheExceptionMapper() {
-        return new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName());
+    void registerRestDataPanacheExceptionMapper(
+            BuildProducer<ResteasyJaxrsProviderBuildItem> resteasyJaxrsProviderBuildItemBuildProducer,
+            BuildProducer<ExceptionMapperBuildItem> exceptionMapperBuildItemBuildProducer) {
+        resteasyJaxrsProviderBuildItemBuildProducer
+                .produce(new ResteasyJaxrsProviderBuildItem(RestDataPanacheExceptionMapper.class.getName()));
+        exceptionMapperBuildItemBuildProducer
+                .produce(new ExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName(),
+                        RestDataPanacheException.class.getName(), Priorities.USER + 100, false));
     }
 
     @BuildStep

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>

--- a/integration-tests/mongodb-rest-data-panache/pom.xml
+++ b/integration-tests/mongodb-rest-data-panache/pom.xml
@@ -19,7 +19,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-links</artifactId>
         </dependency>
         <!-- Service Binding - This isn't necessary to any Kafka functionality, but we want to test that Quarkus provides the proper config from a mock service binding -->
         <dependency>
@@ -63,7 +67,20 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-links</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This means that the `quarkus-hibernate-orm-panache`,
`quarkus-mongodb-rest-data-panache` and `quarkus-spring-data-rest`
no longer have hard dependencies on `quarkus-resteasy` and can thus be used with either `quarkus-resteasy` or `quarkus-resteasy-reactive`.

To work with RESTEasy Classic, the application much add the
`org.jboss.resteasy:resteasy-links` dependency (in addition to any `quarkus-resteasy*` dependency).
To work with RESTEasy Reactive, the application much add the
`quarkus-resteasy-reactive-links` dependency.

Fixes: #20688