### PR TITLE
Avoid running genarate code task as compile task dependency

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -158,7 +158,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
                     tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class,
                             compileJava -> {
-                                compileJava.dependsOn(quarkusGenerateCode);
+                                compileJava.mustRunAfter(quarkusGenerateCode);
                                 compileJava.mustRunAfter(quarkusGenerateCodeDev);
                             });
                     tasks.named(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaCompile.class,


### PR DESCRIPTION
Before the `quarkusGenerateCodeDev` task was introduced, there was an explicit dependency between `quarkusGenerateCode` and `compileJava`

This make sure the `quarkusGenerateCode` is executed only when it is required (`quarkusBuild`/`quarkusTest`)