### PR TITLE
Update OidcClient to accept absolute expires_in time values

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -41,6 +41,13 @@ public class OidcClientConfig extends OidcCommonConfig {
     @ConfigItem
     public Optional<Duration> refreshTokenTimeSkew = Optional.empty();
 
+    /**
+     * If the access token 'expires_in' property should be checked as an absolute time value
+     * as opposed to a duration relative to the current time.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean absoluteExpiresIn;
+
     public Grant grant = new Grant();
 
     @ConfigGroup
@@ -211,5 +218,13 @@ public class OidcClientConfig extends OidcCommonConfig {
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
+    }
+
+    public boolean isAbsoluteExpiresIn() {
+        return absoluteExpiresIn;
+    }
+
+    public void setAbsoluteExpiresIn(boolean absoluteExpiresIn) {
+        this.absoluteExpiresIn = absoluteExpiresIn;
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -130,7 +130,8 @@ public class OidcClientImpl implements OidcClient {
             if (expiresInValue != null) {
                 long accessTokenExpiresIn = expiresInValue instanceof Number ? ((Number) expiresInValue).longValue()
                         : Long.parseLong(expiresInValue.toString());
-                accessTokenExpiresAt = Instant.now().getEpochSecond() + accessTokenExpiresIn;
+                accessTokenExpiresAt = oidcConfig.absoluteExpiresIn ? accessTokenExpiresIn
+                        : Instant.now().getEpochSecond() + accessTokenExpiresIn;
             } else {
                 accessTokenExpiresAt = getExpiresJwtClaim(accessToken);
             }


### PR DESCRIPTION
Fixes #20912 

This PR does a very simple update for `OidcClient` to optionally support custom OAuth2 providers which return `expires_in` as an absolute time as opposed to a standard OAuth2 duration value. I'm not surprised different OAuth2 implementations treat it differently, for example, JWT itself has an absolute `exp` property - which `OidcClient` also recognizes.

We already have quite a few refresh token tests so not sure it is worth adding another test for this custom case 