### PR TITLE
Upgrade to Testcontainers 1.16.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -203,8 +203,8 @@
         <avro.version>1.10.2</avro.version>
         <apicurio-registry.version>2.0.1.Final</apicurio-registry.version>
         <jacoco.version>0.8.7</jacoco.version>
-        <testcontainers.version>1.16.0</testcontainers.version>
-        <docker-java.version>3.2.11</docker-java.version> <!-- must be the version Testcontainers use -->
+        <testcontainers.version>1.16.1</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
+        <docker-java.version>3.2.12</docker-java.version> <!-- must be the version Testcontainers use -->
         <aesh-readline.version>2.1</aesh-readline.version>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <strimzi.oauth.nimbus.version>9.14</strimzi.oauth.nimbus.version>

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -42,6 +42,10 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
@@ -60,6 +60,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>


### PR DESCRIPTION
This improves support for the Oracle DB container images, generally improves the times it takes to start containers, and much more:

 - https://github.com/testcontainers/testcontainers-java/releases/tag/1.16.1