### PR TITLE
Introduce Reactive Routes Codestart (in java and kotlin)

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/base/README.tpl.qute.md
@@ -1,0 +1,1 @@
+{#include readme-header /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,0 +1,1 @@
+{#include index-entry /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/codestart.yml
@@ -1,0 +1,16 @@
+name: reactive-routes-codestart
+ref: reactive-routes-codestart
+tags: extension-codestart
+type: code
+metadata:
+  title: Reactive Route codestart 
+  description: Create your web page using Quarkus Reactive Route in Java or Kotlin
+  path: /greetings?name=quarkus
+  related-guide-section: https://quarkus.io/guides/reactive-routes
+language:
+  base:
+    dependencies:
+      - io.quarkus:quarkus-reactive-routes
+      - io.rest-assured:rest-assured
+    
+      

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/main/java/org/acme/MyDeclarativeRoutes.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/main/java/org/acme/MyDeclarativeRoutes.java
@@ -1,0 +1,27 @@
+package org.acme;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RoutingExchange;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped 
+public class MyDeclarativeRoutes {
+
+    // neither path nor regex is set - match a path derived from the method name (ie => /hello )
+    @Route(methods = Route.HttpMethod.GET) 
+    void hello(RoutingContext rc) { 
+        rc.response().end("Hello RESTEasy Reactive Route");
+    }
+
+    @Route(path = "/world")
+    String helloWorld() { 
+        return "Hello world !!";
+    }
+
+    @Route(path = "/greetings", methods = Route.HttpMethod.GET)
+    void greetings(RoutingExchange ex) { 
+        ex.ok("Hello  " + ex.getParam("name").orElse("RESTEasy Reactive Route") +" !!");
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/test/java/org/acme/MyDeclarativeRoutesTest.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/test/java/org/acme/MyDeclarativeRoutesTest.java
@@ -1,0 +1,33 @@
+package org.acme;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MyDeclarativeRoutesTest {
+
+	@Test
+	public void testHelloEndpoint() {
+		given().when().get("/hello").then().statusCode(200).body(is("Hello RESTEasy Reactive Route"));
+	}
+
+	@Test
+	public void testWorldEndpoint() {
+		given().when().get("/world").then().statusCode(200).body(is("Hello world !!"));
+	}
+
+	@Test
+	public void testGreetingEndpointWithNameParameter() {
+		given().when().get("/greetings?name=Quarkus").then().statusCode(200).body(is("Hello  Quarkus !!"));
+	}
+
+	@Test
+	public void testGreetingEndpointWithoutNameParameter() {
+		given().when().get("/greetings").then().statusCode(200).body(is("Hello  RESTEasy Reactive Route !!"));
+	}
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/kotlin/src/main/kotlin/org/acme/MyDeclarativeRoutes.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/kotlin/src/main/kotlin/org/acme/MyDeclarativeRoutes.kt
@@ -1,0 +1,24 @@
+package org.acme
+
+import io.quarkus.vertx.web.Route
+import io.quarkus.vertx.web.RoutingExchange
+import io.vertx.ext.web.RoutingContext
+import javax.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class ReactiveGreetingResource {
+
+    // neither path nor regex is set - match a path derived from the method name (ie => /hello)
+    @Route( methods = [Route.HttpMethod.GET])
+    fun hello(rc : RoutingContext) {
+        rc.response().end("Hello RESTEasy Reactive Route")
+    }
+
+    @Route( path = "/world")
+    fun helloWorld() = "Hello world !!"
+
+    @Route(path = "/greetings", methods = [Route.HttpMethod.GET])
+    fun hello(ex : RoutingExchange) {
+       return ex.ok("Hello  " + ex.getParam("name").orElse("RESTEasy Reactive Route") +" !!")
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/kotlin/src/test/kotlin/org/acme/MyDeclarativeRoutesTest.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/kotlin/src/test/kotlin/org/acme/MyDeclarativeRoutesTest.kt
@@ -1,0 +1,46 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class ReactiveGreetingResourceTest {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(`is`("Hello RESTEasy Reactive Route"))
+    }
+
+    @Test
+    fun testWorldEndpoint() {
+        given()
+                .`when`().get("/world")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello world !!"))
+    }
+
+    @Test
+    fun testGreetingEndpointWithNameParameter() {
+        given()
+                .`when`().get("/greetings?name=Quarkus")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello  Quarkus !!"))
+    }
+
+    @Test
+    fun testGreetingEndpointWithoutNameParameter() {
+        given()
+                .`when`().get("/greetings")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello  RESTEasy Reactive Route !!"))
+    }
+}

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveRoutesCodestartTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveRoutesCodestartTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.devtools.codestarts.quarkus;
+
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Language.JAVA;
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Language.KOTLIN;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devtools.testing.codestarts.QuarkusCodestartTest;
+
+public class RESTEasyReactiveRoutesCodestartTest {
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartTest = QuarkusCodestartTest.builder()
+            .codestarts("reactive-routes-codestart")
+            .languages(JAVA, KOTLIN)
+            .build();
+
+    @Test
+    void testContent() throws Throwable {
+        codestartTest.checkGeneratedSource("org.acme.MyDeclarativeRoutes");
+        codestartTest.checkGeneratedTestSource("org.acme.MyDeclarativeRoutesTest");
+    }
+
+    @Test
+    void buildAllProjects() throws Throwable {
+        codestartTest.buildAllProjects();
+    }
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_main_java_ilove_quark_us_MyDeclarativeRoutes.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_main_java_ilove_quark_us_MyDeclarativeRoutes.java
@@ -1,0 +1,27 @@
+package ilove.quark.us;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RoutingExchange;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped 
+public class MyDeclarativeRoutes {
+
+    // neither path nor regex is set - match a path derived from the method name (ie => /hello )
+    @Route(methods = Route.HttpMethod.GET) 
+    void hello(RoutingContext rc) { 
+        rc.response().end("Hello RESTEasy Reactive Route");
+    }
+
+    @Route(path = "/world")
+    String helloWorld() { 
+        return "Hello world !!";
+    }
+
+    @Route(path = "/greetings", methods = Route.HttpMethod.GET)
+    void greetings(RoutingExchange ex) { 
+        ex.ok("Hello  " + ex.getParam("name").orElse("RESTEasy Reactive Route") +" !!");
+    }
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_main_kotlin_ilove_quark_us_MyDeclarativeRoutes.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_main_kotlin_ilove_quark_us_MyDeclarativeRoutes.kt
@@ -1,0 +1,24 @@
+package ilove.quark.us
+
+import io.quarkus.vertx.web.Route
+import io.quarkus.vertx.web.RoutingExchange
+import io.vertx.ext.web.RoutingContext
+import javax.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class ReactiveGreetingResource {
+
+    // neither path nor regex is set - match a path derived from the method name (ie => /hello)
+    @Route( methods = [Route.HttpMethod.GET])
+    fun hello(rc : RoutingContext) {
+        rc.response().end("Hello RESTEasy Reactive Route")
+    }
+
+    @Route( path = "/world")
+    fun helloWorld() = "Hello world !!"
+
+    @Route(path = "/greetings", methods = [Route.HttpMethod.GET])
+    fun hello(ex : RoutingExchange) {
+       return ex.ok("Hello  " + ex.getParam("name").orElse("RESTEasy Reactive Route") +" !!")
+    }
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_test_java_ilove_quark_us_MyDeclarativeRoutesTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_test_java_ilove_quark_us_MyDeclarativeRoutesTest.java
@@ -1,0 +1,33 @@
+package ilove.quark.us;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MyDeclarativeRoutesTest {
+
+	@Test
+	public void testHelloEndpoint() {
+		given().when().get("/hello").then().statusCode(200).body(is("Hello RESTEasy Reactive Route"));
+	}
+
+	@Test
+	public void testWorldEndpoint() {
+		given().when().get("/world").then().statusCode(200).body(is("Hello world !!"));
+	}
+
+	@Test
+	public void testGreetingEndpointWithNameParameter() {
+		given().when().get("/greetings?name=Quarkus").then().statusCode(200).body(is("Hello  Quarkus !!"));
+	}
+
+	@Test
+	public void testGreetingEndpointWithoutNameParameter() {
+		given().when().get("/greetings").then().statusCode(200).body(is("Hello  RESTEasy Reactive Route !!"));
+	}
+
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_test_kotlin_ilove_quark_us_MyDeclarativeRoutesTest.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveRoutesCodestartTest/testContent/src_test_kotlin_ilove_quark_us_MyDeclarativeRoutesTest.kt
@@ -1,0 +1,46 @@
+package ilove.quark.us
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class ReactiveGreetingResourceTest {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(`is`("Hello RESTEasy Reactive Route"))
+    }
+
+    @Test
+    fun testWorldEndpoint() {
+        given()
+                .`when`().get("/world")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello world !!"))
+    }
+
+    @Test
+    fun testGreetingEndpointWithNameParameter() {
+        given()
+                .`when`().get("/greetings?name=Quarkus")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello  Quarkus !!"))
+    }
+
+    @Test
+    fun testGreetingEndpointWithoutNameParameter() {
+        given()
+                .`when`().get("/greetings")
+                .then()
+                .statusCode(200)
+                .body(`is`("Hello  RESTEasy Reactive Route !!"))
+    }
+}


### PR DESCRIPTION
Add a new code start for reactive route in java and kotlin 

Fix #20871 

We follow the quarkus guide and add routes like described in guide https://quarkus.io/guides/reactive-routes