### PR TITLE
Lazily initialize (Reactive)MongoClient

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.mongodb.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.enterprise.inject.Default;
@@ -40,27 +41,32 @@ public class MongoClientRecorder {
         };
     }
 
+    /** Helper to lazily create Mongo clients. */
+    static final class MongoClientSupplier<T> implements Supplier<T> {
+        private final Function<MongoClients, T> producer;
+
+        MongoClientSupplier(Function<MongoClients, T> producer) {
+            this.producer = producer;
+        }
+
+        @Override
+        public T get() {
+            // The beans defined in io.quarkus.mongodb.deployment.MongoClientProcessor.createBlockingSyntheticBean and
+            // io.quarkus.mongodb.deployment.MongoClientProcessor.createReactiveSyntheticBean are ApplicationScoped,
+            // so no need to cache the result here.
+            MongoClients mongoClients = Arc.container().instance(MongoClients.class).get();
+            return producer.apply(mongoClients);
+        }
+    }
+
     public Supplier<MongoClient> mongoClientSupplier(String clientName,
             @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
-        MongoClient mongoClient = Arc.container().instance(MongoClients.class).get().createMongoClient(clientName);
-        return new Supplier<MongoClient>() {
-            @Override
-            public MongoClient get() {
-                return mongoClient;
-            }
-        };
+        return new MongoClientSupplier<>(mongoClients -> mongoClients.createMongoClient(clientName));
     }
 
     public Supplier<ReactiveMongoClient> reactiveMongoClientSupplier(String clientName,
             @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
-        ReactiveMongoClient reactiveMongoClient = Arc.container().instance(MongoClients.class).get()
-                .createReactiveMongoClient(clientName);
-        return new Supplier<ReactiveMongoClient>() {
-            @Override
-            public ReactiveMongoClient get() {
-                return reactiveMongoClient;
-            }
-        };
+        return new MongoClientSupplier<>(mongoClients -> mongoClients.createReactiveMongoClient(clientName));
     }
 
     public RuntimeValue<MongoClient> getClient(String name) {


### PR DESCRIPTION
The (Reactive)MongoClient instances are eagerly created once the mongodb-client extension is being used.
If applications are pre-packages with multiple backend options and the user does not use MongoDB, the
eager client creation causes trouble like failing health checks and the application not terminating within
Mongo's default connect timeout (30 seconds).

[Nessie](github.com/projectnessie/nessie) for example offers multiple backend databases like Mongo, Dynamo and Rocks.

This PR does not introduce a functional change and keeps eager mongodb-client initialization. It adds
a new config-item to disable eager init so the mongodb-clients are created upon the first use (injection)
of a (Reactive)MongoClient.

PS: Would be nice to get this one backported to 2.4.