### PR TITLE
Add OIDC DevUiConfig for OIDC Console and Keycloak DevUI support the same grants

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -64,7 +64,7 @@ By default the Keycloak page can be used to support the development of a link:se
 [[keycloak-authorization-code-grant]]
 ==== Authorization Code Grant
 
-If you set `quarkus.keycloak.devservices.grant.type=code` in `application.properties` (this is a default value) then an `authorization_code` grant will be used to acquire both access and ID tokens. Using this grant is recommended to emulate a typical flow where a `Single Page Application` acquires the tokens and uses them to access Quarkus services.
+If you set `quarkus.oidc.devui.grant.type=code` in `application.properties` (this is a default value) then an `authorization_code` grant will be used to acquire both access and ID tokens. Using this grant is recommended to emulate a typical flow where a `Single Page Application` acquires the tokens and uses them to access Quarkus services.
 
 First you will see an option to `Log into Single Page Application`:
 
@@ -112,11 +112,11 @@ You can set the `redirect_uri` value to `*` only for the test purposes, especial
 
 ==== Implicit Grant
 
-If you set `quarkus.keycloak.devservices.grant.type=implicit` in `application.properties` then an `implicit` grant will be used to acquire both access and ID tokens. Use this grant for emulating a `Single Page Application` only if the authorization code grant does not work (for example, a client is configured in Keycloak to support an implicit grant, etc).
+If you set `quarkus.oidc.devui.grant.type=implicit` in `application.properties` then an `implicit` grant will be used to acquire both access and ID tokens. Use this grant for emulating a `Single Page Application` only if the authorization code grant does not work (for example, a client is configured in Keycloak to support an implicit grant, etc).
 
 ==== Password Grant
 
-If you set `quarkus.keycloak.devservices.grant.type=password` in `application.properties` then you will see a screen like this one:
+If you set `quarkus.oidc.devui.grant.type=password` in `application.properties` then you will see a screen like this one:
 
 image::dev-ui-keycloak-password-grant.png[alt=Dev UI OpenId Connect Keycloak Page - Password Grant,role="center"]
 
@@ -136,7 +136,7 @@ A token is acquired from Keycloak using a `password` grant and is sent to the se
 
 ==== Client Credentials Grant
 
