### PR TITLE
Ensure that a large response does not cause OOM in RESTEasy Classic

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
@@ -76,6 +76,9 @@ public class VertxBlockingOutput implements VertxOutput {
             return;
         }
         if (throwable != null) {
+            if (data != null && data.refCnt() > 0) {
+                data.release();
+            }
             throw new IOException(throwable);
         }
         try {


### PR DESCRIPTION
The idea of this change is to make the allocation of buffers only happen
when the previous write has been completed, as opposed to the previous
behavior where all the buffers where allocated upfront and could never
be deallocated if one of the writes caused an error

Fixes: #20822