### PR TITLE
Allow Undertow to work with RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -154,6 +154,11 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     }
 
     @Override
+    public boolean resumeExternalProcessing() {
+        return false;
+    }
+
+    @Override
     public String getRequestHeader(CharSequence name) {
         return request.getHeader(name.toString());
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -74,7 +74,11 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
             ShutdownContext shutdownContext, HttpBuildTimeConfig vertxConfig,
             RequestContextFactory contextFactory,
             BeanFactory<ResteasyReactiveInitialiser> initClassFactory,
-            LaunchMode launchMode) {
+            LaunchMode launchMode, boolean servletPresent) {
+
+        if (servletPresent) {
+            info.setResumeOn404(true);
+        }
 
         CurrentRequestManager
                 .setCurrentRequestInstance(new QuarkusCurrentRequest(beanContainer.instance(CurrentVertxRequest.class)));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -40,6 +40,7 @@ public class Deployment {
     private final List<ServerRestHandler> preMatchHandlers;
     private final List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
     private final List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers;
+    private final boolean resumeOn404;
 
     public Deployment(ExceptionMapping exceptionMapping, ContextResolvers contextResolvers,
             ServerSerialisers serialisers,
@@ -49,7 +50,7 @@ public class Deployment {
             ThreadSetupAction threadSetupAction, RequestContextFactory requestContextFactory,
             List<ServerRestHandler> preMatchHandlers,
             List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers,
-            List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers) {
+            List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers, boolean resumeOn404) {
         this.exceptionMapping = exceptionMapping;
         this.contextResolvers = contextResolvers;
         this.serialisers = serialisers;
@@ -64,6 +65,7 @@ public class Deployment {
         this.preMatchHandlers = preMatchHandlers;
         this.classMappers = classMappers;
         this.runtimeConfigurableServerRestHandlers = runtimeConfigurableServerRestHandlers;
+        this.resumeOn404 = resumeOn404;
     }
 
     public Supplier<Application> getApplicationSupplier() {
@@ -92,6 +94,10 @@ public class Deployment {
 
     public EntityWriter getDynamicEntityWriter() {
         return dynamicEntityWriter;
+    }
+
+    public boolean isResumeOn404() {
+        return resumeOn404;
     }
 
     /**

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
@@ -33,6 +33,7 @@ public class DeploymentInfo {
     private String applicationPath;
     private List<HandlerChainCustomizer> globalHandlerCustomers = new ArrayList<>();
     private boolean developmentMode;
+    private boolean resumeOn404;
 
     public ResourceInterceptors getInterceptors() {
         return interceptors;
@@ -175,6 +176,15 @@ public class DeploymentInfo {
 
     public DeploymentInfo setDevelopmentMode(boolean developmentMode) {
         this.developmentMode = developmentMode;
+        return this;
+    }
+
+    public boolean isResumeOn404() {
+        return resumeOn404;
+    }
+
+    public DeploymentInfo setResumeOn404(boolean resumeOn404) {
+        this.resumeOn404 = resumeOn404;
         return this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -1013,6 +1013,8 @@ public abstract class ResteasyReactiveRequestContext
         return getResourceLocatorPathParam(name, previousResource.prev);
     }
 
+    public abstract boolean resumeExternalProcessing();
+
     static class PreviousResource {
 
         public PreviousResource(RuntimeResource locatorTarget, Object locatorPathParamValues, PreviousResource prev) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -145,7 +145,8 @@ public class RuntimeDeploymentManager {
                     .getValue();
             Map<String, RequestMapper<RuntimeResource>> mappersByMethod = RuntimeMappingDeployment
                     .buildClassMapper(perClassMappers);
-            ClassRoutingHandler classRoutingHandler = new ClassRoutingHandler(mappersByMethod, classTemplateNameCount);
+            ClassRoutingHandler classRoutingHandler = new ClassRoutingHandler(mappersByMethod, classTemplateNameCount,
+                    info.isResumeOn404());
 
             int maxMethodTemplateNameCount = 0;
             for (TreeMap<URITemplate, List<RequestMapper.RequestPath<RuntimeResource>>> i : perClassMappers.values()) {
@@ -206,7 +207,7 @@ public class RuntimeDeploymentManager {
                 abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY), dynamicEntityWriter,
                 prefix, paramConverterProviders, configurationImpl, applicationSupplier,
                 threadSetupAction, requestContextFactory, preMatchHandlers, classMappers,
-                runtimeConfigurableServerRestHandlers);
+                runtimeConfigurableServerRestHandlers, info.isResumeOn404());
     }
 
     private void addRuntimeConfigurableHandlers(RuntimeResource runtimeResource,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -29,10 +29,12 @@ public class ClassRoutingHandler implements ServerRestHandler {
 
     private final Map<String, RequestMapper<RuntimeResource>> mappers;
     private final int parameterOffset;
+    final boolean resumeOn404;
 
-    public ClassRoutingHandler(Map<String, RequestMapper<RuntimeResource>> mappers, int parameterOffset) {
+    public ClassRoutingHandler(Map<String, RequestMapper<RuntimeResource>> mappers, int parameterOffset, boolean resumeOn404) {
         this.mappers = mappers;
         this.parameterOffset = parameterOffset;
+        this.resumeOn404 = resumeOn404;
     }
 
     @Override
@@ -201,9 +203,15 @@ public class ClassRoutingHandler implements ServerRestHandler {
     }
 
     private void throwNotFound(ResteasyReactiveRequestContext requestContext) {
+        if (resumeOn404) {
+            if (requestContext.resumeExternalProcessing()) {
+                return;
+            }
+        }
         // the exception mapper needs access to request scoped beans, so make sure we have the context
         requestContext.requireCDIRequestScope();
         throw new NotFoundException("Unable to find matching target resource method");
+
     }
 
     private String getRemaining(ResteasyReactiveRequestContext requestContext) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -122,6 +122,12 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     }
 
     @Override
+    public boolean resumeExternalProcessing() {
+        context.next();
+        return true;
+    }
+
+    @Override
     public String getRequestHeader(CharSequence name) {
         return request.headers().get(name);
     }

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -30,6 +30,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
+        <!--
+        Makes sure that undertow does not interfere with RESTEasy Reactive
+        Undertow is blocking so if it interfered it would break everything
+        but the RR endpoints should run first
+        -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
@@ -144,7 +153,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Note that this integration is different to the integration provided by
resteasy-reactive-servlet or the RESTEasy classic integration. This
allows RESTEasy Reactive to run before Servlet, and delegate any
unmatched requests to the Servlet container. If RESTEasy reactive
matches then Servlet is not involved in the request handling.