### PR TITLE
Fix resolution of path params when using @BeanParam in Resteasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/ResourceLocatorTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/ResourceLocatorTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.server.test.resource.basic;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
 import java.util.function.Supplier;
 
 import javax.ws.rs.client.Client;
@@ -143,5 +146,13 @@ public class ResourceLocatorTest {
             Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             Assertions.assertEquals("posted: hello!", response.readEntity(String.class));
         }
+    }
+
+    @Test
+    @DisplayName("Test @BeanParam annotation in Subresources")
+    public void testBeanParamsInSubresource() {
+        given().get("/sub3/first/resources/subresource3?value=second")
+                .then()
+                .body(is("first and second"));
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/ResourceLocatorBaseResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/ResourceLocatorBaseResource.java
@@ -46,4 +46,9 @@ public class ResourceLocatorBaseResource {
                 });
     }
 
+    @Path("sub3/{param}/resources")
+    public ResourceLocatorSubresource getSubresource() {
+        return new ResourceLocatorSubresource();
+    }
+
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/ResourceLocatorSubresource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/ResourceLocatorSubresource.java
@@ -2,12 +2,15 @@ package io.quarkus.resteasy.reactive.server.test.resource.basic.resource;
 
 import java.util.List;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestPath;
 import org.junit.jupiter.api.Assertions;
 
 public class ResourceLocatorSubresource {
@@ -51,5 +54,18 @@ public class ResourceLocatorSubresource {
         for (Object ancestor : uri.getMatchedResources())
             LOG.debugv("   {0}", ancestor.getClass().getName());
         return new ResourceLocatorSubresource2();
+    }
+
+    @GET
+    @Path("/subresource3")
+    public String getValueFromBeanParam(@BeanParam Params params) {
+        return params.param + " and " + params.value;
+    }
+
+    public static class Params {
+        @RestPath
+        String param;
+        @QueryParam("value")
+        String value;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -895,12 +895,20 @@ public abstract class ResteasyReactiveRequestContext
         // this is a slower version than getPathParam, but we can't actually bake path indices inside
         // BeanParam classes (which use thismethod ) because they can be used by multiple resources that would have different
         // indices
-        Integer index = this.target.getPathParameterIndexes().get(name);
+        Integer index = target.getPathParameterIndexes().get(name);
+        String value;
+        if (index != null) {
+            value = getPathParam(index);
+        } else {
+            // Check previous resources if the path is not defined in the current target
+            value = getResourceLocatorPathParam(name);
+        }
+
         // It's possible to inject a path param that's not defined, return null in this case
-        String value = index != null ? getPathParam(index) : null;
         if (encoded && value != null) {
             return Encode.encodeQueryParam(value);
         }
+
         return value;
     }
 


### PR DESCRIPTION
Having two resources:

```java
public class Subresource {

    @GET
    @Path("/subresource")
    public String getValueFromBeanParam(@BeanParam Params params) {
        return params.param + " and " + params.value;
    }

    public static class Params {
        @RestPath
        String param;
        @QueryParam("value")
        String value;
    }
}
```

And the main resource that calls the subresource:

```java
@Path("/")
public class Resource {

    @Path("subresource/{param}/path")
    public Subresource getSubresource() {
        return new Subresource();
    }

}
```

Note that the `{param}` is set in the Path of the Resource. 

So, the problem was that the `ResteasyReactiveRequestContext.getPathParameter` was only taking into account the current target (and for subresource, the param name `param` was not found because it was set in the Resource). Using the method `getResourceLocatorPathParam` fixed the issue.

I've also added a test to verify the fix.

Fix https://github.com/quarkusio/quarkus/issues/20897