-If you set `quarkus.keycloak.devservices.grant.type=client` then a `client_credentials` grant will be used to acquire a token, with the page showing no `User` field in this case:
+If you set `quarkus.oidc.devui.grant.type=client` then a `client_credentials` grant will be used to acquire a token, with the page showing no `User` field in this case:
 
 image::dev-ui-keycloak-client-credentials-grant.png[alt=Dev UI OpenId Connect Keycloak Page - Client Credentials Grant,role="center"]
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
@@ -1,0 +1,69 @@
+package io.quarkus.oidc.deployment;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class DevUiConfig {
+
+    /**
+     * Grant type which affects how OpenId Connect Dev UI will facilitate the token acquisition.
+     * 
+     * For example: if the grant type is 'code' then an authorization code will be returned directly to Dev UI which will use a
+     * code
+     * handler to acquire the tokens while a user name and password will have to be entered to request a token using a
+     * 'password' grant.
+     */
+    public Grant grant = new Grant();
+
+    @ConfigGroup
+    public static class Grant {
+        public static enum Type {
+            /**
+             * 'client_credentials' grant
+             */
+            CLIENT("client_credentials"),
+            /**
+             * 'password' grant
+             */
+            PASSWORD("password"),
+
+            /**
+             * 'authorization_code' grant
+             */
+            CODE("code"),
+
+            /**
+             * 'implicit' grant
+             */
+            IMPLICIT("implicit");
+
+            private String grantType;
+
+            private Type(String grantType) {
+                this.grantType = grantType;
+            }
+
+            public String getGrantType() {
+                return grantType;
+            }
+        }
+
+        /**
+         * Grant type which will be used to acquire a token to test the OIDC 'service' applications
+         */
+        @ConfigItem
+        public Optional<Type> type;
+    }
+
+    /**
+     * The WebClient timeout.
+     * Use this property to configure how long an HTTP client used by Dev UI handlers will wait for a response when requesting
+     * tokens from OpenId Connect Provider and sending them to the service endpoint.
+     */
+    @ConfigItem
+    public Optional<Duration> webClienTimeout;
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
@@ -16,6 +16,11 @@ public class OidcBuildTimeConfig {
     public boolean enabled;
 
     /**
+     * Dev UI configuration.
+     */
+    @ConfigItem
+    public DevUiConfig devui;
+    /**
      * Enable the registration of the Default TokenIntrospection and UserInfo Cache implementation bean.
      * Note it only allows to use the default implementation, one needs to configure it in order to activate it,
      * please see {@link OidcConfig#tokenCache}.

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
@@ -43,9 +43,11 @@ public abstract class AbstractDevConsoleProcessor {
     }
 
     protected void produceDevConsoleRouteItems(BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,
-            DevConsolePostHandler testServiceWithToken, DevConsolePostHandler exchangeCodeForTokens) {
+            DevConsolePostHandler testServiceWithToken,
+            DevConsolePostHandler exchangeCodeForTokens,
+            DevConsolePostHandler passwordClientCredHandler) {
         devConsoleRoute.produce(new DevConsoleRouteBuildItem("testServiceWithToken", "POST", testServiceWithToken));
         devConsoleRoute.produce(new DevConsoleRouteBuildItem("exchangeCodeForTokens", "POST", exchangeCodeForTokens));
-
+        devConsoleRoute.produce(new DevConsoleRouteBuildItem("testService", "POST", passwordClientCredHandler));
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.oidc.deployment.DevUiConfig;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -106,6 +107,12 @@ public class DevServicesConfig {
     @ConfigItem
     public Map<String, String> roles;
 
+    /**
+     * Grant type.
+     * 
+     * @deprecated Use {@link DevUiConfig#grant}.
+     */
+    @Deprecated
     public Grant grant = new Grant();
 
     @ConfigGroup
@@ -160,8 +167,11 @@ public class DevServicesConfig {
      * The WebClient timeout.
      * Use this property to configure how long an HTTP client will wait for a response when requesting
      * tokens from Keycloak and sending them to the service endpoint.
+     *
+     * @deprecated Use {@link DevUiConfig#webClienTimeout}.
      */
     @ConfigItem(defaultValue = "4S")
+    @Deprecated
     public Duration webClienTimeout;
 
     @Override

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -237,7 +237,7 @@ var port = {config:property('quarkus.http.port')};
 
 {#if info:oidcGrantType is 'password'}
 
-    function testServiceWithPassword(userName, servicePath){
+    function testServiceWithPassword(userName, password, servicePath){
         $.post("testService",
             {
               tokenUrl: '{info:tokenUrl}',
@@ -245,6 +245,7 @@ var port = {config:property('quarkus.http.port')};
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               user: userName,
+              password: password,
               grant: '{info:oidcGrantType}'
             },
             function(data, status){
@@ -252,13 +253,14 @@ var port = {config:property('quarkus.http.port')};
             });
     }
     
-    function testServiceWithPasswordInSwaggerUi(userName){
+    function testServiceWithPasswordInSwaggerUi(userName, password){
         $.post("testService",
             {
               tokenUrl: '{info:tokenUrl}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               user: userName,
+              password: password,
               grant: '{info:oidcGrantType}'
             },
             function(data, status){
@@ -537,9 +539,23 @@ function signInToService(servicePath) {
                         <label for="userName">User name</label>
                     </div>
                     <div class="col-10">
-                        <input type="text" class="form-control" id="userName" value="{info:keycloakUsers.keySet().iterator().next()}" title="User">
+                        <input type="text" class="form-control" id="userName" value="" title="User">
                     </div>
                 </div>
+                {#if info:keycloakUsers??}
+	                <div class="row">
+	                    <input type="hidden" id="password" value="" title="Password">
+	                </div>
+	            {#else}
+	                <div class="row">
+	                    <div class="col-2">
+	                        <label for="password">Password</label>
+	                    </div>
+	                    <div class="col-10">
+	                        <input type="password" class="form-control" id="password" value="" title="Password">
+	                    </div>
+	                </div> 
+                {/if}
                 <div class="row my-2">
                     <div class="col-2">
                         <label for="servicePath">Service Path</label>
@@ -550,16 +566,16 @@ function signInToService(servicePath) {
                 </div>
                 <div class="row my-2">
                     <div class="col offset-md-2">
-                        <button onclick="testServiceWithPassword($('#userName').val(), $('#servicePath').val());" class="btn btn-primary btn-block" title="Test service">Test service</button>
+                        <button onclick="testServiceWithPassword($('#userName').val(), $('#password').val(), $('#servicePath').val());" class="btn btn-primary btn-block" title="Test service">Test service</button>
                     </div>
                     <div class="float-right">
 	                    {#if info:swaggerIsAvailable??}
-	                    <a onclick="testServiceWithPasswordInSwaggerUi($('#userName').val());" class="btn btn-link" title="Test in Swagger UI">
+	                    <a onclick="testServiceWithPasswordInSwaggerUi($('#userName').val(), $('#password').val());" class="btn btn-link" title="Test in Swagger UI">
 	                        <i class="fas fa-external-link-alt"></i> Swagger UI
 	                    </a>
 	                    {/if}
 	                    {#if info:graphqlIsAvailable??}
-	                    <a onclick="testServiceWithPasswordInGraphQLUi($('#userName').val());" class="btn btn-link" title="Test in GraphQL UI">
+	                    <a onclick="testServiceWithPasswordInGraphQLUi($('#userName').val(), $('#password').val());" class="btn btn-link" title="Test in GraphQL UI">
 	                        <i class="fas fa-external-link-alt"></i> GraphQL UI
 	                    </a>
 	                    {/if}
@@ -575,7 +591,7 @@ function signInToService(servicePath) {
     {#else if info:oidcGrantType is 'client_credentials'}
         <div class="card">
             <div class="card-header">
-                Get access token for {info:clientId} and test your service
+                Get access token for the client {info:clientId} and test your service
             </div>
             <div class="card-body">
                 <div class="row">


### PR DESCRIPTION
Fixes #20903

This PR:
- introduces `DevUiConfig` and deprecates the grant type and webClientTimeout properties in KC DevServices config (since they don't affect the dev services container in anyway) - and completes the alignment between KC DevServices DevUI (with DevServices container running) and `OIDC Dev UI` which is really nearly identical now as  the KC DevServices DevUI when `quarkus.auth-server-url` is set
- updated `provider.html` to supply a password field when  `OIDC Dev UI` is up.

Tested it works for Keycloak and Auth0 (with Auth0, configuring a `password` grant is a bit involved but works, did not manage to configure `client_cred` though but it is purely an Auth0 config issue)

CC @phillip-kruger @stuartwdouglas 