### PR TITLE
Ensure that @QuarkusIntegrationTest tests are closed properly

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -91,7 +91,7 @@ public class QuarkusIntegrationTestExtension
         boolean reloadTestResources = !Objects.equals(extensionContext.getRequiredTestClass(), currentJUnitTestClass)
                 && (hasPerTestResources || QuarkusTestExtension.hasPerTestResources(extensionContext));
         if ((state == null && !failedBoot) || wrongProfile || reloadTestResources) {
-            if (wrongProfile) {
+            if (wrongProfile || reloadTestResources) {
                 if (state != null) {
                     try {
                         state.close();


### PR DESCRIPTION
This change brings `@QuarkusIntegrationTest` in line with `@NativeImageTest`

The problem was discovered when attempting to convert the kubernetes-client
integration test to `@QuarkusIntegrationTest`