### PR TITLE
Extensions should override codestart data for dependencies

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartData.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartData.java
@@ -56,12 +56,8 @@ public final class CodestartData {
     public static Map<String, Object> buildDependenciesData(Stream<Codestart> codestartsStream, String languageName,
             Collection<String> extensions, Collection<String> platforms) {
         final Map<String, Set<CodestartDep>> depsData = new HashMap<>();
-        final Set<CodestartDep> boms = platforms.stream()
-                .map(CodestartDep::new)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        final Set<CodestartDep> dependencies = extensions.stream()
-                .map(CodestartDep::new)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        final Set<CodestartDep> boms = new LinkedHashSet<>();
+        final Set<CodestartDep> dependencies = new LinkedHashSet<>();
         final Set<CodestartDep> testDependencies = new LinkedHashSet<>();
         codestartsStream
                 .flatMap(s -> Stream.of(s.getBaseLanguageSpec(), s.getLanguageSpec(languageName)))
@@ -69,6 +65,12 @@ public final class CodestartData {
                     dependencies.addAll(d.getDependencies());
                     testDependencies.addAll(d.getTestDependencies());
                 });
+        platforms.stream()
+                .map(CodestartDep::new)
+                .forEach(boms::add);
+        extensions.stream()
+                .map(CodestartDep::new)
+                .forEach(dependencies::add);
         depsData.put("dependencies", dependencies);
         depsData.put("boms", boms);
         depsData.put("test-dependencies", testDependencies);

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -31,16 +31,16 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The extension may contain the version to use.