### PR TITLE
Add JSON streaming for RESTEasy Reactive Jsonb and Jackson

### DIFF
--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -229,7 +229,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.acme.kafka.quarkus.Movie;
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
 
@@ -242,7 +242,7 @@ public class ConsumedMovieResource {
 
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestSseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Multi<String> stream() {
         return movies.map(movie -> String.format("'%s' from %s", movie.getTitle(), movie.getYear()));
     }

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -708,7 +708,7 @@ https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Event
 by just annotating your endpoint method with 
 link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces(MediaType.SERVER_SENT_EVENTS)`]
 and specifying that each element should be <<json,serialised to JSON>> with 
-`@RestSseElementType(MediaType.APPLICATION_JSON)`.
+`@RestStreamElementType(MediaType.APPLICATION_JSON)`.
 
 [source,java]
 ----
@@ -720,7 +720,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -739,7 +739,7 @@ public class Endpoint {
     // Send the stream over SSE
     @Produces(MediaType.SERVER_SENT_EVENTS)
     // Each element will be sent as JSON
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Book> stream() {
         return books;
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/pom.xml
@@ -40,6 +40,16 @@
             <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -23,6 +23,7 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
+import org.jboss.resteasy.reactive.common.util.RestMediaType;
 import org.jboss.resteasy.reactive.server.util.MethodId;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -137,15 +138,18 @@ public class ResteasyReactiveJacksonProcessor {
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(getJacksonMessageBodyWriter(applicationNeedsSpecialJacksonFeatures),
                         Object.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                        List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON,
+                                RestMediaType.APPLICATION_STREAM_JSON)));
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(VertxJsonArrayMessageBodyWriter.class.getName(),
                         JsonArray.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                        List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON,
+                                RestMediaType.APPLICATION_STREAM_JSON)));
         additionalWriters
                 .produce(new MessageBodyWriterBuildItem(VertxJsonObjectMessageBodyWriter.class.getName(),
                         JsonObject.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                        List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON,
+                                RestMediaType.APPLICATION_STREAM_JSON)));
     }
 
     private String getJacksonMessageBodyWriter(boolean applicationNeedsSpecialJacksonFeatures) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/Message.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/Message.java
@@ -1,0 +1,13 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.sse;
+
+public class Message {
+    public String name;
+
+    public Message(String name) {
+        this.name = name;
+    }
+
+    // for Jsonb
+    public Message() {
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseResource.java
@@ -10,7 +10,7 @@ import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseBroadcaster;
 import javax.ws.rs.sse.SseEventSink;
 
-import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 
 import io.smallrye.common.annotation.Blocking;
@@ -43,7 +43,7 @@ public class SseResource {
     @Path("json")
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public void sseJson(Sse sse, SseEventSink sink) throws IOException {
         if (sink == null) {
             throw new IllegalStateException("No client connected.");
@@ -60,7 +60,7 @@ public class SseResource {
     @Path("blocking/json")
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public void blockingSseJson(Sse sse, SseEventSink sink) throws IOException {
         if (sink == null) {
             throw new IllegalStateException("No client connected.");
@@ -94,7 +94,7 @@ public class SseResource {
     @Path("json/multi")
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Message> multiJson() {
         return Multi.createFrom().items(new Message("hello"), new Message("stef"));
     }
@@ -109,7 +109,7 @@ public class SseResource {
     @Path("ndjson/multi")
     @GET
     @Produces(RestMediaType.APPLICATION_NDJSON)
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Message> multiNdJson() {
         return Multi.createFrom().items(new Message("hello"), new Message("stef"));
     }
@@ -117,7 +117,7 @@ public class SseResource {
     @Path("stream-json/multi")
     @GET
     @Produces(RestMediaType.APPLICATION_STREAM_JSON)
-    @RestSseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Message> multiStreamJson() {
         return Multi.createFrom().items(new Message("hello"), new Message("stef"));
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.reactive.jsonb.deployment.test.sse;
+package io.quarkus.resteasy.reactive.jackson.deployment.test.sse;
 
 import java.io.IOException;
 
@@ -21,7 +21,7 @@ public class SseResource {
 
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    public void sse(Sse sse, SseEventSink sink) throws IOException {
+    public void sse(Sse sse, SseEventSink sink) {
         if (sink == null) {
             throw new IllegalStateException("No client connected.");
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseTestCase.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.reactive.jsonb.deployment.test.sse;
+package io.quarkus.resteasy.reactive.jackson.deployment.test.sse;
 
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +24,8 @@ import javax.ws.rs.sse.SseEventSource;
 import org.apache.http.HttpStatus;
 import org.jboss.resteasy.reactive.client.impl.MultiInvoker;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -38,7 +40,7 @@ public class SseTestCase {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(SseResource.class, Message.class));
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SseResourceTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SseResourceTest.java
@@ -26,7 +26,7 @@ import javax.ws.rs.sse.SseEventSource;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.jboss.resteasy.reactive.client.impl.MultiInvoker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -154,7 +154,7 @@ public class SseResourceTest {
         @Path("xml")
         @GET
         @Produces(MediaType.SERVER_SENT_EVENTS)
-        @RestSseElementType(MediaType.APPLICATION_XML)
+        @RestStreamElementType(MediaType.APPLICATION_XML)
         public void sseXml(Sse sse, SseEventSink sink) {
             if (sink == null) {
                 throw new IllegalStateException("No client connected.");
@@ -170,7 +170,7 @@ public class SseResourceTest {
         @Path("blocking/xml")
         @GET
         @Produces(MediaType.SERVER_SENT_EVENTS)
-        @RestSseElementType(MediaType.APPLICATION_XML)
+        @RestStreamElementType(MediaType.APPLICATION_XML)
         public void blockingSseXml(Sse sse, SseEventSink sink) {
             if (sink == null) {
                 throw new IllegalStateException("No client connected.");

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/processor/ResteasyReactiveJsonbProcessor.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.common.util.RestMediaType;
 import org.jboss.resteasy.reactive.server.jsonb.JsonbMessageBodyReader;
 import org.jboss.resteasy.reactive.server.jsonb.JsonbMessageBodyWriter;
 
@@ -53,7 +54,7 @@ public class ResteasyReactiveJsonbProcessor {
         additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Object.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));
         additionalWriters.produce(new MessageBodyWriterBuildItem(JsonbMessageBodyWriter.class.getName(), Object.class.getName(),
-                Collections.singletonList(MediaType.APPLICATION_JSON)));
+                List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON, RestMediaType.APPLICATION_STREAM_JSON)));
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseBroadcaster;
 import javax.ws.rs.sse.SseEventSink;
 
+// Using `@RestStreamElementType` on purpose to ensure the backward compatibility.
 import org.jboss.resteasy.reactive.RestSseElementType;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java
@@ -182,7 +182,7 @@ public class QuarkusServerEndpointIndexer
     }
 
     private boolean hasJson(ServerResourceMethod method) {
-        return hasJson(method.getProduces()) || hasJson(method.getConsumes()) || isJson(method.getSseElementType());
+        return hasJson(method.getProduces()) || hasJson(method.getConsumes()) || isJson(method.getStreamElementType());
     }
 
     private boolean hasJson(String[] types) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -49,6 +49,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_QUERY_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_RESPONSE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_SSE_ELEMENT_TYPE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_STREAM_ELEMENT_TYPE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SET;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SORTED_SET;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.STRING;
@@ -329,15 +330,10 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         String[] classProduces = extractProducesConsumesValues(getAnnotationStore().getAnnotation(currentClassInfo, PRODUCES));
         String[] classConsumes = extractProducesConsumesValues(getAnnotationStore().getAnnotation(currentClassInfo, CONSUMES));
 
-        String classSseElementType = null;
-        AnnotationInstance classSseElementTypeAnnotation = getAnnotationStore().getAnnotation(currentClassInfo,
-                REST_SSE_ELEMENT_TYPE);
-        if (classSseElementTypeAnnotation != null) {
-            classSseElementType = classSseElementTypeAnnotation.value().asString();
-        }
+        String classStreamElementType = getStreamAnnotationValue(currentClassInfo);
 
         BasicResourceClassInfo basicResourceClassInfo = new BasicResourceClassInfo(resourceClassPath, classProduces,
-                classConsumes, pathParameters, classSseElementType);
+                classConsumes, pathParameters, classStreamElementType);
 
         Set<String> classNameBindings = NameBindingUtil.nameBindingNames(index, currentClassInfo);
 
@@ -564,19 +560,19 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             produces = applyDefaultProduces(produces, nonAsyncReturnType);
             produces = addDefaultCharsets(produces);
 
-            String sseElementType = basicResourceClassInfo.getSseElementType();
-            AnnotationInstance sseElementTypeAnnotation = getAnnotationStore().getAnnotation(currentMethodInfo,
-                    REST_SSE_ELEMENT_TYPE);
-            if (sseElementTypeAnnotation != null) {
-                sseElementType = sseElementTypeAnnotation.value().asString();
+            String streamElementType = basicResourceClassInfo.getStreamElementType();
+            String streamElementTypeInMethod = getStreamAnnotationValue(currentMethodInfo);
+            if (streamElementTypeInMethod != null) {
+                streamElementType = streamElementTypeInMethod;
             }
+
             boolean returnsMultipart = false;
             if (produces != null && produces.length == 1) {
-                if (sseElementType == null && MediaType.SERVER_SENT_EVENTS.equals(produces[0])) {
+                if (streamElementType == null && MediaType.SERVER_SENT_EVENTS.equals(produces[0])) {
                     // Handle server sent events responses
                     String[] defaultProducesForType = applyAdditionalDefaults(nonAsyncReturnType);
                     if (defaultProducesForType.length == 1) {
-                        sseElementType = defaultProducesForType[0];
+                        streamElementType = defaultProducesForType[0];
                     }
                 } else if (MediaType.MULTIPART_FORM_DATA.equals(produces[0])) {
                     // Handle multipart form data responses
@@ -615,7 +611,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                     .setBlocking(blocking)
                     .setSuspended(suspended)
                     .setSse(sse)
-                    .setSseElementType(sseElementType)
+                    .setStreamElementType(streamElementType)
                     .setFormParamRequired(formParamRequired)
                     .setMultipart(multipart)
                     .setParameters(methodParameters)
@@ -644,6 +640,25 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
 
     protected void handleClientSubResource(ResourceMethod resourceMethod, MethodInfo method, IndexView index) {
 
+    }
+
+    private String getStreamAnnotationValue(AnnotationTarget target) {
+        String value = getAnnotationValueAsString(target, REST_STREAM_ELEMENT_TYPE);
+        if (value == null) {
+            value = getAnnotationValueAsString(target, REST_SSE_ELEMENT_TYPE);
+        }
+
+        return value;
+    }
+
+    private String getAnnotationValueAsString(AnnotationTarget target, DotName annotationType) {
+        String value = null;
+        AnnotationInstance annotation = getAnnotationStore().getAnnotation(target, annotationType);
+        if (annotation != null) {
+            value = annotation.value().asString();
+        }
+
+        return value;
     }
 
     private boolean isBlocking(MethodInfo info, BlockingDefault defaultValue) {
@@ -1375,15 +1390,15 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         private final String[] produces;
         private final String[] consumes;
         private final Set<String> pathParameters;
-        private final String sseElementType;
+        private final String streamElementType;
 
         public BasicResourceClassInfo(String path, String[] produces, String[] consumes, Set<String> pathParameters,
-                String sseElementType) {
+                String streamElementType) {
             this.path = path;
             this.produces = produces;
             this.consumes = consumes;
             this.pathParameters = pathParameters;
-            this.sseElementType = sseElementType;
+            this.streamElementType = streamElementType;
         }
 
         public String getPath() {
@@ -1402,8 +1417,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             return pathParameters;
         }
 
-        public String getSseElementType() {
-            return sseElementType;
+        public String getStreamElementType() {
+            return streamElementType;
         }
     }
 

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -91,6 +91,7 @@ import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.reactivestreams.Publisher;
 
 public final class ResteasyReactiveDotNames {
@@ -111,6 +112,7 @@ public final class ResteasyReactiveDotNames {
             .createSimple("org.jboss.resteasy.reactive.server.spi.ServerRequestContext");
 
     public static final DotName REST_SSE_ELEMENT_TYPE = DotName.createSimple(RestSseElementType.class.getName());
+    public static final DotName REST_STREAM_ELEMENT_TYPE = DotName.createSimple(RestStreamElementType.class.getName());
     public static final DotName CONSUMES = DotName.createSimple(Consumes.class.getName());
     public static final DotName PRODUCES = DotName.createSimple(Produces.class.getName());
     public static final DotName PROVIDER = DotName.createSimple(Provider.class.getName());

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestStreamElementType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestStreamElementType.java
@@ -9,14 +9,11 @@ import java.lang.annotation.Target;
 
 /**
  * Defines the MIME type of each SSE element in the annotated stream.
- *
- * @deprecated replaced by {@link RestStreamElementType}
  */
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Deprecated
-public @interface RestSseElementType {
+public @interface RestStreamElementType {
     String value();
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import org.jboss.resteasy.reactive.RestSseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 /**
  * A representation of a REST endpoint. This is passed directly to recorders so must be bytecode serializable.
@@ -30,10 +31,11 @@ public class ResourceMethod {
     private String[] produces;
 
     /**
-     * The value of the {@link RestSseElementType} annotation, if none is specified on the method
+     * The value of the {@link RestStreamElementType} or the {@link RestSseElementType} annotation, if none is specified on the
+     * method
      * then this represents the value inherited from the class level, or null if not specified.
      */
-    private String sseElementType;
+    private String streamElementType;
 
     /**
      * The value of the {@link Consumes} annotation, if none is specified on the method
@@ -68,14 +70,14 @@ public class ResourceMethod {
     public ResourceMethod() {
     }
 
-    public ResourceMethod(String httpMethod, String path, String[] produces, String sseElementType, String[] consumes,
+    public ResourceMethod(String httpMethod, String path, String[] produces, String streamElementType, String[] consumes,
             Set<String> nameBindingNames, String name, String returnType, String simpleReturnType, MethodParameter[] parameters,
             boolean blocking, boolean suspended, boolean isSse, boolean isFormParamRequired, boolean isMultipart,
             List<ResourceMethod> subResourceMethods) {
         this.httpMethod = httpMethod;
         this.path = path;
         this.produces = produces;
-        this.sseElementType = sseElementType;
+        this.streamElementType = streamElementType;
         this.consumes = consumes;
         this.nameBindingNames = nameBindingNames;
         this.name = name;
@@ -220,13 +222,13 @@ public class ResourceMethod {
         return this;
     }
 
-    public ResourceMethod setSseElementType(String sseElementType) {
-        this.sseElementType = sseElementType;
+    public ResourceMethod setStreamElementType(String streamElementType) {
+        this.streamElementType = streamElementType;
         return this;
     }
 
-    public String getSseElementType() {
-        return sseElementType;
+    public String getStreamElementType() {
+        return streamElementType;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/RestMediaType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/RestMediaType.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.reactive.common.util;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Extended media types in Resteasy Reactive.
+ */
+public final class RestMediaType {
+
+    public static final String APPLICATION_NDJSON = "application/x-ndjson";
+    public static final MediaType APPLICATION_NDJSON_TYPE = new MediaType("application", "x-ndjson");
+    public static final String APPLICATION_STREAM_JSON = "application/stream+json";
+    public static final MediaType APPLICATION_STREAM_JSON_TYPE = new MediaType("application", "stream+json");
+
+    private RestMediaType() {
+
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/RestMediaType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/RestMediaType.java
@@ -5,14 +5,14 @@ import javax.ws.rs.core.MediaType;
 /**
  * Extended media types in Resteasy Reactive.
  */
-public final class RestMediaType {
+public class RestMediaType extends MediaType {
 
     public static final String APPLICATION_NDJSON = "application/x-ndjson";
-    public static final MediaType APPLICATION_NDJSON_TYPE = new MediaType("application", "x-ndjson");
+    public static final RestMediaType APPLICATION_NDJSON_TYPE = new RestMediaType("application", "x-ndjson");
     public static final String APPLICATION_STREAM_JSON = "application/stream+json";
-    public static final MediaType APPLICATION_STREAM_JSON_TYPE = new MediaType("application", "stream+json");
+    public static final RestMediaType APPLICATION_STREAM_JSON_TYPE = new RestMediaType("application", "stream+json");
 
-    private RestMediaType() {
-
+    public RestMediaType(String type, String subtype) {
+        super(type, subtype);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/SseUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/SseUtil.java
@@ -117,7 +117,7 @@ public class SseUtil extends CommonSseUtil {
         Object entity = event.getData();
         Class<?> entityClass = event.getType();
         Type entityType = event.getGenericType();
-        MediaType mediaType = eventMediaType != null ? eventMediaType : context.getTarget().getSseElementType();
+        MediaType mediaType = eventMediaType != null ? eventMediaType : context.getTarget().getStreamElementType();
         if (mediaType == null) {
             mediaType = MediaType.TEXT_PLAIN_TYPE;
         }
@@ -156,8 +156,8 @@ public class SseUtil extends CommonSseUtil {
         if (!response.headWritten()) {
             response.setStatusCode(Response.Status.OK.getStatusCode());
             response.setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.SERVER_SENT_EVENTS);
-            if (context.getTarget().getSseElementType() != null) {
-                response.setResponseHeader(SSE_CONTENT_TYPE, context.getTarget().getSseElementType().toString());
+            if (context.getTarget().getStreamElementType() != null) {
+                response.setResponseHeader(SSE_CONTENT_TYPE, context.getTarget().getStreamElementType().toString());
             }
             response.setChunked(true);
             for (int i = 0; i < customizers.size(); i++) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -134,9 +134,9 @@ public class RuntimeResourceDeployment {
         MultivaluedMap<ScoreSystem.Category, ScoreSystem.Diagnostic> score = new QuarkusMultivaluedHashMap<>();
 
         Map<String, Integer> pathParameterIndexes = buildParamIndexMap(classPathTemplate, methodPathTemplate);
-        MediaType sseElementType = null;
-        if (method.getSseElementType() != null) {
-            sseElementType = MediaType.valueOf(method.getSseElementType());
+        MediaType streamElementType = null;
+        if (method.getStreamElementType() != null) {
+            streamElementType = MediaType.valueOf(method.getStreamElementType());
         }
         List<MediaType> consumesMediaTypes;
         if (method.getConsumes() == null) {
@@ -467,7 +467,8 @@ public class RuntimeResourceDeployment {
                 clazz.getFactory(), handlers.toArray(EMPTY_REST_HANDLER_ARRAY), method.getName(), parameterDeclaredTypes,
                 nonAsyncReturnType, method.isBlocking(), resourceClass,
                 lazyMethod,
-                pathParameterIndexes, info.isDevelopmentMode() ? score : null, sseElementType, clazz.resourceExceptionMapper());
+                pathParameterIndexes, info.isDevelopmentMode() ? score : null, streamElementType,
+                clazz.resourceExceptionMapper());
     }
 
     private void addResponseHandler(ServerResourceMethod method, List<ServerRestHandler> handlers) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RuntimeResource.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RuntimeResource.java
@@ -32,7 +32,7 @@ public class RuntimeResource {
     private final ResteasyReactiveResourceInfo lazyMethod;
     private final Map<String, Integer> pathParameterIndexes;
     private final Map<ScoreSystem.Category, List<ScoreSystem.Diagnostic>> score;
-    private final MediaType sseElementType;
+    private final MediaType streamElementType;
     private final Map<Class<? extends Throwable>, ResourceExceptionMapper<? extends Throwable>> classExceptionMappers;
 
     public RuntimeResource(String httpMethod, URITemplate path, URITemplate classPath, ServerMediaType produces,
@@ -42,7 +42,7 @@ public class RuntimeResource {
             Class<?>[] parameterTypes,
             Type returnType, boolean blocking, Class<?> resourceClass, ResteasyReactiveResourceInfo lazyMethod,
             Map<String, Integer> pathParameterIndexes, Map<ScoreSystem.Category, List<ScoreSystem.Diagnostic>> score,
-            MediaType sseElementType,
+            MediaType streamElementType,
             Map<Class<? extends Throwable>, ResourceExceptionMapper<? extends Throwable>> classExceptionMappers) {
         this.httpMethod = httpMethod;
         this.path = path;
@@ -60,7 +60,7 @@ public class RuntimeResource {
         this.lazyMethod = lazyMethod;
         this.pathParameterIndexes = pathParameterIndexes;
         this.score = score;
-        this.sseElementType = sseElementType;
+        this.streamElementType = streamElementType;
         this.classExceptionMappers = classExceptionMappers;
     }
 
@@ -120,13 +120,13 @@ public class RuntimeResource {
         return new ResteasyReactiveSimplifiedResourceInfo(javaMethodName, resourceClass, parameterTypes);
     }
 
-    public MediaType getSseElementType() {
-        return sseElementType;
+    public MediaType getStreamElementType() {
+        return streamElementType;
     }
 
     /**
      * The @Path that is present on the class itself
-     * 
+     *
      * @return
      */
     public URITemplate getClassPath() {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -21,12 +21,12 @@ public class ServerResourceMethod extends ResourceMethod {
     public ServerResourceMethod() {
     }
 
-    public ServerResourceMethod(String httpMethod, String path, String[] produces, String sseElementType, String[] consumes,
+    public ServerResourceMethod(String httpMethod, String path, String[] produces, String streamElementType, String[] consumes,
             Set<String> nameBindingNames, String name, String returnType, String simpleReturnType, MethodParameter[] parameters,
             boolean blocking, boolean suspended, boolean sse, boolean formParamRequired, boolean multipart,
             List<ResourceMethod> subResourceMethods, Supplier<EndpointInvoker> invoker, Set<String> methodAnnotationNames,
             List<HandlerChainCustomizer> handlerChainCustomizers, ParameterExtractor customerParameterExtractor) {
-        super(httpMethod, path, produces, sseElementType, consumes, nameBindingNames, name, returnType, simpleReturnType,
+        super(httpMethod, path, produces, streamElementType, consumes, nameBindingNames, name, returnType, simpleReturnType,
                 parameters, blocking, suspended, sse, formParamRequired, multipart, subResourceMethods);
         this.invoker = invoker;
         this.methodAnnotationNames = methodAnnotationNames;


### PR DESCRIPTION
We now support json streaming. Example:

```java
    @Path("stream-json/multi")
    @GET
    @Produces(SseMediaType.APPLICATION_STREAM_JSON)
    @RestSseElementType(MediaType.APPLICATION_JSON)
    public Multi<Message> multiStreamJson() {
        return Multi.createFrom().items(new Message("hello"), new Message("stef"));
    }
```

We support "application/x-ndjson" and "application/stream+json".

Moreover, I've added a new utility class called `SseMediaType` to be used by users. The implementation is similar to `MediaType`.

Questions:
- Added for both JSONB and Jackson extensions, is this correct?
- I've copied the existing tests we had for sse in JSONB to Jackson, is this correct?

Fix https://github.com/quarkusio/quarkus/issues/13663